### PR TITLE
fix(prisma): project workflow org in brand migration

### DIFF
--- a/packages/prisma/prisma/migrations/20260707120000_workflow_brand_one_to_one/migration.sql
+++ b/packages/prisma/prisma/migrations/20260707120000_workflow_brand_one_to_one/migration.sql
@@ -34,6 +34,7 @@ WHERE ranked_links.workflow_id = wf."id"
 WITH ranked_links AS (
   SELECT
     wf."id" AS workflow_id,
+    wf."organizationId" AS workflow_org_id,
     wb."A" AS brand_id,
     b."organizationId" AS brand_org_id,
     ROW_NUMBER() OVER (


### PR DESCRIPTION
## Summary
- add the missing `workflow_org_id` projection to the second `ranked_links` CTE in `20260707120000_workflow_brand_one_to_one`

## Root cause
The second Daily Production Deploy attempt passed the previous package-test blocker, then failed during API E2E migration apply with Prisma `P3018` / Postgres `42703`: `column ranked_links.workflow_org_id does not exist`. The migration references that field in `extra_links`, but the second `ranked_links` CTE did not select it.

Failed deploy attempt: https://github.com/genfeedai/genfeed.ai/actions/runs/28878044401
Child deploy run: https://github.com/genfeedai/genfeed.ai/actions/runs/28878081115
Tracking issue: https://github.com/genfeedai/genfeed.ai/issues/1459

## Validation
- static migration scan: all three `ranked_links` CTEs now project `workflow_org_id`
- `bunx prisma validate --schema packages/prisma/prisma/schema.prisma`
- staged diff check and staged secret scan