### PR TITLE
[codex] Add case study social proof pipeline

### DIFF
--- a/apps/website/app/(public)/(home)/home-content.tsx
+++ b/apps/website/app/(public)/(home)/home-content.tsx
@@ -9,6 +9,7 @@ import HomeFormats from '@web-components/home/_formats';
 import HomeHero from '@web-components/home/_hero';
 import HomeHow from '@web-components/home/_how';
 import HomeProof from '@web-components/home/_proof';
+import ProofTestimonials from '@web-components/proof/ProofTestimonials';
 
 export default function HomeContent() {
   return (
@@ -17,6 +18,7 @@ export default function HomeContent() {
       <HomeFormats />
       <HomeHow />
       <HomeProof />
+      <ProofTestimonials context="landing" />
       <HomeAudiences />
       <HomeCredits />
       <HomeFAQ />

--- a/apps/website/app/(public)/case-studies/[slug]/case-study-content.tsx
+++ b/apps/website/app/(public)/case-studies/[slug]/case-study-content.tsx
@@ -1,0 +1,191 @@
+import type { CaseStudy } from '@data/case-studies.data';
+import { ButtonSize, ButtonVariant } from '@genfeedai/enums';
+import EditorialPoster from '@ui/marketing/EditorialPoster';
+import HeroProofRail from '@ui/marketing/HeroProofRail';
+import SectionHeader from '@ui/marketing/SectionHeader';
+import { Button } from '@ui/primitives/button';
+import {
+  NeuralGrid,
+  NeuralGridItem,
+  WebSection,
+} from '@web-components/content/NeuralGrid';
+import PageLayout from '@web-components/PageLayout';
+import Link from 'next/link';
+import { FaCheck } from 'react-icons/fa6';
+
+export default function CaseStudyContent({
+  caseStudy,
+}: {
+  caseStudy: CaseStudy;
+}): React.ReactElement {
+  const isPublicProof =
+    caseStudy.status === 'published' && caseStudy.approvedForPublicUse;
+
+  return (
+    <PageLayout
+      description={caseStudy.summary}
+      heroActions={
+        <div className="flex flex-col items-start gap-3 sm:flex-row">
+          <Button asChild size={ButtonSize.PUBLIC}>
+            <Link href="/case-studies">View pipeline</Link>
+          </Button>
+          <Button
+            asChild
+            size={ButtonSize.PUBLIC}
+            variant={ButtonVariant.GHOST}
+          >
+            <Link href="/pricing">Compare plans</Link>
+          </Button>
+        </div>
+      }
+      heroProof={
+        <HeroProofRail
+          items={[
+            { label: 'Status', value: caseStudy.statusLabel },
+            {
+              label: caseStudy.metrics[0]?.label ?? 'Metric',
+              value: caseStudy.metrics[0]?.value ?? 'Pending',
+            },
+            { label: 'Consent', value: caseStudy.consentSummary },
+          ]}
+          title="Receipt status"
+        />
+      }
+      heroVisual={
+        <EditorialPoster
+          detail={caseStudy.outcomeSummary}
+          eyebrow={caseStudy.companyName}
+          footer={
+            <>
+              <span>{caseStudy.customerType}</span>
+              <span>{caseStudy.industry}</span>
+            </>
+          }
+          items={caseStudy.metrics.map((metric) => ({
+            label: metric.label,
+            value: metric.value,
+          }))}
+          title={caseStudy.headline}
+        />
+      }
+      title={caseStudy.headline}
+      variant="proof"
+    >
+      {!isPublicProof ? (
+        <WebSection maxWidth="lg" py="md">
+          <div className="border border-warning/20 bg-warning/10 p-6">
+            <div className="mb-2 text-xs font-bold uppercase tracking-widest text-warning">
+              Template mode
+            </div>
+            <p className="text-sm leading-6 text-surface/70">
+              This page is a publish template, not a customer claim. Replace the
+              placeholder fields with approved customer copy and verified
+              metrics before switching the case-study status to published.
+            </p>
+          </div>
+        </WebSection>
+      ) : null}
+
+      <WebSection maxWidth="xl" py="md">
+        <SectionHeader
+          className="[&_h2]:text-5xl mb-4"
+          description="The same metric fields feed the case-study page and any reusable testimonial cards."
+          title="Outcome metrics."
+        />
+
+        <NeuralGrid columns={3}>
+          {caseStudy.metrics.map((metric) => (
+            <NeuralGridItem key={metric.label} padding="lg" tierLabel="Metric">
+              <h3 className="mb-3 text-xl font-semibold text-surface">
+                {metric.label}
+              </h3>
+              <div className="mb-4 text-3xl font-semibold tracking-[-0.03em] text-surface">
+                {metric.value}
+              </div>
+              <p className="text-sm leading-6 text-surface/62">
+                {metric.captureWindow}
+              </p>
+              <p className="mt-4 border-t border-edge/5 pt-4 text-xs font-medium leading-5 text-surface/55">
+                Evidence required: {metric.evidenceRequired}
+              </p>
+            </NeuralGridItem>
+          ))}
+        </NeuralGrid>
+      </WebSection>
+
+      <WebSection bg="bordered" maxWidth="lg" py="md">
+        <div className="grid gap-px overflow-hidden border border-edge/10 bg-edge/5 md:grid-cols-3">
+          {[
+            ['Challenge', caseStudy.challenge],
+            ['Genfeed workflow', caseStudy.solution],
+            ['Outcome', caseStudy.outcomeSummary],
+          ].map(([title, body]) => (
+            <div key={title} className="bg-background p-6 shadow-border">
+              <h2 className="mb-3 text-xl font-semibold text-surface">
+                {title}
+              </h2>
+              <p className="text-sm leading-6 text-surface/62">{body}</p>
+            </div>
+          ))}
+        </div>
+      </WebSection>
+
+      <WebSection maxWidth="lg" py="md">
+        <SectionHeader
+          className="[&_h2]:text-5xl mb-4"
+          description="Use these sections to draft the first proof asset without changing page components."
+          title="Story workflow."
+        />
+
+        <div className="border border-edge/5">
+          {caseStudy.workflow.map((step, index) => (
+            <div
+              className={`flex items-start gap-5 p-6 ${index > 0 ? 'border-t border-edge/5' : ''}`}
+              key={step.title}
+            >
+              <div className="flex size-8 shrink-0 items-center justify-center bg-fill/10 text-sm font-bold text-surface/50">
+                {String(index + 1).padStart(2, '0')}
+              </div>
+              <div>
+                <h3 className="mb-1 font-semibold text-surface">
+                  {step.title}
+                </h3>
+                <p className="text-sm leading-6 text-surface/62">
+                  {step.description}
+                </p>
+                <p className="mt-2 text-xs font-medium uppercase tracking-widest text-surface/45">
+                  {step.evidence}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </WebSection>
+
+      <WebSection bg="bordered" maxWidth="lg" py="md">
+        <SectionHeader
+          className="[&_h2]:text-5xl mb-4"
+          description="All required checks must clear before a testimonial can appear on pricing or landing pages."
+          title="Publish checklist."
+        />
+
+        <div className="grid gap-px overflow-hidden border border-edge/10 bg-edge/5 md:grid-cols-2">
+          {caseStudy.publishChecklist.map((item) => (
+            <div
+              className="flex items-start gap-3 bg-background p-5 shadow-border"
+              key={item.label}
+            >
+              <FaCheck className="mt-0.5 size-4 shrink-0 text-success" />
+              <div>
+                <p className="text-sm font-medium text-surface">{item.label}</p>
+                <p className="mt-1 text-xs uppercase tracking-widest text-surface/45">
+                  {item.required ? 'Required' : 'Optional'}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </WebSection>
+    </PageLayout>
+  );
+}

--- a/apps/website/app/(public)/case-studies/[slug]/case-study-loader.ts
+++ b/apps/website/app/(public)/case-studies/[slug]/case-study-loader.ts
@@ -1,0 +1,13 @@
+import { getCaseStudyBySlug } from '@data/case-studies.data';
+import { cache } from 'react';
+
+export function formatCaseStudySlug(slug: string): string {
+  return slug
+    .split('-')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+export const getCaseStudyBySlugCached = cache(async (slug: string) => {
+  return getCaseStudyBySlug(slug);
+});

--- a/apps/website/app/(public)/case-studies/[slug]/page.spec.tsx
+++ b/apps/website/app/(public)/case-studies/[slug]/page.spec.tsx
@@ -1,0 +1,7 @@
+import * as PageModule from '@public/case-studies/[slug]/page';
+import { runPageModuleTests } from '@shared/pages/pageTestUtils';
+
+runPageModuleTests(
+  'apps/website/app/(public)/case-studies/[slug]/page',
+  PageModule,
+);

--- a/apps/website/app/(public)/case-studies/[slug]/page.tsx
+++ b/apps/website/app/(public)/case-studies/[slug]/page.tsx
@@ -1,0 +1,107 @@
+import { getAllCaseStudySlugs } from '@data/case-studies.data';
+import { stringifyJsonLd } from '@data/json-ld';
+import CaseStudyContent from '@public/case-studies/[slug]/case-study-content';
+import {
+  formatCaseStudySlug,
+  getCaseStudyBySlugCached,
+} from '@public/case-studies/[slug]/case-study-loader';
+import { EnvironmentService } from '@services/core/environment.service';
+import LazyLoadingFallback from '@ui/loading/fallback/LazyLoadingFallback';
+import type { Metadata, ResolvingMetadata } from 'next';
+import { notFound } from 'next/navigation';
+import { Suspense } from 'react';
+
+export function generateStaticParams() {
+  return getAllCaseStudySlugs().map((slug) => ({ slug }));
+}
+
+export async function generateMetadata(
+  { params }: { params: Promise<{ slug: string }> },
+  parent: ResolvingMetadata,
+): Promise<Metadata> {
+  const [resolvedParams, resolvedParent] = await Promise.all([params, parent]);
+  const previousImages = resolvedParent.openGraph?.images || [];
+  const caseStudy = await getCaseStudyBySlugCached(resolvedParams.slug);
+  const title = caseStudy?.headline ?? formatCaseStudySlug(resolvedParams.slug);
+  const description =
+    caseStudy?.summary ??
+    'Genfeed case-study template and public social-proof pipeline.';
+  const url = `${EnvironmentService.apps.website}/case-studies/${resolvedParams.slug}`;
+
+  return {
+    alternates: { canonical: url },
+    description,
+    openGraph: { description, images: [...previousImages], title, url },
+    title,
+    twitter: { description, images: [...previousImages] },
+  };
+}
+
+export default async function CaseStudyPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const caseStudy = await getCaseStudyBySlugCached(slug);
+
+  if (!caseStudy) {
+    notFound();
+  }
+
+  const url = `${EnvironmentService.apps.website}/case-studies/${slug}`;
+  const caseStudyJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'Article',
+    about: caseStudy.customerType,
+    dateModified: caseStudy.updatedAt,
+    description: caseStudy.summary,
+    headline: caseStudy.headline,
+    isAccessibleForFree: true,
+    publisher: {
+      '@type': 'Organization',
+      name: 'Genfeed',
+      url: 'https://genfeed.ai',
+    },
+    url,
+  };
+
+  const breadcrumbJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      {
+        '@type': 'ListItem',
+        item: 'https://genfeed.ai',
+        name: 'Home',
+        position: 1,
+      },
+      {
+        '@type': 'ListItem',
+        item: `${EnvironmentService.apps.website}/case-studies`,
+        name: 'Case Studies',
+        position: 2,
+      },
+      {
+        '@type': 'ListItem',
+        item: url,
+        name: caseStudy.headline,
+        position: 3,
+      },
+    ],
+  };
+
+  return (
+    <>
+      <script type="application/ld+json">
+        {stringifyJsonLd(caseStudyJsonLd)}
+      </script>
+      <script type="application/ld+json">
+        {stringifyJsonLd(breadcrumbJsonLd)}
+      </script>
+      <Suspense fallback={<LazyLoadingFallback variant="grid" />}>
+        <CaseStudyContent caseStudy={caseStudy} />
+      </Suspense>
+    </>
+  );
+}

--- a/apps/website/app/(public)/case-studies/case-studies-content.tsx
+++ b/apps/website/app/(public)/case-studies/case-studies-content.tsx
@@ -1,0 +1,179 @@
+import {
+  caseStudies,
+  caseStudyPipeline,
+  getPublishedCaseStudies,
+  requiredCaseStudyMetrics,
+} from '@data/case-studies.data';
+import { ButtonSize, ButtonVariant } from '@genfeedai/enums';
+import EditorialPoster from '@ui/marketing/EditorialPoster';
+import HeroProofRail from '@ui/marketing/HeroProofRail';
+import SectionHeader from '@ui/marketing/SectionHeader';
+import { Button } from '@ui/primitives/button';
+import {
+  NeuralGrid,
+  NeuralGridItem,
+  WebSection,
+} from '@web-components/content/NeuralGrid';
+import PageLayout from '@web-components/PageLayout';
+import ProofTestimonials from '@web-components/proof/ProofTestimonials';
+import Link from 'next/link';
+import { HiCheckCircle } from 'react-icons/hi2';
+
+export default function CaseStudiesContent(): React.ReactElement {
+  const publishedCaseStudies = getPublishedCaseStudies();
+  const templateCaseStudy = caseStudies[0];
+  const visibleCaseStudies =
+    publishedCaseStudies.length > 0 ? publishedCaseStudies : caseStudies;
+
+  return (
+    <PageLayout
+      description="A consent-first pipeline for turning early customer outcomes into public receipts: case studies, testimonials, and reusable proof slots."
+      heroActions={
+        <div className="flex flex-col items-start gap-3 sm:flex-row">
+          <Button asChild size={ButtonSize.PUBLIC}>
+            <Link href={`/case-studies/${templateCaseStudy.slug}`}>
+              Open template
+            </Link>
+          </Button>
+          <Button
+            asChild
+            size={ButtonSize.PUBLIC}
+            variant={ButtonVariant.GHOST}
+          >
+            <Link href="/pricing">View pricing</Link>
+          </Button>
+        </div>
+      }
+      heroProof={
+        <HeroProofRail
+          items={[
+            { label: 'Required flow', value: 'Consent to metrics to approval' },
+            { label: 'Metric window', value: 'First 60 days' },
+            { label: 'Publish rule', value: 'Approved facts only' },
+          ]}
+          title="Proof gate"
+        />
+      }
+      heroVisual={
+        <EditorialPoster
+          detail="Every proof asset moves through the same public-safe review path before it appears on pricing, landing, or case-study pages."
+          eyebrow="Social proof pipeline"
+          footer={
+            <>
+              <span>First 10 customers</span>
+              <span>Public receipts only</span>
+            </>
+          }
+          items={caseStudyPipeline.slice(0, 4).map((step) => ({
+            label: `${step.label} / ${step.title}`,
+            value: step.exitCriteria,
+          }))}
+          title="Turn customer outcomes into reusable proof."
+        />
+      }
+      title="Case studies and social proof pipeline"
+      variant="proof"
+    >
+      <WebSection maxWidth="xl" py="md">
+        <SectionHeader
+          className="[&_h2]:text-5xl mb-4"
+          description="The process keeps customer approval, measured outcomes, and public placement connected so each new receipt can ship without new engineering."
+          title="Consent to publish, in five steps."
+        />
+
+        <div className="grid gap-px overflow-hidden border border-edge/10 bg-edge/5 lg:grid-cols-5">
+          {caseStudyPipeline.map((step) => (
+            <div key={step.id} className="bg-background p-5 shadow-border">
+              <div className="mb-5 text-xs font-black uppercase tracking-widest text-surface/45">
+                {step.label} / {step.owner}
+              </div>
+              <h3 className="mb-3 text-xl font-semibold text-surface">
+                {step.title}
+              </h3>
+              <p className="text-sm leading-6 text-surface/62">
+                {step.description}
+              </p>
+              <p className="mt-5 border-t border-edge/5 pt-4 text-xs font-medium leading-5 text-surface/55">
+                {step.exitCriteria}
+              </p>
+            </div>
+          ))}
+        </div>
+      </WebSection>
+
+      <WebSection bg="bordered" maxWidth="lg" py="md">
+        <SectionHeader
+          className="[&_h2]:text-5xl mb-4"
+          description="Every case study captures the same three outcome fields before it can power a testimonial slot."
+          title="Metrics captured for every receipt."
+        />
+
+        <NeuralGrid columns={3}>
+          {requiredCaseStudyMetrics.map((metric, index) => (
+            <NeuralGridItem
+              key={metric}
+              padding="lg"
+              tierLabel={`Required ${String(index + 1).padStart(2, '0')}`}
+            >
+              <div className="mb-4 flex size-10 items-center justify-center bg-success/10 text-success">
+                <HiCheckCircle className="size-5" />
+              </div>
+              <h3 className="mb-3 text-xl font-semibold text-surface">
+                {metric}
+              </h3>
+              <p className="text-sm leading-6 text-surface/62">
+                Verified before publication and reused as the metric label for
+                pricing, landing-page, and case-study proof.
+              </p>
+            </NeuralGridItem>
+          ))}
+        </NeuralGrid>
+      </WebSection>
+
+      <WebSection maxWidth="xl" py="md">
+        <SectionHeader
+          className="[&_h2]:text-5xl mb-4"
+          description="Published customer stories appear here. Until the first customer clears approval, the template route is visible and explicitly marked as not public proof."
+          title="Case-study surface."
+        />
+
+        <NeuralGrid columns={3}>
+          {visibleCaseStudies.map((caseStudy) => (
+            <NeuralGridItem
+              key={caseStudy.slug}
+              className="flex flex-col gap-5"
+              padding="lg"
+              tierLabel={caseStudy.statusLabel}
+            >
+              <div>
+                <h3 className="mb-3 text-2xl font-semibold tracking-[-0.02em] text-surface">
+                  {caseStudy.headline}
+                </h3>
+                <p className="text-sm leading-6 text-surface/62">
+                  {caseStudy.summary}
+                </p>
+              </div>
+              <div className="mt-auto border-t border-edge/5 pt-5">
+                <div className="text-xs font-bold uppercase tracking-widest text-surface/45">
+                  {caseStudy.customerType}
+                </div>
+                <Button
+                  asChild
+                  className="mt-4"
+                  size={ButtonSize.PUBLIC}
+                  variant={ButtonVariant.OUTLINE}
+                >
+                  <Link href={`/case-studies/${caseStudy.slug}`}>
+                    View case study
+                  </Link>
+                </Button>
+              </div>
+            </NeuralGridItem>
+          ))}
+        </NeuralGrid>
+      </WebSection>
+
+      <ProofTestimonials context="case-studies" />
+    </PageLayout>
+  );
+}

--- a/apps/website/app/(public)/case-studies/page.spec.tsx
+++ b/apps/website/app/(public)/case-studies/page.spec.tsx
@@ -1,0 +1,4 @@
+import * as PageModule from '@public/case-studies/page';
+import { runPageModuleTests } from '@shared/pages/pageTestUtils';
+
+runPageModuleTests('apps/website/app/(public)/case-studies/page', PageModule);

--- a/apps/website/app/(public)/case-studies/page.tsx
+++ b/apps/website/app/(public)/case-studies/page.tsx
@@ -1,0 +1,29 @@
+import { stringifyJsonLd } from '@data/json-ld';
+import { createPageMetadataWithCanonical } from '@helpers/media/metadata/page-metadata.helper';
+import CaseStudiesContent from '@public/case-studies/case-studies-content';
+
+export const generateMetadata = createPageMetadataWithCanonical(
+  'Case Studies',
+  'The Genfeed consent-first process for turning early customer outcomes into case studies, testimonials, and public proof slots.',
+  '/case-studies',
+);
+
+const caseStudiesJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'CollectionPage',
+  description:
+    'A public-safe proof pipeline for Genfeed case studies, testimonials, and social proof slots.',
+  name: 'Genfeed Case Studies',
+  url: 'https://genfeed.ai/case-studies',
+};
+
+export default function CaseStudiesPage() {
+  return (
+    <>
+      <script type="application/ld+json">
+        {stringifyJsonLd(caseStudiesJsonLd)}
+      </script>
+      <CaseStudiesContent />
+    </>
+  );
+}

--- a/apps/website/app/(public)/pricing/pricing-content.tsx
+++ b/apps/website/app/(public)/pricing/pricing-content.tsx
@@ -25,6 +25,7 @@ import {
   WebSection,
 } from '@web-components/content/NeuralGrid';
 import PageLayout from '@web-components/PageLayout';
+import ProofTestimonials from '@web-components/proof/ProofTestimonials';
 import { HiCheckCircle } from 'react-icons/hi2';
 
 const PLAN_ORDER = ['Pay As You Go', 'Pro', 'Scale'];
@@ -330,6 +331,8 @@ export default function PricingContent() {
             </NeuralGrid>
           ) : null}
         </WebSection>
+
+        <ProofTestimonials context="pricing" />
 
         <WebSection maxWidth="lg" py="md">
           <SectionHeader

--- a/apps/website/app/sitemap.ts
+++ b/apps/website/app/sitemap.ts
@@ -1,3 +1,4 @@
+import { getAllCaseStudySlugs } from '@data/case-studies.data';
 import { getAllCompetitorSlugs } from '@data/competitors.data';
 import { getAllIntegrationSlugs } from '@data/integrations.data';
 import { getAllProductSlugs } from '@data/products.data';
@@ -8,6 +9,7 @@ import type { MetadataRoute } from 'next';
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const productSlugs = getAllProductSlugs();
   const competitorSlugs = getAllCompetitorSlugs();
+  const caseStudySlugs = getAllCaseStudySlugs();
   const integrationSlugs = getAllIntegrationSlugs();
   const useCaseSlugs = getAllUseCaseSlugs();
 
@@ -192,6 +194,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: 'monthly',
       lastModified: new Date(),
       priority: 0.7,
+      url: 'https://genfeed.ai/case-studies',
+    },
+    {
+      changeFrequency: 'monthly',
+      lastModified: new Date(),
+      priority: 0.7,
       url: 'https://genfeed.ai/faq',
     },
     {
@@ -264,6 +272,13 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     }),
   );
 
+  const caseStudyRoutes: MetadataRoute.Sitemap = caseStudySlugs.map((slug) => ({
+    changeFrequency: 'monthly',
+    lastModified: new Date(),
+    priority: 0.7,
+    url: `https://genfeed.ai/case-studies/${slug}`,
+  }));
+
   const integrationRoutes: MetadataRoute.Sitemap = integrationSlugs.map(
     (slug) => ({
       changeFrequency: 'monthly',
@@ -315,6 +330,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     ...staticRoutes,
     ...productRoutes,
     ...competitorRoutes,
+    ...caseStudyRoutes,
     ...integrationRoutes,
     ...useCaseRoutes,
     ...articleRoutes,

--- a/apps/website/docs/case-study-social-proof-pipeline.md
+++ b/apps/website/docs/case-study-social-proof-pipeline.md
@@ -1,0 +1,41 @@
+# Case-Study Social-Proof Pipeline
+
+This process turns approved early-customer outcomes into public proof assets:
+case-study pages, testimonial cards, pricing proof, and landing-page proof.
+
+## Publish Gate
+
+1. Consent: get written approval for customer name/logo use, quoted language,
+   metric wording, and the review window.
+2. Metrics: capture baseline plus first 60 days of Genfeed-assisted publishing.
+   Required fields are 60-day engagement lift, time saved per week, and channels
+   activated.
+3. Draft: write the challenge, Genfeed workflow, measured outcome, quote, and
+   placement plan using only customer-approved facts.
+4. Approval: send the exact page copy, testimonial, metric presentation, and page
+   preview for customer approval.
+5. Publish: mark the case-study entry as `published`, set
+   `approvedForPublicUse` to `true`, and reuse the approved testimonial in the
+   website proof slots.
+
+## Data Contract
+
+Case studies live in `apps/website/packages/data/case-studies.data.ts`.
+
+To publish the first customer case study without new component work:
+
+1. Add or replace a `CaseStudy` entry with the approved customer copy.
+2. Fill all three metric objects with verified values and evidence notes.
+3. Fill the testimonial with approved attribution and metric context.
+4. Set the entry `status` to `published`.
+5. Set both `approvedForPublicUse` fields to `true`.
+
+The website routes render `/case-studies`, `/case-studies/[slug]`, homepage
+proof slots, and pricing-page proof slots from that data.
+
+## Public-Safety Rules
+
+- Do not publish customer names, quotes, logos, or metrics before approval.
+- Do not publish internal notes, credentials, or source-system references.
+- Do not invent traction claims. Placeholder values must stay visibly marked as
+  template content until replaced with verified customer data.

--- a/apps/website/packages/components/home/_footer.tsx
+++ b/apps/website/packages/components/home/_footer.tsx
@@ -64,6 +64,7 @@ const WEBSITE_SECTIONS: FooterSection[] = [
     links: [
       { href: '/articles', label: 'Blog' },
       { href: '/posts', label: 'Posts' },
+      { href: '/case-studies', label: 'Case Studies' },
       { href: '/faq', label: 'FAQ' },
       {
         external: true,

--- a/apps/website/packages/components/proof/ProofTestimonials.test.tsx
+++ b/apps/website/packages/components/proof/ProofTestimonials.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import ProofTestimonials from './ProofTestimonials';
+
+describe('ProofTestimonials', () => {
+  it('renders guarded placeholder proof slots until approved testimonials exist', () => {
+    render(<ProofTestimonials context="pricing" />);
+
+    expect(
+      screen.getByRole('heading', {
+        name: /customer proof, gated by approval\./i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByText('Reserved for approved customer proof'),
+    ).toHaveLength(3);
+    expect(screen.getAllByText('Not public proof yet')).toHaveLength(3);
+  });
+
+  it('does not render fabricated testimonial handles or claims', () => {
+    render(<ProofTestimonials />);
+
+    expect(screen.queryByText('@contentcreator')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/doubled my posting frequency/i),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/website/packages/components/proof/ProofTestimonials.tsx
+++ b/apps/website/packages/components/proof/ProofTestimonials.tsx
@@ -1,0 +1,119 @@
+import {
+  caseStudyProofSlots,
+  getApprovedCaseStudyTestimonials,
+} from '@data/case-studies.data';
+import { cn } from '@helpers/formatting/cn/cn.util';
+import SectionHeader from '@ui/marketing/SectionHeader';
+import {
+  NeuralGrid,
+  NeuralGridItem,
+  WebSection,
+} from '@web-components/content/NeuralGrid';
+
+interface ProofTestimonialsProps {
+  className?: string;
+  context?: 'case-studies' | 'landing' | 'pricing';
+}
+
+const TESTIMONIAL_COPY = {
+  'case-studies': {
+    description:
+      'These slots only become customer proof after consent, metric capture, draft approval, and publish approval.',
+    title: 'Approved proof slots.',
+  },
+  landing: {
+    description:
+      'Reserved for permissioned customer receipts tied to measured outcomes, not padded claims.',
+    title: 'Proof slots are ready for real receipts.',
+  },
+  pricing: {
+    description:
+      'Pricing proof will show approved quotes with the metric behind them once the first customer receipts clear review.',
+    title: 'Customer proof, gated by approval.',
+  },
+} as const;
+
+export default function ProofTestimonials({
+  className,
+  context = 'landing',
+}: ProofTestimonialsProps): React.ReactElement {
+  const approvedTestimonials = getApprovedCaseStudyTestimonials();
+  const hasApprovedTestimonials = approvedTestimonials.length > 0;
+  const copy = TESTIMONIAL_COPY[context];
+
+  return (
+    <WebSection
+      bg={context === 'pricing' ? 'bordered' : 'default'}
+      className={className}
+      maxWidth="xl"
+      py="md"
+    >
+      <SectionHeader
+        className="[&_h2]:text-5xl mb-4"
+        description={copy.description}
+        title={copy.title}
+      />
+
+      <NeuralGrid columns={3}>
+        {hasApprovedTestimonials
+          ? approvedTestimonials.map((testimonial) => (
+              <NeuralGridItem
+                key={testimonial.sourceCaseStudySlug}
+                className="flex flex-col gap-5"
+                padding="lg"
+                tierLabel={testimonial.metricLabel}
+              >
+                <p className="text-lg font-medium leading-8 text-surface">
+                  &ldquo;{testimonial.quote}&rdquo;
+                </p>
+                <div className="mt-auto border-t border-edge/5 pt-5">
+                  <div className="text-sm font-semibold text-surface">
+                    {testimonial.attribution}
+                  </div>
+                  <div className="mt-1 text-sm text-surface/55">
+                    {testimonial.role}
+                  </div>
+                  <div className="mt-4 text-xs font-bold uppercase tracking-widest text-success">
+                    {testimonial.metricValue}
+                  </div>
+                </div>
+              </NeuralGridItem>
+            ))
+          : caseStudyProofSlots.map((slot) => (
+              <NeuralGridItem
+                key={slot.label}
+                className={cn(
+                  'flex min-h-72 flex-col gap-5',
+                  'border-dashed border-edge/20 bg-fill/[0.015]',
+                )}
+                padding="lg"
+                tierLabel={slot.label}
+              >
+                <div>
+                  <h3 className="mb-2 text-xl font-semibold text-surface">
+                    {slot.title}
+                  </h3>
+                  <p className="text-sm leading-6 text-surface/62">
+                    {slot.description}
+                  </p>
+                </div>
+                <div className="mt-auto border-t border-edge/5 pt-5">
+                  <div className="text-xs font-bold uppercase tracking-widest text-surface/45">
+                    {slot.placement}
+                  </div>
+                  <div className="mt-3 text-sm font-semibold text-surface">
+                    {slot.metricPrompt}
+                  </div>
+                  <div className="mt-1 text-sm text-surface/55">
+                    Reserved for approved customer proof
+                  </div>
+                  <div className="mt-4 text-xs font-bold uppercase tracking-widest text-warning">
+                    Not public proof yet
+                  </div>
+                </div>
+              </NeuralGridItem>
+            ))}
+      </NeuralGrid>
+    </WebSection>
+  );
+}

--- a/apps/website/packages/data/case-studies.data.test.ts
+++ b/apps/website/packages/data/case-studies.data.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import {
+  caseStudies,
+  caseStudyPipeline,
+  caseStudyProofSlots,
+  getAllCaseStudySlugs,
+  getApprovedCaseStudyTestimonials,
+  getCaseStudyBySlug,
+  getPublishedCaseStudies,
+  requiredCaseStudyMetrics,
+} from './case-studies.data';
+
+describe('case study proof pipeline data', () => {
+  it('documents the required consent to publish flow', () => {
+    expect(caseStudyPipeline.map((step) => step.id)).toEqual([
+      'consent',
+      'metrics',
+      'draft',
+      'approval',
+      'publish',
+    ]);
+  });
+
+  it('requires the outcome metrics from the PRD', () => {
+    expect(requiredCaseStudyMetrics).toEqual([
+      '60-day engagement lift',
+      'Time saved per week',
+      'Channels activated',
+    ]);
+  });
+
+  it('exposes the first case-study template by slug', () => {
+    expect(getAllCaseStudySlugs()).toContain('first-customer-proof-template');
+    expect(getCaseStudyBySlug('first-customer-proof-template')).toEqual(
+      caseStudies[0],
+    );
+  });
+
+  it('keeps template content out of approved public proof', () => {
+    expect(getPublishedCaseStudies()).toEqual([]);
+    expect(getApprovedCaseStudyTestimonials()).toEqual([]);
+    expect(caseStudies[0].approvedForPublicUse).toBe(false);
+    expect(caseStudies[0].testimonial.approvedForPublicUse).toBe(false);
+  });
+
+  it('defines reusable proof slots for landing, pricing, and case-study surfaces', () => {
+    expect(caseStudyProofSlots.map((slot) => slot.placement)).toEqual([
+      'Homepage proof rail',
+      'Pricing page',
+      'Case-study hub',
+    ]);
+  });
+
+  it('does not include private-source placeholders in public data', () => {
+    const serialized = JSON.stringify({
+      caseStudies,
+      caseStudyPipeline,
+      caseStudyProofSlots,
+    }).toLowerCase();
+
+    for (const blockedTerm of [
+      'vault',
+      'gateway ventures',
+      'private strategy',
+    ]) {
+      expect(serialized).not.toContain(blockedTerm);
+    }
+  });
+});

--- a/apps/website/packages/data/case-studies.data.ts
+++ b/apps/website/packages/data/case-studies.data.ts
@@ -1,0 +1,281 @@
+export type CaseStudyStatus = 'template' | 'draft' | 'approved' | 'published';
+
+export interface CaseStudyMetric {
+  captureWindow: string;
+  evidenceRequired: string;
+  label: string;
+  value: string;
+}
+
+export interface CaseStudyPipelineStep {
+  description: string;
+  exitCriteria: string;
+  id: string;
+  label: string;
+  owner: string;
+  title: string;
+}
+
+export interface CaseStudyProofSlot {
+  description: string;
+  label: string;
+  metricPrompt: string;
+  placement: string;
+  title: string;
+}
+
+export interface CaseStudyTestimonial {
+  approvedForPublicUse: boolean;
+  attribution: string;
+  metricLabel: string;
+  metricValue: string;
+  quote: string;
+  role: string;
+  sourceCaseStudySlug: string;
+  statusLabel: string;
+}
+
+export interface CaseStudyWorkflowStep {
+  description: string;
+  evidence: string;
+  title: string;
+}
+
+export interface CaseStudyChecklistItem {
+  label: string;
+  required: boolean;
+}
+
+export interface CaseStudy {
+  approvedForPublicUse: boolean;
+  challenge: string;
+  companyName: string;
+  consentSummary: string;
+  customerType: string;
+  headline: string;
+  industry: string;
+  metrics: CaseStudyMetric[];
+  outcomeSummary: string;
+  publishChecklist: CaseStudyChecklistItem[];
+  solution: string;
+  slug: string;
+  status: CaseStudyStatus;
+  statusLabel: string;
+  summary: string;
+  testimonial: CaseStudyTestimonial;
+  updatedAt: string;
+  workflow: CaseStudyWorkflowStep[];
+}
+
+export const requiredCaseStudyMetrics = [
+  '60-day engagement lift',
+  'Time saved per week',
+  'Channels activated',
+] as const;
+
+export const caseStudyPipeline: CaseStudyPipelineStep[] = [
+  {
+    description:
+      'Confirm the customer is open to a public outcome story before any interview or metric request.',
+    exitCriteria:
+      'Written approval covers name/logo use, quoted language, metric ranges, and the review window.',
+    id: 'consent',
+    label: '01',
+    owner: 'Customer owner',
+    title: 'Consent',
+  },
+  {
+    description:
+      'Capture the baseline and first 60 days of Genfeed-assisted publishing performance.',
+    exitCriteria:
+      'Engagement lift, time saved, and channels activated are backed by source exports or screenshots.',
+    id: 'metrics',
+    label: '02',
+    owner: 'Customer owner + growth',
+    title: 'Metrics',
+  },
+  {
+    description:
+      'Draft a short proof asset with challenge, workflow, measured outcome, quote, and publish locations.',
+    exitCriteria:
+      'Draft uses only customer-approved facts and clearly marks unverified fields as placeholders.',
+    id: 'draft',
+    label: '03',
+    owner: 'Growth',
+    title: 'Draft',
+  },
+  {
+    description:
+      'Send the customer the exact copy, testimonial, metric presentation, and page preview for approval.',
+    exitCriteria:
+      'Customer approves the final text, attribution, and metric wording in writing.',
+    id: 'approval',
+    label: '04',
+    owner: 'Customer owner',
+    title: 'Approval',
+  },
+  {
+    description:
+      'Publish the case study and reuse the approved testimonial in pricing and landing-page proof slots.',
+    exitCriteria:
+      'The case-study entry is marked published and approved testimonials render without new component work.',
+    id: 'publish',
+    label: '05',
+    owner: 'Growth',
+    title: 'Publish',
+  },
+];
+
+export const caseStudyProofSlots: CaseStudyProofSlot[] = [
+  {
+    description:
+      'A customer quote tied to the measured 60-day lift after Genfeed enters the workflow.',
+    label: 'Slot 01',
+    metricPrompt: '60-day engagement lift',
+    placement: 'Homepage proof rail',
+    title: 'Outcome quote',
+  },
+  {
+    description:
+      'A quote from the operator or founder about hours saved after moving content production into Genfeed.',
+    label: 'Slot 02',
+    metricPrompt: 'Time saved per week',
+    placement: 'Pricing page',
+    title: 'Efficiency quote',
+  },
+  {
+    description:
+      'A quote connected to the number of channels activated or campaigns shipped through the platform.',
+    label: 'Slot 03',
+    metricPrompt: 'Channels activated',
+    placement: 'Case-study hub',
+    title: 'Activation quote',
+  },
+];
+
+export const caseStudies: CaseStudy[] = [
+  {
+    approvedForPublicUse: false,
+    challenge:
+      'Replace this with the customer-approved starting point: publishing cadence, workflow bottleneck, and measurable business goal before Genfeed.',
+    companyName: 'Customer-approved name',
+    consentSummary:
+      'Template only. Do not publish as customer proof until written approval covers attribution, metrics, quote, and preview copy.',
+    customerType: 'Early customer',
+    headline: 'Customer outcome case study template',
+    industry: 'Content, marketing, or creator team',
+    metrics: [
+      {
+        captureWindow: 'First 60 days after Genfeed-assisted publishing starts',
+        evidenceRequired: 'Baseline export plus 60-day analytics export',
+        label: '60-day engagement lift',
+        value: 'Replace with verified percentage or range',
+      },
+      {
+        captureWindow: 'Representative production week after onboarding',
+        evidenceRequired: 'Customer interview note or time-tracking summary',
+        label: 'Time saved per week',
+        value: 'Replace with verified hours saved',
+      },
+      {
+        captureWindow: 'Channels live by the end of the case-study window',
+        evidenceRequired: 'Connected-channel list or published campaign URLs',
+        label: 'Channels activated',
+        value: 'Replace with approved channel count',
+      },
+    ],
+    outcomeSummary:
+      'Replace with the customer-approved outcome summary after consent, metric capture, and final review.',
+    publishChecklist: [
+      {
+        label: 'Consent covers public name, logo, attribution, and quote use',
+        required: true,
+      },
+      {
+        label: '60-day engagement lift is backed by source evidence',
+        required: true,
+      },
+      {
+        label:
+          'Time saved and channels activated are verified with the customer',
+        required: true,
+      },
+      {
+        label: 'Customer has approved the final page preview',
+        required: true,
+      },
+      {
+        label:
+          'Pricing and landing-page testimonial slots point to approved copy',
+        required: true,
+      },
+    ],
+    slug: 'first-customer-proof-template',
+    solution:
+      'Replace this with the approved Genfeed workflow: source inputs, content formats generated, approval path, publishing channels, and measurement loop.',
+    status: 'template',
+    statusLabel: 'Template - not public proof yet',
+    summary:
+      'A reusable case-study structure for the first permissioned customer receipt. Fill the data fields and switch the status to published after approval.',
+    testimonial: {
+      approvedForPublicUse: false,
+      attribution: 'Approved customer spokesperson',
+      metricLabel: 'Metric pending',
+      metricValue: 'Awaiting verified result',
+      quote:
+        'Replace this with a customer-approved quote after the approval step.',
+      role: 'Customer-approved title',
+      sourceCaseStudySlug: 'first-customer-proof-template',
+      statusLabel: 'Template copy',
+    },
+    updatedAt: '2026-07-06',
+    workflow: [
+      {
+        description:
+          'Document the customer baseline before Genfeed enters the publishing workflow.',
+        evidence: '30-day baseline, current tools, weekly hours, channels live',
+        title: 'Baseline',
+      },
+      {
+        description:
+          'Capture the Genfeed setup: brand system, workflow, generated formats, approvals, and publishing destinations.',
+        evidence: 'Workflow summary, approved formats, channel list',
+        title: 'Genfeed workflow',
+      },
+      {
+        description:
+          'Measure the first 60 days against the baseline and summarize the operational change.',
+        evidence: '60-day analytics export, interview notes, approved quote',
+        title: 'Measured outcome',
+      },
+    ],
+  },
+];
+
+export function getAllCaseStudySlugs(): string[] {
+  return caseStudies.map((caseStudy) => caseStudy.slug);
+}
+
+export function getApprovedCaseStudyTestimonials(
+  limit = 3,
+): CaseStudyTestimonial[] {
+  return caseStudies
+    .filter(
+      (caseStudy) =>
+        caseStudy.status === 'published' && caseStudy.approvedForPublicUse,
+    )
+    .map((caseStudy) => caseStudy.testimonial)
+    .filter((testimonial) => testimonial.approvedForPublicUse)
+    .slice(0, limit);
+}
+
+export function getCaseStudyBySlug(slug: string): CaseStudy | undefined {
+  return caseStudies.find((caseStudy) => caseStudy.slug === slug);
+}
+
+export function getPublishedCaseStudies(): CaseStudy[] {
+  return caseStudies.filter(
+    (caseStudy) =>
+      caseStudy.status === 'published' && caseStudy.approvedForPublicUse,
+  );
+}


### PR DESCRIPTION
Closes #1436

## Summary
- Add a data-backed case-study/social-proof pipeline covering consent, metrics, draft, approval, and publish gates.
- Add `/case-studies` and `/case-studies/[slug]` public website surfaces with a reusable first-customer template, JSON-LD, and sitemap entries.
- Mount guarded testimonial slots on the homepage and pricing page so approved testimonials can publish from data without new component work.

## Public-safety notes
- The shipped template is explicitly marked as not public proof.
- No non-public customer names, vault references, or private strategy details are included.
- Placeholder proof slots do not render fabricated customer claims.

## Verification
- `bunx biome check --write` on the touched website TS/TSX files.
- `git diff --check`.
- Staged filename/content secret scans plus pre-commit `secretlint`.
- `bun --eval` smoke check for the case-study data contract.
- Targeted Vitest was attempted locally, but this isolated worktree has no `node_modules`; the shared Vitest config could not resolve `vitest/config`. PR CI should be used for runtime test coverage.