### PR TITLE
test(e2e): expect workspace shell section label

### DIFF
--- a/playwright/e2e/tests/shell/page-context-contract.spec.ts
+++ b/playwright/e2e/tests/shell/page-context-contract.spec.ts
@@ -24,6 +24,7 @@ const CONTRACTS: PageContextContract[] = [
   {
     route: `${BRAND_BASE}/workspace/overview`,
     currentApp: 'workspace',
+    sectionLabel: 'Workspace',
     sidebarLabels: ['Dashboard', 'Inbox', 'Tasks', 'Activity'],
   },
   {
@@ -44,6 +45,7 @@ const CONTRACTS: PageContextContract[] = [
   {
     route: `${BRAND_BASE}/posts/scheduled`,
     currentApp: 'posts',
+    sectionLabel: 'Workspace',
     pageLabels: ['Drafts', 'Scheduled', 'Published'],
   },
   {


### PR DESCRIPTION
## Summary
- update shell page context E2E contracts to expect the Workspace section label on workspace/posts routes
- matches AppProtectedLayoutSidebar and component-level assertions for the base workspace sidebar

## Verification
- bunx biome check --write playwright/e2e/tests/shell/page-context-contract.spec.ts
- pre-commit lint-staged checks