### PR TITLE
test(ui): align package tests with native buttons

### DIFF
--- a/packages/ui/src/components/card/Card.test.tsx
+++ b/packages/ui/src/components/card/Card.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import Card from '@ui/card/Card';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -29,7 +30,8 @@ describe('Card', () => {
     expect(screen.getByRole('button', { name: 'Review' })).toBeInTheDocument();
   });
 
-  it('renders keyboard-accessible interactive semantics when onClick is provided', () => {
+  it('renders keyboard-accessible interactive semantics when onClick is provided', async () => {
+    const user = userEvent.setup();
     const activateCard = vi.fn();
     render(<Card label="Interactive" onClick={activateCard} />);
 
@@ -37,8 +39,9 @@ describe('Card', () => {
       name: 'Interactive',
     });
 
-    fireEvent.keyDown(interactiveSurface, { key: 'Enter' });
-    fireEvent.keyDown(interactiveSurface, { key: ' ' });
+    interactiveSurface.focus();
+    await user.keyboard('{Enter}');
+    await user.keyboard(' ');
 
     expect(activateCard).toHaveBeenCalledTimes(2);
   });

--- a/packages/ui/src/components/lists/row-sound/ListRowSound.test.tsx
+++ b/packages/ui/src/components/lists/row-sound/ListRowSound.test.tsx
@@ -24,7 +24,7 @@ describe('ListRowSound', () => {
   it('handles legacy row click interactions', () => {
     const mockOnClick = vi.fn();
     const mockOnPlay = vi.fn();
-    const { container } = render(
+    render(
       <ListRowSound
         ingredient={mockIngredient}
         index={0}
@@ -32,14 +32,13 @@ describe('ListRowSound', () => {
         onPlay={mockOnPlay}
       />,
     );
-    const listItem = container.querySelector('div[role="button"]');
-    expect(listItem).toBeInTheDocument();
+    const listItem = screen.getByRole('button', { name: /Test Sound/i });
     fireEvent.click(listItem);
     expect(mockOnClick).toHaveBeenCalledWith('test-id');
   });
 
   it('renders slot-based content and active state', () => {
-    const { container } = render(
+    render(
       <ListRowSound
         actions={<button type="button">Action</button>}
         badges={<span>Catalog</span>}
@@ -50,7 +49,9 @@ describe('ListRowSound', () => {
         title="Rachel"
       />,
     );
-    const rootElement = container.querySelector('div[role="button"]');
+    const rootElement = screen
+      .getByText('Rachel')
+      .closest('li')?.firstElementChild;
     expect(rootElement).toBeInTheDocument();
     expect(rootElement?.className).toContain('bg-white/[0.06]');
     expect(screen.getByText('Rachel')).toBeInTheDocument();

--- a/packages/ui/src/components/masonry/image/MasonryImage.test.tsx
+++ b/packages/ui/src/components/masonry/image/MasonryImage.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@genfeedai/contexts/user/brand-context/brand-context', () => ({
@@ -127,7 +128,8 @@ describe('MasonryImage', () => {
     expect(screen.getByRole('button')).toHaveClass('rounded-lg');
   });
 
-  it('supports space key activation for keyboard users', () => {
+  it('supports space key activation for keyboard users', async () => {
+    const user = userEvent.setup();
     const handleClickIngredient = vi.fn();
 
     render(
@@ -138,7 +140,8 @@ describe('MasonryImage', () => {
     );
 
     const trigger = screen.getByRole('button');
-    fireEvent.keyDown(trigger, { key: ' ' });
+    trigger.focus();
+    await user.keyboard(' ');
 
     expect(handleClickIngredient).toHaveBeenCalledWith(mockImage);
   });

--- a/packages/ui/src/components/modals/gallery/items/ModalGalleryItemMusic.test.tsx
+++ b/packages/ui/src/components/modals/gallery/items/ModalGalleryItemMusic.test.tsx
@@ -7,16 +7,22 @@ import { describe, expect, it, vi } from 'vitest';
 // Mock dependencies
 vi.mock('@ui/primitives/button', () => ({
   Button: ({
+    children,
     label,
     onClick,
     className,
   }: {
+    children?: ReactNode;
     className?: string;
     label?: ReactNode;
     onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
   }) => (
-    <button onClick={onClick} className={className} data-testid="play-button">
-      {typeof label === 'object' ? 'icon' : label}
+    <button
+      onClick={onClick}
+      className={className}
+      data-testid={label ? 'play-button' : undefined}
+    >
+      {children ?? (typeof label === 'object' ? 'icon' : label)}
     </button>
   ),
   buttonVariants: () => '',
@@ -73,11 +79,8 @@ describe('ModalGalleryItemMusic', () => {
   it('calls onSelect when clicked', async () => {
     const user = userEvent.setup();
     const onSelect = vi.fn();
-    const { container } = render(
-      <ModalGalleryItemMusic {...defaultProps} onSelect={onSelect} />,
-    );
-    const rootDiv = container.firstChild as HTMLElement;
-    await user.click(rootDiv);
+    render(<ModalGalleryItemMusic {...defaultProps} onSelect={onSelect} />);
+    await user.click(screen.getByRole('button', { name: /Test Music/i }));
     expect(onSelect).toHaveBeenCalledWith(defaultProps.music);
   });
 

--- a/packages/ui/src/components/workflow-builder/panels/VariablesPanel.test.tsx
+++ b/packages/ui/src/components/workflow-builder/panels/VariablesPanel.test.tsx
@@ -53,16 +53,12 @@ describe('VariablesPanel', () => {
 
   it('should call onToggleCollapse when header is clicked', () => {
     const onToggleCollapse = vi.fn();
-    const { container } = render(
+    render(
       <VariablesPanel {...defaultProps} onToggleCollapse={onToggleCollapse} />,
     );
 
-    // Header row is clickable for collapse/expand
-    const headerRow = container.querySelector('.cursor-pointer');
-    if (headerRow) {
-      fireEvent.click(headerRow);
-      expect(onToggleCollapse).toHaveBeenCalled();
-    }
+    fireEvent.click(screen.getByRole('button', { name: /Input Variables/i }));
+    expect(onToggleCollapse).toHaveBeenCalled();
   });
 
   it('should render empty state when no variables', () => {
@@ -83,12 +79,8 @@ describe('VariablesPanel', () => {
     );
 
     // Test expanding/collapsing variable item
-    const variableItem = screen.getByText('Prompt').closest('div');
-    if (variableItem) {
-      fireEvent.click(variableItem);
-      // Variable should expand showing input fields
-      expect(screen.getByPlaceholderText('variable_key')).toBeInTheDocument();
-    }
+    fireEvent.click(screen.getByRole('button', { name: /Prompt/i }));
+    expect(screen.getByPlaceholderText('variable_key')).toBeInTheDocument();
 
     // Test updating variable key
     const keyInput = screen.getByPlaceholderText('variable_key');


### PR DESCRIPTION
## Summary
- update stale UI package tests to exercise native button behavior with userEvent
- replace old div-role/button implementation-detail selectors with accessible role/text queries
- fix the ModalGalleryItemMusic Button mock so selection content renders and only the playback control gets the play-button test id

## Root cause
Manual Daily Production Deploy now reaches the normal production deploy workflow, but the deploy QA gate blocks in `Test Packages`. The failing tests were asserting pre-migration div-button behavior even though these components now render native buttons through `@ui/primitives/button`.

Failed deploy attempt: https://github.com/genfeedai/genfeed.ai/actions/runs/28875988448
Child deploy run: https://github.com/genfeedai/genfeed.ai/actions/runs/28876079608
Tracking issue: https://github.com/genfeedai/genfeed.ai/issues/1459

## Validation
- `bunx biome check --write packages/ui/src/components/card/Card.test.tsx packages/ui/src/components/lists/row-sound/ListRowSound.test.tsx packages/ui/src/components/masonry/image/MasonryImage.test.tsx packages/ui/src/components/modals/gallery/items/ModalGalleryItemMusic.test.tsx packages/ui/src/components/workflow-builder/panels/VariablesPanel.test.tsx`
- `bun run --cwd packages/ui test -- src/components/card/Card.test.tsx`
- `bun run --cwd packages/ui test -- src/components/lists/row-sound/ListRowSound.test.tsx`
- `bun run --cwd packages/ui test -- src/components/masonry/image/MasonryImage.test.tsx`
- `bun run --cwd packages/ui test -- src/components/modals/gallery/items/ModalGalleryItemMusic.test.tsx`
- `bun run --cwd packages/ui test -- src/components/workflow-builder/panels/VariablesPanel.test.tsx`
- pre-commit: secretlint, Biome staged check, raw HTML guard, bespoke card guard