### PR TITLE
Summarize brand relocation moving resources

### DIFF
--- a/apps/server/api/src/collections/brands/controllers/brands.controller.ts
+++ b/apps/server/api/src/collections/brands/controllers/brands.controller.ts
@@ -215,8 +215,8 @@ export class BrandsController extends BaseCRUDController<
   }
 
   /**
-   * Preview the impact of relocating a brand to another organization: how many
-   * brand-owned workflows will move with it, and how many members will lose access.
+   * Preview the impact of relocating a brand to another organization: which
+   * brand-owned resources move with it, and how many members lose access.
    * `sharedWorkflows` and `ackToken` remain in the response for compatibility and
    * are always 0/null now that workflows are scoped to one brand.
    */

--- a/apps/server/api/src/collections/brands/services/brands.service.relocate.spec.ts
+++ b/apps/server/api/src/collections/brands/services/brands.service.relocate.spec.ts
@@ -152,6 +152,44 @@ describe('BrandsService.relocateToOrganization', () => {
     getDelegate('workflow').findMany.mockResolvedValue(workflows);
   }
 
+  it('previews every non-zero resource type that will move with the brand', async () => {
+    primeBrand();
+    getDelegate('member').findMany.mockResolvedValue([{ id: 'member_1' }]);
+    getDelegate('workflow').findMany.mockResolvedValue([{ id: 'wf_1' }]);
+    getDelegate('workflow').count.mockResolvedValue(1);
+    getDelegate('post').count.mockResolvedValue(4);
+    getDelegate('workflowExecution').count.mockResolvedValue(2);
+    getDelegate('batchWorkflowJob').count.mockResolvedValue(1);
+
+    const preview = await service.previewRelocation(BRAND_ID, DEST_ORG, {
+      isSuperAdmin: true,
+      userId: USER_ID,
+    });
+
+    expect(preview).toEqual({
+      ackToken: null,
+      counts: {
+        sharedWorkflows: 0,
+        soleBrandWorkflows: 1,
+        staleMembers: 1,
+      },
+      movingResources: [
+        { count: 1, label: 'workflow', resource: 'workflow' },
+        { count: 4, label: 'posts', resource: 'post' },
+        {
+          count: 2,
+          label: 'workflow executions',
+          resource: 'workflowExecution',
+        },
+        {
+          count: 1,
+          label: 'batch workflow job',
+          resource: 'batchWorkflowJob',
+        },
+      ],
+    });
+  });
+
   it('does not relocate (or open a transaction) when the org is unchanged', async () => {
     getDelegate('brand').findFirst.mockResolvedValue({
       id: BRAND_ID,

--- a/apps/server/api/src/collections/brands/services/brands.service.ts
+++ b/apps/server/api/src/collections/brands/services/brands.service.ts
@@ -195,6 +195,12 @@ interface RelocationReconcileResult {
   membersSevered: number;
 }
 
+export interface BrandRelocationMovingResource {
+  resource: string;
+  label: string;
+  count: number;
+}
+
 /** Server-authoritative summary of a completed (or no-op) brand relocation. */
 export interface BrandRelocationSummary {
   workflowsMoved: number;
@@ -218,6 +224,7 @@ export interface BrandRelocationPreview {
     sharedWorkflows: number;
     staleMembers: number;
   };
+  movingResources: BrandRelocationMovingResource[];
   /** Always null after workflow brand ownership became one-to-one. */
   ackToken: string | null;
 }
@@ -228,6 +235,145 @@ const EMPTY_RELOCATION_SUMMARY: BrandRelocationSummary = {
   workflowsClonedPaused: 0,
   membersSevered: 0,
   schedulingPending: 0,
+};
+
+const RELOCATION_RESOURCE_LABELS: Record<
+  string,
+  { singular: string; plural: string }
+> = {
+  adBulkUploadJob: {
+    singular: 'ad bulk upload job',
+    plural: 'ad bulk upload jobs',
+  },
+  adCreativeMapping: {
+    singular: 'ad creative mapping',
+    plural: 'ad creative mappings',
+  },
+  adPerformance: {
+    singular: 'ad performance record',
+    plural: 'ad performance records',
+  },
+  activity: { singular: 'activity', plural: 'activities' },
+  agentCampaign: { singular: 'agent campaign', plural: 'agent campaigns' },
+  agentGoal: { singular: 'agent goal', plural: 'agent goals' },
+  agentMemory: { singular: 'agent memory', plural: 'agent memories' },
+  agentMessage: { singular: 'agent message', plural: 'agent messages' },
+  agentStrategy: { singular: 'agent strategy', plural: 'agent strategies' },
+  agentStrategyOpportunity: {
+    singular: 'agent strategy opportunity',
+    plural: 'agent strategy opportunities',
+  },
+  agentStrategyReport: {
+    singular: 'agent strategy report',
+    plural: 'agent strategy reports',
+  },
+  articleAnalytics: {
+    singular: 'article analytics record',
+    plural: 'article analytics records',
+  },
+  article: { singular: 'article', plural: 'articles' },
+  asset: { singular: 'asset', plural: 'assets' },
+  batchWorkflowJob: {
+    singular: 'batch workflow job',
+    plural: 'batch workflow jobs',
+  },
+  batch: { singular: 'batch', plural: 'batches' },
+  bookmark: { singular: 'bookmark', plural: 'bookmarks' },
+  botActivity: { singular: 'bot activity', plural: 'bot activities' },
+  bot: { singular: 'bot', plural: 'bots' },
+  brandInterview: {
+    singular: 'brand interview',
+    plural: 'brand interviews',
+  },
+  brandMemory: { singular: 'brand memory', plural: 'brand memories' },
+  campaignTarget: { singular: 'campaign target', plural: 'campaign targets' },
+  caption: { singular: 'caption', plural: 'captions' },
+  clipProject: { singular: 'clip project', plural: 'clip projects' },
+  contentPerformance: {
+    singular: 'content performance record',
+    plural: 'content performance records',
+  },
+  contentDraft: { singular: 'content draft', plural: 'content drafts' },
+  contentPlan: { singular: 'content plan', plural: 'content plans' },
+  contentPlanItem: {
+    singular: 'content plan item',
+    plural: 'content plan items',
+  },
+  contentRun: { singular: 'content run', plural: 'content runs' },
+  contextBase: { singular: 'context base', plural: 'context bases' },
+  contextEntry: { singular: 'context entry', plural: 'context entries' },
+  credential: { singular: 'credential', plural: 'credentials' },
+  creativePattern: {
+    singular: 'creative pattern',
+    plural: 'creative patterns',
+  },
+  distribution: { singular: 'distribution', plural: 'distributions' },
+  editorProject: {
+    singular: 'editor project',
+    plural: 'editor projects',
+  },
+  folder: { singular: 'folder', plural: 'folders' },
+  ingredient: { singular: 'ingredient', plural: 'ingredients' },
+  lead: { singular: 'lead', plural: 'leads' },
+  model: { singular: 'model', plural: 'models' },
+  monitoredAccount: {
+    singular: 'monitored account',
+    plural: 'monitored accounts',
+  },
+  moodBoard: { singular: 'mood board', plural: 'mood boards' },
+  newsletter: { singular: 'newsletter', plural: 'newsletters' },
+  outreachCampaign: {
+    singular: 'outreach campaign',
+    plural: 'outreach campaigns',
+  },
+  persona: { singular: 'persona', plural: 'personas' },
+  post: { singular: 'post', plural: 'posts' },
+  postAnalytics: {
+    singular: 'post analytics record',
+    plural: 'post analytics records',
+  },
+  preset: { singular: 'preset', plural: 'presets' },
+  processedTweet: {
+    singular: 'processed tweet',
+    plural: 'processed tweets',
+  },
+  prompt: { singular: 'prompt', plural: 'prompts' },
+  replyBotConfig: {
+    singular: 'reply bot config',
+    plural: 'reply bot configs',
+  },
+  run: { singular: 'run', plural: 'runs' },
+  schedule: { singular: 'schedule', plural: 'schedules' },
+  socialConversation: {
+    singular: 'social conversation',
+    plural: 'social conversations',
+  },
+  socialMessage: { singular: 'social message', plural: 'social messages' },
+  tag: { singular: 'tag', plural: 'tags' },
+  task: { singular: 'task', plural: 'tasks' },
+  taskComment: { singular: 'task comment', plural: 'task comments' },
+  training: { singular: 'training', plural: 'trainings' },
+  trackedLink: { singular: 'tracked link', plural: 'tracked links' },
+  transcript: { singular: 'transcript', plural: 'transcripts' },
+  trend: { singular: 'trend', plural: 'trends' },
+  trendPreferences: {
+    singular: 'trend preference',
+    plural: 'trend preferences',
+  },
+  trendRemixLineage: {
+    singular: 'trend remix lineage',
+    plural: 'trend remix lineages',
+  },
+  warmupAccount: {
+    singular: 'warmup account',
+    plural: 'warmup accounts',
+  },
+  watchlist: { singular: 'watchlist', plural: 'watchlists' },
+  workflowExecution: {
+    singular: 'workflow execution',
+    plural: 'workflow executions',
+  },
+  workflow: { singular: 'workflow', plural: 'workflows' },
 };
 
 @Injectable()
@@ -1804,6 +1950,11 @@ Respond ONLY with the JSON array.`;
       brandId,
       destOrgId,
     );
+    const movingResources = await this.countRelocationMovingResources(
+      this.prisma as unknown as Prisma.TransactionClient,
+      brandId,
+      destOrgId,
+    );
 
     return {
       ackToken: null,
@@ -1812,7 +1963,91 @@ Respond ONLY with the JSON array.`;
         soleBrandWorkflows: impact.soleBrandWorkflowIds.length,
         staleMembers: impact.staleMemberIds.length,
       },
+      movingResources,
     };
+  }
+
+  private async countRelocationMovingResources(
+    client: Prisma.TransactionClient,
+    brandId: string,
+    destOrgId: string,
+  ): Promise<BrandRelocationMovingResource[]> {
+    const delegateClient = client as unknown as Record<string, CascadeDelegate>;
+    const firstOrderResources = await Promise.all(
+      FIRST_ORDER_TARGETS.map(async (target) => {
+        const count = await delegateClient[target.delegate].count({
+          where: {
+            [target.brandField]: brandId,
+            [target.orgField]: { not: destOrgId },
+          },
+        });
+        return this.toMovingResource(target.delegate, count);
+      }),
+    );
+
+    const secondOrderResources = await Promise.all(
+      SECOND_ORDER_TARGETS.map(async (child) => {
+        const orClauses: Record<string, unknown>[] = [];
+        await Promise.all(
+          child.parents.map(async (parent) => {
+            const parentRows = await delegateClient[
+              parent.parentDelegate
+            ].findMany({
+              select: { id: true },
+              where: { [parent.parentBrandField]: brandId },
+            });
+            if (parentRows.length > 0) {
+              orClauses.push({
+                [parent.fkField]: { in: parentRows.map((row) => row.id) },
+              });
+            }
+          }),
+        );
+        if (orClauses.length === 0) {
+          return null;
+        }
+
+        const count = await delegateClient[child.delegate].count({
+          where: {
+            OR: orClauses,
+            [child.orgField]: { not: destOrgId },
+          },
+        });
+        return this.toMovingResource(child.delegate, count);
+      }),
+    );
+
+    return [...firstOrderResources, ...secondOrderResources].filter(
+      (resource): resource is BrandRelocationMovingResource =>
+        resource !== null,
+    );
+  }
+
+  private toMovingResource(
+    resource: string,
+    count: number,
+  ): BrandRelocationMovingResource | null {
+    if (count <= 0) {
+      return null;
+    }
+    return {
+      count,
+      label: this.formatRelocationResourceLabel(resource, count),
+      resource,
+    };
+  }
+
+  private formatRelocationResourceLabel(
+    resource: string,
+    count: number,
+  ): string {
+    const labels = RELOCATION_RESOURCE_LABELS[resource];
+    if (labels) {
+      return count === 1 ? labels.singular : labels.plural;
+    }
+
+    const words = resource.replace(/([a-z])([A-Z])/g, '$1 $2').toLowerCase();
+    return `${words} ${count === 1 ? 'record' : 'records'}`;
   }
 
   /**

--- a/packages/services/social/brand-relocation.types.ts
+++ b/packages/services/social/brand-relocation.types.ts
@@ -1,8 +1,9 @@
 import type { Brand } from '@genfeedai/models/organization/brand.model';
 
 /**
- * Counts returned by the relocation preview endpoint, describing the
- * clone/severance impact of moving a brand to a destination organization.
+ * Counts returned by the relocation preview endpoint. `sharedWorkflows` remains
+ * for backwards compatibility and is always 0 now that workflows are one-to-one
+ * with a brand.
  */
 export interface IBrandRelocationCounts {
   sharedWorkflows: number;
@@ -10,21 +11,29 @@ export interface IBrandRelocationCounts {
   staleMembers: number;
 }
 
+export interface IBrandRelocationMovingResource {
+  resource: string;
+  label: string;
+  count: number;
+}
+
 /**
  * Response shape for `GET /brands/:id/relocation-preview`.
  *
- * `ackToken` is `null` when the move has no clone impact (no shared
- * workflows attached to the brand) and therefore doesn't require an ack.
+ * `movingResources` lists non-zero resource counts whose organization scope
+ * will be rewritten with the brand. `ackToken` remains for backwards
+ * compatibility and is always `null`.
  */
 export interface IBrandRelocationPreview {
   ackToken: string | null;
   counts: IBrandRelocationCounts;
+  movingResources: IBrandRelocationMovingResource[];
 }
 
 /**
  * Request body for the relocation-specific `PATCH /brands/:id` call.
- * `relocationAck` must echo the `ackToken` from the preview whenever
- * `counts.sharedWorkflows > 0` — the server returns 409 otherwise.
+ * `relocationAck` is accepted for backwards compatibility with older clients
+ * and ignored by the current one-to-one workflow relocation path.
  */
 export type IBrandRelocationPatchBody = Record<string, unknown> & {
   organizationId: string;

--- a/packages/services/social/brands.service.ts
+++ b/packages/services/social/brands.service.ts
@@ -409,10 +409,9 @@ export class BrandsService extends BaseService<Brand> {
   }
 
   /**
-   * Previews the clone/severance impact of moving a brand to a destination
-   * organization. Read-only. `ackToken` is `null` when there's no clone
-   * impact (no shared workflows attached to the brand), meaning the
-   * relocation patch does not need to pass `relocationAck`.
+   * Previews the impact of moving a brand to a destination organization.
+   * Read-only. `movingResources` lists non-zero brand-owned resource counts
+   * whose organization scope will be rewritten with the brand.
    */
   public async getRelocationPreview(
     id: string,
@@ -433,10 +432,8 @@ export class BrandsService extends BaseService<Brand> {
    * (`workflowsMoved`, `workflowsClonedActive`, `workflowsClonedPaused`,
    * `membersSevered`, `schedulingPending`).
    *
-   * Pass `relocationAck` = the `ackToken` from `getRelocationPreview()`.
-   * It is required whenever the preview's `counts.sharedWorkflows > 0` —
-   * the server returns 409 otherwise (or if the impacted set changed
-   * since the preview was taken).
+   * `relocationAck` is still accepted for older clients but current workflow
+   * relocation no longer needs clone/disconnect acknowledgement.
    */
   public async relocateBrand(
     id: string,

--- a/packages/ui/src/components/modals/brands/brand/brand-relocation-summary.util.test.ts
+++ b/packages/ui/src/components/modals/brands/brand/brand-relocation-summary.util.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { buildMovingResourcesSummary } from './brand-relocation-summary.util';
+
+describe('buildMovingResourcesSummary', () => {
+  it('summarizes every moving resource in the relocation warning', () => {
+    expect(
+      buildMovingResourcesSummary([
+        { count: 2, label: 'workflows', resource: 'workflow' },
+        { count: 5, label: 'posts', resource: 'post' },
+        {
+          count: 1,
+          label: 'workflow execution',
+          resource: 'workflowExecution',
+        },
+      ]),
+    ).toBe(
+      'Also moving with it: 2 workflows, 5 posts, and 1 workflow execution.',
+    );
+  });
+
+  it('omits the sentence when no resources move', () => {
+    expect(
+      buildMovingResourcesSummary([
+        { count: 0, label: 'posts', resource: 'post' },
+      ]),
+    ).toBeNull();
+  });
+});

--- a/packages/ui/src/components/modals/brands/brand/brand-relocation-summary.util.ts
+++ b/packages/ui/src/components/modals/brands/brand/brand-relocation-summary.util.ts
@@ -1,0 +1,29 @@
+import type { IBrandRelocationMovingResource } from '@genfeedai/services/social/brand-relocation.types';
+
+function joinRelocationSummaryItems(items: string[]): string {
+  if (items.length === 0) {
+    return '';
+  }
+  if (items.length === 1) {
+    return items[0];
+  }
+  if (items.length === 2) {
+    return `${items[0]} and ${items[1]}`;
+  }
+
+  return `${items.slice(0, -1).join(', ')}, and ${items[items.length - 1]}`;
+}
+
+export function buildMovingResourcesSummary(
+  resources: readonly IBrandRelocationMovingResource[] | undefined,
+): string | null {
+  const items = (resources ?? [])
+    .filter((resource) => resource.count > 0)
+    .map((resource) => `${resource.count} ${resource.label}`);
+
+  if (items.length === 0) {
+    return null;
+  }
+
+  return `Also moving with it: ${joinRelocationSummaryItems(items)}.`;
+}

--- a/packages/ui/src/components/modals/brands/brand/useModalBrand.ts
+++ b/packages/ui/src/components/modals/brands/brand/useModalBrand.ts
@@ -58,6 +58,7 @@ import {
   useState,
 } from 'react';
 import { useForm } from 'react-hook-form';
+import { buildMovingResourcesSummary } from './brand-relocation-summary.util';
 import {
   type BrandEditorTab,
   type BrandFormValues,
@@ -65,14 +66,6 @@ import {
   type BrandOverlayView,
   buildSocialConnections,
 } from './ModalBrand.types';
-
-function getStructuredErrorStatus(error: unknown): number | undefined {
-  if (!error || typeof error !== 'object') {
-    return undefined;
-  }
-  const status = (error as IStructuredError).status;
-  return typeof status === 'number' ? status : undefined;
-}
 
 const DEFAULT_BRAND_FORM_VALUES: BrandFormValues = {
   backgroundColor: THEME_COLORS.PRIMARY,
@@ -94,6 +87,14 @@ export type OrganizationOption = {
   id: string;
   label: string;
 };
+
+function getStructuredErrorStatus(error: unknown): number | undefined {
+  if (!error || typeof error !== 'object') {
+    return undefined;
+  }
+  const status = (error as IStructuredError).status;
+  return typeof status === 'number' ? status : undefined;
+}
 
 const DEFAULT_BRAND_LINK_FORM_VALUES: BrandLinkEditorValues = {
   category: LinkCategory.WEBSITE,
@@ -767,21 +768,19 @@ export function useModalBrand(
       destinationLabel: string,
       preview: IBrandRelocationPreview,
     ): string => {
-      const { soleBrandWorkflows, sharedWorkflows, staleMembers } =
-        preview.counts;
+      const { soleBrandWorkflows, staleMembers } = preview.counts;
       const sentences: string[] = [
         `${brandLabel} moves to ${destinationLabel}.`,
       ];
+      const movingResourcesSummary = buildMovingResourcesSummary(
+        preview.movingResources,
+      );
 
-      if (soleBrandWorkflows > 0) {
+      if (movingResourcesSummary) {
+        sentences.push(movingResourcesSummary);
+      } else if (soleBrandWorkflows > 0) {
         sentences.push(
           `${soleBrandWorkflows} dedicated workflow${soleBrandWorkflows === 1 ? '' : 's'} move${soleBrandWorkflows === 1 ? 's' : ''} with it.`,
-        );
-      }
-
-      if (sharedWorkflows > 0) {
-        sentences.push(
-          `${sharedWorkflows} shared workflow${sharedWorkflows === 1 ? '' : 's'} will be COPIED into ${destinationLabel} and will run there (any that reference other brands' resources are created paused for review).`,
         );
       }
 
@@ -944,7 +943,7 @@ export function useModalBrand(
     } catch (previewError) {
       logger.error('Failed to load brand relocation preview', previewError);
       setError(
-        "Couldn't check the move's impact on workflows and members. Please try again.",
+        "Couldn't check the move's impact on resources and members. Please try again.",
       );
       resetOrganizationSelection();
     }


### PR DESCRIPTION
## Summary
- Add movingResources to the brand relocation preview, counted from the same first-/second-order cascade config used by relocation.
- Show a compact warning sentence in the brand move confirmation for every resource type moving with the brand.
- Update relocation client types/docs and focused backend/UI coverage.

## Verification
- bunx biome check --write apps/server/api/src/collections/brands/services/brands.service.ts apps/server/api/src/collections/brands/services/brands.service.relocate.spec.ts apps/server/api/src/collections/brands/controllers/brands.controller.ts packages/services/social/brand-relocation.types.ts packages/services/social/brands.service.ts packages/ui/src/components/modals/brands/brand/useModalBrand.ts packages/ui/src/components/modals/brands/brand/brand-relocation-summary.util.ts packages/ui/src/components/modals/brands/brand/brand-relocation-summary.util.test.ts
- (apps/server/api) bun run test:file src/collections/brands/services/brands.service.relocate.spec.ts
- (packages/ui) bun run test -- src/components/modals/brands/brand/brand-relocation-summary.util.test.ts

Note: I intentionally did not run workspace builds, workspace typechecks, package-wide typechecks, turbo, or broad test suites locally; PR CI should cover broad validation.