### PR TITLE
feat(website): consent-gate marketing dataLayer events

### DIFF
--- a/apps/website/app/layout.tsx
+++ b/apps/website/app/layout.tsx
@@ -111,18 +111,8 @@ export default async function RootLayout({ children }: LayoutProps) {
       <AppProviders
         initialTheme={initialTheme}
         storageKey={THEME_STORAGE_KEY}
-        googleAnalyticsId={EnvironmentService.GA_ID}
         marketingConsentDefault={EnvironmentService.marketing.consentDefault}
         marketingGtmContainerId={EnvironmentService.marketing.gtmContainerId}
-        marketingLinkedinConversionIds={
-          EnvironmentService.marketing.linkedinConversionIds
-        }
-        marketingLinkedinPartnerId={
-          EnvironmentService.marketing.linkedinPartnerId
-        }
-        marketingMetaPixelId={EnvironmentService.marketing.metaPixelId}
-        marketingXEventIds={EnvironmentService.marketing.xEventIds}
-        marketingXPixelId={EnvironmentService.marketing.xPixelId}
       >
         {children}
       </AppProviders>

--- a/apps/website/docs/marketing-tracking.md
+++ b/apps/website/docs/marketing-tracking.md
@@ -1,62 +1,78 @@
 # Website Marketing Tracking
 
-The website owns one canonical marketing event layer in `apps/website/packages/marketing`.
+The website owns one canonical marketing event layer in
+`apps/website/packages/marketing`.
 
 ## Event Contract
 
-Browser-only events:
+Browser marketing events:
 
 - `page_view`
 - `view_pricing`
 - `cta_click`
 - `start_signup`
-
-Browser + server events with shared `eventId` for dedupe:
-
 - `book_call`
 - `lead_submit`
 - `signup_complete`
 
-`ButtonTracked` keeps the existing Vercel Analytics event and also emits a `genfeed:marketing:button-click` browser event. The website provider maps CTA actions such as `book_demo`, `view_plans`, and `core_cta` onto the canonical event names.
+`book_call`, `lead_submit`, and `signup_complete` also carry a shared
+`eventId` to the same-site conversion endpoint when the browser has granted
+marketing consent.
+
+`ButtonTracked` keeps the existing Vercel Analytics event and also emits a
+`genfeed:marketing:button-click` browser event. The website provider maps CTA
+actions such as `book_demo`, `view_plans`, and `core_cta` onto the canonical
+event names.
 
 ## Consent
 
-`NEXT_PUBLIC_MARKETING_CONSENT_DEFAULT=denied` is the default. GTM, GA4, Meta Pixel, LinkedIn Insight Tag, and X Pixel are not loaded until the visitor grants marketing consent. Consent is stored in `localStorage` under `genfeed:marketing-consent`.
+`NEXT_PUBLIC_MARKETING_CONSENT_DEFAULT=denied` is the default. Marketing event
+dispatch fails closed while consent is unavailable or denied. Consented events
+are pushed to `window.dataLayer` as `genfeed_marketing_event`; vendor pixels are
+configured in GTM or server-side conversion configuration, not in page
+components.
+
+Consent is stored in `localStorage` under `genfeed:marketing-consent` using
+this contract:
+
+```json
+{
+  "adStorage": "granted",
+  "analyticsStorage": "granted",
+  "updatedAt": "2026-06-30T00:00:00.000Z"
+}
+```
+
+`adStorage` must be `granted` before any marketing event reaches
+GTM/dataLayer.
 
 ## Environment
 
 Public browser config:
 
-- `NEXT_PUBLIC_GA_ID`
+- `NEXT_PUBLIC_MARKETING_CONSENT_DEFAULT`
 - `NEXT_PUBLIC_GTM_CONTAINER_ID`
-- `NEXT_PUBLIC_META_PIXEL_ID`
-- `NEXT_PUBLIC_LINKEDIN_PARTNER_ID`
-- `NEXT_PUBLIC_LINKEDIN_CONVERSION_ID_BOOK_CALL`
-- `NEXT_PUBLIC_LINKEDIN_CONVERSION_ID_CTA_CLICK`
-- `NEXT_PUBLIC_LINKEDIN_CONVERSION_ID_LEAD_SUBMIT`
-- `NEXT_PUBLIC_LINKEDIN_CONVERSION_ID_SIGNUP_COMPLETE`
-- `NEXT_PUBLIC_LINKEDIN_CONVERSION_ID_START_SIGNUP`
-- `NEXT_PUBLIC_LINKEDIN_CONVERSION_ID_VIEW_PRICING`
-- `NEXT_PUBLIC_X_PIXEL_ID`
-- `NEXT_PUBLIC_X_BOOK_CALL_EVENT_ID`
-- `NEXT_PUBLIC_X_CTA_CLICK_EVENT_ID`
-- `NEXT_PUBLIC_X_LEAD_SUBMIT_EVENT_ID`
-- `NEXT_PUBLIC_X_SIGNUP_COMPLETE_EVENT_ID`
-- `NEXT_PUBLIC_X_START_SIGNUP_EVENT_ID`
-- `NEXT_PUBLIC_X_VIEW_PRICING_EVENT_ID`
 
 Server conversion config:
 
 - `LINKEDIN_CONVERSIONS_API_ACCESS_TOKEN`
 - `LINKEDIN_CONVERSIONS_API_VERSION` (defaults to `202606`)
-- `LINKEDIN_CONVERSIONS_API_ENDPOINT` (optional; defaults to LinkedIn's REST conversion events endpoint)
+- `LINKEDIN_CONVERSIONS_API_ENDPOINT` (optional; defaults to LinkedIn's REST
+  conversion events endpoint)
 - `LINKEDIN_CONVERSION_URN_BOOK_CALL`
 - `LINKEDIN_CONVERSION_URN_LEAD_SUBMIT`
 - `LINKEDIN_CONVERSION_URN_SIGNUP_COMPLETE`
 - `META_CONVERSIONS_API_ACCESS_TOKEN`
 - `META_CONVERSIONS_API_GRAPH_VERSION`
+- `META_PIXEL_ID`
 - `X_CONVERSIONS_API_ENDPOINT`
 - `X_CONVERSIONS_API_BEARER_TOKEN`
+- `X_BOOK_CALL_EVENT_ID`
+- `X_CTA_CLICK_EVENT_ID`
+- `X_LEAD_SUBMIT_EVENT_ID`
+- `X_SIGNUP_COMPLETE_EVENT_ID`
+- `X_START_SIGNUP_EVENT_ID`
+- `X_VIEW_PRICING_EVENT_ID`
 
 LinkedIn Conversions API remains opt-in: the server skips dispatch unless the
 access token, event-specific conversion rule URN, and at least one match
@@ -66,10 +82,11 @@ identifier such as email, `liFatId`, or client IPv4 address are present.
 
 Local or staging:
 
-- Open GTM Preview and confirm `genfeed_marketing_event` data layer events for `page_view`, `cta_click`, and lower-funnel CTAs after accepting consent.
-- Use Meta Pixel Helper to confirm Meta Pixel is absent before consent and receives `PageView`, `Contact`, `Schedule`, `Lead`, or `CompleteRegistration` after consent.
-- Use LinkedIn Insight Tag verification to confirm the tag loads only after consent and receives mapped conversion events.
-- Use X Pixel Helper to confirm X Pixel is absent before consent and receives mapped events after consent.
-- Trigger a booking, lead, or signup success event and confirm the browser event and `/api/marketing/conversions` request share the same `eventId`.
-- In LinkedIn Campaign Manager diagnostics, confirm configured server events use the same event ID as browser events and skip when conversion rule URNs or identifiers are absent.
-- In Meta Events Manager and X Ads diagnostics, confirm server events dedupe with browser events by the shared event ID.
+- Open GTM Preview and confirm no `genfeed_marketing_event` dataLayer events
+  are emitted before accepting marketing consent.
+- Accept marketing consent and confirm `genfeed_marketing_event` dataLayer
+  events for `page_view`, `cta_click`, and lower-funnel CTAs.
+- Confirm Meta, LinkedIn, X, or other vendor browser pixels are configured in
+  GTM rather than in website page components.
+- Trigger a booking, lead, or signup success event and confirm the dataLayer
+  event and `/api/marketing/conversions` request share the same `eventId`.

--- a/apps/website/packages/marketing/MarketingTrackingProvider.test.tsx
+++ b/apps/website/packages/marketing/MarketingTrackingProvider.test.tsx
@@ -55,7 +55,6 @@ function renderProvider(
     <MarketingTrackingProvider
       config={{
         gtmContainerId: 'GTM-TEST',
-        metaPixelId: 'meta-test',
       }}
       consentDefault="denied"
     >
@@ -134,17 +133,22 @@ describe('MarketingTrackingProvider', () => {
     fireEvent.click(await screen.findByRole('button', { name: /accept/i }));
 
     await waitFor(() =>
-      expect(browserMocks.loadMarketingTags).toHaveBeenCalledWith({
-        gtmContainerId: 'GTM-TEST',
-        metaPixelId: 'meta-test',
-      }),
+      expect(browserMocks.loadMarketingTags).toHaveBeenCalledWith(
+        {
+          gtmContainerId: 'GTM-TEST',
+        },
+        expect.objectContaining({ adStorage: 'granted' }),
+      ),
     );
     await waitFor(() =>
       expect(browserMocks.trackWebsiteMarketingEvent).toHaveBeenCalledWith(
         expect.objectContaining({
           name: WEBSITE_MARKETING_EVENTS.PAGE_VIEW,
         }),
-        expect.any(Object),
+        expect.objectContaining({
+          config: { gtmContainerId: 'GTM-TEST' },
+          consent: expect.objectContaining({ adStorage: 'granted' }),
+        }),
       ),
     );
 

--- a/apps/website/packages/marketing/MarketingTrackingProvider.tsx
+++ b/apps/website/packages/marketing/MarketingTrackingProvider.tsx
@@ -42,13 +42,7 @@ interface MarketingPageTrackerProps {
 }
 
 const hasConfiguredMarketingTag = (config: MarketingTrackingConfig): boolean =>
-  Boolean(
-    config.gaId ||
-      config.gtmContainerId ||
-      config.linkedinPartnerId ||
-      config.metaPixelId ||
-      config.xPixelId,
-  );
+  Boolean(config.gtmContainerId);
 
 /**
  * Renders no UI — owns the page-view and CTA tracking effects that depend on
@@ -92,7 +86,7 @@ function MarketingPageTracker({
         },
         url: currentUrl,
       },
-      config,
+      { config, consent },
     );
 
     if (pathname === '/pricing') {
@@ -102,7 +96,7 @@ function MarketingPageTracker({
           payload: { path: pathname },
           url: currentUrl,
         },
-        config,
+        { config, consent },
       );
     }
   }, [config, consent, currentUrl, pathname, search]);
@@ -133,7 +127,7 @@ function MarketingPageTracker({
             payload,
             url: currentUrl,
           },
-          config,
+          { config, consent: currentConsent },
         );
       }
     };
@@ -182,7 +176,7 @@ export default function MarketingTrackingProvider({
     });
 
     if (hasMarketingConsent(initialConsent)) {
-      loadMarketingTags(config);
+      loadMarketingTags(config, initialConsent);
     }
   }, [config, consentDefault]);
 
@@ -199,7 +193,7 @@ export default function MarketingTrackingProvider({
     });
 
     if (hasMarketingConsent(nextConsent)) {
-      loadMarketingTags(config);
+      loadMarketingTags(config, nextConsent);
     }
   };
 

--- a/apps/website/packages/marketing/browser.test.ts
+++ b/apps/website/packages/marketing/browser.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { loadMarketingTags, trackWebsiteMarketingEvent } from './browser';
+import { createConsentState } from './consent';
+import { WEBSITE_MARKETING_EVENTS } from './events';
+
+describe('website marketing browser layer', () => {
+  beforeEach(() => {
+    document.head
+      .querySelectorAll('script[id^="genfeed-"]')
+      .forEach((element) => {
+        element.remove();
+      });
+    delete window.dataLayer;
+    delete window.gtag;
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('fails closed without granted marketing consent', () => {
+    const sendBeacon = vi.fn();
+    const fetchMock = vi.fn();
+
+    Object.defineProperty(window.navigator, 'sendBeacon', {
+      configurable: true,
+      value: sendBeacon,
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    loadMarketingTags({ gtmContainerId: 'GTM-TEST' }, null);
+
+    const eventId = trackWebsiteMarketingEvent(
+      {
+        name: WEBSITE_MARKETING_EVENTS.BOOK_CALL,
+        payload: { action: 'book_demo' },
+        url: 'https://genfeed.ai',
+      },
+      {
+        config: { gtmContainerId: 'GTM-TEST' },
+        consent: createConsentState('denied'),
+      },
+    );
+
+    expect(eventId).toBeNull();
+    expect(window.dataLayer).toBeUndefined();
+    expect(document.getElementById('genfeed-gtm')).toBeNull();
+    expect(sendBeacon).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('pushes consented events to dataLayer without browser pixel snippets', () => {
+    const sendBeacon = vi.fn().mockReturnValue(true);
+    const consent = createConsentState('granted');
+
+    Object.defineProperty(window.navigator, 'sendBeacon', {
+      configurable: true,
+      value: sendBeacon,
+    });
+
+    loadMarketingTags({ gtmContainerId: 'GTM-TEST' }, consent);
+
+    const eventId = trackWebsiteMarketingEvent(
+      {
+        name: WEBSITE_MARKETING_EVENTS.BOOK_CALL,
+        payload: { action: 'book_demo' },
+        url: 'https://genfeed.ai/demo',
+      },
+      {
+        config: { gtmContainerId: 'GTM-TEST' },
+        consent,
+      },
+    );
+
+    expect(eventId).toMatch(/^book_call:/);
+    expect(document.getElementById('genfeed-gtm')).toHaveAttribute(
+      'src',
+      'https://www.googletagmanager.com/gtm.js?id=GTM-TEST',
+    );
+    expect(window.dataLayer).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          event: 'gtm.js',
+        }),
+        expect.objectContaining({
+          action: 'book_demo',
+          event: 'genfeed_marketing_event',
+          event_id: eventId,
+          event_name: WEBSITE_MARKETING_EVENTS.BOOK_CALL,
+          event_source_url: 'https://genfeed.ai/demo',
+          marketing_consent_ad_storage: 'granted',
+        }),
+      ]),
+    );
+    expect(sendBeacon).toHaveBeenCalledWith(
+      '/api/marketing/conversions',
+      expect.any(Blob),
+    );
+    expect(document.getElementById('genfeed-meta-pixel')).toBeNull();
+    expect(document.getElementById('genfeed-linkedin-insight')).toBeNull();
+    expect(document.getElementById('genfeed-x-pixel')).toBeNull();
+  });
+});

--- a/apps/website/packages/marketing/browser.ts
+++ b/apps/website/packages/marketing/browser.ts
@@ -141,14 +141,16 @@ export function trackWebsiteMarketingEvent(
   event: WebsiteMarketingEvent,
   options: TrackWebsiteMarketingEventOptions,
 ): string | null {
-  if (!hasMarketingConsent(options.consent)) {
+  const consent = options.consent;
+
+  if (!hasMarketingConsent(consent)) {
     return null;
   }
 
   const eventId = event.eventId || createMarketingEventId(event.name);
   const nextEvent = { ...event, eventId };
 
-  pushMarketingDataLayerEvent(nextEvent, options.consent);
+  pushMarketingDataLayerEvent(nextEvent, consent);
   sendServerConversion(nextEvent);
 
   return eventId;

--- a/apps/website/packages/marketing/browser.ts
+++ b/apps/website/packages/marketing/browser.ts
@@ -1,37 +1,26 @@
 'use client';
 
+import { hasMarketingConsent, type MarketingConsentState } from './consent';
 import {
   BROWSER_AND_SERVER_MARKETING_EVENTS,
   createMarketingEventId,
-  META_EVENT_NAMES,
-  WEBSITE_MARKETING_EVENTS,
   type WebsiteMarketingEvent,
-  type WebsiteMarketingEventName,
-  X_EVENT_NAMES,
 } from './events';
 
 declare global {
   interface Window {
-    _linkedin_data_partner_ids?: string[];
-    _linkedin_partner_id?: string;
     dataLayer?: Array<Record<string, unknown>>;
-    fbq?: (...args: unknown[]) => void;
     gtag?: (...args: unknown[]) => void;
-    lintrk?: (command: string, payload: Record<string, unknown>) => void;
-    twq?: (...args: unknown[]) => void;
   }
 }
 
 export interface MarketingTrackingConfig {
-  gaId?: string;
   gtmContainerId?: string;
-  linkedinConversionIds?: Partial<
-    Record<WebsiteMarketingEventName, number | undefined>
-  >;
-  linkedinPartnerId?: string;
-  metaPixelId?: string;
-  xEventIds?: Partial<Record<WebsiteMarketingEventName, string>>;
-  xPixelId?: string;
+}
+
+export interface TrackWebsiteMarketingEventOptions {
+  config: MarketingTrackingConfig;
+  consent: MarketingConsentState | null;
 }
 
 const loadedScripts = new Set<string>();
@@ -77,7 +66,14 @@ export function setGoogleConsent({
   });
 }
 
-export function loadMarketingTags(config: MarketingTrackingConfig): void {
+export function loadMarketingTags(
+  config: MarketingTrackingConfig,
+  consent: MarketingConsentState | null,
+): void {
+  if (!hasMarketingConsent(consent)) {
+    return;
+  }
+
   if (config.gtmContainerId) {
     pushDataLayer({
       event: 'gtm.js',
@@ -90,60 +86,12 @@ export function loadMarketingTags(config: MarketingTrackingConfig): void {
       )}`,
     );
   }
-
-  if (config.gaId) {
-    appendScript(
-      'genfeed-ga4',
-      `https://www.googletagmanager.com/gtag/js?id=${encodeURIComponent(
-        config.gaId,
-      )}`,
-    );
-    window.gtag?.('js', new Date());
-    window.gtag?.('config', config.gaId, {
-      send_page_view: false,
-    });
-  }
-
-  if (config.metaPixelId) {
-    window.fbq =
-      window.fbq ||
-      ((...args: unknown[]) => {
-        pushDataLayer({ event: 'meta.pixel.queue', args });
-      });
-    appendScript(
-      'genfeed-meta-pixel',
-      'https://connect.facebook.net/en_US/fbevents.js',
-    );
-    window.fbq('init', config.metaPixelId);
-  }
-
-  if (config.linkedinPartnerId) {
-    window._linkedin_partner_id = config.linkedinPartnerId;
-    window._linkedin_data_partner_ids = window._linkedin_data_partner_ids || [];
-    if (!window._linkedin_data_partner_ids.includes(config.linkedinPartnerId)) {
-      window._linkedin_data_partner_ids.push(config.linkedinPartnerId);
-    }
-    appendScript(
-      'genfeed-linkedin-insight',
-      'https://snap.licdn.com/li.lms-analytics/insight.min.js',
-    );
-  }
-
-  if (config.xPixelId) {
-    window.twq =
-      window.twq ||
-      ((...args: unknown[]) => {
-        pushDataLayer({ event: 'x.pixel.queue', args });
-      });
-    appendScript('genfeed-x-pixel', 'https://static.ads-twitter.com/uwt.js');
-    window.twq('config', config.xPixelId);
-  }
 }
 
-function dispatchBrowserVendorEvents(
+function pushMarketingDataLayerEvent(
   event: Required<Pick<WebsiteMarketingEvent, 'eventId' | 'name'>> &
     WebsiteMarketingEvent,
-  config: MarketingTrackingConfig,
+  consent: MarketingConsentState,
 ): void {
   const payload = event.payload ?? {};
   const eventUrl =
@@ -154,44 +102,10 @@ function dispatchBrowserVendorEvents(
     event_id: event.eventId,
     event_name: event.name,
     event_source_url: eventUrl,
+    marketing_consent_ad_storage: consent.adStorage,
+    marketing_consent_analytics_storage: consent.analyticsStorage,
     ...payload,
   });
-
-  if (config.gaId) {
-    window.gtag?.('event', event.name, {
-      event_id: event.eventId,
-      event_source_url: eventUrl,
-      ...payload,
-    });
-  }
-
-  if (config.metaPixelId) {
-    window.fbq?.('track', META_EVENT_NAMES[event.name], payload, {
-      eventID: event.eventId,
-    });
-  }
-
-  const linkedinConversionId = config.linkedinConversionIds?.[event.name];
-  if (
-    config.linkedinPartnerId &&
-    event.name !== WEBSITE_MARKETING_EVENTS.PAGE_VIEW &&
-    typeof linkedinConversionId === 'number'
-  ) {
-    window.lintrk?.('track', {
-      conversion_id: linkedinConversionId,
-    });
-  }
-
-  if (config.xPixelId) {
-    const xEventId =
-      config.xEventIds?.[event.name] || X_EVENT_NAMES[event.name];
-
-    window.twq?.('event', xEventId, {
-      event_id: event.eventId,
-      event_name: X_EVENT_NAMES[event.name],
-      ...payload,
-    });
-  }
 }
 
 function sendServerConversion(event: WebsiteMarketingEvent): void {
@@ -225,12 +139,16 @@ function sendServerConversion(event: WebsiteMarketingEvent): void {
 
 export function trackWebsiteMarketingEvent(
   event: WebsiteMarketingEvent,
-  config: MarketingTrackingConfig,
-): string {
+  options: TrackWebsiteMarketingEventOptions,
+): string | null {
+  if (!hasMarketingConsent(options.consent)) {
+    return null;
+  }
+
   const eventId = event.eventId || createMarketingEventId(event.name);
   const nextEvent = { ...event, eventId };
 
-  dispatchBrowserVendorEvents(nextEvent, config);
+  pushMarketingDataLayerEvent(nextEvent, options.consent);
   sendServerConversion(nextEvent);
 
   return eventId;

--- a/apps/website/packages/marketing/consent.ts
+++ b/apps/website/packages/marketing/consent.ts
@@ -51,6 +51,6 @@ export function parseMarketingConsent(
 
 export function hasMarketingConsent(
   state: MarketingConsentState | null,
-): boolean {
+): state is MarketingConsentState {
   return state?.adStorage === 'granted';
 }

--- a/apps/website/packages/marketing/server-conversions.ts
+++ b/apps/website/packages/marketing/server-conversions.ts
@@ -140,16 +140,41 @@ function getLinkedinConversionUrns(): Partial<
   };
 }
 
+function getConversionEventId(
+  key: string,
+  legacyPublicKey: string,
+): string | undefined {
+  return process.env[key] || process.env[legacyPublicKey];
+}
+
 function getDefaultXEventIds(): Partial<
   Record<WebsiteMarketingEventName, string>
 > {
   return {
-    book_call: process.env.NEXT_PUBLIC_X_BOOK_CALL_EVENT_ID,
-    cta_click: process.env.NEXT_PUBLIC_X_CTA_CLICK_EVENT_ID,
-    lead_submit: process.env.NEXT_PUBLIC_X_LEAD_SUBMIT_EVENT_ID,
-    signup_complete: process.env.NEXT_PUBLIC_X_SIGNUP_COMPLETE_EVENT_ID,
-    start_signup: process.env.NEXT_PUBLIC_X_START_SIGNUP_EVENT_ID,
-    view_pricing: process.env.NEXT_PUBLIC_X_VIEW_PRICING_EVENT_ID,
+    book_call: getConversionEventId(
+      'X_BOOK_CALL_EVENT_ID',
+      'NEXT_PUBLIC_X_BOOK_CALL_EVENT_ID',
+    ),
+    cta_click: getConversionEventId(
+      'X_CTA_CLICK_EVENT_ID',
+      'NEXT_PUBLIC_X_CTA_CLICK_EVENT_ID',
+    ),
+    lead_submit: getConversionEventId(
+      'X_LEAD_SUBMIT_EVENT_ID',
+      'NEXT_PUBLIC_X_LEAD_SUBMIT_EVENT_ID',
+    ),
+    signup_complete: getConversionEventId(
+      'X_SIGNUP_COMPLETE_EVENT_ID',
+      'NEXT_PUBLIC_X_SIGNUP_COMPLETE_EVENT_ID',
+    ),
+    start_signup: getConversionEventId(
+      'X_START_SIGNUP_EVENT_ID',
+      'NEXT_PUBLIC_X_START_SIGNUP_EVENT_ID',
+    ),
+    view_pricing: getConversionEventId(
+      'X_VIEW_PRICING_EVENT_ID',
+      'NEXT_PUBLIC_X_VIEW_PRICING_EVENT_ID',
+    ),
   };
 }
 
@@ -223,7 +248,8 @@ export async function sendServerConversions(
     linkedinConversionUrns: getLinkedinConversionUrns(),
     metaAccessToken: process.env.META_CONVERSIONS_API_ACCESS_TOKEN,
     metaGraphVersion: process.env.META_CONVERSIONS_API_GRAPH_VERSION,
-    metaPixelId: process.env.NEXT_PUBLIC_META_PIXEL_ID,
+    metaPixelId:
+      process.env.META_PIXEL_ID || process.env.NEXT_PUBLIC_META_PIXEL_ID,
     xApiEndpoint: process.env.X_CONVERSIONS_API_ENDPOINT,
     xBearerToken: process.env.X_CONVERSIONS_API_BEARER_TOKEN,
     xEventIds: getDefaultXEventIds(),

--- a/apps/website/packages/ui/providers/AppProviders.test.tsx
+++ b/apps/website/packages/ui/providers/AppProviders.test.tsx
@@ -43,17 +43,11 @@ describe('website AppProviders', () => {
   it('passes marketing tracking config through one provider', () => {
     render(
       <AppProviders
-        googleAnalyticsId="G-123"
         initialTheme="dark"
         includeLazyModalErrorDebug={false}
         includeToaster={false}
         marketingConsentDefault="denied"
         marketingGtmContainerId="GTM-123"
-        marketingLinkedinConversionIds={{ book_call: 12345 }}
-        marketingLinkedinPartnerId="li-123"
-        marketingMetaPixelId="meta-123"
-        marketingXEventIds={{ book_call: 'tw-book-call' }}
-        marketingXPixelId="x-123"
       >
         <div>Website child</div>
       </AppProviders>,
@@ -62,13 +56,7 @@ describe('website AppProviders', () => {
     expect(screen.getByText('Website child')).toBeInTheDocument();
     expect(marketingProviderSpy).toHaveBeenCalledWith({
       config: {
-        gaId: 'G-123',
         gtmContainerId: 'GTM-123',
-        linkedinConversionIds: { book_call: 12345 },
-        linkedinPartnerId: 'li-123',
-        metaPixelId: 'meta-123',
-        xEventIds: { book_call: 'tw-book-call' },
-        xPixelId: 'x-123',
       },
       consentDefault: 'denied',
     });

--- a/apps/website/packages/ui/providers/AppProviders.tsx
+++ b/apps/website/packages/ui/providers/AppProviders.tsx
@@ -9,7 +9,6 @@ import { ThemeProvider, useTheme } from 'next-themes';
 import type { ReactNode } from 'react';
 import { useMemo } from 'react';
 import { Toaster } from 'sonner';
-import type { MarketingTrackingConfig } from '../../marketing/browser';
 import MarketingTrackingProvider from '../../marketing/MarketingTrackingProvider';
 
 const LazyModalErrorDebug = dynamic(
@@ -31,17 +30,11 @@ export interface AppProvidersProps {
   authProps?: BetterAuthProviderProps;
   disableTransitionOnChange?: boolean;
   enableSystem?: boolean;
-  googleAnalyticsId?: string;
   includeLazyModalErrorDebug?: boolean;
   includeMarketingTracking?: boolean;
   includeToaster?: boolean;
   marketingConsentDefault?: 'denied' | 'granted';
   marketingGtmContainerId?: string;
-  marketingLinkedinConversionIds?: MarketingTrackingConfig['linkedinConversionIds'];
-  marketingLinkedinPartnerId?: string;
-  marketingMetaPixelId?: string;
-  marketingXEventIds?: MarketingTrackingConfig['xEventIds'];
-  marketingXPixelId?: string;
   storageKey?: string;
 }
 
@@ -74,38 +67,18 @@ export default function AppProviders({
   authProps,
   disableTransitionOnChange = true,
   enableSystem = false,
-  googleAnalyticsId,
   includeLazyModalErrorDebug = true,
   includeMarketingTracking = true,
   includeToaster = true,
   marketingConsentDefault = 'denied',
   marketingGtmContainerId,
-  marketingLinkedinConversionIds,
-  marketingLinkedinPartnerId,
-  marketingMetaPixelId,
-  marketingXEventIds,
-  marketingXPixelId,
   storageKey = THEME_STORAGE_KEY,
 }: AppProvidersProps) {
   const marketingConfig = useMemo(
     () => ({
-      gaId: googleAnalyticsId,
       gtmContainerId: marketingGtmContainerId,
-      linkedinConversionIds: marketingLinkedinConversionIds,
-      linkedinPartnerId: marketingLinkedinPartnerId,
-      metaPixelId: marketingMetaPixelId,
-      xEventIds: marketingXEventIds,
-      xPixelId: marketingXPixelId,
     }),
-    [
-      googleAnalyticsId,
-      marketingGtmContainerId,
-      marketingLinkedinConversionIds,
-      marketingLinkedinPartnerId,
-      marketingMetaPixelId,
-      marketingXEventIds,
-      marketingXPixelId,
-    ],
+    [marketingGtmContainerId],
   );
   const content = (
     <>

--- a/packages/services/core/environment.service.ts
+++ b/packages/services/core/environment.service.ts
@@ -25,16 +25,6 @@ const getDesktopEnvironmentOverrides = (): DesktopEnvironmentOverrides => {
   return globalThis.__GENFEED_DESKTOP_ENV__ ?? {};
 };
 
-const readOptionalNumberEnv = (key: string): number | undefined => {
-  const value = process.env[key];
-  if (!value) {
-    return undefined;
-  }
-
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : undefined;
-};
-
 export const EnvironmentService = {
   get apiEndpoint(): string {
     return (
@@ -171,37 +161,6 @@ export const EnvironmentService = {
         ? 'granted'
         : 'denied',
     gtmContainerId: process.env.NEXT_PUBLIC_GTM_CONTAINER_ID || '',
-    linkedinConversionIds: {
-      book_call: readOptionalNumberEnv(
-        'NEXT_PUBLIC_LINKEDIN_CONVERSION_ID_BOOK_CALL',
-      ),
-      cta_click: readOptionalNumberEnv(
-        'NEXT_PUBLIC_LINKEDIN_CONVERSION_ID_CTA_CLICK',
-      ),
-      lead_submit: readOptionalNumberEnv(
-        'NEXT_PUBLIC_LINKEDIN_CONVERSION_ID_LEAD_SUBMIT',
-      ),
-      signup_complete: readOptionalNumberEnv(
-        'NEXT_PUBLIC_LINKEDIN_CONVERSION_ID_SIGNUP_COMPLETE',
-      ),
-      start_signup: readOptionalNumberEnv(
-        'NEXT_PUBLIC_LINKEDIN_CONVERSION_ID_START_SIGNUP',
-      ),
-      view_pricing: readOptionalNumberEnv(
-        'NEXT_PUBLIC_LINKEDIN_CONVERSION_ID_VIEW_PRICING',
-      ),
-    },
-    linkedinPartnerId: process.env.NEXT_PUBLIC_LINKEDIN_PARTNER_ID || '',
-    metaPixelId: process.env.NEXT_PUBLIC_META_PIXEL_ID || '',
-    xEventIds: {
-      book_call: process.env.NEXT_PUBLIC_X_BOOK_CALL_EVENT_ID || '',
-      cta_click: process.env.NEXT_PUBLIC_X_CTA_CLICK_EVENT_ID || '',
-      lead_submit: process.env.NEXT_PUBLIC_X_LEAD_SUBMIT_EVENT_ID || '',
-      signup_complete: process.env.NEXT_PUBLIC_X_SIGNUP_COMPLETE_EVENT_ID || '',
-      start_signup: process.env.NEXT_PUBLIC_X_START_SIGNUP_EVENT_ID || '',
-      view_pricing: process.env.NEXT_PUBLIC_X_VIEW_PRICING_EVENT_ID || '',
-    },
-    xPixelId: process.env.NEXT_PUBLIC_X_PIXEL_ID || '',
   },
 
   getApiUrl(): string {


### PR DESCRIPTION
## Summary
- make the website marketing browser API fail closed unless marketing consent is granted
- route consented marketing events through GTM/dataLayer only, removing direct Meta/LinkedIn/X browser pixel loading from the website provider path
- keep same-site server conversion dispatch gated by the same consented event API and prefer private server env names for conversion IDs
- update docs and focused tests for denied/unavailable consent and one wired CTA emitter

Closes #932
Refs #250

## Verification
- `bunx biome check apps/website/packages/marketing/browser.ts apps/website/packages/marketing/browser.test.ts apps/website/packages/marketing/MarketingTrackingProvider.tsx apps/website/packages/marketing/MarketingTrackingProvider.test.tsx apps/website/packages/marketing/server-conversions.ts apps/website/packages/ui/providers/AppProviders.tsx apps/website/packages/ui/providers/AppProviders.test.tsx apps/website/app/layout.tsx packages/services/core/environment.service.ts apps/website/docs/marketing-tracking.md`
- `bun run --cwd apps/website test -- packages/marketing/browser.test.ts packages/marketing/MarketingTrackingProvider.test.tsx packages/marketing/server-conversions.test.ts packages/ui/providers/AppProviders.test.tsx packages/components/buttons/request-access/button-request-access/ButtonRequestAccess.test.tsx`
- `git diff --check`

## Notes
- Did not run a full workspace type-check/build locally; those are left to PR CI per repo local verification policy.