### PR TITLE
fix(ci): catch mixed type-only DI imports

### DIFF
--- a/scripts/check-di-value-imports.test.ts
+++ b/scripts/check-di-value-imports.test.ts
@@ -1,0 +1,96 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { runCheckDiValueImports } from './check-di-value-imports';
+
+describe('check-di-value-imports', () => {
+  let originalCwd = '';
+  let testDir = '';
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    testDir = mkdtempSync(path.join(tmpdir(), 'di-value-import-check-'));
+    process.chdir(testDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(testDir, { force: true, recursive: true });
+  });
+
+  it('flags non-leading named type-only imports used by constructor metadata', () => {
+    writeFixture(
+      'apps/server/api/src/demo/demo.controller.ts',
+      [
+        "import { Injectable, type DemoService } from './demo.service';",
+        '',
+        '@Injectable()',
+        'export class DemoController {',
+        '  constructor(private readonly demoService: DemoService) {}',
+        '}',
+      ].join('\n'),
+    );
+
+    const result = runCheckDiValueImports();
+
+    expect(result.violations).toEqual([
+      expect.objectContaining({
+        context: 'constructor',
+        owner: 'DemoController',
+        typeName: 'DemoService',
+      }),
+    ]);
+  });
+
+  it('flags non-leading named type-only DTO imports used by route metadata', () => {
+    writeFixture(
+      'apps/server/api/src/demo/demo.controller.ts',
+      [
+        "import { Body, Controller, Post, type CreateDemoDto } from '@nestjs/common';",
+        '',
+        '@Controller()',
+        'export class DemoController {',
+        '  @Post()',
+        '  create(@Body() body: CreateDemoDto): void {',
+        '    void body;',
+        '  }',
+        '}',
+      ].join('\n'),
+    );
+
+    const result = runCheckDiValueImports();
+
+    expect(result.violations).toEqual([
+      expect.objectContaining({
+        context: 'decorated-parameter',
+        owner: 'DemoController.create',
+        typeName: 'CreateDemoDto',
+      }),
+    ]);
+  });
+
+  it('allows type-only constructor params with an explicit injection token', () => {
+    writeFixture(
+      'apps/server/api/src/demo/demo.service.ts',
+      [
+        "import { Inject, Injectable, type DemoPort } from './demo.port';",
+        '',
+        '@Injectable()',
+        'export class DemoService {',
+        "  constructor(@Inject('DEMO_PORT') private readonly port: DemoPort) {}",
+        '}',
+      ].join('\n'),
+    );
+
+    const result = runCheckDiValueImports();
+
+    expect(result.violations).toHaveLength(0);
+  });
+});
+
+function writeFixture(relativePath: string, content: string): void {
+  const filePath = path.join(process.cwd(), relativePath);
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, content, 'utf8');
+}

--- a/scripts/check-di-value-imports.ts
+++ b/scripts/check-di-value-imports.ts
@@ -35,13 +35,25 @@ const IGNORE_GLOBS = [
   '**/generated/**',
 ];
 
-type Violation = {
+export type DiValueImportViolation = {
   file: string;
   line: number;
   typeName: string;
   context: 'constructor' | 'decorated-parameter';
   owner: string;
 };
+
+export type DiValueImportCheckOptions = {
+  ignoreGlobs?: string[];
+  includeGlobs?: string[];
+};
+
+export type DiValueImportCheckResult = {
+  filesScanned: number;
+  violations: DiValueImportViolation[];
+};
+
+const NAMED_TYPE_SPECIFIER_PATTERN = /(?:\{|,)\s*type\s+/;
 
 function collectTypeOnlyImports(
   sourceFile: ts.SourceFile,
@@ -118,9 +130,12 @@ function parameterDecoratorNames(parameter: ts.ParameterDeclaration): string[] {
  */
 const VALIDATED_PARAM_DECORATORS = new Set(['Body', 'Query', 'Param']);
 
-function checkFile(file: string): Violation[] {
+function checkFile(file: string): DiValueImportViolation[] {
   const content = readFileSync(file, 'utf8');
-  if (!content.includes('import type') && !/\{\s*type\s+/.test(content)) {
+  if (
+    !content.includes('import type') &&
+    !NAMED_TYPE_SPECIFIER_PATTERN.test(content)
+  ) {
     return [];
   }
   const sourceFile = ts.createSourceFile(
@@ -134,7 +149,7 @@ function checkFile(file: string): Violation[] {
     return [];
   }
 
-  const violations: Violation[] = [];
+  const violations: DiValueImportViolation[] = [];
 
   const visit = (node: ts.Node): void => {
     if (
@@ -205,13 +220,27 @@ function checkFile(file: string): Violation[] {
   return violations;
 }
 
-function main(): void {
-  const files = globSync(INCLUDE_GLOBS, { ignore: IGNORE_GLOBS, nodir: true });
+export function runCheckDiValueImports(
+  options: DiValueImportCheckOptions = {},
+): DiValueImportCheckResult {
+  const files = globSync(options.includeGlobs ?? INCLUDE_GLOBS, {
+    ignore: options.ignoreGlobs ?? IGNORE_GLOBS,
+    nodir: true,
+  });
   const violations = files.flatMap(checkFile);
+
+  return {
+    filesScanned: files.length,
+    violations,
+  };
+}
+
+function main(): void {
+  const { filesScanned, violations } = runCheckDiValueImports();
 
   if (violations.length === 0) {
     console.log(
-      `check:di-value-imports — ${files.length} files scanned, no violations.`,
+      `check:di-value-imports — ${filesScanned} files scanned, no violations.`,
     );
     return;
   }
@@ -235,4 +264,6 @@ function main(): void {
   process.exit(1);
 }
 
-main();
+if (import.meta.main) {
+  main();
+}


### PR DESCRIPTION
## Summary
- catch named `type` import specifiers anywhere in mixed import lists before the DI value-import checker decides to skip a file
- expose the checker runner for focused temp-fixture coverage while preserving the CI CLI output
- add regression tests for constructor DI, validated route DTOs, and the explicit `@Inject` token escape hatch

Closes #1427

## Review feedback notes
- Verified PR #1377 CodeRabbit thread 1 is still valid on current `master`: `import { Injectable, type SomeType }` was skipped by the fast-path prefilter.
- Verified thread 2. I did not add symbol-resolution skipping for interface/type-alias constructor params because an undecorated constructor param still relies on Nest `design:paramtypes`; interface/type abstractions need an explicit token decorator. The existing checker already skips decorated params, and the new test locks that escape hatch.

## Verification
- `bunx biome check --write scripts/check-di-value-imports.ts scripts/check-di-value-imports.test.ts`
- `bun run check:di-value-imports`
- `bunx vitest run scripts/check-di-value-imports.test.ts --config <temporary node-only vitest config> --reporter verbose`
- commit hook: staged Biome + `bun scripts/run-secretlint.ts --no-glob`