### PR TITLE
fix(onboarding): restore signup handoff

### DIFF
--- a/apps/app/app/(onboarding)/onboarding/(wizard)/brand/brand-content.behavior.test.tsx
+++ b/apps/app/app/(onboarding)/onboarding/(wizard)/brand/brand-content.behavior.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import '@testing-library/jest-dom/vitest';
-import { render, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { ChangeEvent, ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ONBOARDING_STORAGE_KEYS } from '@/lib/onboarding/onboarding-access.util';
@@ -10,6 +10,7 @@ import BrandContent from './brand-content';
 const {
   findMeBrandsMock,
   findMeOrganizationsMock,
+  handleStepCompleteMock,
   pushMock,
   renameWithOrganizationSyncMock,
   resolveAuthTokenMock,
@@ -19,6 +20,7 @@ const {
 } = vi.hoisted(() => ({
   findMeBrandsMock: vi.fn(),
   findMeOrganizationsMock: vi.fn(),
+  handleStepCompleteMock: vi.fn(),
   pushMock: vi.fn(),
   renameWithOrganizationSyncMock: vi.fn(),
   resolveAuthTokenMock: vi.fn(),
@@ -27,8 +29,14 @@ const {
   updateAccountTypeMock: vi.fn(),
 }));
 
-vi.mock('@genfeedai/auth-client/react', () => ({
-  useAuth: () => ({
+vi.mock('@contexts/onboarding/onboarding-context', () => ({
+  useOnboarding: () => ({
+    handleStepComplete: handleStepCompleteMock,
+  }),
+}));
+
+vi.mock('@genfeedai/hooks/auth/use-auth-identity/use-auth-identity', () => ({
+  useAuthIdentity: () => ({
     getToken: vi.fn(),
   }),
 }));
@@ -69,6 +77,7 @@ vi.mock('@services/organization/users.service', () => ({
     getInstance: vi.fn(() => ({
       findMeBrands: findMeBrandsMock,
       findMeOrganizations: findMeOrganizationsMock,
+      patchMe: vi.fn(),
     })),
   },
 }));
@@ -140,6 +149,7 @@ describe('BrandContent behavior', () => {
   beforeEach(() => {
     findMeBrandsMock.mockReset();
     findMeOrganizationsMock.mockReset();
+    handleStepCompleteMock.mockReset();
     pushMock.mockReset();
     renameWithOrganizationSyncMock.mockReset();
     resolveAuthTokenMock.mockReset();
@@ -152,7 +162,10 @@ describe('BrandContent behavior', () => {
     // A default brand + org exist by the brand step for a normal signup, so the
     // resource routes can resolve their target ids (REST audit #1354).
     findMeBrandsMock.mockResolvedValue([{ id: 'brand_1' }]);
-    findMeOrganizationsMock.mockResolvedValue([{ id: 'org_1' }]);
+    findMeOrganizationsMock.mockResolvedValue([
+      { id: 'org_1', label: 'Default Organization' },
+    ]);
+    handleStepCompleteMock.mockResolvedValue(undefined);
     scrapeMock.mockResolvedValue({ brandId: 'brand_1', success: true });
     renameWithOrganizationSyncMock.mockResolvedValue({ id: 'brand_1' });
 
@@ -162,28 +175,62 @@ describe('BrandContent behavior', () => {
     });
   });
 
-  it('auto-continues with stored cloud handoff brand context', async () => {
+  it('prefills auto cloud handoff context and continues after confirmation', async () => {
     searchParamsMock.set('auto', 'true');
     localStorage.setItem(ONBOARDING_STORAGE_KEYS.brandDomain, 'acme.co');
     localStorage.setItem(ONBOARDING_STORAGE_KEYS.brandName, 'Acme');
 
     render(<BrandContent />);
 
+    expect(scrapeMock).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Founders' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Bold' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+
     await waitFor(() => {
-      expect(scrapeMock).toHaveBeenCalledWith('brand_1', {
-        brandName: 'Acme',
-        brandUrl: 'https://acme.co',
-      });
+      expect(renameWithOrganizationSyncMock).toHaveBeenCalledWith(
+        'brand_1',
+        'Acme',
+        {
+          agentConfig: {
+            voice: {
+              audience: 'Founders',
+              tone: 'Bold',
+            },
+          },
+          description: [
+            'Brand: Acme.',
+            'Organization: Acme.',
+            'Audience: Founders.',
+            'Tone: Bold.',
+          ].join('\n'),
+          organizationLabel: 'Acme',
+          text: [
+            'Brand: Acme.',
+            'Organization: Acme.',
+            'Audience: Founders.',
+            'Tone: Bold.',
+          ].join('\n'),
+        },
+      );
     });
 
+    expect(scrapeMock).toHaveBeenCalledWith('brand_1', {
+      additionalNotes: 'Preferred tone: Bold',
+      brandName: 'Acme',
+      brandUrl: 'https://acme.co',
+      organizationName: 'Acme',
+      targetAudience: 'Founders',
+    });
     expect(localStorage.getItem(ONBOARDING_STORAGE_KEYS.brandDomain)).toBe(
       'acme.co',
     );
     expect(localStorage.getItem(ONBOARDING_STORAGE_KEYS.brandName)).toBe(
       'Acme',
     );
-    expect(pushMock).toHaveBeenCalledWith('/onboarding/providers');
-    expect(renameWithOrganizationSyncMock).not.toHaveBeenCalled();
+    expect(handleStepCompleteMock).toHaveBeenCalledWith('brand');
+    expect(pushMock).not.toHaveBeenCalledWith('/onboarding/providers');
   });
 
   it('infers a brand name from the stored domain when cloud handoff has no brand name', async () => {
@@ -193,15 +240,14 @@ describe('BrandContent behavior', () => {
     render(<BrandContent />);
 
     await waitFor(() => {
-      expect(scrapeMock).toHaveBeenCalledWith('brand_1', {
-        brandName: 'Studio Acme',
-        brandUrl: 'https://studio.acme.io',
-      });
+      expect(screen.getByPlaceholderText('Your name or brand')).toHaveValue(
+        'Studio Acme',
+      );
     });
 
-    expect(localStorage.getItem(ONBOARDING_STORAGE_KEYS.brandName)).toBe(
+    expect(screen.getByPlaceholderText('Your organization')).toHaveValue(
       'Studio Acme',
     );
-    expect(pushMock).toHaveBeenCalledWith('/onboarding/providers');
+    expect(scrapeMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/app/app/(onboarding)/onboarding/(wizard)/brand/brand-content.tsx
+++ b/apps/app/app/(onboarding)/onboarding/(wizard)/brand/brand-content.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { APP_ROUTES } from '@genfeedai/constants';
+import { useOnboarding } from '@contexts/onboarding/onboarding-context';
 import { LinkCategory, type OrganizationCategory } from '@genfeedai/enums';
 import { useAuthIdentity } from '@genfeedai/hooks/auth/use-auth-identity/use-auth-identity';
 import { resolveAuthToken } from '@helpers/auth/auth.helper';
@@ -19,6 +19,8 @@ import {
 import BrandAccountTypeSelector from './brand-account-type-selector';
 import BrandFormFields from './brand-form-fields';
 import BrandStepHeader from './brand-step-header';
+
+const DEFAULT_ORGANIZATION_LABEL = 'Default Organization';
 
 const TIMELINE_STEPS = [
   {
@@ -61,19 +63,51 @@ function normalizeWebsiteUrl(url: string): string | null {
   return trimmedUrl.includes('://') ? trimmedUrl : `https://${trimmedUrl}`;
 }
 
+function isPlaceholderName(value?: string | null): boolean {
+  return !value?.trim() || value.trim() === DEFAULT_ORGANIZATION_LABEL;
+}
+
+function buildBrandGuidance(input: {
+  brandName: string;
+  organizationName: string;
+  targetAudience?: string;
+  tone?: string;
+}): string {
+  const parts = [
+    `Brand: ${input.brandName}.`,
+    `Organization: ${input.organizationName}.`,
+  ];
+
+  if (input.targetAudience) {
+    parts.push(`Audience: ${input.targetAudience}.`);
+  }
+
+  if (input.tone) {
+    parts.push(`Tone: ${input.tone}.`);
+  }
+
+  return parts.join('\n');
+}
+
 function BrandContentContent() {
   const sectionRef = useGsapTimeline<HTMLDivElement>({ steps: TIMELINE_STEPS });
   const { getToken } = useAuthIdentity();
   const { push } = useRouter();
+  const { handleStepComplete } = useOnboarding();
   const searchParams = useSearchParams();
   const isAutoRequested = searchParams.get('auto') === 'true';
+  const initialBrandName =
+    localStorage.getItem(ONBOARDING_STORAGE_KEYS.brandName) ?? '';
+  const initialWebsiteUrl =
+    localStorage.getItem(ONBOARDING_STORAGE_KEYS.brandDomain) ?? '';
 
-  const [brandName, setBrandName] = useState(
-    () => localStorage.getItem(ONBOARDING_STORAGE_KEYS.brandName) ?? '',
+  const [brandName, setBrandName] = useState(() => initialBrandName);
+  const [organizationName, setOrganizationName] = useState(
+    () => initialBrandName,
   );
-  const [websiteUrl, setWebsiteUrl] = useState(
-    () => localStorage.getItem(ONBOARDING_STORAGE_KEYS.brandDomain) ?? '',
-  );
+  const [websiteUrl, setWebsiteUrl] = useState(() => initialWebsiteUrl);
+  const [targetAudience, setTargetAudience] = useState('');
+  const [tone, setTone] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [accountType, setAccountType] = useState<OrganizationCategory | null>(
     null,
@@ -122,8 +156,14 @@ function BrandContentContent() {
           orgIdRef.current = org.id;
         }
 
-        if (brand?.label) {
+        if (!isPlaceholderName(brand?.label)) {
           setBrandName((prev) => prev || brand.label);
+        }
+
+        if (!isPlaceholderName(org?.label)) {
+          setOrganizationName((prev) => prev || org.label);
+        } else if (!isPlaceholderName(brand?.label)) {
+          setOrganizationName((prev) => prev || brand.label);
         }
 
         const websiteLink = brand?.links?.find(
@@ -204,15 +244,20 @@ function BrandContentContent() {
   const handleContinue = useCallback(
     async ({
       brandNameOverride,
+      organizationNameOverride,
       skipWebsite = false,
       urlOverride,
     }: {
       brandNameOverride?: string;
+      organizationNameOverride?: string;
       skipWebsite?: boolean;
       urlOverride?: string;
     } = {}) => {
       const effectiveBrandName = (brandNameOverride ?? brandName).trim();
-      if (!effectiveBrandName) {
+      const effectiveOrganizationName = (
+        organizationNameOverride ?? organizationName
+      ).trim();
+      if (!effectiveBrandName || !effectiveOrganizationName) {
         return;
       }
 
@@ -249,27 +294,74 @@ function BrandContentContent() {
         }
 
         const brandsService = BrandsService.getInstance(token);
+        const trimmedTargetAudience = targetAudience.trim();
+        const trimmedTone = tone.trim();
+        const guidancePrompt = buildBrandGuidance({
+          brandName: effectiveBrandName,
+          organizationName: effectiveOrganizationName,
+          ...(trimmedTargetAudience
+            ? { targetAudience: trimmedTargetAudience }
+            : {}),
+          ...(trimmedTone ? { tone: trimmedTone } : {}),
+        });
+        const voiceConfig =
+          trimmedTargetAudience || trimmedTone
+            ? {
+                voice: {
+                  ...(trimmedTargetAudience
+                    ? { audience: trimmedTargetAudience }
+                    : {}),
+                  ...(trimmedTone ? { tone: trimmedTone } : {}),
+                },
+              }
+            : undefined;
+
+        await brandsService.renameWithOrganizationSync(
+          brandId,
+          effectiveBrandName,
+          {
+            description: guidancePrompt,
+            organizationLabel: effectiveOrganizationName,
+            text: guidancePrompt,
+            ...(voiceConfig ? { agentConfig: voiceConfig } : {}),
+          },
+        );
+
         if (brandUrl) {
-          // Scrape + AI orchestration on the brand resource (was brand-setup).
-          await brandsService.scrape(brandId, {
-            brandName: effectiveBrandName,
-            brandUrl,
-          });
-        } else {
-          // Rename the brand, cascading to the org name during onboarding.
-          await brandsService.renameWithOrganizationSync(
-            brandId,
-            effectiveBrandName,
-          );
+          // Enrichment should not block the user from continuing.
+          void brandsService
+            .scrape(brandId, {
+              brandName: effectiveBrandName,
+              brandUrl,
+              organizationName: effectiveOrganizationName,
+              ...(trimmedTone
+                ? { additionalNotes: `Preferred tone: ${trimmedTone}` }
+                : {}),
+              ...(trimmedTargetAudience
+                ? { targetAudience: trimmedTargetAudience }
+                : {}),
+            })
+            .catch((error) => {
+              logger.error('Failed to scrape brand during onboarding', error);
+            });
         }
 
-        push(APP_ROUTES.ONBOARDING.PROVIDERS);
+        await handleStepComplete('brand');
       } catch (error) {
         logger.error('Failed to continue onboarding', error);
         setSubmitting(false);
       }
     },
-    [getToken, brandName, websiteUrl, push, resolveBrandId],
+    [
+      getToken,
+      brandName,
+      organizationName,
+      websiteUrl,
+      resolveBrandId,
+      targetAudience,
+      tone,
+      handleStepComplete,
+    ],
   );
 
   const handleSkipOnboarding = useCallback(async () => {
@@ -290,6 +382,9 @@ function BrandContentContent() {
       await OrganizationsService.getInstance(token).patchSettings(orgId, {
         isFirstLogin: false,
       });
+      await UsersService.getInstance(token).patchMe({
+        isOnboardingCompleted: true,
+      });
       push('/');
     } catch (error) {
       logger.error('Failed to skip onboarding', error);
@@ -297,9 +392,20 @@ function BrandContentContent() {
     }
   }, [getToken, push, resolveOrgId]);
 
-  // Auto-scan from corporate email flow.
-  // websiteUrl and brandName are already initialised from localStorage in useState,
-  // so we read them directly instead of re-reading localStorage and setting state.
+  const handleWebsiteUrlChange = useCallback((value: string) => {
+    setWebsiteUrl(value);
+
+    const domain = extractBrandDomain(value);
+    if (!domain) {
+      return;
+    }
+
+    const inferredBrandName = deriveBrandNameFromDomain(domain);
+    setBrandName((prev) => prev || inferredBrandName);
+    setOrganizationName((prev) => prev || inferredBrandName);
+  }, []);
+
+  // Auto mode pre-fills from the corporate email domain; the user confirms.
   useEffect(() => {
     if (autoScanRef.current) {
       return;
@@ -309,14 +415,10 @@ function BrandContentContent() {
       const inferredBrandName =
         brandName.trim() || deriveBrandNameFromDomain(websiteUrl);
       autoScanRef.current = true;
-      handleContinue({
-        brandNameOverride: inferredBrandName,
-        urlOverride: websiteUrl,
-      }).catch((error) => {
-        logger.error('Failed to continue auto onboarding flow', error);
-      });
+      setBrandName((prev) => prev || inferredBrandName);
+      setOrganizationName((prev) => prev || inferredBrandName);
     }
-  }, [handleContinue, isAutoRequested, websiteUrl, brandName]);
+  }, [isAutoRequested, websiteUrl, brandName]);
 
   return (
     <div ref={sectionRef}>
@@ -329,10 +431,16 @@ function BrandContentContent() {
 
       <BrandFormFields
         brandName={brandName}
+        organizationName={organizationName}
         websiteUrl={websiteUrl}
+        targetAudience={targetAudience}
+        tone={tone}
         submitting={submitting}
         onBrandNameChange={setBrandName}
-        onWebsiteUrlChange={setWebsiteUrl}
+        onOrganizationNameChange={setOrganizationName}
+        onWebsiteUrlChange={handleWebsiteUrlChange}
+        onTargetAudienceChange={setTargetAudience}
+        onToneChange={setTone}
         onContinue={() => handleContinue()}
         onSkip={handleSkipOnboarding}
       />

--- a/apps/app/app/(onboarding)/onboarding/(wizard)/brand/brand-form-fields.tsx
+++ b/apps/app/app/(onboarding)/onboarding/(wizard)/brand/brand-form-fields.tsx
@@ -7,19 +7,85 @@ import { HiArrowRight, HiGlobeAlt } from 'react-icons/hi2';
 
 type Props = {
   brandName: string;
+  organizationName: string;
+  targetAudience: string;
+  tone: string;
   websiteUrl: string;
   submitting: boolean;
   onBrandNameChange: (value: string) => void;
+  onOrganizationNameChange: (value: string) => void;
+  onTargetAudienceChange: (value: string) => void;
+  onToneChange: (value: string) => void;
   onWebsiteUrlChange: (value: string) => void;
   onContinue: () => void;
   onSkip: () => void;
 };
 
+const AUDIENCE_OPTIONS = [
+  'Founders',
+  'Marketing teams',
+  'Creators',
+  'Developers',
+] as const;
+
+const TONE_OPTIONS = ['Professional', 'Playful', 'Bold', 'Minimal'] as const;
+
+function ChipGroup({
+  label,
+  onChange,
+  options,
+  value,
+}: {
+  label: string;
+  onChange: (value: string) => void;
+  options: readonly string[];
+  value: string;
+}) {
+  return (
+    <div>
+      <p className="block text-xs font-medium text-white/50 uppercase tracking-wider mb-2">
+        {label}
+        <span className="text-white/20 font-normal normal-case tracking-normal ml-1">
+          (optional)
+        </span>
+      </p>
+      <div className="flex flex-wrap gap-2">
+        {options.map((option) => {
+          const isSelected = value === option;
+
+          return (
+            <Button
+              key={option}
+              type="button"
+              variant={ButtonVariant.UNSTYLED}
+              label={option}
+              aria-pressed={isSelected}
+              withWrapper={false}
+              onClick={() => onChange(isSelected ? '' : option)}
+              className={`h-9 border px-3 text-xs font-medium transition ${
+                isSelected
+                  ? 'border-white/35 bg-white/15 text-white'
+                  : 'border-white/[0.08] bg-white/[0.03] text-white/45 hover:border-white/20 hover:text-white/75'
+              }`}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 export default function BrandFormFields({
   brandName,
+  organizationName,
+  targetAudience,
+  tone,
   websiteUrl,
   submitting,
   onBrandNameChange,
+  onOrganizationNameChange,
+  onTargetAudienceChange,
+  onToneChange,
   onWebsiteUrlChange,
   onContinue,
   onSkip,
@@ -43,6 +109,28 @@ export default function BrandFormFields({
           value={brandName}
           onChange={(e) => onBrandNameChange(e.target.value)}
           placeholder="Your name or brand"
+          required
+          className="h-12 rounded-none border-white/[0.08] bg-white/[0.04] px-4 text-sm text-white placeholder:text-white/20 focus-visible:border-white/30 focus-visible:ring-0"
+        />
+      </div>
+
+      {/* Organization Name */}
+      <div>
+        <label
+          htmlFor="organization-name"
+          className="block text-xs font-medium text-white/50 uppercase tracking-wider mb-2"
+        >
+          Organization
+          <span className="text-white/25 font-normal normal-case tracking-normal ml-1">
+            (required)
+          </span>
+        </label>
+        <Input
+          id="organization-name"
+          type="text"
+          value={organizationName}
+          onChange={(e) => onOrganizationNameChange(e.target.value)}
+          placeholder="Your organization"
           required
           className="h-12 rounded-none border-white/[0.08] bg-white/[0.04] px-4 text-sm text-white placeholder:text-white/20 focus-visible:border-white/30 focus-visible:ring-0"
         />
@@ -75,6 +163,20 @@ export default function BrandFormFields({
         </p>
       </div>
 
+      <ChipGroup
+        label="Who is this for?"
+        options={AUDIENCE_OPTIONS}
+        value={targetAudience}
+        onChange={onTargetAudienceChange}
+      />
+
+      <ChipGroup
+        label="How should it sound?"
+        options={TONE_OPTIONS}
+        value={tone}
+        onChange={onToneChange}
+      />
+
       {/* Continue button */}
       <div className="step-actions opacity-0">
         <div className="flex items-center gap-3">
@@ -84,7 +186,7 @@ export default function BrandFormFields({
             label="Continue"
             icon={<HiArrowRight className="size-4" />}
             isLoading={submitting}
-            isDisabled={!brandName.trim()}
+            isDisabled={!brandName.trim() || !organizationName.trim()}
             onClick={onContinue}
             className="rounded-none px-5"
           />

--- a/apps/app/app/(onboarding)/onboarding/(wizard)/providers/providers-content.behavior.test.tsx
+++ b/apps/app/app/(onboarding)/onboarding/(wizard)/providers/providers-content.behavior.test.tsx
@@ -11,6 +11,7 @@ const {
   assignMock,
   getInstallReadinessMock,
   getUsersServiceMock,
+  handleStepCompleteMock,
   patchSettingsMock,
   pushMock,
   resolveAuthTokenMock,
@@ -18,6 +19,7 @@ const {
   assignMock: vi.fn(),
   getInstallReadinessMock: vi.fn(),
   getUsersServiceMock: vi.fn(),
+  handleStepCompleteMock: vi.fn(),
   patchSettingsMock: vi.fn(),
   pushMock: vi.fn(),
   resolveAuthTokenMock: vi.fn(),
@@ -26,6 +28,12 @@ const {
 vi.mock('@genfeedai/auth-client/react', () => ({
   useAuth: () => ({
     getToken: vi.fn(),
+  }),
+}));
+
+vi.mock('@contexts/onboarding/onboarding-context', () => ({
+  useOnboarding: () => ({
+    handleStepComplete: handleStepCompleteMock,
   }),
 }));
 
@@ -143,6 +151,7 @@ describe('ProvidersContent behavior', () => {
     assignMock.mockReset();
     getInstallReadinessMock.mockReset();
     getUsersServiceMock.mockReset();
+    handleStepCompleteMock.mockReset();
     patchSettingsMock.mockReset();
     pushMock.mockReset();
     resolveAuthTokenMock.mockReset();
@@ -192,6 +201,7 @@ describe('ProvidersContent behavior', () => {
       patchSettings: patchSettingsMock,
     });
     patchSettingsMock.mockResolvedValue({});
+    handleStepCompleteMock.mockResolvedValue(undefined);
 
     Object.defineProperty(globalThis, 'localStorage', {
       configurable: true,
@@ -236,7 +246,8 @@ describe('ProvidersContent behavior', () => {
       );
     });
 
-    expect(pushMock).toHaveBeenCalledWith('/onboarding/summary');
+    expect(handleStepCompleteMock).toHaveBeenCalledWith('providers');
+    expect(pushMock).not.toHaveBeenCalledWith('/onboarding/summary');
     expect(assignMock).not.toHaveBeenCalled();
   });
 
@@ -269,6 +280,7 @@ describe('ProvidersContent behavior', () => {
     });
 
     expect(pushMock).toHaveBeenCalledWith('/settings/api-keys');
+    expect(handleStepCompleteMock).toHaveBeenCalledWith('providers');
   });
 
   it('marks the saved access choice as the current selection', async () => {
@@ -401,6 +413,7 @@ describe('ProvidersContent behavior', () => {
     });
 
     expect(assignMock).toHaveBeenCalledTimes(1);
+    expect(handleStepCompleteMock).toHaveBeenCalledWith('providers');
 
     const redirectUrl = new URL(assignMock.mock.calls[0][0] as string);
 

--- a/apps/app/app/(onboarding)/onboarding/(wizard)/providers/providers-content.tsx
+++ b/apps/app/app/(onboarding)/onboarding/(wizard)/providers/providers-content.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useOnboarding } from '@contexts/onboarding/onboarding-context';
 import { useCurrentUser } from '@contexts/user/user-context/user-context';
 import { APP_ROUTES } from '@genfeedai/constants';
 import { useAuthIdentity } from '@genfeedai/hooks/auth/use-auth-identity/use-auth-identity';
@@ -123,6 +124,7 @@ export default function ProvidersContent() {
   const sectionRef = useGsapTimeline<HTMLDivElement>({ steps: TIMELINE_STEPS });
   const { getToken } = useAuthIdentity();
   const { currentUser } = useCurrentUser();
+  const { handleStepComplete } = useOnboarding();
   const getUsersService = useAuthedService((token: string) =>
     UsersService.getInstance(token),
   );
@@ -231,7 +233,7 @@ export default function ProvidersContent() {
   const handleServerContinue = async () => {
     setPendingMode('server');
     await persistAccessMode('server');
-    push(APP_ROUTES.ONBOARDING.SUMMARY);
+    await handleStepComplete('providers');
   };
 
   const handleByokClick = async (
@@ -245,12 +247,14 @@ export default function ProvidersContent() {
 
     setPendingMode('byok');
     await persistAccessMode('byok');
+    await handleStepComplete('providers');
     push(APP_ROUTES.SETTINGS.API_KEYS);
   };
 
   const handleCloudContinue = async () => {
     setPendingMode('cloud');
     await persistAccessMode('cloud');
+    await handleStepComplete('providers');
 
     const cloudSignupUrl = buildGenfeedCloudSignupUrl({
       accessMode: 'cloud',

--- a/apps/app/app/(onboarding)/onboarding/post-signup/page.behavior.test.tsx
+++ b/apps/app/app/(onboarding)/onboarding/post-signup/page.behavior.test.tsx
@@ -230,6 +230,48 @@ describe('PostSignupPage behavior', () => {
     expect(createCheckoutSessionMock).not.toHaveBeenCalled();
   });
 
+  it('uses URL payg handoff to bypass stale stored paid plan checkout', async () => {
+    searchParamsState.value = new URLSearchParams(
+      'plan=payg&brandDomain=https://www.acme.co/path&brandName=Acme',
+    );
+    localStorage.setItem(ONBOARDING_STORAGE_KEYS.selectedPlan, 'price_stale');
+
+    render(<PostSignupPage />);
+
+    await waitFor(() => {
+      expect(locationState.href).toBe('/onboarding/brand?auto=true');
+    });
+
+    expect(
+      localStorage.getItem(ONBOARDING_STORAGE_KEYS.selectedPlan),
+    ).toBeNull();
+    expect(localStorage.getItem(ONBOARDING_STORAGE_KEYS.brandDomain)).toBe(
+      'acme.co',
+    );
+    expect(localStorage.getItem(ONBOARDING_STORAGE_KEYS.brandName)).toBe(
+      'Acme',
+    );
+    expect(createCheckoutSessionMock).not.toHaveBeenCalled();
+  });
+
+  it('starts an EE plan checkout from a post-signup plan query', async () => {
+    isEEEnabledMock.mockReturnValue(true);
+    isSelfHostedMock.mockReturnValue(false);
+    searchParamsState.value = new URLSearchParams('plan=price_123');
+
+    render(<PostSignupPage />);
+
+    await waitFor(() => {
+      expect(createCheckoutSessionMock).toHaveBeenCalledWith({
+        cancelUrl: 'http://localhost/onboarding/providers',
+        quantity: null,
+        stripePriceId: 'price_123',
+        successUrl: 'http://localhost/onboarding/brand',
+      });
+    });
+    expect(locationState.href).toBe('https://checkout.stripe.test/session');
+  });
+
   it('drops malformed credit handoff values and continues normal onboarding routing', async () => {
     localStorage.setItem(ONBOARDING_STORAGE_KEYS.selectedCredits, '500abc');
 

--- a/apps/app/app/(onboarding)/onboarding/post-signup/post-signup-routing.util.spec.ts
+++ b/apps/app/app/(onboarding)/onboarding/post-signup/post-signup-routing.util.spec.ts
@@ -1,6 +1,7 @@
 import {
   buildOnboardingResumeHref,
   deriveBrandNameFromDomain,
+  isFreePlanHandoff,
   parseSelectedCredits,
   resolvePostSignupIntent,
 } from '@app/(onboarding)/onboarding/post-signup/post-signup-routing.util';
@@ -34,6 +35,20 @@ describe('resolvePostSignupIntent', () => {
     expect(intent).toEqual({
       credits: 1000,
       kind: 'credits-checkout',
+    });
+  });
+
+  it('treats free payg plan handoffs as normal onboarding', () => {
+    const intent = resolvePostSignupIntent({
+      personalEmailDomains: PERSONAL_DOMAINS,
+      primaryEmail: 'team@acme.com',
+      selectedCredits: null,
+      selectedPlan: 'payg',
+    });
+
+    expect(intent).toEqual({
+      domain: 'acme.com',
+      kind: 'auto-brand',
     });
   });
 
@@ -82,6 +97,14 @@ describe('resolvePostSignupIntent', () => {
     });
 
     expect(intent).toEqual({ kind: 'manual-brand' });
+  });
+});
+
+describe('isFreePlanHandoff', () => {
+  it('recognizes free marketing plan slugs', () => {
+    expect(isFreePlanHandoff('payg')).toBe(true);
+    expect(isFreePlanHandoff(' FREE ')).toBe(true);
+    expect(isFreePlanHandoff('price_123')).toBe(false);
   });
 });
 

--- a/apps/app/app/(onboarding)/onboarding/post-signup/post-signup-routing.util.ts
+++ b/apps/app/app/(onboarding)/onboarding/post-signup/post-signup-routing.util.ts
@@ -22,6 +22,11 @@ function extractDomain(email?: string | null): string | null {
   return domain || null;
 }
 
+export function isFreePlanHandoff(rawPlan?: string | null): boolean {
+  const normalizedPlan = rawPlan?.trim().toLowerCase();
+  return normalizedPlan === 'payg' || normalizedPlan === 'free';
+}
+
 export function parseSelectedCredits(
   rawCredits?: string | null,
 ): number | null {
@@ -54,7 +59,7 @@ export function resolvePostSignupIntent(
   input: ResolvePostSignupIntentInput,
 ): PostSignupIntent {
   const selectedPlan = input.selectedPlan?.trim();
-  if (selectedPlan) {
+  if (selectedPlan && !isFreePlanHandoff(selectedPlan)) {
     return { kind: 'plan-checkout', stripePriceId: selectedPlan };
   }
 

--- a/apps/app/app/(onboarding)/onboarding/post-signup/use-post-signup-routing.hook.ts
+++ b/apps/app/app/(onboarding)/onboarding/post-signup/use-post-signup-routing.hook.ts
@@ -2,6 +2,7 @@
 
 import {
   buildOnboardingResumeHref,
+  isFreePlanHandoff,
   parseSelectedCredits,
 } from '@app/(onboarding)/onboarding/post-signup/post-signup-routing.util';
 import { useCurrentUser } from '@contexts/user/user-context/user-context';
@@ -17,7 +18,11 @@ import { OrganizationsService } from '@services/organization/organizations.servi
 import { useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { isEEEnabled, isSelfHosted } from '@/lib/config/edition';
-import { ONBOARDING_STORAGE_KEYS } from '@/lib/onboarding/onboarding-access.util';
+import {
+  extractBrandDomain,
+  ONBOARDING_STORAGE_KEYS,
+  resolveSelectedPlanParam,
+} from '@/lib/onboarding/onboarding-access.util';
 
 export type PostSignupRoutingState = {
   showFallback: boolean;
@@ -30,7 +35,10 @@ export function usePostSignupRouting(): PostSignupRoutingState {
   const { user: authUser } = useAuthUser();
   const { currentUser, isLoading } = useCurrentUser();
   const searchParams = useSearchParams();
+  const requestedPlanParam = searchParams.get('plan');
   const requestedCreditsParam = searchParams.get('credits');
+  const requestedBrandDomainParam = searchParams.get('brandDomain');
+  const requestedBrandNameParam = searchParams.get('brandName');
   const calledRef = useRef(false);
   const [showFallback, setShowFallback] = useState(false);
   const [statusMessage, setStatusMessage] = useState(
@@ -47,12 +55,12 @@ export function usePostSignupRouting(): PostSignupRoutingState {
     }
 
     const completedSteps = currentUser?.onboardingStepsCompleted ?? [];
-    const hasCompletedAllOnboardingSteps = ONBOARDING_STEPS.every((step) =>
-      completedSteps.includes(step),
-    );
+    const hasCompletedAllOnboardingSteps =
+      currentUser?.isOnboardingCompleted === true ||
+      ONBOARDING_STEPS.every((step) => completedSteps.includes(step));
 
     if (hasCompletedAllOnboardingSteps) {
-      return '/onboarding/summary';
+      return '/';
     }
 
     const resumeStep = getResumeStep(completedSteps);
@@ -111,23 +119,63 @@ export function usePostSignupRouting(): PostSignupRoutingState {
         redirectTo(await resolveOnboardingHref());
       };
 
+      const requestedBrandDomain = extractBrandDomain(
+        requestedBrandDomainParam,
+      );
+      const requestedBrandName = requestedBrandNameParam?.trim();
+      if (requestedBrandDomain) {
+        localStorage.setItem(
+          ONBOARDING_STORAGE_KEYS.brandDomain,
+          requestedBrandDomain,
+        );
+      }
+      if (requestedBrandName) {
+        localStorage.setItem(
+          ONBOARDING_STORAGE_KEYS.brandName,
+          requestedBrandName,
+        );
+      }
+
+      const requestedPlan = resolveSelectedPlanParam(requestedPlanParam);
       const requestedCredits = parseSelectedCredits(requestedCreditsParam);
-      if (requestedCredits) {
+      const hasRequestedPlan = requestedPlanParam !== null;
+      const hasRequestedCredits = requestedCreditsParam !== null;
+
+      if (hasRequestedPlan) {
+        localStorage.removeItem(ONBOARDING_STORAGE_KEYS.selectedCredits);
+        if (requestedPlan) {
+          localStorage.setItem(
+            ONBOARDING_STORAGE_KEYS.selectedPlan,
+            requestedPlan,
+          );
+        } else {
+          localStorage.removeItem(ONBOARDING_STORAGE_KEYS.selectedPlan);
+        }
+      } else if (requestedCredits) {
         localStorage.removeItem(ONBOARDING_STORAGE_KEYS.selectedPlan);
         localStorage.setItem(
           ONBOARDING_STORAGE_KEYS.selectedCredits,
           requestedCredits.toString(),
         );
+      } else if (hasRequestedCredits) {
+        localStorage.removeItem(ONBOARDING_STORAGE_KEYS.selectedPlan);
+        localStorage.removeItem(ONBOARDING_STORAGE_KEYS.selectedCredits);
       }
 
-      const selectedPlan = localStorage.getItem(
-        ONBOARDING_STORAGE_KEYS.selectedPlan,
-      );
-      const selectedCredits = localStorage.getItem(
-        ONBOARDING_STORAGE_KEYS.selectedCredits,
-      );
+      const selectedPlan = hasRequestedPlan
+        ? requestedPlan
+        : localStorage.getItem(ONBOARDING_STORAGE_KEYS.selectedPlan);
+      const selectedCredits =
+        hasRequestedPlan || hasRequestedCredits
+          ? (requestedCredits?.toString() ?? null)
+          : localStorage.getItem(ONBOARDING_STORAGE_KEYS.selectedCredits);
       if (selectedPlan?.trim()) {
         localStorage.removeItem(ONBOARDING_STORAGE_KEYS.selectedPlan);
+
+        if (isFreePlanHandoff(selectedPlan)) {
+          await redirectToOnboarding();
+          return;
+        }
 
         if (!isEEEnabled()) {
           await redirectToOnboarding();
@@ -299,7 +347,10 @@ export function usePostSignupRouting(): PostSignupRoutingState {
     getToken,
     hasAuthUser,
     isLoading,
+    requestedBrandDomainParam,
+    requestedBrandNameParam,
     requestedCreditsParam,
+    requestedPlanParam,
     resolveOnboardingHref,
   ]);
 

--- a/apps/app/app/(protected)/[orgSlug]/org-landing-content.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/org-landing-content.test.tsx
@@ -17,11 +17,23 @@ const mocks = vi.hoisted(() => ({
     }>,
     isReady: true,
   },
+  currentUserState: {
+    currentUser: {
+      id: 'user_1',
+      isOnboardingCompleted: true,
+      onboardingStepsCompleted: ['brand', 'providers', 'summary'] as string[],
+    },
+    isLoading: false,
+  },
   replace: vi.fn(),
 }));
 
 vi.mock('@contexts/user/brand-context/brand-context', () => ({
   useBrand: () => mocks.brandState,
+}));
+
+vi.mock('@contexts/user/user-context/user-context', () => ({
+  useCurrentUser: () => mocks.currentUserState,
 }));
 
 vi.mock('@hooks/navigation/use-org-url', () => ({
@@ -60,6 +72,12 @@ describe('OrgLandingContent', () => {
     vi.clearAllMocks();
     mocks.brandState.isReady = true;
     mocks.brandState.brands = [];
+    mocks.currentUserState.currentUser = {
+      id: 'user_1',
+      isOnboardingCompleted: true,
+      onboardingStepsCompleted: ['brand', 'providers', 'summary'],
+    };
+    mocks.currentUserState.isLoading = false;
   });
 
   it('redirects to onboarding when the organization has no projects', async () => {
@@ -86,6 +104,28 @@ describe('OrgLandingContent', () => {
       expect(mocks.replace).toHaveBeenCalledWith(
         '/acme/moonrise/workspace/overview',
       );
+    });
+  });
+
+  it('resumes onboarding before redirecting into a seeded project', async () => {
+    mocks.currentUserState.currentUser = {
+      id: 'user_1',
+      isOnboardingCompleted: false,
+      onboardingStepsCompleted: [],
+    };
+    mocks.brandState.brands = [
+      {
+        id: 'brand_1',
+        label: 'Default Organization',
+        slug: 'default',
+        totalCredentials: 0,
+      },
+    ];
+
+    render(<OrgLandingContent />);
+
+    await waitFor(() => {
+      expect(mocks.replace).toHaveBeenCalledWith('/onboarding/brand');
     });
   });
 

--- a/apps/app/app/(protected)/[orgSlug]/org-landing-content.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/org-landing-content.tsx
@@ -1,7 +1,13 @@
 'use client';
 
 import { useBrand } from '@contexts/user/brand-context/brand-context';
-import { APP_ROUTES, createBrandAppRoute } from '@genfeedai/constants';
+import { useCurrentUser } from '@contexts/user/user-context/user-context';
+import {
+  APP_ROUTES,
+  createBrandAppRoute,
+  getResumeStep,
+  ONBOARDING_STEPS,
+} from '@genfeedai/constants';
 import { useOrgUrl } from '@hooks/navigation/use-org-url';
 import type { Brand } from '@models/organization/brand.model';
 import Image from 'next/image';
@@ -72,12 +78,23 @@ function BrandCard({ brand, orgSlug }: { brand: Brand; orgSlug: string }) {
 
 export default function OrgLandingContent() {
   const { brands, isReady } = useBrand();
+  const { currentUser, isLoading: isCurrentUserLoading } = useCurrentUser();
   const { orgSlug, orgHref } = useOrgUrl();
   const { replace } = useRouter();
   const primaryBrandSlug = brands[0]?.slug ?? '';
 
   useEffect(() => {
-    if (!isReady) {
+    if (!isReady || isCurrentUserLoading || !currentUser) {
+      return;
+    }
+
+    const completedSteps = currentUser.onboardingStepsCompleted ?? [];
+    const hasCompletedOnboarding =
+      currentUser.isOnboardingCompleted === true ||
+      ONBOARDING_STEPS.every((step) => completedSteps.includes(step));
+
+    if (!hasCompletedOnboarding) {
+      replace(`/onboarding/${getResumeStep(completedSteps)}`);
       return;
     }
 
@@ -91,9 +108,17 @@ export default function OrgLandingContent() {
         createBrandAppRoute(orgSlug, primaryBrandSlug, '/workspace/overview'),
       );
     }
-  }, [brands.length, isReady, orgSlug, primaryBrandSlug, replace]);
+  }, [
+    brands.length,
+    currentUser,
+    isCurrentUserLoading,
+    isReady,
+    orgSlug,
+    primaryBrandSlug,
+    replace,
+  ]);
 
-  if (!isReady || brands.length <= 1) {
+  if (!isReady || isCurrentUserLoading || !currentUser || brands.length <= 1) {
     return (
       <div className="flex min-h-[60vh] items-center justify-center">
         <div

--- a/apps/app/app/(protected)/root-resolver-client.test.tsx
+++ b/apps/app/app/(protected)/root-resolver-client.test.tsx
@@ -18,12 +18,24 @@ const mocks = vi.hoisted(() => ({
       slug?: string;
     } | null,
   },
+  currentUserState: {
+    currentUser: {
+      id: 'user_1',
+      isOnboardingCompleted: true,
+      onboardingStepsCompleted: ['brand', 'providers', 'summary'] as string[],
+    },
+    isLoading: false,
+  },
   isAccessStateLoading: false,
   replace: vi.fn(),
 }));
 
 vi.mock('@contexts/user/brand-context/brand-context', () => ({
   useBrand: () => mocks.brandState,
+}));
+
+vi.mock('@contexts/user/user-context/user-context', () => ({
+  useCurrentUser: () => mocks.currentUserState,
 }));
 
 vi.mock('@providers/access-state/access-state.provider', () => ({
@@ -58,6 +70,12 @@ describe('ProtectedRootResolver', () => {
     mocks.brandState.brands = [];
     mocks.brandState.organizationId = '';
     mocks.brandState.selectedBrand = null;
+    mocks.currentUserState.currentUser = {
+      id: 'user_1',
+      isOnboardingCompleted: true,
+      onboardingStepsCompleted: ['brand', 'providers', 'summary'],
+    };
+    mocks.currentUserState.isLoading = false;
   });
 
   it('opens the selected brand workspace when org and brand are selected', async () => {
@@ -90,6 +108,26 @@ describe('ProtectedRootResolver', () => {
 
     await waitFor(() => {
       expect(mocks.replace).toHaveBeenCalledWith('/acme/~/overview');
+    });
+  });
+
+  it('resumes onboarding before opening a seeded workspace', async () => {
+    mocks.currentUserState.currentUser = {
+      id: 'user_1',
+      isOnboardingCompleted: false,
+      onboardingStepsCompleted: ['brand'],
+    };
+    mocks.brandState.organizationId = 'org_1';
+    mocks.brandState.brandId = 'brand_1';
+    mocks.brandState.selectedBrand = {
+      organization: { slug: 'acme' },
+      slug: 'default',
+    };
+
+    render(<ProtectedRootResolver />);
+
+    await waitFor(() => {
+      expect(mocks.replace).toHaveBeenCalledWith('/onboarding/providers');
     });
   });
 

--- a/apps/app/app/(protected)/root-resolver-client.tsx
+++ b/apps/app/app/(protected)/root-resolver-client.tsx
@@ -1,7 +1,12 @@
 'use client';
 
 import { useBrand } from '@contexts/user/brand-context/brand-context';
-import { createBrandAppRoute } from '@genfeedai/constants';
+import { useCurrentUser } from '@contexts/user/user-context/user-context';
+import {
+  createBrandAppRoute,
+  getResumeStep,
+  ONBOARDING_STEPS,
+} from '@genfeedai/constants';
 import { useAccessState } from '@providers/access-state/access-state.provider';
 import PageLoadingState from '@ui/loading/page/PageLoadingState';
 import { useRouter } from 'next/navigation';
@@ -26,6 +31,7 @@ function getBrandOrganizationSlug(
 
 export default function ProtectedRootResolver() {
   const { brandId, brands, organizationId, selectedBrand } = useBrand();
+  const { currentUser, isLoading: isCurrentUserLoading } = useCurrentUser();
   const { accessState, isLoading: isAccessStateLoading } = useAccessState();
   const { replace } = useRouter();
   const hasStartedRef = useRef(false);
@@ -34,11 +40,27 @@ export default function ProtectedRootResolver() {
   );
 
   useEffect(() => {
-    if (isAccessStateLoading || hasStartedRef.current) {
+    if (
+      isAccessStateLoading ||
+      isCurrentUserLoading ||
+      !currentUser ||
+      hasStartedRef.current
+    ) {
       return;
     }
 
     hasStartedRef.current = true;
+    const completedSteps = currentUser.onboardingStepsCompleted ?? [];
+    const hasCompletedOnboarding =
+      currentUser.isOnboardingCompleted === true ||
+      ONBOARDING_STEPS.every((step) => completedSteps.includes(step));
+
+    if (!hasCompletedOnboarding) {
+      const resumeStep = getResumeStep(completedSteps);
+      setStatusMessage('Opening onboarding...');
+      replace(`/onboarding/${resumeStep}`);
+      return;
+    }
 
     const hasOrganization =
       (typeof organizationId === 'string' && organizationId.length > 0) ||
@@ -92,6 +114,8 @@ export default function ProtectedRootResolver() {
     accessState,
     brandId,
     brands,
+    currentUser,
+    isCurrentUserLoading,
     isAccessStateLoading,
     organizationId,
     replace,

--- a/apps/app/app/(public)/auth-callback-url.test.ts
+++ b/apps/app/app/(public)/auth-callback-url.test.ts
@@ -1,11 +1,17 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   getAuthCallbackURL,
   toAbsoluteAuthCallbackURL,
 } from './auth-callback-url';
 
+const SERVER_FALLBACK_ORIGIN = 'https://app.genfeed.ai';
+
 describe('auth callback URL helpers', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it('prefers callbackUrl and falls back to root', () => {
     expect(
       getAuthCallbackURL(new URLSearchParams('callbackUrl=%2Fonboarding')),
@@ -13,9 +19,41 @@ describe('auth callback URL helpers', () => {
     expect(getAuthCallbackURL(new URLSearchParams())).toBe('/');
   });
 
+  it('builds a post-signup callback carrying onboarding handoff params', () => {
+    expect(
+      getAuthCallbackURL(
+        new URLSearchParams(
+          'plan=pro&credits=0500&brandDomain=https%3A%2F%2Fwww.acme.co%2Fproducts&brandName= Acme ',
+        ),
+        { includeOnboardingHandoffParams: true },
+      ),
+    ).toBe(
+      '/onboarding/post-signup?plan=pro&credits=500&brandDomain=acme.co&brandName=Acme',
+    );
+  });
+
+  it('preserves explicit callbacks when handoff params are present', () => {
+    expect(
+      getAuthCallbackURL(
+        new URLSearchParams(
+          'callbackUrl=genfeedai-desktop%3A%2F%2Fauth&plan=pro',
+        ),
+        { includeOnboardingHandoffParams: true },
+      ),
+    ).toBe('genfeedai-desktop://auth');
+  });
+
   it('expands relative callbacks to the active app origin', () => {
     expect(toAbsoluteAuthCallbackURL('/oauth/cli?port=4321')).toBe(
       `${window.location.origin}/oauth/cli?port=4321`,
+    );
+  });
+
+  it('falls back to the hosted app origin when no window is available', () => {
+    vi.stubGlobal('window', undefined);
+
+    expect(toAbsoluteAuthCallbackURL('/oauth/cli?port=4321')).toBe(
+      `${SERVER_FALLBACK_ORIGIN}/oauth/cli?port=4321`,
     );
   });
 
@@ -25,6 +63,12 @@ describe('auth callback URL helpers', () => {
     );
     expect(toAbsoluteAuthCallbackURL('genfeedai-desktop://auth')).toBe(
       'genfeedai-desktop://auth',
+    );
+  });
+
+  it('rejects insecure callbacks to fixed hosted app domains', () => {
+    expect(toAbsoluteAuthCallbackURL('http://app.genfeed.ai/oauth')).toBe(
+      `${window.location.origin}/`,
     );
   });
 

--- a/apps/app/app/(public)/auth-callback-url.ts
+++ b/apps/app/app/(public)/auth-callback-url.ts
@@ -1,12 +1,85 @@
-export function getAuthCallbackURL(
+import {
+  extractBrandDomain,
+  resolveSelectedPlanParam,
+} from '@/lib/onboarding/onboarding-access.util';
+
+const ROOT_CALLBACK_URL = '/';
+const POST_SIGNUP_CALLBACK_URL = '/onboarding/post-signup';
+
+type AuthCallbackURLOptions = {
+  defaultCallbackURL?: string;
+  includeOnboardingHandoffParams?: boolean;
+};
+
+function getExplicitAuthCallbackURL(
   searchParams: Pick<URLSearchParams, 'get'>,
-): string {
+): string | null {
   return (
     searchParams.get('callbackUrl') ||
     searchParams.get('return_to') ||
     searchParams.get('redirect_url') ||
-    '/'
+    null
   );
+}
+
+function parsePositiveIntegerParam(value?: string | null): string | null {
+  const normalizedValue = value?.trim();
+
+  if (!normalizedValue || !/^\d+$/.test(normalizedValue)) {
+    return null;
+  }
+
+  const parsed = Number.parseInt(normalizedValue, 10);
+  return parsed > 0 ? String(parsed) : null;
+}
+
+function buildPostSignupCallbackURL(
+  searchParams: Pick<URLSearchParams, 'get'>,
+): string {
+  const params = new URLSearchParams();
+  const selectedPlan = resolveSelectedPlanParam(searchParams.get('plan'));
+  const selectedCredits = parsePositiveIntegerParam(
+    searchParams.get('credits'),
+  );
+  const brandDomain = extractBrandDomain(searchParams.get('brandDomain'));
+  const brandName = searchParams.get('brandName')?.trim();
+
+  if (selectedPlan) {
+    params.set('plan', selectedPlan);
+  }
+
+  if (selectedCredits) {
+    params.set('credits', selectedCredits);
+  }
+
+  if (brandDomain) {
+    params.set('brandDomain', brandDomain);
+  }
+
+  if (brandName) {
+    params.set('brandName', brandName);
+  }
+
+  const query = params.toString();
+  return query
+    ? `${POST_SIGNUP_CALLBACK_URL}?${query}`
+    : POST_SIGNUP_CALLBACK_URL;
+}
+
+export function getAuthCallbackURL(
+  searchParams: Pick<URLSearchParams, 'get'>,
+  options: AuthCallbackURLOptions = {},
+): string {
+  const explicitCallbackURL = getExplicitAuthCallbackURL(searchParams);
+  if (explicitCallbackURL) {
+    return explicitCallbackURL;
+  }
+
+  if (options.includeOnboardingHandoffParams) {
+    return buildPostSignupCallbackURL(searchParams);
+  }
+
+  return options.defaultCallbackURL ?? ROOT_CALLBACK_URL;
 }
 
 /**
@@ -51,8 +124,11 @@ export function toAbsoluteAuthCallbackURL(callbackURL: string): string {
       if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
         return fallback;
       }
+      if (parsed.origin === origin) {
+        return callbackURL;
+      }
       if (
-        parsed.origin === origin ||
+        parsed.protocol === 'https:' &&
         ALLOWED_CALLBACK_HOSTS.has(parsed.hostname)
       ) {
         return callbackURL;

--- a/apps/app/app/(public)/sign-up/sign-up-better-auth.tsx
+++ b/apps/app/app/(public)/sign-up/sign-up-better-auth.tsx
@@ -76,7 +76,10 @@ export default function SignUpBetterAuth({
   const [socialErrorMessage, setSocialErrorMessage] = useState<string | null>(
     null,
   );
-  const callbackURL = getAuthCallbackURL(searchParams);
+  const callbackURL = getAuthCallbackURL(searchParams, {
+    defaultCallbackURL: '/onboarding/post-signup',
+    includeOnboardingHandoffParams: true,
+  });
   const authCallbackURL = toAbsoluteAuthCallbackURL(callbackURL);
   const chooserHref = getSignUpModeHref('/sign-up', searchParams);
   const magicLinkHref = getSignUpModeHref('/sign-up/magic-link', searchParams);

--- a/apps/app/app/(public)/sign-up/sign-up-form.test.tsx
+++ b/apps/app/app/(public)/sign-up/sign-up-form.test.tsx
@@ -141,6 +141,33 @@ describe('SignUpForm', () => {
     expect(screen.getByText('Check your email')).toBeInTheDocument();
   });
 
+  it('defaults sign-up magic links to post-signup with handoff params', async () => {
+    window.history.replaceState(
+      {},
+      '',
+      '/sign-up?plan=payg&brandDomain=https://www.acme.co&brandName=Acme',
+    );
+
+    render(<SignUpBetterAuth mode="magic-link" />);
+
+    fireEvent.change(getEmailInput(), {
+      target: { value: 'new@example.com' },
+    });
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Email me a sign-up link' }),
+    );
+
+    await waitFor(() => {
+      expect(authClientMocks.magicLink).toHaveBeenCalledWith({
+        callbackURL: absoluteCallback(
+          '/onboarding/post-signup?plan=payg&brandDomain=acme.co&brandName=Acme',
+        ),
+        email: 'new@example.com',
+        metadata: { intent: 'signup' },
+      });
+    });
+  });
+
   it('persists cloud handoff query params into onboarding localStorage keys', async () => {
     window.history.replaceState(
       {},
@@ -174,7 +201,7 @@ describe('SignUpForm', () => {
   });
 
   it('starts Google sign-up with the callback URL', async () => {
-    window.history.replaceState({}, '', '/sign-up?callbackUrl=%2Fonboarding');
+    window.history.replaceState({}, '', '/sign-up?plan=payg');
 
     render(<SignUpForm />);
 
@@ -182,7 +209,7 @@ describe('SignUpForm', () => {
 
     await waitFor(() => {
       expect(authClientMocks.social).toHaveBeenCalledWith({
-        callbackURL: absoluteCallback('/onboarding'),
+        callbackURL: absoluteCallback('/onboarding/post-signup?plan=payg'),
         provider: 'google',
       });
     });

--- a/apps/app/proxy.test.ts
+++ b/apps/app/proxy.test.ts
@@ -183,6 +183,89 @@ describe('proxy', () => {
     );
   });
 
+  it('redirects signed-in root to onboarding when a seeded brand exists but onboarding is incomplete', async () => {
+    fetchMock.mockImplementation(async (input: string | URL) => {
+      const url = String(input);
+
+      if (url.endsWith('/auth/token')) {
+        return new Response(JSON.stringify({ token: BEARER_TOKEN }), {
+          status: 200,
+        });
+      }
+
+      if (url.endsWith('/auth/bootstrap')) {
+        return new Response(
+          JSON.stringify({
+            access: { brandId: 'brand_1', isOnboardingCompleted: false },
+            brands: [{ id: 'brand_1', slug: 'default' }],
+            currentUser: {
+              id: 'user_1',
+              isOnboardingCompleted: false,
+              onboardingStepsCompleted: [],
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response('not found', { status: 404 });
+    });
+
+    const { default: proxy } = await import('./proxy');
+
+    const response = await proxy(makeSignedInRequest('/'), {} as never);
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe(
+      'http://localhost:3000/onboarding',
+    );
+  });
+
+  it('keeps completed users on workspace routing even when their only brand is seeded', async () => {
+    fetchMock.mockImplementation(async (input: string | URL) => {
+      const url = String(input);
+
+      if (url.endsWith('/auth/token')) {
+        return new Response(JSON.stringify({ token: BEARER_TOKEN }), {
+          status: 200,
+        });
+      }
+
+      if (url.endsWith('/auth/bootstrap')) {
+        return new Response(
+          JSON.stringify({
+            access: { brandId: 'brand_1', isOnboardingCompleted: true },
+            brands: [{ id: 'brand_1', slug: 'default' }],
+            currentUser: {
+              id: 'user_1',
+              isOnboardingCompleted: true,
+              onboardingStepsCompleted: [],
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      if (url.endsWith('/organizations/mine')) {
+        return new Response(
+          JSON.stringify([{ isActive: true, slug: 'acme' }]),
+          { status: 200 },
+        );
+      }
+
+      return new Response('not found', { status: 404 });
+    });
+
+    const { default: proxy } = await import('./proxy');
+
+    const response = await proxy(makeSignedInRequest('/'), {} as never);
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe(
+      'http://localhost:3000/acme/default/workspace/overview',
+    );
+  });
+
   it('redirects signed-in root to org overview when no brand is selected', async () => {
     fetchMock.mockImplementation(async (input: string | URL) => {
       const url = String(input);
@@ -551,13 +634,27 @@ describe('proxy', () => {
     );
   });
 
-  it('does not gate brand-scoped routes through the onboarding bootstrap check', async () => {
+  it('redirects brand-scoped routes to onboarding while onboarding is incomplete', async () => {
     fetchMock.mockImplementation(async (input: string | URL) => {
       const url = String(input);
 
+      if (url.endsWith('/auth/token')) {
+        return new Response(JSON.stringify({ token: BEARER_TOKEN }), {
+          status: 200,
+        });
+      }
+
       if (url.endsWith('/auth/bootstrap')) {
         return new Response(
-          JSON.stringify({ brands: [], currentUser: { id: 'user_1' } }),
+          JSON.stringify({
+            access: { brandId: 'brand_1', isOnboardingCompleted: false },
+            brands: [{ id: 'brand_1', slug: 'moonrise-studio' }],
+            currentUser: {
+              id: 'user_1',
+              isOnboardingCompleted: false,
+              onboardingStepsCompleted: ['brand'],
+            },
+          }),
           { status: 200 },
         );
       }
@@ -572,16 +669,10 @@ describe('proxy', () => {
       {} as never,
     );
 
-    // Brand-scoped paths must fall through, never the org-root (~) onboarding
-    // gate, and must not trigger a bootstrap fetch on every navigation.
-    expect(response.headers.get('location')).not.toBe(
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe(
       'http://localhost:3000/onboarding',
     );
-    expect(
-      fetchMock.mock.calls.some(([input]) =>
-        String(input).endsWith('/auth/bootstrap'),
-      ),
-    ).toBe(false);
   });
 
   it('redirects signed-in flat chat to the canonical org-scoped chat path', async () => {
@@ -854,14 +945,14 @@ describe('proxy', () => {
     expect(secondResponse.headers.get('location')).toBe(
       'http://localhost:3000/acme/moonrise-studio/posts',
     );
-    // The slug cookie caches org/brand slugs — the expensive bootstrap and org
-    // resolution fetches must be skipped. The Better Auth token exchange
-    // (/auth/token) is a required per-request step and is expected to be called.
+    // The slug cookie caches org/brand slugs, but bootstrap is still required
+    // so the onboarding gate can inspect completed steps before routing.
+    // The expensive org resolution fetch must stay skipped.
     expect(
       fetchMock.mock.calls.some(([input]) =>
         String(input).endsWith('/auth/bootstrap'),
       ),
-    ).toBe(false);
+    ).toBe(true);
     expect(
       fetchMock.mock.calls.some(([input]) =>
         String(input).endsWith('/organizations/mine'),

--- a/apps/app/proxy.ts
+++ b/apps/app/proxy.ts
@@ -12,9 +12,13 @@ type BootstrapBrandSummary = {
 type BootstrapResponse = {
   access?: {
     brandId?: string;
+    isOnboardingCompleted?: boolean;
   };
   brands?: BootstrapBrandSummary[];
-  currentUser?: unknown;
+  currentUser?: {
+    isOnboardingCompleted?: boolean;
+    onboardingStepsCompleted?: unknown;
+  } | null;
 };
 
 type OrganizationMineResponseItem = {
@@ -27,6 +31,7 @@ const isBetterAuthEnabled =
   process.env.NEXT_PUBLIC_BETTER_AUTH_ENABLED !== 'false';
 const ONBOARDING_PATH = '/onboarding';
 const SEEDED_WORKSPACE_PATH = '/default/default/workspace/overview';
+const ONBOARDING_STEPS = ['brand', 'providers', 'summary'] as const;
 
 const BRAND_SCOPED_PREFIXES = [
   'analytics',
@@ -443,7 +448,24 @@ async function shouldRedirectSignedInUserToOnboarding(
   const bootstrap =
     (await bootstrapResponse.json()) as BootstrapResponse | null;
 
-  return Array.isArray(bootstrap?.brands) && bootstrap.brands.length === 0;
+  if (
+    bootstrap?.access?.isOnboardingCompleted === true ||
+    bootstrap?.currentUser?.isOnboardingCompleted === true
+  ) {
+    return false;
+  }
+
+  if (!bootstrap?.currentUser) {
+    return false;
+  }
+
+  const completedSteps = Array.isArray(
+    bootstrap.currentUser.onboardingStepsCompleted,
+  )
+    ? bootstrap.currentUser.onboardingStepsCompleted
+    : [];
+
+  return !ONBOARDING_STEPS.every((step) => completedSteps.includes(step));
 }
 
 type CanonicalResolution = {
@@ -756,6 +778,10 @@ export default async function proxy(req: NextRequest) {
       return redirectPreservingSearch(req, '/login');
     }
 
+    if (await shouldRedirectSignedInUserToOnboarding(token)) {
+      return redirectPreservingSearch(req, ONBOARDING_PATH);
+    }
+
     if (pathname === '/') {
       const resolved = await resolveCanonicalProtectedPath(
         '/workspace/overview',
@@ -772,9 +798,6 @@ export default async function proxy(req: NextRequest) {
         return response;
       }
 
-      if (await shouldRedirectSignedInUserToOnboarding(token)) {
-        return redirectPreservingSearch(req, ONBOARDING_PATH);
-      }
       return NextResponse.next();
     }
 
@@ -794,17 +817,7 @@ export default async function proxy(req: NextRequest) {
         return response;
       }
 
-      if (await shouldRedirectSignedInUserToOnboarding(token)) {
-        return redirectPreservingSearch(req, ONBOARDING_PATH);
-      }
       return NextResponse.next();
-    }
-
-    if (
-      isScopedWorkspacePath(pathname) &&
-      (await shouldRedirectSignedInUserToOnboarding(token))
-    ) {
-      return redirectPreservingSearch(req, ONBOARDING_PATH);
     }
 
     return NextResponse.next();

--- a/apps/server/api/openapi/openapi.json
+++ b/apps/server/api/openapi/openapi.json
@@ -714,6 +714,11 @@
             "example": "https://linkedin.com/company/example",
             "type": "string"
           },
+          "organizationName": {
+            "description": "User-provided organization name",
+            "example": "Acme Studio",
+            "type": "string"
+          },
           "targetAudience": {
             "description": "Target audience description",
             "example": "B2B SaaS companies",
@@ -10555,6 +10560,10 @@
           },
           "organizationId": {
             "description": "Destination organization identifier. Providing a different value than the brand's current organization relocates the brand — cascading organizationId across all brand-owned records in one transaction. Superadmin, or an owner/admin of both the source and destination organizations, only.",
+            "type": "string"
+          },
+          "organizationLabel": {
+            "description": "Onboarding-only organization label override used with syncOrganizationName. The server regenerates the unique organization slug and never persists this control field on the brand record.",
             "type": "string"
           },
           "primaryColor": {

--- a/apps/server/api/src/collections/brands/controllers/brands.controller.spec.ts
+++ b/apps/server/api/src/collections/brands/controllers/brands.controller.spec.ts
@@ -49,6 +49,7 @@ vi.mock('@helpers/utils/response/response.util', () => ({
 
 describe('BrandsController', () => {
   let controller: BrandsController;
+  let brandSetupService: vi.Mocked<BrandSetupService>;
   let brandsService: vi.Mocked<BrandsService>;
   let _loggerService: vi.Mocked<LoggerService>;
 
@@ -173,6 +174,7 @@ describe('BrandsController', () => {
       .compile();
 
     controller = module.get<BrandsController>(BrandsController);
+    brandSetupService = module.get(BrandSetupService);
     brandsService = module.get(BrandsService);
     _loggerService = module.get(LoggerService);
 
@@ -187,6 +189,34 @@ describe('BrandsController', () => {
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  it('passes onboarding profile fields through the sync rename path', async () => {
+    brandsService.findOne
+      .mockResolvedValueOnce(mockBrand as never)
+      .mockResolvedValueOnce({ ...mockBrand, label: 'Moonrise' } as never);
+
+    const result = await controller.patch(mockRequest, mockUser, 'brand_1', {
+      agentConfig: { voice: { audience: 'Founders', tone: 'Bold' } },
+      description: 'Brand: Moonrise.',
+      label: 'Moonrise',
+      organizationLabel: 'Acme Studio',
+      syncOrganizationName: true,
+      text: 'Tone: Bold.',
+    } as never);
+
+    expect(brandSetupService.updateBrandNameById).toHaveBeenCalledWith(
+      'brand_1',
+      'Moonrise',
+      mockUser,
+      {
+        agentConfig: { voice: { audience: 'Founders', tone: 'Bold' } },
+        description: 'Brand: Moonrise.',
+        organizationName: 'Acme Studio',
+        text: 'Tone: Bold.',
+      },
+    );
+    expect(result).toEqual({ data: { ...mockBrand, label: 'Moonrise' } });
   });
 
   describe('findAll', () => {

--- a/apps/server/api/src/collections/brands/controllers/brands.controller.ts
+++ b/apps/server/api/src/collections/brands/controllers/brands.controller.ts
@@ -129,9 +129,11 @@ export class BrandsController extends BaseCRUDController<
   ): Promise<JsonApiSingleResponse> {
     // `syncOrganizationName` is an onboarding-only control flag, never persisted
     // on the brand row — strip it before any CRUD patch (REST audit #1354).
-    const { syncOrganizationName, ...rest } = updateDto as UpdateBrandDto & {
-      syncOrganizationName?: boolean;
-    };
+    const { organizationLabel, syncOrganizationName, ...rest } =
+      updateDto as UpdateBrandDto & {
+        organizationLabel?: string;
+        syncOrganizationName?: boolean;
+      };
 
     // Brand rename that cascades to the owning organization's name/slug. The
     // cascade itself is gated server-side to the first-login window inside the
@@ -139,7 +141,24 @@ export class BrandsController extends BaseCRUDController<
     const label = (rest as { label?: string }).label;
     if (syncOrganizationName && typeof label === 'string' && label.trim()) {
       await this.verifyBrandAccess(id, user);
-      await this.brandSetupService.updateBrandNameById(id, label, user);
+      const onboardingProfileOptions = {
+        ...(typeof rest.agentConfig === 'object' && rest.agentConfig !== null
+          ? { agentConfig: rest.agentConfig }
+          : {}),
+        ...(typeof rest.description === 'string'
+          ? { description: rest.description }
+          : {}),
+        ...(typeof organizationLabel === 'string'
+          ? { organizationName: organizationLabel }
+          : {}),
+        ...(typeof rest.text === 'string' ? { text: rest.text } : {}),
+      };
+      await this.brandSetupService.updateBrandNameById(
+        id,
+        label,
+        user,
+        onboardingProfileOptions,
+      );
       const renamed = await this.brandsService.findOne({ _id: id });
       return serializeSingle(request, BrandSerializer, renamed);
     }

--- a/apps/server/api/src/collections/brands/dto/update-brand.dto.ts
+++ b/apps/server/api/src/collections/brands/dto/update-brand.dto.ts
@@ -11,6 +11,7 @@ import {
   IsObject,
   IsOptional,
   IsString,
+  MaxLength,
 } from 'class-validator';
 
 export class UpdateBrandDto extends PartialType(CreateBrandDto) {
@@ -71,6 +72,18 @@ export class UpdateBrandDto extends PartialType(CreateBrandDto) {
     required: false,
   })
   readonly syncOrganizationName?: boolean;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(120)
+  @ApiProperty({
+    description:
+      'Onboarding-only organization label override used with syncOrganizationName. ' +
+      'The server regenerates the unique organization slug and never persists this ' +
+      'control field on the brand record.',
+    required: false,
+  })
+  readonly organizationLabel?: string;
 
   @IsOptional()
   @IsString()

--- a/apps/server/api/src/collections/brands/services/brand-persistence.service.spec.ts
+++ b/apps/server/api/src/collections/brands/services/brand-persistence.service.spec.ts
@@ -77,6 +77,7 @@ describe('BrandPersistenceService', () => {
         tagline: 'Anvils for all',
       };
       const dto = {
+        additionalNotes: 'Preferred tone: Bold',
         brandUrl: 'https://acme.com',
         industry: 'Manufacturing',
         targetAudience: 'Coyotes',
@@ -99,6 +100,7 @@ describe('BrandPersistenceService', () => {
           'About the brand: About us',
           'Industry: Manufacturing',
           'Target audience: Coyotes',
+          'Additional guidance: Preferred tone: Bold',
         ].join('\n\n'),
       });
     });
@@ -224,6 +226,34 @@ describe('BrandPersistenceService', () => {
       );
       expect(brandsService.patch).toHaveBeenCalledWith('brand_1', {
         slug: 'acme-brand',
+      });
+    });
+
+    it('uses a distinct organization label when provided', async () => {
+      organizationsService.generateUniqueSlug.mockResolvedValue('acme-studio');
+      brandsService.generateUniqueSlug.mockResolvedValue('moonrise');
+
+      await service.syncBrandAndOrgSlug(
+        'Moonrise',
+        'org_1',
+        'brand_1',
+        'Acme Studio',
+      );
+
+      expect(organizationsService.generateUniqueSlug).toHaveBeenCalledWith(
+        'Acme Studio',
+        'org_1',
+      );
+      expect(organizationsService.patch).toHaveBeenCalledWith('org_1', {
+        label: 'Acme Studio',
+        slug: 'acme-studio',
+      });
+      expect(brandsService.generateUniqueSlug).toHaveBeenCalledWith(
+        'Moonrise',
+        'brand_1',
+      );
+      expect(brandsService.patch).toHaveBeenCalledWith('brand_1', {
+        slug: 'moonrise',
       });
     });
   });

--- a/apps/server/api/src/collections/brands/services/brand-persistence.service.ts
+++ b/apps/server/api/src/collections/brands/services/brand-persistence.service.ts
@@ -95,6 +95,10 @@ export class BrandPersistenceService {
         systemPromptParts.push(`Target audience: ${dto.targetAudience}`);
       }
 
+      if (dto.additionalNotes) {
+        systemPromptParts.push(`Additional guidance: ${dto.additionalNotes}`);
+      }
+
       updateData.text = systemPromptParts.join('\n\n');
     }
 
@@ -188,8 +192,9 @@ export class BrandPersistenceService {
     label: string,
     organizationId: string,
     brandId: string,
+    organizationLabel = label,
   ): Promise<void> {
-    await this.syncOrgLabelAndSlug(label, organizationId);
+    await this.syncOrgLabelAndSlug(organizationLabel, organizationId);
 
     const brandSlug = await this.brandsService.generateUniqueSlug(
       label,

--- a/apps/server/api/src/collections/brands/services/brand-setup.service.ts
+++ b/apps/server/api/src/collections/brands/services/brand-setup.service.ts
@@ -1,4 +1,5 @@
 import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticated-user.interface';
+import type { UpdateBrandDto } from '@api/collections/brands/dto/update-brand.dto';
 import { BrandDataMapper } from '@api/collections/brands/services/brand-data.mapper';
 import { BrandPersistenceService } from '@api/collections/brands/services/brand-persistence.service';
 import { BrandsService } from '@api/collections/brands/services/brands.service';
@@ -293,6 +294,7 @@ export class BrandSetupService {
             resolvedLabel,
             organizationId,
             targetBrandId,
+            dto.organizationName?.trim() || resolvedLabel,
           );
         }
 
@@ -328,6 +330,12 @@ export class BrandSetupService {
     brandId: string,
     name: string,
     _user: User,
+    options: {
+      agentConfig?: UpdateBrandDto['agentConfig'];
+      description?: string;
+      organizationName?: string;
+      text?: string;
+    } = {},
   ): Promise<{ success: boolean; message: string }> {
     const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
     this.loggerService.log(`${caller} starting`, { brandId, name });
@@ -346,7 +354,10 @@ export class BrandSetupService {
           await this.resolveBrandScope(brandId);
 
         await this.brandsService.patch(targetBrandId, {
+          ...(options.agentConfig ? { agentConfig: options.agentConfig } : {}),
+          ...(options.description ? { description: options.description } : {}),
           label: name,
+          ...(options.text ? { text: options.text } : {}),
         });
 
         // Only cascade the rename to the organization during the first-login
@@ -362,6 +373,7 @@ export class BrandSetupService {
             name,
             organizationId,
             targetBrandId,
+            options.organizationName?.trim() || name,
           );
         }
 

--- a/apps/server/api/src/collections/users/controllers/users.controller.spec.ts
+++ b/apps/server/api/src/collections/users/controllers/users.controller.spec.ts
@@ -483,7 +483,7 @@ describe('UsersController', () => {
         userId,
         {
           isOnboardingCompleted: true,
-          onboardingStepsCompleted: ['brand', 'plan'],
+          onboardingStepsCompleted: ['brand', 'providers', 'summary'],
         } as never,
       );
 

--- a/apps/server/api/src/collections/users/controllers/users.controller.ts
+++ b/apps/server/api/src/collections/users/controllers/users.controller.ts
@@ -234,7 +234,7 @@ export class UsersController {
       if (!hasField || hasAccessByEntitlement) {
         data = await this.usersService.patch(data.id.toString(), {
           isOnboardingCompleted: true,
-          onboardingStepsCompleted: ['brand', 'plan'],
+          onboardingStepsCompleted: ['brand', 'providers', 'summary'],
         });
 
         const userIdString = data.id?.toString();
@@ -560,7 +560,7 @@ export class UsersController {
       await this.usersService.patch(dbUser.id, {
         isOnboardingCompleted: true,
         onboardingCompletedAt: new Date(),
-        onboardingStepsCompleted: ['brand', 'providers'],
+        onboardingStepsCompleted: ['brand', 'providers', 'summary'],
       } as Partial<UpdateUserDto>);
     }
 

--- a/apps/server/api/src/endpoints/onboarding/dto/brand-setup.dto.ts
+++ b/apps/server/api/src/endpoints/onboarding/dto/brand-setup.dto.ts
@@ -51,6 +51,15 @@ export class BrandSetupDto {
 
   @IsString()
   @IsOptional()
+  @MaxLength(120)
+  @ApiPropertyOptional({
+    description: 'User-provided organization name',
+    example: 'Acme Studio',
+  })
+  organizationName?: string;
+
+  @IsString()
+  @IsOptional()
   @MaxLength(100)
   @ApiPropertyOptional({
     description: 'Industry/niche of the brand',

--- a/apps/server/api/src/endpoints/webhooks/stripe/handlers/stripe-checkout-webhook.handler.spec.ts
+++ b/apps/server/api/src/endpoints/webhooks/stripe/handlers/stripe-checkout-webhook.handler.spec.ts
@@ -720,7 +720,7 @@ describe('StripeCheckoutWebhookHandler', () => {
       usersService.findOne.mockResolvedValue({
         id: 'user_existing_1',
         isOnboardingCompleted: true,
-        onboardingStepsCompleted: ['brand', 'plan'],
+        onboardingStepsCompleted: ['brand', 'providers', 'summary'],
       });
 
       await provisionAccessor().provisionManagedCheckoutAccount(
@@ -754,7 +754,7 @@ describe('StripeCheckoutWebhookHandler', () => {
       usersService.findOne.mockResolvedValue({
         id: 'user_existing_1',
         isOnboardingCompleted: true,
-        onboardingStepsCompleted: ['brand', 'plan'],
+        onboardingStepsCompleted: ['brand', 'providers', 'summary'],
       });
       supportService.addPurchasedCredits.mockResolvedValueOnce(false);
 

--- a/apps/server/api/src/endpoints/webhooks/stripe/handlers/stripe-checkout-webhook.handler.ts
+++ b/apps/server/api/src/endpoints/webhooks/stripe/handlers/stripe-checkout-webhook.handler.ts
@@ -519,7 +519,7 @@ export class StripeCheckoutWebhookHandler {
       onboardingStepsCompleted:
         dbUser.onboardingStepsCompleted?.length > 0
           ? dbUser.onboardingStepsCompleted
-          : ['brand', 'plan'],
+          : ['brand', 'providers', 'summary'],
     };
 
     if (typeof session.customer === 'string') {

--- a/apps/server/api/src/endpoints/webhooks/stripe/handlers/stripe-webhook-support.service.spec.ts
+++ b/apps/server/api/src/endpoints/webhooks/stripe/handlers/stripe-webhook-support.service.spec.ts
@@ -324,7 +324,7 @@ describe('StripeWebhookSupportService', () => {
       expect(usersService.patch).toHaveBeenCalledWith('user_1', {
         isOnboardingCompleted: true,
         onboardingCompletedAt: expect.any(Date),
-        onboardingStepsCompleted: ['brand', 'plan'],
+        onboardingStepsCompleted: ['brand', 'providers', 'summary'],
       });
     });
 

--- a/apps/server/api/src/endpoints/webhooks/stripe/handlers/stripe-webhook-support.service.ts
+++ b/apps/server/api/src/endpoints/webhooks/stripe/handlers/stripe-webhook-support.service.ts
@@ -300,7 +300,7 @@ export class StripeWebhookSupportService {
     await this.usersService.patch(dbUser.id, {
       isOnboardingCompleted: true,
       onboardingCompletedAt: new Date(),
-      onboardingStepsCompleted: ['brand', 'plan'],
+      onboardingStepsCompleted: ['brand', 'providers', 'summary'],
     });
   }
 

--- a/packages/interfaces/src/onboarding/onboarding.interface.ts
+++ b/packages/interfaces/src/onboarding/onboarding.interface.ts
@@ -116,6 +116,7 @@ export interface IBrandSetupRequest {
   linkedinUrl?: string;
   xProfileUrl?: string;
   brandName?: string;
+  organizationName?: string;
   industry?: string;
   targetAudience?: string;
   additionalNotes?: string;

--- a/packages/services/social/brands.service.ts
+++ b/packages/services/social/brands.service.ts
@@ -366,9 +366,21 @@ export class BrandsService extends BaseService<Brand> {
   public async renameWithOrganizationSync(
     id: string,
     label: string,
+    options: {
+      agentConfig?: {
+        voice?: {
+          audience?: string[] | string;
+          tone?: string;
+        };
+      };
+      description?: string;
+      organizationLabel?: string;
+      text?: string;
+    } = {},
   ): Promise<Brand> {
     return await this.instance
       .patch<JsonApiResponseDocument>(`/${id}`, {
+        ...options,
         label,
         syncOrganizationName: true,
       })

--- a/packages/tools/src/registry/generated/mcp-operations.generated.ts
+++ b/packages/tools/src/registry/generated/mcp-operations.generated.ts
@@ -2862,6 +2862,7 @@ export const GENERATED_MCP_OPERATIONS: IGeneratedMcpOperationBinding[] = [
       "label",
       "music",
       "organizationId",
+      "organizationLabel",
       "primaryColor",
       "referenceImages",
       "relocationAck",
@@ -2919,6 +2920,7 @@ export const GENERATED_MCP_OPERATIONS: IGeneratedMcpOperationBinding[] = [
       "brandUrl",
       "industry",
       "linkedinUrl",
+      "organizationName",
       "targetAudience",
       "xProfileUrl"
     ],

--- a/packages/tools/src/registry/generated/mcp-tools.generated.ts
+++ b/packages/tools/src/registry/generated/mcp-tools.generated.ts
@@ -8442,6 +8442,10 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
           "description": "Destination organization identifier. Providing a different value than the brand's current organization relocates the brand — cascading organizationId across all brand-owned records in one transaction. Superadmin, or an owner/admin of both the source and destination organizations, only.",
           "type": "string"
         },
+        "organizationLabel": {
+          "description": "Onboarding-only organization label override used with syncOrganizationName. The server regenerates the unique organization slug and never persists this control field on the brand record.",
+          "type": "string"
+        },
         "primaryColor": {
           "default": "#000000",
           "description": "The primary color theme for the brand",
@@ -8603,6 +8607,11 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
         "linkedinUrl": {
           "description": "LinkedIn company page URL",
           "example": "https://linkedin.com/company/example",
+          "type": "string"
+        },
+        "organizationName": {
+          "description": "User-provided organization name",
+          "example": "Acme Studio",
           "type": "string"
         },
         "targetAudience": {

--- a/packages/ui/src/components/guards/onboarding/OnboardingGuard.tsx
+++ b/packages/ui/src/components/guards/onboarding/OnboardingGuard.tsx
@@ -2,7 +2,6 @@
 
 import { getResumeStep, ONBOARDING_STEPS } from '@genfeedai/constants';
 import { useAccessState } from '@genfeedai/contexts/providers/access-state/access-state.provider';
-import { useBrand } from '@genfeedai/contexts/user/brand-context/brand-context';
 import { useCurrentUser } from '@genfeedai/contexts/user/user-context/user-context';
 import { getPlaywrightAuthState } from '@genfeedai/helpers/auth/auth.helper';
 import { useAuthIdentity } from '@genfeedai/hooks/auth/use-auth-identity/use-auth-identity';
@@ -22,7 +21,6 @@ function OnboardingGuardInner({ children }: OnboardingGuardProps) {
   const effectiveIsAuthLoaded =
     isAuthLoaded || playwrightAuth?.isLoaded === true;
   const effectiveIsSignedIn = isSignedIn || playwrightAuth?.isSignedIn === true;
-  const { brandId, organizationId } = useBrand();
   const { currentUser, isLoading: isUserLoading } = useCurrentUser();
   const {
     accessState,
@@ -52,17 +50,7 @@ function OnboardingGuardInner({ children }: OnboardingGuardProps) {
     }
 
     if (needsOnboarding) {
-      const hasExistingWorkspace =
-        (typeof organizationId === 'string' &&
-          organizationId.length > 0 &&
-          typeof brandId === 'string' &&
-          brandId.length > 0) ||
-        (typeof accessState.organizationId === 'string' &&
-          accessState.organizationId.length > 0 &&
-          typeof accessState.brandId === 'string' &&
-          accessState.brandId.length > 0);
-
-      if (!isOnboardingRoute && hasExistingWorkspace) {
+      if (currentUser.isOnboardingCompleted === true) {
         return null;
       }
 
@@ -100,7 +88,6 @@ function OnboardingGuardInner({ children }: OnboardingGuardProps) {
     return null;
   }, [
     accessState,
-    brandId,
     currentUser,
     effectiveIsAuthLoaded,
     effectiveIsSignedIn,
@@ -113,7 +100,6 @@ function OnboardingGuardInner({ children }: OnboardingGuardProps) {
     isSuperAdmin,
     isUserLoading,
     needsOnboarding,
-    organizationId,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
Closes #1421

## Summary
- Restore signup callbacks to `/onboarding/post-signup` and carry plan, credits, brand domain, and brand name through the magic-link callback URL.
- Route onboarding from canonical completed steps instead of seeded brand presence, including proxy/client guard fallbacks.
- Rename the provisioned placeholder org and brand, capture optional audience/tone context, and run website scrape as non-blocking enrichment.
- Keep PAYG/free handoff out of Stripe price-id checkout while preserving managed credits checkout.

## Verification
- `bun test apps/app/app/(public)/auth-callback-url.test.ts apps/app/app/(onboarding)/onboarding/post-signup/post-signup-routing.util.spec.ts`
- `bun run test -- app/(public)/sign-up/sign-up-form.test.tsx app/(onboarding)/onboarding/post-signup/page.behavior.test.tsx app/(onboarding)/onboarding/(wizard)/brand/brand-content.behavior.test.tsx app/(onboarding)/onboarding/(wizard)/providers/providers-content.behavior.test.tsx` from `apps/app`
- `bun run test -- app/(protected)/root-resolver-client.test.tsx app/(protected)/[orgSlug]/org-landing-content.test.tsx proxy.test.ts` from `apps/app`
- `bun run test -- src/components/guards/onboarding/OnboardingGuard.test.tsx` from `packages/ui`
- `bun run test -- src/collections/brands/controllers/brands.controller.spec.ts src/collections/brands/services/brand-persistence.service.spec.ts src/endpoints/webhooks/stripe/handlers/stripe-webhook-support.service.spec.ts src/endpoints/webhooks/stripe/handlers/stripe-checkout-webhook.handler.spec.ts src/collections/users/controllers/users.controller.spec.ts` from `apps/server/api`
- `git diff --name-only -z | xargs -0 bunx biome check --write`
- `git diff --check`
- staged secret scan + pre-commit secretlint/Biome/raw HTML/card guards