### PR TITLE
fix(e2e): align shell context workspace label

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/~/agent/AgentWorkspaceLayoutClient.spec.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/agent/AgentWorkspaceLayoutClient.spec.tsx
@@ -7,6 +7,7 @@ const routerReplace = vi.fn();
 const sendMessage = vi.fn();
 const patchMe = vi.fn();
 const touchSession = vi.fn();
+const getToken = vi.fn();
 
 const navigationState = {
   params: {
@@ -30,6 +31,13 @@ vi.mock('@genfeedai/auth-client/react', () => ({
     session: {
       touch: touchSession,
     },
+  }),
+}));
+
+vi.mock('@genfeedai/hooks/auth/use-auth-identity/use-auth-identity', () => ({
+  useAuthIdentity: () => ({
+    getToken,
+    isLoaded: true,
   }),
 }));
 
@@ -106,6 +114,8 @@ describe('AgentWorkspaceLayoutClient', () => {
     patchMe.mockReset();
     patchMe.mockResolvedValue(undefined);
     touchSession.mockReset();
+    getToken.mockReset();
+    getToken.mockResolvedValue('token');
   });
 
   it('does not immediately redirect /agent/new back to the previously active thread', async () => {

--- a/packages/prisma/prisma/migrations/20260707120000_workflow_brand_one_to_one/migration.sql
+++ b/packages/prisma/prisma/migrations/20260707120000_workflow_brand_one_to_one/migration.sql
@@ -34,6 +34,7 @@ WHERE ranked_links.workflow_id = wf."id"
 WITH ranked_links AS (
   SELECT
     wf."id" AS workflow_id,
+    wf."organizationId" AS workflow_org_id,
     wb."A" AS brand_id,
     b."organizationId" AS brand_org_id,
     ROW_NUMBER() OVER (

--- a/playwright/e2e/tests/shell/page-context-contract.spec.ts
+++ b/playwright/e2e/tests/shell/page-context-contract.spec.ts
@@ -24,6 +24,7 @@ const CONTRACTS: PageContextContract[] = [
   {
     route: `${BRAND_BASE}/workspace/overview`,
     currentApp: 'workspace',
+    sectionLabel: 'Workspace',
     sidebarLabels: ['Dashboard', 'Inbox', 'Tasks', 'Activity'],
   },
   {
@@ -44,6 +45,7 @@ const CONTRACTS: PageContextContract[] = [
   {
     route: `${BRAND_BASE}/posts/scheduled`,
     currentApp: 'posts',
+    sectionLabel: 'Workspace',
     pageLabels: ['Drafts', 'Scheduled', 'Published'],
   },
   {


### PR DESCRIPTION
## Summary
- Update the shell page-context E2E contract for workspace and posts routes to expect the intentional `Workspace` sidebar section label.
- Repair the workflow brand one-to-one migration CTE so API E2E can apply Prisma migrations from a fresh database.
- Refresh the agent layout spec auth mock so current PR CI passes after `useAuthIdentity` became the component auth source.
- Keep #1450 separate: its release E2E failure is root-route/self-hosted behavior, not this shell/API E2E path.

## Verification
- `bunx biome check playwright/e2e/tests/shell/page-context-contract.spec.ts`
- `bun run test:e2e:routes`
- `bunx biome check apps/app/app/(protected)/[orgSlug]/~/agent/AgentWorkspaceLayoutClient.spec.tsx`
- E2E Tests workflow: https://github.com/genfeedai/genfeed.ai/actions/runs/28875020368 passed route coverage, API E2E, all frontend shards, authed E2E, report merge, and E2E gate.
- PR CI: https://github.com/genfeedai/genfeed.ai/actions/runs/28875590609 passed.

Local note: the focused Playwright/Vitest commands could not execute in this worktree because local test dependencies (`@playwright/test`, `vitest`) are not installed; heavy/browser validation was run through GitHub Actions instead.

Refs #1448