### PR TITLE
fix(auth): validate body organization in role guard

### DIFF
--- a/apps/server/api/src/helpers/guards/roles/roles.guard.spec.ts
+++ b/apps/server/api/src/helpers/guards/roles/roles.guard.spec.ts
@@ -148,11 +148,35 @@ describe('RolesGuard', () => {
           user: USER_ID,
         },
       },
-      { body: { organization: REQUEST_ORGANIZATION_ID } },
+      { body: { organizationId: REQUEST_ORGANIZATION_ID } },
     );
 
     await expectForbidden(guard.canActivate(context));
     expect(mockMembersService.findOne).not.toHaveBeenCalled();
+  });
+
+  it('ignores non-ID body organization payloads when token organization exists', async () => {
+    vi.spyOn(reflector, 'get').mockReturnValue(undefined);
+    mockMembersService.findOne.mockResolvedValue({ id: 'member-1' });
+
+    const context = createContext(
+      {
+        publicMetadata: {
+          organization: TOKEN_ORGANIZATION_ID,
+          user: USER_ID,
+        },
+      },
+      { body: { organization: 'creator-handle' } },
+    );
+
+    await expect(guard.canActivate(context)).resolves.toBe(true);
+    expect(mockMembersService.findOne).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organization: TOKEN_ORGANIZATION_ID,
+        user: USER_ID,
+      }),
+      expect.any(Array),
+    );
   });
 
   it('uses explicit route organization when token organization is absent', async () => {
@@ -166,6 +190,29 @@ describe('RolesGuard', () => {
         },
       },
       { params: { organizationId: REQUEST_ORGANIZATION_ID } },
+    );
+
+    await expect(guard.canActivate(context)).resolves.toBe(true);
+    expect(mockMembersService.findOne).toHaveBeenCalledWith(
+      expect.objectContaining({
+        organization: REQUEST_ORGANIZATION_ID,
+        user: USER_ID,
+      }),
+      expect.any(Array),
+    );
+  });
+
+  it('uses explicit body organizationId when token organization is absent', async () => {
+    vi.spyOn(reflector, 'get').mockReturnValue(undefined);
+    mockMembersService.findOne.mockResolvedValue({ id: 'member-1' });
+
+    const context = createContext(
+      {
+        publicMetadata: {
+          user: USER_ID,
+        },
+      },
+      { body: { organizationId: REQUEST_ORGANIZATION_ID } },
     );
 
     await expect(guard.canActivate(context)).resolves.toBe(true);

--- a/apps/server/api/src/helpers/guards/roles/roles.guard.ts
+++ b/apps/server/api/src/helpers/guards/roles/roles.guard.ts
@@ -199,7 +199,7 @@ export class RolesGuard implements CanActivate {
     return [
       params.organizationId,
       params.orgId,
-      body?.organization,
+      this.normalizeOrganizationId(body?.organization),
       body?.organizationId,
       body?.orgId,
     ].filter((value) => value !== undefined && value !== null && value !== '');


### PR DESCRIPTION
## Summary

- Validate legacy `body.organization` before treating it as explicit role-guard organization context.
- Keep `organizationId` / `orgId` mismatch checks intact for params and request bodies.
- Add focused RolesGuard coverage for non-ID `organization` payloads and body `organizationId` fallback.

Fixes #1428

## Verification

- `bunx biome check --write apps/server/api/src/helpers/guards/roles/roles.guard.ts apps/server/api/src/helpers/guards/roles/roles.guard.spec.ts`
- `bun install --frozen-lockfile --ignore-scripts` (workspace setup only; scripts disabled)
- `bun run --cwd packages/prisma db:generate` (needed for generated Prisma test artifacts)
- `bun run --cwd apps/server/api test:file src/helpers/guards/roles/roles.guard.spec.ts` (14 passed)
- `git diff --check -- apps/server/api/src/helpers/guards/roles/roles.guard.ts apps/server/api/src/helpers/guards/roles/roles.guard.spec.ts`
- `bunx secretlint apps/server/api/src/helpers/guards/roles/roles.guard.ts apps/server/api/src/helpers/guards/roles/roles.guard.spec.ts`

Full local suites/workspace typecheck intentionally not run; heavy gates are left to PR CI per repo policy.