### PR TITLE
docs(skills): guard README drift

### DIFF
--- a/.agents/memory/context/skills-architecture.md
+++ b/.agents/memory/context/skills-architecture.md
@@ -1,6 +1,6 @@
 ---
 created: 2026-04-21
-last_verified: 2026-04-21
+last_verified: 2026-07-06
 ---
 
 # Skills Architecture — Genfeed.ai
@@ -16,7 +16,7 @@ genfeed.ai/
 ├── skills/                  # Product/content skills (used by the app)
 │   ├── prompt-generator/
 │   ├── workflow-creator/
-│   └── ...                  # 27 content skills
+│   └── ...                  # 31 content skills
 ├── .agents/skills/          # Dev/build skills (for building the app)
 │   ├── react-patterns/
 │   ├── docker-expert/

--- a/.github/workflows/codebase-health.yml
+++ b/.github/workflows/codebase-health.yml
@@ -95,8 +95,15 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.14'
+
       - name: Validate skills
         run: scripts/setup-skills.sh --check
+
+      - name: Validate root skills README
+        run: bun run check:skills-readme
 
   # Full-repo React health gate. The PR job in ci.yml only scans the diff, so
   # pre-existing errors in untouched files never gate it. This scans every

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "setup:skills": "scripts/setup-skills.sh",
     "setup:skills:sync": "scripts/setup-skills.sh --sync",
     "check:skills": "scripts/setup-skills.sh --check",
+    "check:skills-readme": "bun run scripts/check-skills-readme-drift.ts",
     "build": "bunx turbo run build --filter='./packages/*'",
     "build:app": "bunx turbo run build --filter=@genfeedai/app",
     "build:backend:parallel": "bunx turbo run build --filter='./apps/server/*'",

--- a/scripts/check-skills-readme-drift.ts
+++ b/scripts/check-skills-readme-drift.ts
@@ -1,0 +1,194 @@
+#!/usr/bin/env bun
+/**
+ * Ensures the public root skills README matches root skill frontmatter.
+ *
+ * Usage:
+ *   bun run scripts/check-skills-readme-drift.ts
+ *   bun run scripts/check-skills-readme-drift.ts --write
+ */
+import {
+  existsSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { basename, dirname, join, relative } from 'node:path';
+
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---/;
+const ROOT = process.cwd();
+const SKILLS_DIR = join(ROOT, 'skills');
+const README_PATH = join(SKILLS_DIR, 'README.md');
+
+interface ProductSkill {
+  description: string;
+  name: string;
+}
+
+function fail(message: string): never {
+  console.error(message);
+  process.exit(1);
+}
+
+function unquote(value: string): string {
+  const trimmed = value.trim();
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+function parseFrontmatter(skillPath: string): ProductSkill {
+  const content = readFileSync(skillPath, 'utf-8');
+  const match = content.match(FRONTMATTER_RE);
+  if (!match) {
+    fail(`${relative(ROOT, skillPath)} is missing YAML frontmatter.`);
+  }
+
+  const fields: Record<string, string> = {};
+  for (const line of match[1].split('\n')) {
+    const idx = line.indexOf(':');
+    if (idx === -1) {
+      continue;
+    }
+
+    const key = line.slice(0, idx).trim();
+    const value = unquote(line.slice(idx + 1));
+    fields[key] = value;
+  }
+
+  if (!fields.name) {
+    fail(`${relative(ROOT, skillPath)} is missing frontmatter field "name".`);
+  }
+  if (!fields.description) {
+    fail(
+      `${relative(ROOT, skillPath)} is missing frontmatter field "description".`,
+    );
+  }
+
+  const folderName = basename(dirname(skillPath));
+  if (fields.name !== folderName) {
+    fail(
+      `${relative(ROOT, skillPath)} frontmatter name "${fields.name}" does not match folder "${folderName}".`,
+    );
+  }
+
+  return {
+    description: fields.description,
+    name: fields.name,
+  };
+}
+
+function loadProductSkills(): ProductSkill[] {
+  if (!existsSync(SKILLS_DIR)) {
+    fail('skills/ directory does not exist.');
+  }
+
+  const skills: ProductSkill[] = [];
+  for (const entry of readdirSync(SKILLS_DIR)) {
+    const skillDir = join(SKILLS_DIR, entry);
+    if (!statSync(skillDir).isDirectory()) {
+      continue;
+    }
+
+    const skillPath = join(skillDir, 'SKILL.md');
+    if (!existsSync(skillPath)) {
+      continue;
+    }
+
+    skills.push(parseFrontmatter(skillPath));
+  }
+
+  return skills.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function escapeTableCell(value: string): string {
+  return value.replace(/\r?\n/g, ' ').replace(/\|/g, '\\|');
+}
+
+function renderSkillsSection(skills: ProductSkill[]): string {
+  const lines = [
+    'Generated from `skills/*/SKILL.md` frontmatter. Run `bun run scripts/check-skills-readme-drift.ts --write` after adding or changing a root product skill.',
+    '',
+    '| Skill | Description |',
+    '| --- | --- |',
+  ];
+
+  for (const skill of skills) {
+    lines.push(`| \`${skill.name}\` | ${escapeTableCell(skill.description)} |`);
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+function replaceSkillsSection(readme: string, expectedSection: string): string {
+  const sectionRe = /(## Skills\r?\n\r?\n)([\s\S]*?)(\r?\n## Adding a skill)/;
+  if (!sectionRe.test(readme)) {
+    fail(
+      'skills/README.md must contain "## Skills" before "## Adding a skill".',
+    );
+  }
+
+  return readme.replace(sectionRe, `$1${expectedSection}$3`);
+}
+
+function parseReadmeSkillNames(section: string): string[] {
+  const names: string[] = [];
+  for (const line of section.split('\n')) {
+    const match = line.match(/^\| `([^`]+)` \| /);
+    if (match) {
+      names.push(match[1]);
+    }
+  }
+  return names.sort((a, b) => a.localeCompare(b));
+}
+
+function main(): void {
+  const shouldWrite = process.argv.includes('--write');
+  const skills = loadProductSkills();
+  const expectedSection = renderSkillsSection(skills);
+  const readme = readFileSync(README_PATH, 'utf-8');
+  const nextReadme = replaceSkillsSection(readme, expectedSection);
+
+  if (nextReadme === readme) {
+    console.log(
+      `skills/README.md is in sync with ${skills.length} root product skills.`,
+    );
+    return;
+  }
+
+  if (shouldWrite) {
+    writeFileSync(README_PATH, nextReadme);
+    console.log(
+      `Updated skills/README.md from ${skills.length} root product skills.`,
+    );
+    return;
+  }
+
+  const currentSection = readme.match(
+    /## Skills\r?\n\r?\n([\s\S]*?)\r?\n## Adding a skill/,
+  )?.[1];
+  const currentNames = currentSection
+    ? parseReadmeSkillNames(currentSection)
+    : [];
+  const expectedNames = skills.map((skill) => skill.name);
+  const missing = expectedNames.filter((name) => !currentNames.includes(name));
+  const extra = currentNames.filter((name) => !expectedNames.includes(name));
+
+  console.error('skills/README.md has drifted from skills/*/SKILL.md.');
+  if (missing.length > 0) {
+    console.error(`Missing from README: ${missing.join(', ')}`);
+  }
+  if (extra.length > 0) {
+    console.error(`Extra in README: ${extra.join(', ')}`);
+  }
+  console.error(
+    'Run `bun run scripts/check-skills-readme-drift.ts --write` to regenerate it.',
+  );
+  process.exit(1);
+}
+
+main();

--- a/skills/README.md
+++ b/skills/README.md
@@ -4,33 +4,41 @@ Genfeed.ai content and product skills — used by the application itself to powe
 
 ## Skills
 
-| Skill                       | Purpose                                        |
-| --------------------------- | ---------------------------------------------- |
-| `ad-copy-creator`           | Generate ad copy for campaigns                 |
-| `ad-performance-analyzer`   | Analyze ad performance metrics                 |
-| `blog-content-creator`      | Create blog posts and articles                 |
-| `brand-os-architect`        | Create source-backed Brand OS systems          |
-| `competitor-analyzer`       | Analyze competitor content strategies          |
-| `content-atomizer`          | Break long-form content into social posts      |
-| `content-geo-optimizer`     | Optimize content for generative answer engines |
-| `content-reviewer`          | Review and score content quality               |
-| `content-seo-optimizer`     | Optimize content for search engines            |
-| `content-strategist`        | Plan content calendars and strategy            |
-| `genfeed-brand-os`          | Apply the Genfeed.ai Brand OS                  |
-| `image-prompt-engineer`     | Generate image prompts for AI models           |
-| `instagram-content-creator` | Create Instagram-optimized content             |
-| `linkedin-content-creator`  | Create LinkedIn posts and articles             |
-| `model-selector`            | Select optimal AI model for a task             |
-| `newsletter-creator`        | Generate email newsletters                     |
-| `node-creator`              | Create workflow nodes                          |
-| `onboarding`                | Guide new user onboarding flows                |
-| `openclaw-integration`      | OpenClaw agent integration                     |
-| `prompt-generator`          | Generate AI prompts for content                |
-| `scope-validator`           | Validate task scope and requirements           |
-| `visual-brand-kit`          | Maintain visual brand consistency              |
-| `workflow-creator`          | Build automation workflows                     |
-| `x-content-creator`         | Create X/Twitter content                       |
-| `youtube-content-creator`   | Create YouTube titles, descriptions, scripts   |
+Generated from `skills/*/SKILL.md` frontmatter. Run `bun run scripts/check-skills-readme-drift.ts --write` after adding or changing a root product skill.
+
+| Skill | Description |
+| --- | --- |
+| `ad-copy-creator` | Create high-converting ad copy for Meta, Google, LinkedIn, TikTok, and X using proven direct response frameworks. Triggers on "write ad copy", "create an ad", "write a facebook ad", "google ad copy", "ad headline", "write ad creative", "ad variants". |
+| `ad-performance-analyzer` | Analyze paid media performance, diagnose issues, and provide optimization recommendations across all major ad platforms. Triggers on "analyze ad performance", "ad metrics", "why is my ROAS low", "ad optimization", "campaign performance", "creative fatigue", "ad budget allocation". |
+| `blog-content-creator` | Create SEO-optimized blog posts in multiple formats with heading hierarchy, meta descriptions, and internal link strategy. Triggers on "write a blog post", "create a blog article", "draft a blog", "write an article", "blog about". |
+| `brand-os-architect` | Create source-backed Brand OS systems for AI-era brands, including positioning, voice, visual rules, content pillars, launch storytelling, CTA strategy, evidence, and generation checklists. Triggers on Brand OS, brand system, brand operating system, AI-readable brand book, brand kit generator, launch storytelling, Japanese color references, cute studies, and source-backed brand strategy. |
+| `competitor-analyzer` | Analyze competitors' content strategies, identify gaps and opportunities, and deliver actionable competitive intelligence reports. Triggers on "analyze competitor", "competitive analysis", "competitor content", "gap analysis", "what are competitors doing", "competitor research". |
+| `content-atomizer` | Repurpose one piece of content into dozens of platform-optimized derivatives with scheduling cadence and adaptation rules. Triggers on "atomize content", "repurpose content", "turn this into", "create derivatives", "cross-platform content". |
+| `content-geo-optimizer` | Optimize long-form content for generative answer engines with a GEO scorecard, citation-ready structure, source attribution, and schema recommendations. Triggers on "optimize for GEO", "AI answer engine optimization", "make this citation-ready", "improve AI Overviews", "optimize for ChatGPT citations". |
+| `content-reviewer` | Review and score content quality across six dimensions with actionable feedback. Triggers on "review this content", "score this post", "check content quality", "review my copy", "is this post ready to publish", "critique this content". |
+| `content-seo-optimizer` | Analyze and optimize content for SEO with a 0-100 scoring rubric, platform-specific rules, and actionable improvement priorities. Triggers on "optimize for SEO", "SEO score", "check SEO", "audit content", "improve search ranking". |
+| `content-strategist` | Build comprehensive content strategies including audience definition, content pillars, platform selection, posting cadence, editorial calendars, and KPI frameworks. Triggers on "content strategy", "editorial calendar", "content plan", "what should I post", "posting schedule", "content pillars". |
+| `genfeed-brand-os` | Apply the Genfeed.ai Brand OS to product copy, website CTAs, launch content, skills, examples, prompts, and generation context. Triggers when creating Genfeed-branded content, Genfeed website copy, Genfeed launch narratives, Brand OS generator examples, product messaging, or AI-readable Genfeed brand guidance. |
+| `image-prompt-engineer` | Craft optimized prompts for AI image generation across all major models. Triggers on "write an image prompt", "create a prompt for", "optimize this image prompt", "prompt for flux", "prompt for dall-e", "prompt for midjourney", "image prompt for". |
+| `instagram-content-creator` | Create Instagram content including captions, carousel outlines, Reels scripts, Story sequences, and hashtag strategies. Triggers on "write an instagram caption", "create instagram content", "carousel outline", "reel script", "hashtag strategy". |
+| `instagram-warmup` | Guide Instagram account warmup with engagement plans, Stories strategy, Reel and carousel warmup content, and post-warmup assessment frameworks. Triggers on "instagram warmup", "warm up instagram account", "new instagram account", "instagram account warmup plan", "instagram engagement plan", "warmup content instagram", "instagram trust score", "first post on instagram". |
+| `launch-copy-creator` | Generate channel-conform launch copy for Hacker News (Show HN) and Product Hunt. Triggers on "write a show hn", "show hn title", "hacker news launch", "product hunt tagline", "product hunt launch copy", "maker comment", "launch copy". |
+| `linkedin-content-creator` | Create LinkedIn content including posts, articles, carousels, and newsletters for professional growth. Triggers on "write a linkedin post", "linkedin article", "linkedin carousel", "thought leadership", "professional post". |
+| `linkedin-warmup` | Guide LinkedIn account warmup with engagement plans, SSI-building strategy, comment-first content, and post-warmup assessment. Triggers on "linkedin warmup", "warm up linkedin", "new linkedin account", "linkedin account warmup plan", "linkedin engagement plan", "warmup content linkedin", "linkedin trust score", "first post on linkedin", "SSI score". |
+| `model-selector` | Recommend the best AI model for image, video, and audio generation tasks. Triggers on "which model should I use", "recommend a model", "best model for", "what model for", "compare models", "fastest model for", "cheapest model for". |
+| `newsletter-creator` | Create high-performing email newsletters with subject lines, editorial structures, and subscriber growth tactics. Triggers on "write a newsletter", "create a newsletter", "draft newsletter", "email newsletter", "newsletter edition". |
+| `node-creator` | Create custom Genfeed nodes using the SDK. Triggers on "create a new node", "add a custom node type", "build a node for X". |
+| `onboarding` | Quick onboarding for Genfeed focused on first content creation. Triggers on "how do I use genfeed", "getting started", "what is this app", "help me create my first content". |
+| `openclaw-integration` | Connect to Genfeed.ai to create AI videos, images, articles, and more. Use when "genfeed", "create content", "generate video", "generate image", "publish content" mentioned. |
+| `prompt-generator` | Generate optimized prompts for AI image and video generation. Triggers on "generate a prompt for", "write me a prompt", "create an image prompt", "create a video prompt", "optimize this prompt". |
+| `scope-validator` | Validate feature requests against Genfeed OSS core vs Cloud scope. Helps users and contributors understand whether a feature belongs in the open-source core (submit PR) or Cloud SaaS (subscribe). |
+| `tiktok-warmup` | Guide TikTok account warmup with engagement plans, warmup content, and post-warmup strategy. Triggers on "tiktok warmup", "warm up tiktok account", "new tiktok account", "tiktok account warmup plan", "tiktok engagement plan", "warmup content tiktok". |
+| `visual-brand-kit` | Create comprehensive visual brand identity systems for AI-generated content. Triggers on "create a brand kit", "visual brand identity", "brand style guide", "define brand visuals", "brand colors and style", "create visual guidelines", "brand photography style". |
+| `workflow-creator` | Create Genfeed workflows from natural language descriptions. Triggers on "create a workflow", "build a content pipeline", "make a video generation workflow". |
+| `x-content-creator` | Create high-performing X/Twitter content including tweets, threads, quote tweets, and reply strategies. Triggers on "write a tweet", "create a thread", "draft a tweet", "compose a tweet", "quote tweet", "tweet about". |
+| `x-warmup` | Guide X/Twitter account warmup and source-backed X content hardening with engagement plans, reply-first strategy, warmup thread content, and post-warmup assessment. Triggers on "x warmup", "twitter warmup", "warm up x account", "new x account", "x account warmup plan", "x engagement plan", "warmup content x", "harder X content", "X content hardening". |
+| `youtube-content-creator` | Create YouTube content including titles, descriptions, tags, thumbnail briefs, Shorts scripts, and retention strategies. Triggers on "write a youtube title", "youtube description", "youtube tags", "thumbnail brief", "shorts script", "youtube seo". |
+| `youtube-warmup` | Guide YouTube channel warmup with engagement plans, channel optimization, warmup Shorts content, SEO-first setup, and post-warmup assessment. Triggers on "youtube warmup", "warm up youtube channel", "new youtube channel", "youtube channel warmup plan", "youtube engagement plan", "warmup content youtube", "youtube shorts warmup". |
 
 ## Adding a skill
 


### PR DESCRIPTION
## Summary

- Regenerated `skills/README.md` from the actual root `skills/*/SKILL.md` frontmatter.
- Added `check:skills-readme` to fail when the README drifts from root product skills.
- Wired the guard into the weekly Skills Integrity health job and updated the stale root skill count in project memory.

## Validation

- `bun run check:skills-readme`
- `scripts/setup-skills.sh --check`
- `bunx biome check scripts/check-skills-readme-drift.ts package.json`
- lint-staged pre-commit hook: Biome + `bun scripts/run-secretlint.ts --no-glob`

Closes #1437