### PR TITLE
Enforce plan tier limits

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/organization/api-keys/content.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/organization/api-keys/content.test.tsx
@@ -25,6 +25,7 @@ const mocks = vi.hoisted(() => ({
   revokeApiKey: vi.fn(),
   rotateApiKey: vi.fn(),
   saveByokProviderKey: vi.fn(),
+  settingsSubscriptionTier: 'pro',
   validateByokProviderKey: vi.fn(),
 }));
 
@@ -32,6 +33,7 @@ vi.mock('@contexts/user/brand-context/brand-context', () => ({
   useBrand: () => ({
     isReady: mocks.isReady,
     organizationId: mocks.organizationId,
+    settings: { subscriptionTier: mocks.settingsSubscriptionTier },
   }),
 }));
 
@@ -232,6 +234,7 @@ describe('SettingsApiKeysPage', () => {
     mocks.isReady = true;
     mocks.isSelfHosted = false;
     mocks.organizationId = 'org-1';
+    mocks.settingsSubscriptionTier = 'pro';
     mocks.getByokAllProviders.mockResolvedValue(providerStatuses());
     mocks.findAllApiKeys.mockResolvedValue(productApiKeys());
     mocks.createApiKey.mockResolvedValue({
@@ -312,6 +315,24 @@ describe('SettingsApiKeysPage', () => {
     });
 
     expect(screen.getByText('gf_test_created')).toBeInTheDocument();
+  });
+
+  it('disables Genfeed API key creation for free-tier organizations', async () => {
+    mocks.settingsSubscriptionTier = 'free';
+    render(<SettingsApiKeysPage />);
+
+    await screen.findByText('MCP Key');
+    expect(
+      screen.getByText(/API access is included on paid plans/),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Create Key' })).toBeDisabled();
+
+    fireEvent.change(screen.getByPlaceholderText('MCP Server'), {
+      target: { value: 'Automation MCP' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create Key' }));
+
+    expect(mocks.createApiKey).not.toHaveBeenCalled();
   });
 
   it('rotates and revokes Genfeed API keys', async () => {

--- a/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/organization/api-keys/content.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/organization/api-keys/content.tsx
@@ -5,6 +5,7 @@ import { API_KEY_SCOPE_PRESETS } from '@genfeedai/constants/api-key-presets.cons
 import type { ButtonVariant } from '@genfeedai/enums';
 import type { IByokProviderStatus } from '@genfeedai/interfaces';
 import type { ApiKey } from '@genfeedai/models/auth/api-key.model';
+import { hasApiAccess } from '@genfeedai/pricing';
 import { useAuthedService } from '@hooks/auth/use-authed-service/use-authed-service';
 import { logger } from '@services/core/logger.service';
 import { NotificationsService } from '@services/core/notifications.service';
@@ -213,8 +214,11 @@ function getVisibleKey(apiKey: ApiKey): string | undefined {
 }
 
 export default function SettingsApiKeysPage() {
-  const { organizationId, isReady } = useBrand();
+  const { organizationId, isReady, settings } = useBrand();
   const desktop = isDesktopShell();
+  const isSelfHostedDeployment = isSelfHosted();
+  const hasProductApiAccess =
+    isSelfHostedDeployment || hasApiAccess(settings?.subscriptionTier);
 
   const [state, dispatch] = useReducer(apiKeysReducer, initialApiKeysState);
   const [productApiKeys, setProductApiKeys] = useState<ApiKey[]>([]);
@@ -347,6 +351,13 @@ export default function SettingsApiKeysPage() {
   };
 
   const handleCreateProductKey = async () => {
+    if (!hasProductApiAccess) {
+      NotificationsService.getInstance().error(
+        'API access is available on paid plans.',
+      );
+      return;
+    }
+
     const label = productForm.label.trim();
     if (!label || productForm.selectedScopes.length === 0) {
       return;
@@ -524,7 +535,7 @@ export default function SettingsApiKeysPage() {
   return (
     <div className="space-y-6">
       {desktop ? <DesktopLocalProviderSettings variant="card" /> : null}
-      {isSelfHosted() ? <ManagedCreditsCheckoutCard /> : null}
+      {isSelfHostedDeployment ? <ManagedCreditsCheckoutCard /> : null}
 
       <ApiKeysHeader />
 
@@ -537,6 +548,12 @@ export default function SettingsApiKeysPage() {
                 Use these keys for CLI profiles, MCP servers, and unattended
                 workflows.
               </p>
+              {!hasProductApiAccess ? (
+                <p className="mt-2 text-xs text-amber-600">
+                  API access is included on paid plans. Upgrade to Pro to create
+                  Genfeed API keys.
+                </p>
+              ) : null}
             </div>
             <Button
               variant={SECONDARY_BUTTON_VARIANT}
@@ -675,6 +692,7 @@ export default function SettingsApiKeysPage() {
               onClick={handleCreateProductKey}
               isDisabled={
                 isCreatingProductKey ||
+                !hasProductApiAccess ||
                 !productForm.label.trim() ||
                 productForm.selectedScopes.length === 0
               }

--- a/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/organization/billing/content.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/organization/billing/content.tsx
@@ -2,6 +2,7 @@
 
 import { useBrand } from '@contexts/user/brand-context/brand-context';
 import { ButtonVariant, ByokBillingStatus } from '@genfeedai/enums';
+import { getPlanEntitlementForTier } from '@genfeedai/pricing';
 import {
   BYOK_FEE_PERCENTAGE,
   BYOK_FREE_THRESHOLD_CREDITS,
@@ -39,6 +40,20 @@ function BillingCard({
       </VStack>
     </Card>
   );
+}
+
+function formatPlanLimit(limit: number | null): string {
+  return limit === null ? 'Unlimited' : limit.toLocaleString();
+}
+
+function getApiAccessLabel(
+  entitlement: ReturnType<typeof getPlanEntitlementForTier>,
+): string {
+  if (!entitlement.apiAccess) {
+    return 'Paid plans';
+  }
+
+  return entitlement.apiRateLimit === null ? 'Custom' : 'Included';
 }
 
 function ByokUsageSection({
@@ -138,7 +153,7 @@ function ByokUsageSection({
 }
 
 export default function SettingsBillingPage() {
-  const { isReady } = useBrand();
+  const { isReady, settings } = useBrand();
   const {
     subscription,
     creditsBreakdown,
@@ -164,6 +179,7 @@ export default function SettingsBillingPage() {
       )
     : null;
   const isLowCredits = (creditsBreakdown?.total ?? 0) < 1000;
+  const planEntitlement = getPlanEntitlementForTier(settings?.subscriptionTier);
 
   if (!isReady || isLoading) {
     return (
@@ -221,6 +237,43 @@ export default function SettingsBillingPage() {
             No active subscription. Subscribe to unlock all features.
           </Text>
         )}
+      </BillingCard>
+
+      <BillingCard title="Plan Limits">
+        <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+          <div className="p-4 bg-muted/50 rounded">
+            <Text size="sm" color="muted">
+              Brands
+            </Text>
+            <Text as="p" size="lg" weight="bold">
+              {formatPlanLimit(planEntitlement.brandLimit)}
+            </Text>
+          </div>
+          <div className="p-4 bg-muted/50 rounded">
+            <Text size="sm" color="muted">
+              Channels
+            </Text>
+            <Text as="p" size="lg" weight="bold">
+              {formatPlanLimit(planEntitlement.channelLimit)}
+            </Text>
+          </div>
+          <div className="p-4 bg-muted/50 rounded">
+            <Text size="sm" color="muted">
+              Seats
+            </Text>
+            <Text as="p" size="lg" weight="bold">
+              {formatPlanLimit(planEntitlement.seatLimit)}
+            </Text>
+          </div>
+          <div className="p-4 bg-muted/50 rounded">
+            <Text size="sm" color="muted">
+              API
+            </Text>
+            <Text as="p" size="lg" weight="bold">
+              {getApiAccessLabel(planEntitlement)}
+            </Text>
+          </div>
+        </div>
       </BillingCard>
 
       {isByokTier && <ByokUsageSection openBillingPortal={openBillingPortal} />}

--- a/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/organization/members/members-list.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/organization/members/members-list.test.tsx
@@ -6,6 +6,7 @@ import '@testing-library/jest-dom/vitest';
 vi.mock('@contexts/user/brand-context/brand-context', () => ({
   useBrand: vi.fn(() => ({
     organizationId: 'org-123',
+    settings: { subscriptionTier: 'pro' },
   })),
 }));
 

--- a/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/organization/members/members-list.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/organization/members/members-list.tsx
@@ -4,6 +4,10 @@ import { useBrand } from '@contexts/user/brand-context/brand-context';
 import { EMPTY_STATES, ITEMS_PER_PAGE } from '@genfeedai/constants';
 import { ModalEnum } from '@genfeedai/enums';
 import type { IQueryParams } from '@genfeedai/interfaces';
+import {
+  getSeatLimitForTier,
+  getUpgradeTierForLimit,
+} from '@genfeedai/pricing';
 import { formatDate } from '@helpers/formatting/date/date.helper';
 import { openModal } from '@helpers/ui/modal/modal.helper';
 import { useAuthedService } from '@hooks/auth/use-authed-service/use-authed-service';
@@ -21,9 +25,21 @@ import { useSearchParams } from 'next/navigation';
 import { Suspense, useCallback, useEffect, useState } from 'react';
 import { HiOutlineUsers, HiUserPlus } from 'react-icons/hi2';
 
+function formatTierLabel(tier: string | null): string {
+  if (!tier) {
+    return 'a paid plan';
+  }
+
+  return tier.charAt(0).toUpperCase() + tier.slice(1);
+}
+
+function formatSeatLabel(limit: number): string {
+  return limit === 1 ? 'team seat' : 'team seats';
+}
+
 function MembersListContent() {
   const notificationsService = NotificationsService.getInstance();
-  const { organizationId } = useBrand();
+  const { organizationId, settings } = useBrand();
   const searchParams = useSearchParams();
   const currentPage = Number(searchParams.get('page')) || 1;
 
@@ -86,15 +102,26 @@ function MembersListContent() {
     findAllMembers();
   }, [findAllMembers]);
 
+  const seatLimit = getSeatLimitForTier(settings?.subscriptionTier);
+  const isAtSeatLimit =
+    seatLimit !== null && members !== null && members.length >= seatLimit;
+  const memberLimitDescription = isAtSeatLimit
+    ? `Current plan includes ${seatLimit} ${formatSeatLabel(seatLimit)}. Upgrade to ${formatTierLabel(
+        getUpgradeTierForLimit('seats', settings?.subscriptionTier),
+      )} to invite more people.`
+    : undefined;
+
   return (
     <Container
       label="Team Members"
+      description={memberLimitDescription}
       icon={HiOutlineUsers}
       right={
         <Button
           onClick={() => openModal(ModalEnum.MEMBER)}
           icon={<HiUserPlus className="size-4" />}
           label="Invite Member"
+          isDisabled={isAtSeatLimit}
         />
       }
     >

--- a/apps/app/app/(protected)/[orgSlug]/~/settings/brands/brands-list.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/settings/brands/brands-list.test.tsx
@@ -17,6 +17,7 @@ const mockBrands = [
 vi.mock('@contexts/user/brand-context/brand-context', () => ({
   useBrand: vi.fn(() => ({
     organizationId: 'org-123',
+    settings: { subscriptionTier: 'pro' },
   })),
 }));
 

--- a/apps/app/app/(protected)/[orgSlug]/~/settings/brands/brands-list.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/settings/brands/brands-list.tsx
@@ -3,6 +3,10 @@
 import { useBrand } from '@contexts/user/brand-context/brand-context';
 import { ButtonVariant } from '@genfeedai/enums';
 import type { IQueryParams } from '@genfeedai/interfaces';
+import {
+  getBrandLimitForTier,
+  getUpgradeTierForLimit,
+} from '@genfeedai/pricing';
 import { useAuthedService } from '@hooks/auth/use-authed-service/use-authed-service';
 import type { Brand } from '@models/organization/brand.model';
 import {
@@ -30,8 +34,20 @@ import { ClientFormattedDate } from '@/components/ui/client-formatted-date';
 
 const ITEMS_PER_PAGE = 20;
 
+function formatTierLabel(tier: string | null): string {
+  if (!tier) {
+    return 'a paid plan';
+  }
+
+  return tier.charAt(0).toUpperCase() + tier.slice(1);
+}
+
+function formatBrandLabel(limit: number): string {
+  return limit === 1 ? 'brand kit' : 'brand kits';
+}
+
 function BrandsListContent() {
-  const { organizationId } = useBrand();
+  const { organizationId, settings } = useBrand();
   const { openBrandOverlay } = useBrandOverlay();
   const { openConfirm } = useConfirmModal();
   const notificationsService = NotificationsService.getInstance();
@@ -84,6 +100,15 @@ function BrandsListContent() {
   const refresh = useCallback(async () => {
     await refetch();
   }, [refetch]);
+
+  const brandLimit = getBrandLimitForTier(settings?.subscriptionTier);
+  const isAtBrandLimit =
+    brandLimit !== null && !isLoading && (brands?.length ?? 0) >= brandLimit;
+  const brandLimitDescription = isAtBrandLimit
+    ? `Current plan includes ${brandLimit} ${formatBrandLabel(brandLimit)}. Upgrade to ${formatTierLabel(
+        getUpgradeTierForLimit('brands', settings?.subscriptionTier),
+      )} to add more.`
+    : 'Manage brands and settings.';
 
   const handleDelete = useCallback(
     async (brand: Brand) => {
@@ -190,13 +215,14 @@ function BrandsListContent() {
   return (
     <Container
       label="Brands"
-      description="Manage brands and settings."
+      description={brandLimitDescription}
       icon={HiOutlineBuildingOffice2}
       right={
         <Button
           variant={ButtonVariant.DEFAULT}
           icon={<HiPlus />}
           label="Add Brand"
+          isDisabled={isAtBrandLimit}
           onClick={() => openBrandOverlay(null, () => refresh())}
         />
       }

--- a/apps/server/api/src/collections/brands/brands.module.ts
+++ b/apps/server/api/src/collections/brands/brands.module.ts
@@ -25,7 +25,6 @@ import { PostsModule } from '@api/collections/posts/posts.module';
 import { VideosModule } from '@api/collections/videos/videos.module';
 import { WorkflowsModule } from '@api/collections/workflows/workflows.module';
 import { BrandCreditsGuard } from '@api/helpers/guards/brand-credits/brand-credits.guard';
-import { CreditsInterceptor } from '@api/helpers/interceptors/credits/credits.interceptor';
 import { BrandScraperModule } from '@api/services/brand-scraper/brand-scraper.module';
 import { ByokModule } from '@api/services/byok/byok.module';
 import { FilesClientModule } from '@api/services/files-microservice/client/files-client.module';
@@ -64,7 +63,6 @@ import { forwardRef, Module } from '@nestjs/common';
   providers: [
     BrandsService,
     BrandCreditsGuard,
-    CreditsInterceptor,
     DefaultRecurringContentService,
     // Brand-setup orchestration (scrape → analyze → guidance → slug sync),
     // dissolved out of OnboardingModule per REST audit #1354 so the brand write

--- a/apps/server/api/src/collections/brands/controllers/brands-agent-config.controller.spec.ts
+++ b/apps/server/api/src/collections/brands/controllers/brands-agent-config.controller.spec.ts
@@ -56,7 +56,6 @@ describe('BrandsController agent-config endpoint', () => {
     };
 
     controller = new BrandsController(
-      mockRequest,
       mockBrandsService as unknown as BrandsService,
       {} as never,
       {} as never,
@@ -70,6 +69,7 @@ describe('BrandsController agent-config endpoint', () => {
       {} as never,
       {} as never,
       loggerService as unknown as LoggerService,
+      {} as never,
     );
 
     vi.clearAllMocks();

--- a/apps/server/api/src/collections/brands/controllers/brands.controller.spec.ts
+++ b/apps/server/api/src/collections/brands/controllers/brands.controller.spec.ts
@@ -1,7 +1,6 @@
 import type { BrandEntity } from '@api/collections/brands/entities/brand.entity';
 import { BrandCreditsGuard } from '@api/helpers/guards/brand-credits/brand-credits.guard';
 import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
-import { CreditsInterceptor } from '@api/helpers/interceptors/credits/credits.interceptor';
 import type { AggregatePaginateResult } from '@api/types/aggregate-paginate-result';
 import 'reflect-metadata';
 
@@ -165,11 +164,6 @@ describe('BrandsController', () => {
       .useValue({ canActivate: () => true })
       .overrideGuard(BrandCreditsGuard)
       .useValue({ canActivate: () => true })
-      .overrideInterceptor(CreditsInterceptor)
-      .useValue({
-        intercept: (_ctx: unknown, next: { handle: () => unknown }) =>
-          next.handle(),
-      })
       .compile();
 
     controller = module.get<BrandsController>(BrandsController);

--- a/apps/server/api/src/collections/brands/controllers/brands.controller.ts
+++ b/apps/server/api/src/collections/brands/controllers/brands.controller.ts
@@ -28,7 +28,6 @@ import { VideosService } from '@api/collections/videos/services/videos.service';
 import { BrandSetupDto } from '@api/endpoints/onboarding/dto/brand-setup.dto';
 import { AddReferenceImagesDto } from '@api/endpoints/onboarding/dto/reference-images.dto';
 import { Cache } from '@api/helpers/decorators/cache/cache.decorator';
-import { Credits } from '@api/helpers/decorators/credits/credits.decorator';
 import { LogMethod } from '@api/helpers/decorators/log/log-method.decorator';
 import { RolesDecorator } from '@api/helpers/decorators/roles/roles.decorator';
 import { AutoSwagger } from '@api/helpers/decorators/swagger/auto-swagger.decorator';
@@ -36,7 +35,6 @@ import { CurrentUser } from '@api/helpers/decorators/user/current-user.decorator
 import { BaseQueryDto } from '@api/helpers/dto/base-query.dto';
 import { BrandCreditsGuard } from '@api/helpers/guards/brand-credits/brand-credits.guard';
 import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
-import { CreditsInterceptor } from '@api/helpers/interceptors/credits/credits.interceptor';
 import {
   getIsSuperAdmin,
   getPublicMetadata,
@@ -62,16 +60,13 @@ import {
   HttpCode,
   HttpException,
   HttpStatus,
-  Inject,
   Param,
   Patch,
   Post,
   Query,
   Req,
   UseGuards,
-  UseInterceptors,
 } from '@nestjs/common';
-import { REQUEST } from '@nestjs/core';
 import type { Request } from 'express';
 
 @AutoSwagger()
@@ -84,8 +79,6 @@ export class BrandsController extends BaseCRUDController<
   BaseQueryDto
 > {
   constructor(
-    @Inject(REQUEST) private readonly request: Request,
-
     public readonly brandsService: BrandsService,
     public readonly activitiesService: ActivitiesService,
     public readonly videosService: VideosService,
@@ -315,8 +308,6 @@ export class BrandsController extends BaseCRUDController<
 
   @Post()
   @UseGuards(BrandCreditsGuard)
-  @UseInterceptors(CreditsInterceptor)
-  @Credits({ amount: 1_000, description: 'Create brand' })
   @LogMethod({ logEnd: false, logError: true, logStart: true })
   async create(
     @Req() request: Request,
@@ -324,38 +315,9 @@ export class BrandsController extends BaseCRUDController<
     @Body() createDto: CreateBrandDto,
   ): Promise<JsonApiSingleResponse> {
     const enrichedDto = this.enrichCreateDto(createDto, user);
+    const data: BrandDocument = await this.brandsService.create(enrichedDto);
 
-    const limit = (
-      this.request as unknown as {
-        brandsLimit?: { id: string; current: number };
-      }
-    ).brandsLimit;
-    let limitUpdated = false;
-
-    try {
-      // Atomically update the brand limit to the new count before creating the brand
-      if (limit) {
-        await this.organizationSettingsService.updateBrandsLimit(
-          limit.id,
-          limit.current + 1,
-        );
-
-        limitUpdated = true;
-      }
-
-      const data: BrandDocument = await this.brandsService.create(enrichedDto);
-
-      return serializeSingle(request, BrandSerializer, data);
-    } catch (error: unknown) {
-      // Rollback the limit to the original count if brand creation fails
-      if (limitUpdated && limit) {
-        await this.organizationSettingsService.updateBrandsLimit(
-          limit.id,
-          limit.current,
-        );
-      }
-      throw error;
-    }
+    return serializeSingle(request, BrandSerializer, data);
   }
 
   /**

--- a/apps/server/api/src/collections/credentials/services/credentials.service.spec.ts
+++ b/apps/server/api/src/collections/credentials/services/credentials.service.spec.ts
@@ -8,9 +8,22 @@ vi.mock('@genfeedai/prisma', async () => {
   return canonicalPrismaMock();
 });
 
+let mockCloudMode = true;
+vi.mock('@genfeedai/config', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@genfeedai/config')>();
+  return {
+    ...actual,
+    get IS_CLOUD_MODE() {
+      return mockCloudMode;
+    },
+  };
+});
+
 import process from 'node:process';
 import { CredentialCryptoService } from '@api/collections/credentials/services/credential-crypto.service';
 import { CredentialsService } from '@api/collections/credentials/services/credentials.service';
+import { SubscriptionTier } from '@genfeedai/enums';
+import { FREE_CHANNEL_LIMIT, PRO_CHANNEL_LIMIT } from '@genfeedai/pricing';
 import type { ConfigService } from '@libs/config/config.service';
 
 const KEY =
@@ -27,6 +40,7 @@ describe('CredentialsService', () => {
   const brandId = 'test-brand-id';
 
   beforeEach(() => {
+    mockCloudMode = true;
     prisma = {
       credential: {
         count: vi.fn().mockResolvedValue(0),
@@ -38,6 +52,11 @@ describe('CredentialsService', () => {
           Promise.resolve({ id: 'existing-id', ...args.data }),
         ),
         updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
+      organizationSetting: {
+        findUnique: vi.fn().mockResolvedValue({
+          subscriptionTier: SubscriptionTier.FREE,
+        }),
       },
     };
     logger = { debug: vi.fn(), error: vi.fn(), log: vi.fn(), warn: vi.fn() };
@@ -208,6 +227,125 @@ describe('CredentialsService', () => {
       >;
       expect(data.accessToken).toMatch(CIPHERTEXT_PATTERN);
       expect(crypto.decrypt(data.accessToken)).toBe('save-raw');
+    });
+  });
+
+  describe('connected-channel plan limits', () => {
+    const connectedCredentialDto = {
+      brand: brandId,
+      isConnected: true,
+      organization: orgId,
+      platform: 'twitter',
+      user: 'u1',
+    };
+
+    it('blocks a new connected credential when PAYG has reached its channel limit', async () => {
+      prisma.credential.count.mockResolvedValue(FREE_CHANNEL_LIMIT);
+
+      await expect(
+        service.create(connectedCredentialDto as never),
+      ).rejects.toMatchObject({
+        response: {
+          code: 'PLAN_LIMIT_EXCEEDED',
+          meta: {
+            currentCount: FREE_CHANNEL_LIMIT,
+            limit: FREE_CHANNEL_LIMIT,
+            resource: 'channels',
+            upgradeTier: SubscriptionTier.PRO,
+          },
+        },
+        status: 403,
+      });
+      expect(prisma.credential.create).not.toHaveBeenCalled();
+    });
+
+    it('allows Pro while under its channel limit', async () => {
+      prisma.organizationSetting.findUnique.mockResolvedValue({
+        subscriptionTier: SubscriptionTier.PRO,
+      });
+      prisma.credential.count.mockResolvedValue(PRO_CHANNEL_LIMIT - 1);
+
+      await expect(
+        service.create(connectedCredentialDto as never),
+      ).resolves.toMatchObject({ id: 'new-id' });
+      expect(prisma.credential.create).toHaveBeenCalled();
+    });
+
+    it('blocks Pro at its channel limit and points to Scale', async () => {
+      prisma.organizationSetting.findUnique.mockResolvedValue({
+        subscriptionTier: SubscriptionTier.PRO,
+      });
+      prisma.credential.count.mockResolvedValue(PRO_CHANNEL_LIMIT);
+
+      await expect(
+        service.create(connectedCredentialDto as never),
+      ).rejects.toMatchObject({
+        response: {
+          meta: {
+            limit: PRO_CHANNEL_LIMIT,
+            resource: 'channels',
+            upgradeTier: SubscriptionTier.SCALE,
+          },
+        },
+      });
+    });
+
+    it('does not count channels for Scale because the tier is unlimited', async () => {
+      prisma.organizationSetting.findUnique.mockResolvedValue({
+        subscriptionTier: SubscriptionTier.SCALE,
+      });
+
+      await expect(
+        service.create(connectedCredentialDto as never),
+      ).resolves.toMatchObject({ id: 'new-id' });
+      expect(prisma.credential.count).not.toHaveBeenCalled();
+    });
+
+    it('allows patching an already connected credential without consuming another channel', async () => {
+      prisma.credential.findFirst.mockResolvedValue({
+        id: 'existing-id',
+        isConnected: true,
+        isDeleted: false,
+        organizationId: orgId,
+      });
+
+      await expect(
+        service.patch('existing-id', { isConnected: true }),
+      ).resolves.toMatchObject({ id: 'existing-id' });
+      expect(prisma.credential.count).not.toHaveBeenCalled();
+    });
+
+    it('blocks patching a pending credential connected when the tier is already at its channel limit', async () => {
+      prisma.credential.findFirst.mockResolvedValue({
+        id: 'existing-id',
+        isConnected: false,
+        isDeleted: false,
+        organizationId: orgId,
+      });
+      prisma.credential.count.mockResolvedValue(FREE_CHANNEL_LIMIT);
+
+      await expect(
+        service.patch('existing-id', { isConnected: true }),
+      ).rejects.toMatchObject({
+        response: {
+          code: 'PLAN_LIMIT_EXCEEDED',
+          meta: {
+            resource: 'channels',
+            upgradeTier: SubscriptionTier.PRO,
+          },
+        },
+      });
+      expect(prisma.credential.update).not.toHaveBeenCalled();
+    });
+
+    it('skips cloud plan limits outside managed cloud', async () => {
+      mockCloudMode = false;
+
+      await expect(
+        service.create(connectedCredentialDto as never),
+      ).resolves.toMatchObject({ id: 'new-id' });
+      expect(prisma.organizationSetting.findUnique).not.toHaveBeenCalled();
+      expect(prisma.credential.count).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/server/api/src/collections/credentials/services/credentials.service.ts
+++ b/apps/server/api/src/collections/credentials/services/credentials.service.ts
@@ -3,14 +3,38 @@ import { UpdateCredentialDto } from '@api/collections/credentials/dto/update-cre
 import { CredentialEntity } from '@api/collections/credentials/entities/credential.entity';
 import type { CredentialDocument } from '@api/collections/credentials/schemas/credential.schema';
 import { CredentialCryptoService } from '@api/collections/credentials/services/credential-crypto.service';
+import { PlanLimitExceededException } from '@api/helpers/exceptions/business/business-logic.exception';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { BaseService } from '@api/shared/services/base/base.service';
+import { IS_CLOUD_MODE } from '@genfeedai/config';
 import { CredentialPlatform } from '@genfeedai/enums';
 import type { PopulateOption } from '@genfeedai/interfaces';
+import {
+  getChannelLimitForTier,
+  getUpgradeTierForLimit,
+} from '@genfeedai/pricing';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
 
 type PopulateInput = (string | PopulateOption)[] | 'none';
+
+function readStringId(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (value && typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    if (typeof record.id === 'string') {
+      return record.id;
+    }
+    if (typeof record._id === 'string') {
+      return record._id;
+    }
+  }
+
+  return '';
+}
 
 @Injectable()
 export class CredentialsService extends BaseService<
@@ -34,10 +58,15 @@ export class CredentialsService extends BaseService<
    * each read site (see `CredentialHelper.getDecryptedCredential`). The crypto
    * is idempotent, so values that arrive already encrypted are left untouched.
    */
-  override create(
+  override async create(
     createDto: CreateCredentialDto,
     populate: PopulateInput = [],
   ): Promise<CredentialDocument> {
+    await this.assertChannelLimitForConnect(
+      null,
+      createDto as unknown as Record<string, unknown>,
+    );
+
     return super.create(
       this.cryptoService.encryptSecretFields(
         createDto as unknown as Record<string, unknown>,
@@ -46,11 +75,16 @@ export class CredentialsService extends BaseService<
     );
   }
 
-  override patch(
+  override async patch(
     id: string,
     updateDto: Partial<UpdateCredentialDto> | Record<string, unknown>,
     populate: PopulateInput = [],
   ): Promise<CredentialDocument> {
+    await this.assertChannelLimitForConnect(
+      id,
+      updateDto as Record<string, unknown>,
+    );
+
     return super.patch(
       id,
       this.cryptoService.encryptSecretFields(
@@ -58,6 +92,58 @@ export class CredentialsService extends BaseService<
       ),
       populate,
     );
+  }
+
+  private async assertChannelLimitForConnect(
+    credentialId: string | null,
+    mutation: Record<string, unknown>,
+  ): Promise<void> {
+    if (!IS_CLOUD_MODE || mutation.isConnected !== true) {
+      return;
+    }
+
+    const existing = credentialId
+      ? await this.findOne({ _id: credentialId })
+      : null;
+
+    if (existing?.isConnected === true && existing.isDeleted !== true) {
+      return;
+    }
+
+    const organizationId = readStringId(
+      mutation.organizationId ??
+        mutation.organization ??
+        existing?.organizationId ??
+        existing?.organization,
+    );
+
+    if (!organizationId) {
+      return;
+    }
+
+    const setting = await this.prisma.organizationSetting.findUnique({
+      select: { subscriptionTier: true },
+      where: { organizationId },
+    });
+    const tier = setting?.subscriptionTier ?? null;
+    const channelLimit = getChannelLimitForTier(tier);
+
+    if (channelLimit === null) {
+      return;
+    }
+
+    const connectedCount = await this.countConnected(organizationId);
+
+    if (connectedCount < channelLimit) {
+      return;
+    }
+
+    throw new PlanLimitExceededException({
+      currentCount: connectedCount,
+      limit: channelLimit,
+      resource: 'channels',
+      upgradeTier: getUpgradeTierForLimit('channels', tier),
+    });
   }
 
   override patchAll(

--- a/apps/server/api/src/collections/organization-settings/utils/seat-policy.util.ts
+++ b/apps/server/api/src/collections/organization-settings/utils/seat-policy.util.ts
@@ -1,4 +1,5 @@
 import { SubscriptionTier } from '@genfeedai/enums';
+import { FREE_SEAT_LIMIT } from '@genfeedai/pricing';
 
 /**
  * Seat policy resolution.
@@ -17,7 +18,7 @@ import { SubscriptionTier } from '@genfeedai/enums';
  * solo workspace). Mirrors the Prisma `OrganizationSetting.seatsLimit`
  * default applied at org-creation call sites.
  */
-export const DEFAULT_FREE_SEATS = 1;
+export const DEFAULT_FREE_SEATS = FREE_SEAT_LIMIT;
 
 /**
  * Sentinel returned by {@link resolveEffectiveSeatsLimit} for tiers that include

--- a/apps/server/api/src/collections/organizations/controllers/organizations-members.controller.spec.ts
+++ b/apps/server/api/src/collections/organizations/controllers/organizations-members.controller.spec.ts
@@ -26,7 +26,6 @@ import { BetterAuthIdentityCacheService } from '@api/common/services/better-auth
 import { RequestContextCacheService } from '@api/common/services/request-context-cache.service';
 import { MemberCreditsGuard } from '@api/helpers/guards/member-credits/member-credits.guard';
 import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
-import { CreditsInterceptor } from '@api/helpers/interceptors/credits/credits.interceptor';
 import { ConfigService } from '@libs/config/config.service';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Test, TestingModule } from '@nestjs/testing';
@@ -178,11 +177,6 @@ describe('OrganizationsMembersController', () => {
       .useValue({ canActivate: () => true })
       .overrideGuard(MemberCreditsGuard)
       .useValue({ canActivate: () => true })
-      .overrideInterceptor(CreditsInterceptor)
-      .useValue({
-        intercept: (_ctx: unknown, next: { handle: () => unknown }) =>
-          next.handle(),
-      })
       .compile();
 
     controller = module.get<OrganizationsMembersController>(

--- a/apps/server/api/src/collections/organizations/controllers/organizations-members.controller.ts
+++ b/apps/server/api/src/collections/organizations/controllers/organizations-members.controller.ts
@@ -14,7 +14,6 @@ import { InviteMemberDto } from '@api/collections/members/dto/invite-member.dto'
 import { UpdateMemberDto } from '@api/collections/members/dto/update-member.dto';
 import { InvitationService } from '@api/collections/members/services/invitation.service';
 import { MembersService } from '@api/collections/members/services/members.service';
-import { OrganizationSettingsService } from '@api/collections/organization-settings/services/organization-settings.service';
 import { OrganizationsService } from '@api/collections/organizations/services/organizations.service';
 import { RolesService } from '@api/collections/roles/services/roles.service';
 import { SettingsService } from '@api/collections/settings/services/settings.service';
@@ -22,14 +21,12 @@ import { UsersService } from '@api/collections/users/services/users.service';
 import { AccessBootstrapCacheService } from '@api/common/services/access-bootstrap-cache.service';
 import { BetterAuthIdentityCacheService } from '@api/common/services/better-auth-identity-cache.service';
 import { RequestContextCacheService } from '@api/common/services/request-context-cache.service';
-import { Credits } from '@api/helpers/decorators/credits/credits.decorator';
 import { LogMethod } from '@api/helpers/decorators/log/log-method.decorator';
 import { AutoSwagger } from '@api/helpers/decorators/swagger/auto-swagger.decorator';
 import { CurrentUser } from '@api/helpers/decorators/user/current-user.decorator';
 import { BaseQueryDto } from '@api/helpers/dto/base-query.dto';
 import { MemberCreditsGuard } from '@api/helpers/guards/member-credits/member-credits.guard';
 import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
-import { CreditsInterceptor } from '@api/helpers/interceptors/credits/credits.interceptor';
 import { getPublicMetadata } from '@api/helpers/utils/auth/auth.util';
 import { customLabels } from '@api/helpers/utils/pagination/pagination.util';
 import { QueryDefaultsUtil } from '@api/helpers/utils/query-defaults/query-defaults.util';
@@ -57,7 +54,6 @@ import {
   Query,
   Req,
   UseGuards,
-  UseInterceptors,
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import type { Request } from 'express';
@@ -74,7 +70,6 @@ export class OrganizationsMembersController {
     private readonly loggerService: LoggerService,
     private readonly membersService: MembersService,
     private readonly organizationsService: OrganizationsService,
-    private readonly organizationSettingsService: OrganizationSettingsService,
     private readonly rolesService: RolesService,
     private readonly settingsService: SettingsService,
     private readonly usersService: UsersService,
@@ -119,8 +114,6 @@ export class OrganizationsMembersController {
 
   @Post(':organizationId/members')
   @UseGuards(MemberCreditsGuard)
-  @UseInterceptors(CreditsInterceptor)
-  @Credits({ amount: 1000, description: 'Invite member' })
   async inviteMember(
     @Req() request: Request,
     @Param('organizationId') organizationId: string,
@@ -177,59 +170,33 @@ export class OrganizationsMembersController {
 
     if (existingUser) {
       // Existing first-party users can be added immediately.
-      const limit = (
-        request as unknown as { seatsLimit?: { id: string; current: number } }
-      ).seatsLimit;
-      let limitUpdated = false;
+      const member = await this.membersService.create({
+        isActive: true,
+        organizationId,
+        roleId: String(roleToAssign),
+        userId: String(existingUser.id),
+      } as unknown as Parameters<typeof this.membersService.create>[0]);
 
-      try {
-        // Atomically update the seats limit
-        if (limit) {
-          await this.organizationSettingsService.updateSeatsLimit(
-            limit.id,
-            limit.current + 1,
-          );
-          limitUpdated = true;
-        }
+      // Switch the invited user's active org to the org they were just added
+      // to, preserving the pre-Phase-C behavior now that routing is
+      // DB-authoritative (epic #735 — User.lastUsedOrganizationId replaces the
+      // legacy auth provider publicMetadata.organization write-back).
+      await this.usersService.patch(String(existingUser.id), {
+        lastUsedOrganizationId: organizationId,
+      });
+      await Promise.all([
+        this.requestContextCacheService.invalidateForUser(
+          String(existingUser._id),
+        ),
+        this.accessBootstrapCacheService.invalidateForUser(
+          String(existingUser._id),
+        ),
+        this.betterAuthIdentityCacheService.invalidateForUser(
+          String(existingUser._id),
+        ),
+      ]);
 
-        // Create the member record for existing user
-        const member = await this.membersService.create({
-          isActive: true,
-          organizationId,
-          roleId: String(roleToAssign),
-          userId: String(existingUser.id),
-        } as unknown as Parameters<typeof this.membersService.create>[0]);
-
-        // Switch the invited user's active org to the org they were just added
-        // to, preserving the pre-Phase-C behavior now that routing is
-        // DB-authoritative (epic #735 — User.lastUsedOrganizationId replaces the
-        // legacy auth provider publicMetadata.organization write-back).
-        await this.usersService.patch(String(existingUser.id), {
-          lastUsedOrganizationId: organizationId,
-        });
-        await Promise.all([
-          this.requestContextCacheService.invalidateForUser(
-            String(existingUser._id),
-          ),
-          this.accessBootstrapCacheService.invalidateForUser(
-            String(existingUser._id),
-          ),
-          this.betterAuthIdentityCacheService.invalidateForUser(
-            String(existingUser._id),
-          ),
-        ]);
-
-        return serializeSingle(request, MemberSerializer, member);
-      } catch (error: unknown) {
-        // Rollback the limit if something fails
-        if (limitUpdated && limit) {
-          await this.organizationSettingsService.updateSeatsLimit(
-            limit.id,
-            limit.current,
-          );
-        }
-        throw error;
-      }
+      return serializeSingle(request, MemberSerializer, member);
     } else {
       // New user - first check if a pending invited user with this email already exists
       let newUser = await this.usersService.findOne({
@@ -285,50 +252,25 @@ export class OrganizationsMembersController {
       }
 
       // Create the member record (inactive until they sign up)
-      const limit = (
-        request as unknown as { seatsLimit?: { id: string; current: number } }
-      ).seatsLimit;
-      let limitUpdated = false;
+      const member = await this.membersService.create({
+        isActive: false, // Inactive until they sign up
+        organizationId,
+        roleId: String(roleToAssign),
+        userId: String(newUser.id),
+      } as unknown as Parameters<typeof this.membersService.create>[0]);
 
-      try {
-        // Atomically update the seats limit
-        if (limit) {
-          await this.organizationSettingsService.updateSeatsLimit(
-            limit.id,
-            limit.current + 1,
-          );
-          limitUpdated = true;
-        }
+      await this.invitationService.createInvitation({
+        defaultRoleKey: 'user',
+        email: inviteDto.email,
+        firstName: inviteDto.firstName,
+        invitedByUserId,
+        lastName: inviteDto.lastName,
+        organizationId,
+        redirectUrl: this.getInvitationRedirectUrl(organizationId),
+        roleId: String(roleToAssign),
+      });
 
-        const member = await this.membersService.create({
-          isActive: false, // Inactive until they sign up
-          organizationId,
-          roleId: String(roleToAssign),
-          userId: String(newUser.id),
-        } as unknown as Parameters<typeof this.membersService.create>[0]);
-
-        await this.invitationService.createInvitation({
-          defaultRoleKey: 'user',
-          email: inviteDto.email,
-          firstName: inviteDto.firstName,
-          invitedByUserId,
-          lastName: inviteDto.lastName,
-          organizationId,
-          redirectUrl: this.getInvitationRedirectUrl(organizationId),
-          roleId: String(roleToAssign),
-        });
-
-        return serializeSingle(request, MemberSerializer, member);
-      } catch (error: unknown) {
-        // Rollback the limit if something fails
-        if (limitUpdated && limit) {
-          await this.organizationSettingsService.updateSeatsLimit(
-            limit.id,
-            limit.current,
-          );
-        }
-        throw error;
-      }
+      return serializeSingle(request, MemberSerializer, member);
     }
   }
 

--- a/apps/server/api/src/collections/organizations/controllers/organizations.controller.ts
+++ b/apps/server/api/src/collections/organizations/controllers/organizations.controller.ts
@@ -54,6 +54,7 @@ import type {
   JsonApiCollectionResponse,
   SortObject,
 } from '@genfeedai/interfaces';
+import { FREE_BRAND_LIMIT } from '@genfeedai/pricing';
 import {
   ActivitySerializer,
   BrandSerializer,
@@ -658,7 +659,7 @@ export class OrganizationsController extends BaseCRUDController<
     const enabledModelIds =
       await this.organizationSettingsService.getLatestMajorVersionModelIds();
     await this.organizationSettingsService.create({
-      brandsLimit: 5,
+      brandsLimit: FREE_BRAND_LIMIT,
       enabledModels: enabledModelIds,
       isAutoEvaluateEnabled: false,
       isGenerateArticlesEnabled: false,

--- a/apps/server/api/src/collections/organizations/organizations.module.ts
+++ b/apps/server/api/src/collections/organizations/organizations.module.ts
@@ -6,7 +6,6 @@ and member access control.
 import { ActivitiesModule } from '@api/collections/activities/activities.module';
 import { BrandsModule } from '@api/collections/brands/brands.module';
 import { CredentialsCoreModule } from '@api/collections/credentials/credentials-core.module';
-import { CreditsModule } from '@api/collections/credits/credits.module';
 import { IngredientsModule } from '@api/collections/ingredients/ingredients.module';
 import { MembersModule } from '@api/collections/members/members.module';
 import { ModelsModule } from '@api/collections/models/models.module';
@@ -27,7 +26,6 @@ import { VideosModule } from '@api/collections/videos/videos.module';
 import { CommonModule } from '@api/common/common.module';
 import { IntegrationsModule } from '@api/endpoints/integrations/integrations.module';
 import { MemberCreditsGuard } from '@api/helpers/guards/member-credits/member-credits.guard';
-import { CreditsInterceptor } from '@api/helpers/interceptors/credits/credits.interceptor';
 import { ByokModule } from '@api/services/byok/byok.module';
 import { LoggerModule } from '@libs/logger/logger.module';
 import { forwardRef, Module } from '@nestjs/common';
@@ -48,7 +46,6 @@ import { forwardRef, Module } from '@nestjs/common';
     forwardRef(() => ByokModule),
     forwardRef(() => CommonModule),
     forwardRef(() => CredentialsCoreModule),
-    forwardRef(() => CreditsModule),
     forwardRef(() => IngredientsModule),
     forwardRef(() => IntegrationsModule),
     forwardRef(() => LoggerModule),
@@ -63,6 +60,6 @@ import { forwardRef, Module } from '@nestjs/common';
     forwardRef(() => UsersModule),
     forwardRef(() => VideosModule),
   ],
-  providers: [OrganizationsService, MemberCreditsGuard, CreditsInterceptor],
+  providers: [OrganizationsService, MemberCreditsGuard],
 })
 export class OrganizationsModule {}

--- a/apps/server/api/src/collections/users/services/user-setup.service.ts
+++ b/apps/server/api/src/collections/users/services/user-setup.service.ts
@@ -25,6 +25,7 @@ import { RolesService } from '@api/collections/roles/services/roles.service';
 import type { SettingDocument } from '@api/collections/settings/schemas/setting.schema';
 import { SettingsService } from '@api/collections/settings/services/settings.service';
 import { OrganizationCategory } from '@genfeedai/enums';
+import { FREE_BRAND_LIMIT } from '@genfeedai/pricing';
 import { ONBOARDING_SIGNUP_GIFT_CREDITS } from '@genfeedai/types';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
@@ -301,7 +302,7 @@ export class UserSetupService {
       await this.organizationSettingsService.getLatestMajorVersionModelIds();
 
     const orgSettings = await this.organizationSettingsService.create({
-      brandsLimit: 5,
+      brandsLimit: FREE_BRAND_LIMIT,
       enabledModels: enabledModelIds,
       isAutoEvaluateEnabled: false,
       isFastlaneEnabled: false,

--- a/apps/server/api/src/helpers/exceptions/business/business-logic.exception.ts
+++ b/apps/server/api/src/helpers/exceptions/business/business-logic.exception.ts
@@ -1,6 +1,34 @@
 import { HttpException, HttpStatus } from '@nestjs/common';
 
 type BusinessErrorDetails = Record<string, unknown>;
+type PlanLimitResource = 'brands' | 'channels' | 'seats';
+
+interface PlanLimitExceededOptions {
+  currentCount: number;
+  limit: number;
+  resource: PlanLimitResource;
+  upgradeTier: string | null;
+}
+
+const PLAN_LIMIT_RESOURCE_LABELS: Record<
+  PlanLimitResource,
+  { plural: string; singular: string }
+> = {
+  brands: { plural: 'brand kits', singular: 'brand kit' },
+  channels: {
+    plural: 'connected channels',
+    singular: 'connected channel',
+  },
+  seats: { plural: 'team seats', singular: 'team seat' },
+};
+
+function formatTierLabel(tier: string | null): string {
+  if (!tier) {
+    return 'a higher plan';
+  }
+
+  return tier.charAt(0).toUpperCase() + tier.slice(1);
+}
 
 export class BusinessLogicException extends HttpException {
   constructor(
@@ -30,6 +58,33 @@ export class InsufficientCreditsException extends BusinessLogicException {
       { available, required },
       'INSUFFICIENT_CREDITS',
     );
+  }
+}
+
+export class PlanLimitExceededException extends HttpException {
+  constructor(options: PlanLimitExceededOptions) {
+    const resourceLabel = PLAN_LIMIT_RESOURCE_LABELS[options.resource];
+    const label =
+      options.limit === 1 ? resourceLabel.singular : resourceLabel.plural;
+    const tierLabel = formatTierLabel(options.upgradeTier);
+
+    super(
+      {
+        code: 'PLAN_LIMIT_EXCEEDED',
+        detail: `Your current plan includes ${options.limit} ${label}. Upgrade to ${tierLabel} to add more.`,
+        meta: {
+          currentCount: options.currentCount,
+          limit: options.limit,
+          resource: options.resource,
+          upgradeTier: options.upgradeTier,
+        },
+        status: HttpStatus.FORBIDDEN,
+        timestamp: new Date().toISOString(),
+        title: 'Plan limit reached',
+      },
+      HttpStatus.FORBIDDEN,
+    );
+    this.name = 'PlanLimitExceededException';
   }
 }
 

--- a/apps/server/api/src/helpers/guards/api-access/api-access.guard.spec.ts
+++ b/apps/server/api/src/helpers/guards/api-access/api-access.guard.spec.ts
@@ -102,7 +102,19 @@ describe('ApiAccessGuard', () => {
       );
       const ctx = buildContext(buildUser());
       expect(() => guard.canActivate(ctx)).toThrow(ForbiddenException);
-      expect(() => guard.canActivate(ctx)).toThrow(/upgrade/i);
+      try {
+        guard.canActivate(ctx);
+      } catch (error) {
+        expect(error).toMatchObject({
+          response: {
+            code: 'PLAN_LIMIT_EXCEEDED',
+            meta: {
+              resource: 'api',
+              upgradeTier: SubscriptionTier.PRO,
+            },
+          },
+        });
+      }
     });
 
     it('blocks BYOK (free) tier', () => {

--- a/apps/server/api/src/helpers/guards/api-access/api-access.guard.ts
+++ b/apps/server/api/src/helpers/guards/api-access/api-access.guard.ts
@@ -4,6 +4,7 @@ import {
   getSubscriptionTier,
 } from '@api/helpers/utils/auth/auth.util';
 import { IS_CLOUD_MODE } from '@genfeedai/config';
+import { SubscriptionTier } from '@genfeedai/enums';
 import { hasApiAccess } from '@genfeedai/pricing';
 import { LoggerService } from '@libs/logger/logger.service';
 import {
@@ -79,9 +80,16 @@ export class ApiAccessGuard implements CanActivate {
         userId: user.id,
       });
 
-      throw new ForbiddenException(
-        'API access is available on paid plans. Upgrade to Pro, Scale, or Enterprise to create and use API keys.',
-      );
+      throw new ForbiddenException({
+        code: 'PLAN_LIMIT_EXCEEDED',
+        detail:
+          'API access is available on paid plans. Upgrade to Pro to create and use API keys.',
+        meta: {
+          resource: 'api',
+          upgradeTier: SubscriptionTier.PRO,
+        },
+        title: 'API access requires a paid plan',
+      });
     }
 
     return true;

--- a/apps/server/api/src/helpers/guards/api-access/tier-entitlements.spec.ts
+++ b/apps/server/api/src/helpers/guards/api-access/tier-entitlements.spec.ts
@@ -1,11 +1,22 @@
 import { SubscriptionTier } from '@genfeedai/enums';
 import {
+  FREE_BRAND_LIMIT,
+  FREE_CHANNEL_LIMIT,
+  FREE_SEAT_LIMIT,
   getApiEntitlementForTier,
   getApiRateLimitForTier,
+  getBrandLimitForTier,
+  getChannelLimitForTier,
+  getPlanEntitlementForTier,
+  getSeatLimitForTier,
+  getUpgradeTierForLimit,
   HIGHER_API_RATE_LIMIT,
   hasApiAccess,
+  PLAN_LIMIT_UNLIMITED,
+  PRO_CHANNEL_LIMIT,
   SCALE_API_RATE_LIMIT,
   TIER_API_ENTITLEMENTS,
+  TIER_PLAN_ENTITLEMENTS,
 } from '@genfeedai/pricing';
 
 /**
@@ -16,6 +27,7 @@ import {
 describe('tier API entitlements', () => {
   it('covers every SubscriptionTier (exhaustive map)', () => {
     for (const tier of Object.values(SubscriptionTier)) {
+      expect(TIER_PLAN_ENTITLEMENTS[tier]).toBeDefined();
       expect(TIER_API_ENTITLEMENTS[tier]).toBeDefined();
     }
   });
@@ -69,6 +81,54 @@ describe('tier API entitlements', () => {
         apiRateLimit: 0,
       });
     }
+  });
+
+  it('resolves PAYG/BYOK finite product limits from the pricing package', () => {
+    for (const tier of [SubscriptionTier.FREE, SubscriptionTier.BYOK]) {
+      expect(getBrandLimitForTier(tier)).toBe(FREE_BRAND_LIMIT);
+      expect(getChannelLimitForTier(tier)).toBe(FREE_CHANNEL_LIMIT);
+      expect(getSeatLimitForTier(tier)).toBe(FREE_SEAT_LIMIT);
+    }
+  });
+
+  it('resolves paid tier product limits: unlimited seats/brands, Pro channel cap, Scale+ unlimited channels', () => {
+    expect(getPlanEntitlementForTier(SubscriptionTier.PRO)).toMatchObject({
+      brandLimit: PLAN_LIMIT_UNLIMITED,
+      channelLimit: PRO_CHANNEL_LIMIT,
+      seatLimit: PLAN_LIMIT_UNLIMITED,
+    });
+
+    for (const tier of [SubscriptionTier.SCALE, SubscriptionTier.ENTERPRISE]) {
+      expect(getBrandLimitForTier(tier)).toBeNull();
+      expect(getChannelLimitForTier(tier)).toBeNull();
+      expect(getSeatLimitForTier(tier)).toBeNull();
+    }
+  });
+
+  it('uses PAYG/free limits for empty or unknown tiers', () => {
+    for (const tier of ['', 'bogus', null, undefined]) {
+      expect(getBrandLimitForTier(tier)).toBe(FREE_BRAND_LIMIT);
+      expect(getChannelLimitForTier(tier)).toBe(FREE_CHANNEL_LIMIT);
+      expect(getSeatLimitForTier(tier)).toBe(FREE_SEAT_LIMIT);
+    }
+  });
+
+  it('names the next tier that lifts each finite product limit', () => {
+    expect(getUpgradeTierForLimit('brands', SubscriptionTier.FREE)).toBe(
+      SubscriptionTier.PRO,
+    );
+    expect(getUpgradeTierForLimit('seats', SubscriptionTier.BYOK)).toBe(
+      SubscriptionTier.PRO,
+    );
+    expect(getUpgradeTierForLimit('channels', SubscriptionTier.FREE)).toBe(
+      SubscriptionTier.PRO,
+    );
+    expect(getUpgradeTierForLimit('channels', SubscriptionTier.PRO)).toBe(
+      SubscriptionTier.SCALE,
+    );
+    expect(getUpgradeTierForLimit('channels', SubscriptionTier.SCALE)).toBe(
+      null,
+    );
   });
 
   it('exposes per-tier rate limits via getApiRateLimitForTier', () => {

--- a/apps/server/api/src/helpers/guards/brand-credits/brand-credits.guard.spec.ts
+++ b/apps/server/api/src/helpers/guards/brand-credits/brand-credits.guard.spec.ts
@@ -1,35 +1,48 @@
+let mockCloudMode = true;
+vi.mock('@genfeedai/config', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@genfeedai/config')>();
+  return {
+    ...actual,
+    get IS_CLOUD_MODE() {
+      return mockCloudMode;
+    },
+  };
+});
+
 import type { BrandsService } from '@api/collections/brands/services/brands.service';
-import type { CreditsUtilsService } from '@api/collections/credits/services/credits.utils.service';
-import type { ModelsService } from '@api/collections/models/services/models.service';
 import type { OrganizationSettingsService } from '@api/collections/organization-settings/services/organization-settings.service';
 import { BrandCreditsGuard } from '@api/helpers/guards/brand-credits/brand-credits.guard';
-import { CreditsGuard } from '@api/helpers/guards/credits/credits.guard';
-import type { ByokService } from '@api/services/byok/byok.service';
-import type { ConfigService } from '@libs/config/config.service';
-import type { LoggerService } from '@libs/logger/logger.service';
-import type { ExecutionContext } from '@nestjs/common';
-import { Reflector } from '@nestjs/core';
+import * as authUtil from '@api/helpers/utils/auth/auth.util';
+import { SubscriptionTier } from '@genfeedai/enums';
+import { FREE_BRAND_LIMIT } from '@genfeedai/pricing';
+import { type ExecutionContext, HttpException } from '@nestjs/common';
+
+vi.mock('@api/helpers/utils/auth/auth.util', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@api/helpers/utils/auth/auth.util')>();
+  return {
+    ...actual,
+    getIsSuperAdmin: vi.fn(),
+    getSubscriptionTier: vi.fn(),
+  };
+});
 
 const orgId = '507f191e810c19729de860ee'.toString();
 
-const createContext = (): ExecutionContext => {
+function createContext(): ExecutionContext {
   const req: Record<string, unknown> = {
-    params: { id: '507f191e810c19729de860ee'.toString() },
-    user: { publicMetadata: { organization: orgId } },
+    params: { id: orgId },
+    user: {
+      id: 'user_123',
+      publicMetadata: { organization: orgId, subscriptionTier: '' },
+    },
   };
   return {
     getClass: vi.fn(),
     getHandler: vi.fn(),
     switchToHttp: () => ({ getRequest: () => req }),
   } as unknown as ExecutionContext;
-};
-
-const loggerService = {
-  debug: vi.fn(),
-  error: vi.fn(),
-  log: vi.fn(),
-  warn: vi.fn(),
-} as unknown as LoggerService;
+}
 
 describe('BrandCreditsGuard', () => {
   let guard: BrandCreditsGuard;
@@ -37,112 +50,112 @@ describe('BrandCreditsGuard', () => {
   let brandsService: { findAll: ReturnType<typeof vi.fn> };
 
   beforeEach(() => {
+    mockCloudMode = true;
     organizationSettingsService = { findOne: vi.fn() };
     brandsService = { findAll: vi.fn() };
 
     guard = new BrandCreditsGuard(
-      new Reflector(),
-      {} as CreditsUtilsService,
-      {} as ModelsService,
-      {} as ByokService,
-      loggerService,
-      { get: vi.fn() } as unknown as ConfigService,
       organizationSettingsService as unknown as OrganizationSettingsService,
       brandsService as unknown as BrandsService,
     );
+
+    vi.mocked(authUtil.getIsSuperAdmin).mockReturnValue(false);
+    vi.mocked(authUtil.getSubscriptionTier).mockReturnValue('');
   });
 
   afterEach(() => {
-    vi.restoreAllMocks();
+    vi.clearAllMocks();
   });
 
-  it('should be defined', () => {
-    expect(guard).toBeDefined();
-  });
-
-  it('returns true when no settings found', async () => {
-    organizationSettingsService.findOne.mockResolvedValue(null);
-    const result = await guard.canActivate(createContext());
-    expect(result).toBe(true);
-  });
-
-  it('returns true when brand count is under the limit', async () => {
-    organizationSettingsService.findOne.mockResolvedValue({ brandsLimit: 5 });
-    brandsService.findAll.mockResolvedValue({ docs: [1, 2] });
-    const result = await guard.canActivate(createContext());
-    expect(result).toBe(true);
-  });
-
-  it('delegates to CreditsGuard when brand limit is reached', async () => {
-    const spy = vi
-      .spyOn(CreditsGuard.prototype, 'canActivate')
-      .mockResolvedValue(true);
-
+  it('returns true when the current free-tier brand count is under the pricing limit', async () => {
     organizationSettingsService.findOne.mockResolvedValue({
-      id: '507f191e810c19729de860ee',
-      brandsLimit: 2,
+      subscriptionTier: SubscriptionTier.FREE,
     });
-    brandsService.findAll.mockResolvedValue({ docs: [1, 2] });
-
-    const ctx = createContext();
-    const result = await guard.canActivate(ctx);
-
-    expect(result).toBe(true);
-    expect(spy).toHaveBeenCalled();
-    spy.mockRestore();
-  });
-
-  it('sets brandsLimit on the request when at limit', async () => {
-    vi.spyOn(CreditsGuard.prototype, 'canActivate').mockResolvedValue(true);
-
-    const settingsId = '507f191e810c19729de860ee';
-    organizationSettingsService.findOne.mockResolvedValue({
-      id: settingsId,
-      brandsLimit: 1,
-    });
-    brandsService.findAll.mockResolvedValue({ docs: [1] });
-
-    const ctx = createContext();
-    await guard.canActivate(ctx);
-
-    const req = ctx.switchToHttp().getRequest() as Record<string, unknown>;
-    expect(req.brandsLimit).toEqual({
-      current: 1,
-      id: settingsId.toString(),
-    });
-  });
-
-  it('calls organizationSettingsService.findOne with correct org id', async () => {
-    organizationSettingsService.findOne.mockResolvedValue(null);
-    await guard.canActivate(createContext());
-    expect(organizationSettingsService.findOne).toHaveBeenCalledWith({
-      organization: expect.any(String),
-    });
-  });
-
-  it('calls brandsService.findAll with correct aggregate query', async () => {
-    organizationSettingsService.findOne.mockResolvedValue({ brandsLimit: 5 });
     brandsService.findAll.mockResolvedValue({ docs: [] });
+
+    await expect(guard.canActivate(createContext())).resolves.toBe(true);
+  });
+
+  it('throws a structured plan-limit error when PAYG reaches its brand cap', async () => {
+    organizationSettingsService.findOne.mockResolvedValue({
+      subscriptionTier: SubscriptionTier.FREE,
+    });
+    brandsService.findAll.mockResolvedValue({
+      docs: new Array(FREE_BRAND_LIMIT).fill({}),
+    });
+
+    await expect(guard.canActivate(createContext())).rejects.toMatchObject({
+      response: {
+        code: 'PLAN_LIMIT_EXCEEDED',
+        meta: {
+          currentCount: FREE_BRAND_LIMIT,
+          limit: FREE_BRAND_LIMIT,
+          resource: 'brands',
+          upgradeTier: SubscriptionTier.PRO,
+        },
+      },
+      status: 403,
+    } satisfies Partial<HttpException>);
+  });
+
+  it.each([
+    SubscriptionTier.PRO,
+    SubscriptionTier.SCALE,
+    SubscriptionTier.ENTERPRISE,
+  ])('allows unlimited brand creation for paid tier %s', async (tier) => {
+    organizationSettingsService.findOne.mockResolvedValue({
+      subscriptionTier: tier,
+    });
+    brandsService.findAll.mockResolvedValue({ docs: new Array(50).fill({}) });
+
+    await expect(guard.canActivate(createContext())).resolves.toBe(true);
+    expect(brandsService.findAll).not.toHaveBeenCalled();
+  });
+
+  it('uses PAYG/free limits when settings are missing', async () => {
+    organizationSettingsService.findOne.mockResolvedValue(null);
+    brandsService.findAll.mockResolvedValue({
+      docs: new Array(FREE_BRAND_LIMIT).fill({}),
+    });
+
+    await expect(guard.canActivate(createContext())).rejects.toMatchObject({
+      response: expect.objectContaining({
+        code: 'PLAN_LIMIT_EXCEEDED',
+      }),
+    });
+  });
+
+  it('allows super admins regardless of tier', async () => {
+    vi.mocked(authUtil.getIsSuperAdmin).mockReturnValue(true);
+
+    await expect(guard.canActivate(createContext())).resolves.toBe(true);
+    expect(organizationSettingsService.findOne).not.toHaveBeenCalled();
+  });
+
+  it('bypasses brand plan limits outside managed cloud', async () => {
+    mockCloudMode = false;
+
+    await expect(guard.canActivate(createContext())).resolves.toBe(true);
+    expect(organizationSettingsService.findOne).not.toHaveBeenCalled();
+  });
+
+  it('counts active brands with the current organization scope', async () => {
+    organizationSettingsService.findOne.mockResolvedValue({
+      subscriptionTier: SubscriptionTier.FREE,
+    });
+    brandsService.findAll.mockResolvedValue({ docs: [] });
+
     await guard.canActivate(createContext());
+
     expect(brandsService.findAll).toHaveBeenCalledWith(
       {
         where: {
           isDeleted: false,
-          organization: expect.any(String),
+          organization: orgId,
         },
       },
       { pagination: false },
       false,
     );
-  });
-
-  it('does not call brandsService when settings is null', async () => {
-    organizationSettingsService.findOne.mockResolvedValue(null);
-    await guard.canActivate(createContext());
-    expect(brandsService.findAll).not.toHaveBeenCalled();
-  });
-
-  it('extends CreditsGuard', () => {
-    expect(guard).toBeInstanceOf(CreditsGuard);
   });
 });

--- a/apps/server/api/src/helpers/guards/brand-credits/brand-credits.guard.ts
+++ b/apps/server/api/src/helpers/guards/brand-credits/brand-credits.guard.ts
@@ -1,55 +1,57 @@
 import { BrandsService } from '@api/collections/brands/services/brands.service';
-import { CreditsUtilsService } from '@api/collections/credits/services/credits.utils.service';
-import { ModelsService } from '@api/collections/models/services/models.service';
 import { OrganizationSettingsService } from '@api/collections/organization-settings/services/organization-settings.service';
-import { CreditsGuard } from '@api/helpers/guards/credits/credits.guard';
-import { ByokService } from '@api/services/byok/byok.service';
+import { PlanLimitExceededException } from '@api/helpers/exceptions/business/business-logic.exception';
+import {
+  getIsSuperAdmin,
+  getSubscriptionTier,
+} from '@api/helpers/utils/auth/auth.util';
 import { IAuthPublicMetadata } from '@api/shared/interfaces/auth/auth-public-metadata.interface';
-import { ConfigService } from '@libs/config/config.service';
-import { LoggerService } from '@libs/logger/logger.service';
+import { IS_CLOUD_MODE } from '@genfeedai/config';
+import {
+  getBrandLimitForTier,
+  getUpgradeTierForLimit,
+} from '@genfeedai/pricing';
 import {
   type CanActivate,
   type ExecutionContext,
   Injectable,
 } from '@nestjs/common';
-import { Reflector } from '@nestjs/core';
 import type { Request } from 'express';
 
 @Injectable()
-export class BrandCreditsGuard extends CreditsGuard implements CanActivate {
+export class BrandCreditsGuard implements CanActivate {
   constructor(
-    reflector: Reflector,
-    creditsUtilsService: CreditsUtilsService,
-    modelsService: ModelsService,
-    byokService: ByokService,
-    loggerService: LoggerService,
-    configService: ConfigService,
-
     private readonly organizationSettingsService: OrganizationSettingsService,
     private readonly brandsService: BrandsService,
-  ) {
-    super(
-      reflector,
-      creditsUtilsService,
-      modelsService,
-      byokService,
-      loggerService,
-      configService,
-    );
-  }
+  ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
+    // Plan limits are a managed-cloud product boundary. Self-hosted/community
+    // deployments must not lose core brand creation.
+    if (!IS_CLOUD_MODE) {
+      return true;
+    }
+
     const request = context.switchToHttp().getRequest<Request>();
     const user = (
       request as unknown as { user: { publicMetadata: IAuthPublicMetadata } }
     ).user;
+
+    if (getIsSuperAdmin(user, request)) {
+      return true;
+    }
+
     const publicMetadata: IAuthPublicMetadata = user.publicMetadata;
 
     const settings = await this.organizationSettingsService.findOne({
       organization: publicMetadata.organization,
     });
 
-    if (!settings) {
+    const tier =
+      settings?.subscriptionTier ?? getSubscriptionTier(user, request);
+    const brandLimit = getBrandLimitForTier(tier);
+
+    if (brandLimit === null) {
       return true;
     }
 
@@ -66,15 +68,15 @@ export class BrandCreditsGuard extends CreditsGuard implements CanActivate {
 
     const brandCount = existingBrands.docs.length;
 
-    if (brandCount < settings.brandsLimit) {
+    if (brandCount < brandLimit) {
       return true;
     }
 
-    (request as unknown as Record<string, unknown>).brandsLimit = {
-      current: brandCount, // Pass the actual current count, not the limit
-      id: settings.id.toString(),
-    };
-
-    return super.canActivate(context);
+    throw new PlanLimitExceededException({
+      currentCount: brandCount,
+      limit: brandLimit,
+      resource: 'brands',
+      upgradeTier: getUpgradeTierForLimit('brands', tier),
+    });
   }
 }

--- a/apps/server/api/src/helpers/guards/brand-credits/brand-credits.guard.ts
+++ b/apps/server/api/src/helpers/guards/brand-credits/brand-credits.guard.ts
@@ -1,3 +1,4 @@
+import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticated-user.interface';
 import { BrandsService } from '@api/collections/brands/services/brands.service';
 import { OrganizationSettingsService } from '@api/collections/organization-settings/services/organization-settings.service';
 import { PlanLimitExceededException } from '@api/helpers/exceptions/business/business-logic.exception';
@@ -33,15 +34,13 @@ export class BrandCreditsGuard implements CanActivate {
     }
 
     const request = context.switchToHttp().getRequest<Request>();
-    const user = (
-      request as unknown as { user: { publicMetadata: IAuthPublicMetadata } }
-    ).user;
+    const user = (request as unknown as { user: User }).user;
 
     if (getIsSuperAdmin(user, request)) {
       return true;
     }
 
-    const publicMetadata: IAuthPublicMetadata = user.publicMetadata;
+    const publicMetadata = user.publicMetadata as IAuthPublicMetadata;
 
     const settings = await this.organizationSettingsService.findOne({
       organization: publicMetadata.organization,

--- a/apps/server/api/src/helpers/guards/member-credits/member-credits.guard.spec.ts
+++ b/apps/server/api/src/helpers/guards/member-credits/member-credits.guard.spec.ts
@@ -1,32 +1,42 @@
+let mockCloudMode = true;
 vi.mock('@genfeedai/config', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@genfeedai/config')>();
-
   return {
     ...actual,
-    IS_SELF_HOSTED: false,
+    get IS_CLOUD_MODE() {
+      return mockCloudMode;
+    },
   };
 });
 
-import { CreditsUtilsService } from '@api/collections/credits/services/credits.utils.service';
 import { MembersService } from '@api/collections/members/services/members.service';
-import { ModelsService } from '@api/collections/models/services/models.service';
 import { OrganizationSettingsService } from '@api/collections/organization-settings/services/organization-settings.service';
 import { UNLIMITED_SEATS_FAIR_USE_CEILING } from '@api/collections/organization-settings/utils/seat-policy.util';
-import { CreditsGuard } from '@api/helpers/guards/credits/credits.guard';
 import { MemberCreditsGuard } from '@api/helpers/guards/member-credits/member-credits.guard';
-import { ByokService } from '@api/services/byok/byok.service';
+import * as authUtil from '@api/helpers/utils/auth/auth.util';
 import { SubscriptionTier } from '@genfeedai/enums';
-import { ConfigService } from '@libs/config/config.service';
-import { LoggerService } from '@libs/logger/logger.service';
+import { FREE_SEAT_LIMIT } from '@genfeedai/pricing';
 import type { ExecutionContext } from '@nestjs/common';
 import { ForbiddenException } from '@nestjs/common';
-import { Reflector } from '@nestjs/core';
 
-const createContext = (): ExecutionContext => {
+vi.mock('@api/helpers/utils/auth/auth.util', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@api/helpers/utils/auth/auth.util')>();
+  return {
+    ...actual,
+    getIsSuperAdmin: vi.fn(),
+    getSubscriptionTier: vi.fn(),
+  };
+});
+
+const orgId = '507f191e810c19729de860ee'.toString();
+
+function createContext(): ExecutionContext {
   const req: Record<string, unknown> = {
-    params: { id: '507f191e810c19729de860ee'.toString() },
+    params: { id: orgId },
     user: {
-      publicMetadata: { organization: '507f191e810c19729de860ee'.toString() },
+      id: 'user_123',
+      publicMetadata: { organization: orgId, subscriptionTier: '' },
     },
   };
   return {
@@ -34,7 +44,7 @@ const createContext = (): ExecutionContext => {
     getHandler: vi.fn(),
     switchToHttp: () => ({ getRequest: () => req }),
   } as ExecutionContext;
-};
+}
 
 describe('MemberCreditsGuard', () => {
   let guard: MemberCreditsGuard;
@@ -42,81 +52,79 @@ describe('MemberCreditsGuard', () => {
   let membersService: { findAll: ReturnType<typeof vi.fn> };
 
   beforeEach(() => {
+    mockCloudMode = true;
     organizationSettingsService = { findOne: vi.fn() };
     membersService = { findAll: vi.fn() };
 
     guard = new MemberCreditsGuard(
-      new Reflector(),
-      {} as CreditsUtilsService,
-      {} as ModelsService,
-      {} as ByokService,
-      {
-        error: vi.fn(),
-        log: vi.fn(),
-        warn: vi.fn(),
-      } as LoggerService,
-      { get: vi.fn() } as ConfigService,
-      organizationSettingsService as OrganizationSettingsService,
-      membersService as MembersService,
+      organizationSettingsService as unknown as OrganizationSettingsService,
+      membersService as unknown as MembersService,
     );
+
+    vi.mocked(authUtil.getIsSuperAdmin).mockReturnValue(false);
+    vi.mocked(authUtil.getSubscriptionTier).mockReturnValue('');
   });
 
-  it('returns true when under seat limit', async () => {
-    organizationSettingsService.findOne.mockResolvedValue({ seatsLimit: 2 });
-    membersService.findAll.mockResolvedValue({ docs: [1] });
-
-    const result = await guard.canActivate(createContext());
-    expect(result).toBe(true);
+  afterEach(() => {
+    vi.clearAllMocks();
   });
 
-  it('checks credits when seat limit reached', async () => {
-    const spy = vi
-      .spyOn(CreditsGuard.prototype, 'canActivate')
-      .mockResolvedValue(true);
-
+  it('returns true when under the free solo seat limit', async () => {
     organizationSettingsService.findOne.mockResolvedValue({
-      id: '507f191e810c19729de860ee',
-      seatsLimit: 1,
+      seatsLimit: FREE_SEAT_LIMIT,
+      subscriptionTier: SubscriptionTier.FREE,
     });
-    membersService.findAll.mockResolvedValue({ docs: [1] });
+    membersService.findAll.mockResolvedValue({ docs: [] });
 
-    const context = createContext();
-    const result = await guard.canActivate(context);
+    await expect(guard.canActivate(createContext())).resolves.toBe(true);
+  });
 
-    expect(result).toBe(true);
-    expect(spy).toHaveBeenCalled();
-    expect(context.switchToHttp().getRequest().seatsLimit).toBeDefined();
+  it('throws a structured plan-limit error when a free org already has its solo member', async () => {
+    organizationSettingsService.findOne.mockResolvedValue({
+      seatsLimit: FREE_SEAT_LIMIT,
+      subscriptionTier: SubscriptionTier.FREE,
+    });
+    membersService.findAll.mockResolvedValue({
+      docs: new Array(FREE_SEAT_LIMIT).fill({}),
+    });
 
-    spy.mockRestore();
+    await expect(guard.canActivate(createContext())).rejects.toMatchObject({
+      response: {
+        code: 'PLAN_LIMIT_EXCEEDED',
+        meta: {
+          currentCount: FREE_SEAT_LIMIT,
+          limit: FREE_SEAT_LIMIT,
+          resource: 'seats',
+          upgradeTier: SubscriptionTier.PRO,
+        },
+      },
+      status: 403,
+    });
   });
 
   it.each([
-    [SubscriptionTier.PRO],
-    [SubscriptionTier.SCALE],
-    [SubscriptionTier.ENTERPRISE],
-  ])('allows adding members past the stored seatsLimit on the unlimited-seat %s tier', async (subscriptionTier) => {
+    SubscriptionTier.PRO,
+    SubscriptionTier.SCALE,
+    SubscriptionTier.ENTERPRISE,
+  ])('allows adding members past stored seatsLimit on unlimited-seat %s', async (subscriptionTier) => {
     organizationSettingsService.findOne.mockResolvedValue({
-      id: '507f191e810c19729de860ee',
       seatsLimit: 1,
       subscriptionTier,
     });
-    // Far past any finite seatsLimit, but still well under the fair-use ceiling.
     membersService.findAll.mockResolvedValue({
-      docs: new Array(50).fill(1),
+      docs: new Array(50).fill({}),
     });
 
-    const result = await guard.canActivate(createContext());
-    expect(result).toBe(true);
+    await expect(guard.canActivate(createContext())).resolves.toBe(true);
   });
 
   it('blocks with ForbiddenException once an unlimited-seat org hits the fair-use ceiling', async () => {
     organizationSettingsService.findOne.mockResolvedValue({
-      id: '507f191e810c19729de860ee',
       seatsLimit: 1,
       subscriptionTier: SubscriptionTier.SCALE,
     });
     membersService.findAll.mockResolvedValue({
-      docs: new Array(UNLIMITED_SEATS_FAIR_USE_CEILING).fill(1),
+      docs: new Array(UNLIMITED_SEATS_FAIR_USE_CEILING).fill({}),
     });
 
     await expect(guard.canActivate(createContext())).rejects.toBeInstanceOf(
@@ -124,47 +132,52 @@ describe('MemberCreditsGuard', () => {
     );
   });
 
-  it('never seat-gates self-hosted/community deployments (no billing context)', async () => {
-    vi.resetModules();
-    vi.doMock('@genfeedai/config', async (importOriginal) => {
-      const actual = await importOriginal<typeof import('@genfeedai/config')>();
-      return { ...actual, IS_SELF_HOSTED: true };
+  it('uses PAYG/free limits when settings are missing', async () => {
+    organizationSettingsService.findOne.mockResolvedValue(null);
+    membersService.findAll.mockResolvedValue({
+      docs: new Array(FREE_SEAT_LIMIT).fill({}),
     });
 
-    const { MemberCreditsGuard: SelfHostedMemberCreditsGuard } = await import(
-      '@api/helpers/guards/member-credits/member-credits.guard'
-    );
+    await expect(guard.canActivate(createContext())).rejects.toMatchObject({
+      response: expect.objectContaining({
+        code: 'PLAN_LIMIT_EXCEEDED',
+      }),
+    });
+  });
 
-    const selfHostedOrganizationSettingsService = { findOne: vi.fn() };
-    const selfHostedMembersService = { findAll: vi.fn() };
+  it('allows super admins regardless of tier', async () => {
+    vi.mocked(authUtil.getIsSuperAdmin).mockReturnValue(true);
 
-    const selfHostedGuard = new SelfHostedMemberCreditsGuard(
-      new Reflector(),
-      {} as CreditsUtilsService,
-      {} as ModelsService,
-      {} as ByokService,
+    await expect(guard.canActivate(createContext())).resolves.toBe(true);
+    expect(organizationSettingsService.findOne).not.toHaveBeenCalled();
+  });
+
+  it('never seat-gates outside managed cloud', async () => {
+    mockCloudMode = false;
+
+    await expect(guard.canActivate(createContext())).resolves.toBe(true);
+    expect(organizationSettingsService.findOne).not.toHaveBeenCalled();
+    expect(membersService.findAll).not.toHaveBeenCalled();
+  });
+
+  it('counts non-deleted organization members before allowing an invite', async () => {
+    organizationSettingsService.findOne.mockResolvedValue({
+      seatsLimit: FREE_SEAT_LIMIT,
+      subscriptionTier: SubscriptionTier.FREE,
+    });
+    membersService.findAll.mockResolvedValue({ docs: [] });
+
+    await guard.canActivate(createContext());
+
+    expect(membersService.findAll).toHaveBeenCalledWith(
       {
-        error: vi.fn(),
-        log: vi.fn(),
-        warn: vi.fn(),
-      } as LoggerService,
-      { get: vi.fn() } as ConfigService,
-      selfHostedOrganizationSettingsService as OrganizationSettingsService,
-      selfHostedMembersService as MembersService,
+        where: {
+          isDeleted: false,
+          organization: orgId,
+        },
+      },
+      { pagination: false },
+      false,
     );
-
-    const result = await selfHostedGuard.canActivate(createContext());
-
-    expect(result).toBe(true);
-    // The self-hosted short-circuit must return before ever touching
-    // OrganizationSetting/member lookups — there is no seat or billing
-    // concept to enforce in self-hosted mode.
-    expect(
-      selfHostedOrganizationSettingsService.findOne,
-    ).not.toHaveBeenCalled();
-    expect(selfHostedMembersService.findAll).not.toHaveBeenCalled();
-
-    vi.doUnmock('@genfeedai/config');
-    vi.resetModules();
   });
 });

--- a/apps/server/api/src/helpers/guards/member-credits/member-credits.guard.ts
+++ b/apps/server/api/src/helpers/guards/member-credits/member-credits.guard.ts
@@ -1,3 +1,4 @@
+import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticated-user.interface';
 import { MembersService } from '@api/collections/members/services/members.service';
 import { OrganizationSettingsService } from '@api/collections/organization-settings/services/organization-settings.service';
 import {
@@ -34,15 +35,13 @@ export class MemberCreditsGuard implements CanActivate {
     }
 
     const request = context.switchToHttp().getRequest<Request>();
-    const user = (
-      request as unknown as { user: { publicMetadata: IAuthPublicMetadata } }
-    ).user;
+    const user = (request as unknown as { user: User }).user;
 
     if (getIsSuperAdmin(user, request)) {
       return true;
     }
 
-    const publicMetadata: IAuthPublicMetadata = user.publicMetadata;
+    const publicMetadata = user.publicMetadata as IAuthPublicMetadata;
     const organizationId =
       request.params.organizationId ||
       request.params.id ||

--- a/apps/server/api/src/helpers/guards/member-credits/member-credits.guard.ts
+++ b/apps/server/api/src/helpers/guards/member-credits/member-credits.guard.ts
@@ -1,53 +1,35 @@
-import { CreditsUtilsService } from '@api/collections/credits/services/credits.utils.service';
 import { MembersService } from '@api/collections/members/services/members.service';
-import { ModelsService } from '@api/collections/models/services/models.service';
 import { OrganizationSettingsService } from '@api/collections/organization-settings/services/organization-settings.service';
 import {
   resolveEffectiveSeatsLimit,
   UNLIMITED_SEATS_FAIR_USE_CEILING,
 } from '@api/collections/organization-settings/utils/seat-policy.util';
-import { CreditsGuard } from '@api/helpers/guards/credits/credits.guard';
-import { ByokService } from '@api/services/byok/byok.service';
+import { PlanLimitExceededException } from '@api/helpers/exceptions/business/business-logic.exception';
+import {
+  getIsSuperAdmin,
+  getSubscriptionTier,
+} from '@api/helpers/utils/auth/auth.util';
 import { IAuthPublicMetadata } from '@api/shared/interfaces/auth/auth-public-metadata.interface';
-import { IS_SELF_HOSTED } from '@genfeedai/config';
-import { ConfigService } from '@libs/config/config.service';
-import { LoggerService } from '@libs/logger/logger.service';
+import { IS_CLOUD_MODE } from '@genfeedai/config';
+import { getUpgradeTierForLimit } from '@genfeedai/pricing';
 import {
   type CanActivate,
   type ExecutionContext,
   ForbiddenException,
   Injectable,
 } from '@nestjs/common';
-import { Reflector } from '@nestjs/core';
 import type { Request } from 'express';
 
 @Injectable()
-export class MemberCreditsGuard extends CreditsGuard implements CanActivate {
+export class MemberCreditsGuard implements CanActivate {
   constructor(
-    reflector: Reflector,
-    creditsUtilsService: CreditsUtilsService,
-    modelsService: ModelsService,
-    byokService: ByokService,
-    loggerService: LoggerService,
-    configService: ConfigService,
     private readonly organizationSettingsService: OrganizationSettingsService,
     private readonly membersService: MembersService,
-  ) {
-    super(
-      reflector,
-      creditsUtilsService,
-      modelsService,
-      byokService,
-      loggerService,
-      configService,
-    );
-  }
+  ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
-    // Self-hosted/community deployments have no billing or seat concept —
-    // seats and credits are cloud-only constructs. Never gate member invites
-    // there, regardless of what's stored on OrganizationSetting.
-    if (IS_SELF_HOSTED) {
+    // Self-hosted/community deployments have no billing or seat concept.
+    if (!IS_CLOUD_MODE) {
       return true;
     }
 
@@ -55,6 +37,11 @@ export class MemberCreditsGuard extends CreditsGuard implements CanActivate {
     const user = (
       request as unknown as { user: { publicMetadata: IAuthPublicMetadata } }
     ).user;
+
+    if (getIsSuperAdmin(user, request)) {
+      return true;
+    }
+
     const publicMetadata: IAuthPublicMetadata = user.publicMetadata;
     const organizationId =
       request.params.organizationId ||
@@ -64,10 +51,6 @@ export class MemberCreditsGuard extends CreditsGuard implements CanActivate {
     const settings = await this.organizationSettingsService.findOne({
       organization: organizationId,
     });
-
-    if (!settings) {
-      return true;
-    }
 
     const activeMembers = await this.membersService.findAll(
       {
@@ -82,9 +65,11 @@ export class MemberCreditsGuard extends CreditsGuard implements CanActivate {
 
     const activeMembersCount = activeMembers.docs.length;
 
+    const tier =
+      settings?.subscriptionTier ?? getSubscriptionTier(user, request);
     const effectiveSeatsLimit = resolveEffectiveSeatsLimit(
-      settings.subscriptionTier,
-      settings.seatsLimit,
+      tier,
+      settings?.seatsLimit,
     );
 
     // Unlimited-seat tiers (Pro/Scale/Enterprise) are never gated by seat
@@ -104,11 +89,11 @@ export class MemberCreditsGuard extends CreditsGuard implements CanActivate {
       return true;
     }
 
-    (request as unknown as Record<string, unknown>).seatsLimit = {
-      current: activeMembersCount, // Pass the actual current count, not the limit
-      id: settings.id.toString(),
-    };
-
-    return super.canActivate(context);
+    throw new PlanLimitExceededException({
+      currentCount: activeMembersCount,
+      limit: effectiveSeatsLimit,
+      resource: 'seats',
+      upgradeTier: getUpgradeTierForLimit('seats', tier),
+    });
   }
 }

--- a/packages/pricing/src/tier-entitlements.ts
+++ b/packages/pricing/src/tier-entitlements.ts
@@ -1,17 +1,19 @@
 /**
- * Per-tier API entitlements — the canonical source of truth for the
- * "Model B" API-access promise: every PAID plan advertises API access at the
- * same credit price, differentiated by rate limits.
+ * Per-tier entitlements — the canonical source of truth for the cloud plan
+ * limits promised in plans-pricing.ts.
  *
- *   Marketing plan (plans-pricing.ts)      → SubscriptionTier   → API access
+ *   Marketing plan (plans-pricing.ts)      → SubscriptionTier   → finite gates
  *   ─────────────────────────────────────────────────────────────────────────
- *   Pay As You Go (free)                   → FREE               → none
- *   BYOK (free, bring-your-own-key)        → BYOK               → none
- *   Pro                        ($49/mo)    → PRO                → higher limit
- *   Scale                      ($499/mo)   → SCALE              → highest fixed
- *   Enterprise                 (custom)    → ENTERPRISE         → custom / SLA
+ *   Pay As You Go (free)                   → FREE               → 1 brand, 3 channels, no API, solo
+ *   BYOK (free, bring-your-own-key)        → BYOK               → 1 brand, 3 channels, no API, solo
+ *   Pro                                    → PRO                → 15 channels, API, unlimited seats/brands
+ *   Scale                                  → SCALE              → API, unlimited seats/brands/channels
+ *   Enterprise                             → ENTERPRISE         → custom API, unlimited seats/brands/channels
  *
  * Enforcement lives in the API:
+ *   - brand gate:   apps/server/api/src/helpers/guards/brand-credits/brand-credits.guard.ts
+ *   - channel gate: apps/server/api/src/collections/credentials/services/credentials.service.ts
+ *   - seat gate:    apps/server/api/src/helpers/guards/member-credits/member-credits.guard.ts
  *   - issuance gate:  apps/server/api/src/helpers/guards/api-access/api-access.guard.ts
  *   - rate limiting:  apps/server/api/src/collections/api-keys/services/api-keys.service.ts
  *
@@ -21,6 +23,8 @@
  * (the `Record<SubscriptionTier, …>` is exhaustive and TS-enforced).
  */
 import { SubscriptionTier } from '@genfeedai/enums';
+
+export type TierLimit = number | null;
 
 export type ApiTierEntitlement = {
   /** Whether the tier may mint API keys and authenticate requests with them. */
@@ -34,54 +38,130 @@ export type ApiTierEntitlement = {
   apiRateLimit: number | null;
 };
 
+export type TierPlanEntitlement = ApiTierEntitlement & {
+  /** Connected brand kits. `null` means no platform-enforced product cap. */
+  brandLimit: TierLimit;
+  /** Connected publishing/integration channels. `null` means unlimited. */
+  channelLimit: TierLimit;
+  /** Organization seats. `null` means unlimited team seats. */
+  seatLimit: TierLimit;
+};
+
+export type LimitedPlanResource = 'brands' | 'channels' | 'seats';
+
+/** Sentinel for product limits that are unlimited for a tier. */
+export const PLAN_LIMIT_UNLIMITED = null;
+
+/** PAYG/BYOK brand-kit cap from plans-pricing.ts. */
+export const FREE_BRAND_LIMIT = 1;
+/** PAYG/BYOK connected-channel cap from plans-pricing.ts. */
+export const FREE_CHANNEL_LIMIT = 3;
+/** PAYG/BYOK solo workspace seat cap. */
+export const FREE_SEAT_LIMIT = 1;
+/** Pro connected-channel cap from plans-pricing.ts. */
+export const PRO_CHANNEL_LIMIT = 15;
+
 /** Higher ceiling for the Pro tier. */
 export const HIGHER_API_RATE_LIMIT = 300;
 /** Highest fixed ceiling for the Scale tier. */
 export const SCALE_API_RATE_LIMIT = 600;
 
 /**
- * Exhaustive tier → entitlement map. Free tiers (FREE, BYOK) get no API access;
- * every paid tier does, with an escalating rate limit; Enterprise is uncapped
- * (custom / negotiated).
+ * Exhaustive tier → cloud entitlement map. Free tiers (FREE, BYOK) are solo
+ * workspaces with limited brands/channels and no managed API access; every paid
+ * tier has unlimited seats and brands; Scale+ removes the connected-channel cap.
  */
-export const TIER_API_ENTITLEMENTS: Record<
+export const TIER_PLAN_ENTITLEMENTS: Record<
   SubscriptionTier,
-  ApiTierEntitlement
+  TierPlanEntitlement
 > = {
-  [SubscriptionTier.FREE]: { apiAccess: false, apiRateLimit: 0 },
-  [SubscriptionTier.BYOK]: { apiAccess: false, apiRateLimit: 0 },
+  [SubscriptionTier.FREE]: {
+    apiAccess: false,
+    apiRateLimit: 0,
+    brandLimit: FREE_BRAND_LIMIT,
+    channelLimit: FREE_CHANNEL_LIMIT,
+    seatLimit: FREE_SEAT_LIMIT,
+  },
+  [SubscriptionTier.BYOK]: {
+    apiAccess: false,
+    apiRateLimit: 0,
+    brandLimit: FREE_BRAND_LIMIT,
+    channelLimit: FREE_CHANNEL_LIMIT,
+    seatLimit: FREE_SEAT_LIMIT,
+  },
   [SubscriptionTier.PRO]: {
     apiAccess: true,
     apiRateLimit: HIGHER_API_RATE_LIMIT,
+    brandLimit: PLAN_LIMIT_UNLIMITED,
+    channelLimit: PRO_CHANNEL_LIMIT,
+    seatLimit: PLAN_LIMIT_UNLIMITED,
   },
   [SubscriptionTier.SCALE]: {
     apiAccess: true,
     apiRateLimit: SCALE_API_RATE_LIMIT,
+    brandLimit: PLAN_LIMIT_UNLIMITED,
+    channelLimit: PLAN_LIMIT_UNLIMITED,
+    seatLimit: PLAN_LIMIT_UNLIMITED,
   },
-  [SubscriptionTier.ENTERPRISE]: { apiAccess: true, apiRateLimit: null },
+  [SubscriptionTier.ENTERPRISE]: {
+    apiAccess: true,
+    apiRateLimit: null,
+    brandLimit: PLAN_LIMIT_UNLIMITED,
+    channelLimit: PLAN_LIMIT_UNLIMITED,
+    seatLimit: PLAN_LIMIT_UNLIMITED,
+  },
 };
 
 /**
- * Default-deny entitlement for an unknown/empty tier. In a managed-cloud
- * deployment an org with no resolvable paid tier has no API access.
+ * API-only projection kept for existing call sites and tests.
  */
-const NO_API_ENTITLEMENT: ApiTierEntitlement = {
-  apiAccess: false,
-  apiRateLimit: 0,
-};
+export const TIER_API_ENTITLEMENTS: Record<
+  SubscriptionTier,
+  ApiTierEntitlement
+> = Object.fromEntries(
+  Object.entries(TIER_PLAN_ENTITLEMENTS).map(([tier, entitlement]) => [
+    tier,
+    {
+      apiAccess: entitlement.apiAccess,
+      apiRateLimit: entitlement.apiRateLimit,
+    },
+  ]),
+) as Record<SubscriptionTier, ApiTierEntitlement>;
 
 /**
- * Resolve the API entitlement for a subscription tier. Accepts the raw string
- * stored on `OrganizationSetting.subscriptionTier`; unknown/empty tiers
- * default-deny.
+ * Default entitlement for unknown/empty tiers. In managed cloud, an org with
+ * no resolvable tier behaves like PAYG/free for product limits and API access.
+ */
+const DEFAULT_PLAN_ENTITLEMENT = TIER_PLAN_ENTITLEMENTS[SubscriptionTier.FREE];
+
+/**
+ * Resolve all cloud entitlements for a subscription tier. Accepts the raw
+ * string stored on `OrganizationSetting.subscriptionTier`; unknown/empty tiers
+ * fall back to PAYG/free behavior.
+ */
+export function getPlanEntitlementForTier(
+  tier: string | null | undefined,
+): TierPlanEntitlement {
+  if (!tier) {
+    return DEFAULT_PLAN_ENTITLEMENT;
+  }
+  return (
+    TIER_PLAN_ENTITLEMENTS[tier as SubscriptionTier] ?? DEFAULT_PLAN_ENTITLEMENT
+  );
+}
+
+/**
+ * Resolve the API entitlement for a subscription tier. Unknown/empty tiers have
+ * no API access.
  */
 export function getApiEntitlementForTier(
   tier: string | null | undefined,
 ): ApiTierEntitlement {
-  if (!tier) {
-    return NO_API_ENTITLEMENT;
-  }
-  return TIER_API_ENTITLEMENTS[tier as SubscriptionTier] ?? NO_API_ENTITLEMENT;
+  const entitlement = getPlanEntitlementForTier(tier);
+  return {
+    apiAccess: entitlement.apiAccess,
+    apiRateLimit: entitlement.apiRateLimit,
+  };
 }
 
 /** Whether a tier may create and use API keys. */
@@ -97,4 +177,61 @@ export function getApiRateLimitForTier(
   tier: string | null | undefined,
 ): number | null {
   return getApiEntitlementForTier(tier).apiRateLimit;
+}
+
+/** Connected brand-kit limit for a tier. `null` means unlimited. */
+export function getBrandLimitForTier(
+  tier: string | null | undefined,
+): TierLimit {
+  return getPlanEntitlementForTier(tier).brandLimit;
+}
+
+/** Connected-channel limit for a tier. `null` means unlimited. */
+export function getChannelLimitForTier(
+  tier: string | null | undefined,
+): TierLimit {
+  return getPlanEntitlementForTier(tier).channelLimit;
+}
+
+/** Seat limit for a tier. `null` means unlimited seats. */
+export function getSeatLimitForTier(
+  tier: string | null | undefined,
+): TierLimit {
+  return getPlanEntitlementForTier(tier).seatLimit;
+}
+
+/**
+ * Next tier that lifts the given finite resource cap. Used for upgrade prompts.
+ */
+export function getUpgradeTierForLimit(
+  resource: LimitedPlanResource,
+  tier: string | null | undefined,
+): SubscriptionTier | null {
+  const currentTier =
+    tier && tier in TIER_PLAN_ENTITLEMENTS
+      ? (tier as SubscriptionTier)
+      : SubscriptionTier.FREE;
+
+  if (
+    (resource === 'brands' || resource === 'seats') &&
+    ![
+      SubscriptionTier.PRO,
+      SubscriptionTier.SCALE,
+      SubscriptionTier.ENTERPRISE,
+    ].includes(currentTier as SubscriptionTier)
+  ) {
+    return SubscriptionTier.PRO;
+  }
+
+  if (
+    resource === 'channels' &&
+    ![SubscriptionTier.SCALE, SubscriptionTier.ENTERPRISE].includes(currentTier)
+  ) {
+    return currentTier === SubscriptionTier.FREE ||
+      currentTier === SubscriptionTier.BYOK
+      ? SubscriptionTier.PRO
+      : SubscriptionTier.SCALE;
+  }
+
+  return null;
 }

--- a/packages/prisma/prisma/migrations/20260706143000_plan_limit_defaults/migration.sql
+++ b/packages/prisma/prisma/migrations/20260706143000_plan_limit_defaults/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "organization_settings" ALTER COLUMN "seatsLimit" SET DEFAULT 1;
+ALTER TABLE "organization_settings" ALTER COLUMN "brandsLimit" SET DEFAULT 1;

--- a/packages/prisma/prisma/schema.prisma
+++ b/packages/prisma/prisma/schema.prisma
@@ -1181,8 +1181,8 @@ model OrganizationSetting {
   isGenerateMusicEnabled        Boolean           @default(true)
   isAutoEvaluateEnabled         Boolean           @default(false)
   isFastlaneEnabled             Boolean           @default(false)
-  seatsLimit                    Int               @default(3)
-  brandsLimit                   Int               @default(5)
+  seatsLimit                    Int               @default(1)
+  brandsLimit                   Int               @default(1)
   timezone                      String            @default("UTC")
   isWebhookEnabled              Boolean           @default(false)
   webhookEndpoint               String?


### PR DESCRIPTION
## Summary
- define canonical brand, channel, seat, and API entitlements in `@genfeedai/pricing`
- enforce cloud plan limits server-side for brand creation, member invites, connected channels, and API access
- mirror limit state in billing, API keys, brands, and members settings UI without exposing pricing details
- align new organization defaults and migration with the free solo/one-brand limits

## Verification
- `bunx biome check --write --no-errors-on-unmatched <changed files>`
- `bun run --cwd apps/server/api test:file src/helpers/guards/api-access/tier-entitlements.spec.ts src/helpers/guards/api-access/api-access.guard.spec.ts src/helpers/guards/brand-credits/brand-credits.guard.spec.ts src/helpers/guards/member-credits/member-credits.guard.spec.ts src/collections/credentials/services/credentials.service.spec.ts src/collections/brands/controllers/brands.controller.spec.ts src/collections/organizations/controllers/organizations-members.controller.spec.ts`
- `bun run --cwd apps/app test app/(protected)/[orgSlug]/~/settings/(pages)/organization/api-keys/content.test.tsx app/(protected)/[orgSlug]/~/settings/brands/brands-list.test.tsx app/(protected)/[orgSlug]/~/settings/(pages)/organization/members/members-list.test.tsx`
- `bun run --cwd apps/app test app/(protected)/[orgSlug]/~/settings/(pages)/organization/billing/content.test.tsx`
- `bunx prisma validate --schema packages/prisma/prisma/schema.prisma`
- `git diff --cached --check`
- `git diff --cached --name-only -z | xargs -0 bunx secretlint`

Closes #1434