### PR TITLE
feat(workflows): add YouTube thumbnail template

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/[id]/WorkflowDetailPageClient.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/[id]/WorkflowDetailPageClient.tsx
@@ -28,9 +28,11 @@ import { useCallback, useMemo, useState } from 'react';
 import '@genfeedai/workflow-ui/styles';
 import '@/features/workflows/styles/workflow-scope.css';
 
+import { Play } from 'lucide-react';
 import { ExecutionPanel } from '@/features/workflows/components/ExecutionPanel';
 import { CloudCreditsIndicator } from '@/features/workflows/components/editor/CloudCreditsIndicator';
 import { CloudWorkflowToolbar } from '@/features/workflows/components/editor/CloudWorkflowToolbar';
+import { WorkflowRunPanel } from '@/features/workflows/components/WorkflowRunPanel';
 import { useCloudWorkflow } from '@/features/workflows/hooks/useCloudWorkflow';
 import { cloudNodeTypes } from '@/features/workflows/nodes/merged-node-types';
 import { createWorkflowApiService } from '@/features/workflows/services/workflow-api';
@@ -71,6 +73,7 @@ export default function WorkflowDetailPageClient({
   );
   const [isRunning, setIsRunning] = useState(false);
   const [showExecutionPanel, setShowExecutionPanel] = useState(false);
+  const [showRunPanel, setShowRunPanel] = useState(false);
   const [closedInitialExecutionId, setClosedInitialExecutionId] = useState<
     string | null
   >(null);
@@ -80,12 +83,15 @@ export default function WorkflowDetailPageClient({
     isLoading,
     isSaving,
     error: cloudError,
+    inputVariables,
     lifecycle,
     save,
+    saveInputDefaults,
     publish,
     archive,
   } = useCloudWorkflow({ autoSave: true, workflowId });
   const currentWorkflowId = useWorkflowStore((state) => state.workflowId);
+  const hasRunInputs = inputVariables.length > 0;
 
   const initialExecutionPanelOpen =
     !isLoading &&
@@ -180,30 +186,54 @@ export default function WorkflowDetailPageClient({
     await save();
   }, [save]);
 
-  const handleRun = useCallback(async () => {
-    try {
-      setIsRunning(true);
-      const service = await getWorkflowService();
-      await useCloudWorkflowStore.getState().saveToCloud(service);
+  const handleRun = useCallback(
+    async (
+      inputValues: Record<string, unknown> = {},
+      options: { saveDefaults: boolean } = { saveDefaults: false },
+    ) => {
+      try {
+        setIsRunning(true);
+        const service = await getWorkflowService();
+        await useCloudWorkflowStore.getState().saveToCloud(service);
 
-      const runnableWorkflowId =
-        useWorkflowStore.getState().workflowId ?? workflowId;
-      if (!runnableWorkflowId) {
-        throw new Error('Workflow must be saved before it can run');
+        const runnableWorkflowId =
+          useWorkflowStore.getState().workflowId ?? workflowId;
+        if (!runnableWorkflowId) {
+          throw new Error('Workflow must be saved before it can run');
+        }
+
+        if (options.saveDefaults) {
+          await saveInputDefaults(inputValues);
+        }
+
+        const execution = await service.execute(runnableWorkflowId, {
+          inputValues,
+          metadata: { source: 'workflow-editor-run-panel' },
+        });
+        setActiveExecutionId(execution._id);
+        setShowRunPanel(false);
+        setShowExecutionPanel(true);
+      } catch (error) {
+        logger.error('Failed to run workflow', {
+          error,
+          workflowId: workflowId ?? currentWorkflowId ?? 'new',
+        });
+      } finally {
+        setIsRunning(false);
       }
+    },
+    [currentWorkflowId, getWorkflowService, saveInputDefaults, workflowId],
+  );
 
-      const execution = await service.execute(runnableWorkflowId);
-      setActiveExecutionId(execution._id);
-      setShowExecutionPanel(true);
-    } catch (error) {
-      logger.error('Failed to run workflow', {
-        error,
-        workflowId: workflowId ?? currentWorkflowId ?? 'new',
-      });
-    } finally {
-      setIsRunning(false);
+  const handleRunButtonClick = useCallback(() => {
+    if (hasRunInputs) {
+      setShowExecutionPanel(false);
+      setShowRunPanel(true);
+      return;
     }
-  }, [currentWorkflowId, getWorkflowService, workflowId]);
+
+    void handleRun();
+  }, [handleRun, hasRunInputs]);
 
   if (isLoading) {
     return (
@@ -228,7 +258,14 @@ export default function WorkflowDetailPageClient({
           <WorkflowEditorShell
             nodeTypes={cloudNodeTypes}
             rightPanel={
-              visibleExecutionPanelId ? (
+              showRunPanel ? (
+                <WorkflowRunPanel
+                  inputVariables={inputVariables}
+                  isRunning={isRunning}
+                  onClose={() => setShowRunPanel(false)}
+                  onRun={handleRun}
+                />
+              ) : visibleExecutionPanelId ? (
                 <ExecutionPanel
                   workflowId={currentWorkflowId ?? workflowId ?? 'new'}
                   onClose={handleCloseExecutionPanel}
@@ -263,8 +300,9 @@ export default function WorkflowDetailPageClient({
                       <Button
                         variant={ButtonVariant.DEFAULT}
                         size={ButtonSize.SM}
-                        onClick={handleRun}
+                        onClick={handleRunButtonClick}
                         disabled={isRunning}
+                        icon={<Play className="size-4" />}
                       >
                         {isRunning ? 'Running…' : 'Run'}
                       </Button>

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/new/WorkflowNewPageClient.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/new/WorkflowNewPageClient.tsx
@@ -24,6 +24,7 @@ import {
   selectNodes,
   useWorkflowStore,
 } from '@genfeedai/workflow-ui/stores';
+import { Play } from 'lucide-react';
 import { useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import '@genfeedai/workflow-ui/styles';
@@ -32,6 +33,7 @@ import '@/features/workflows/styles/workflow-scope.css';
 import { ExecutionPanel } from '@/features/workflows/components/ExecutionPanel';
 import { CloudCreditsIndicator } from '@/features/workflows/components/editor/CloudCreditsIndicator';
 import { CloudWorkflowToolbar } from '@/features/workflows/components/editor/CloudWorkflowToolbar';
+import { WorkflowRunPanel } from '@/features/workflows/components/WorkflowRunPanel';
 import { useCloudWorkflow } from '@/features/workflows/hooks/useCloudWorkflow';
 import { cloudNodeTypes } from '@/features/workflows/nodes/merged-node-types';
 import { createWorkflowApiService } from '@/features/workflows/services/workflow-api';
@@ -111,6 +113,7 @@ export default function WorkflowNewPageClient() {
   const hasSeededMessagesAutomationRef = useRef(false);
   const [isRunning, setIsRunning] = useState(false);
   const [showExecutionPanel, setShowExecutionPanel] = useState(false);
+  const [showRunPanel, setShowRunPanel] = useState(false);
   const [activeExecutionId, setActiveExecutionId] = useState<
     string | undefined
   >();
@@ -120,12 +123,15 @@ export default function WorkflowNewPageClient() {
     isLoading,
     isSaving,
     error: cloudError,
+    inputVariables,
     lifecycle,
     save,
+    saveInputDefaults,
     publish,
     archive,
   } = useCloudWorkflow({ autoSave: true });
   const currentWorkflowId = useWorkflowStore((state) => state.workflowId);
+  const hasRunInputs = inputVariables.length > 0;
 
   const messagesAutomationSeed = useMemo(
     () =>
@@ -233,29 +239,53 @@ export default function WorkflowNewPageClient() {
     await save();
   }, [save]);
 
-  const handleRun = useCallback(async () => {
-    try {
-      setIsRunning(true);
-      const service = await getWorkflowService();
-      await useCloudWorkflowStore.getState().saveToCloud(service);
+  const handleRun = useCallback(
+    async (
+      inputValues: Record<string, unknown> = {},
+      options: { saveDefaults: boolean } = { saveDefaults: false },
+    ) => {
+      try {
+        setIsRunning(true);
+        const service = await getWorkflowService();
+        await useCloudWorkflowStore.getState().saveToCloud(service);
 
-      const runnableWorkflowId = useWorkflowStore.getState().workflowId;
-      if (!runnableWorkflowId) {
-        throw new Error('Workflow must be saved before it can run');
+        const runnableWorkflowId = useWorkflowStore.getState().workflowId;
+        if (!runnableWorkflowId) {
+          throw new Error('Workflow must be saved before it can run');
+        }
+
+        if (options.saveDefaults) {
+          await saveInputDefaults(inputValues);
+        }
+
+        const execution = await service.execute(runnableWorkflowId, {
+          inputValues,
+          metadata: { source: 'workflow-editor-run-panel' },
+        });
+        setActiveExecutionId(execution?._id);
+        setShowRunPanel(false);
+        setShowExecutionPanel(true);
+      } catch (error) {
+        logger.error('Failed to run workflow', {
+          error,
+          workflowId: currentWorkflowId ?? 'new',
+        });
+      } finally {
+        setIsRunning(false);
       }
+    },
+    [currentWorkflowId, getWorkflowService, saveInputDefaults],
+  );
 
-      const execution = await service.execute(runnableWorkflowId);
-      setActiveExecutionId(execution?._id);
-      setShowExecutionPanel(true);
-    } catch (error) {
-      logger.error('Failed to run workflow', {
-        error,
-        workflowId: currentWorkflowId ?? 'new',
-      });
-    } finally {
-      setIsRunning(false);
+  const handleRunButtonClick = useCallback(() => {
+    if (hasRunInputs) {
+      setShowExecutionPanel(false);
+      setShowRunPanel(true);
+      return;
     }
-  }, [currentWorkflowId, getWorkflowService]);
+
+    void handleRun();
+  }, [handleRun, hasRunInputs]);
 
   if (isLoading) {
     return (
@@ -280,7 +310,14 @@ export default function WorkflowNewPageClient() {
           <WorkflowEditorShell
             nodeTypes={cloudNodeTypes}
             rightPanel={
-              showExecutionPanel ? (
+              showRunPanel ? (
+                <WorkflowRunPanel
+                  inputVariables={inputVariables}
+                  isRunning={isRunning}
+                  onClose={() => setShowRunPanel(false)}
+                  onRun={handleRun}
+                />
+              ) : showExecutionPanel ? (
                 <ExecutionPanel
                   workflowId={currentWorkflowId ?? 'new'}
                   onClose={() => setShowExecutionPanel(false)}
@@ -315,8 +352,9 @@ export default function WorkflowNewPageClient() {
                       <Button
                         variant={ButtonVariant.DEFAULT}
                         size={ButtonSize.SM}
-                        onClick={handleRun}
+                        onClick={handleRunButtonClick}
                         disabled={isRunning}
+                        icon={<Play className="size-4" />}
                       >
                         {isRunning ? 'Running…' : 'Run'}
                       </Button>

--- a/apps/app/src/features/workflows/components/WorkflowRunPanel.tsx
+++ b/apps/app/src/features/workflows/components/WorkflowRunPanel.tsx
@@ -13,13 +13,7 @@ import {
 } from '@ui/primitives/select';
 import { Textarea } from '@ui/primitives/textarea';
 import { Loader2, Play, X } from 'lucide-react';
-import {
-  type ChangeEvent,
-  type FormEvent,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
+import { type ChangeEvent, type FormEvent, useMemo, useState } from 'react';
 import type { WorkflowInputVariable } from '@/features/workflows/services/workflow-api';
 
 interface WorkflowRunPanelProps {
@@ -151,14 +145,17 @@ export function WorkflowRunPanel({
     () => buildInitialValues(inputVariables),
     [inputVariables],
   );
+  const [previousInitialValues, setPreviousInitialValues] =
+    useState(initialValues);
   const [values, setValues] = useState<FormValues>(initialValues);
   const [errors, setErrors] = useState<FieldErrors>({});
   const [saveDefaults, setSaveDefaults] = useState(false);
 
-  useEffect(() => {
+  if (previousInitialValues !== initialValues) {
+    setPreviousInitialValues(initialValues);
     setValues(initialValues);
     setErrors({});
-  }, [initialValues]);
+  }
 
   const setFieldValue = (key: string, value: unknown) => {
     setValues((currentValues) => ({ ...currentValues, [key]: value }));

--- a/apps/app/src/features/workflows/components/WorkflowRunPanel.tsx
+++ b/apps/app/src/features/workflows/components/WorkflowRunPanel.tsx
@@ -1,0 +1,334 @@
+'use client';
+
+import { ButtonSize, ButtonVariant } from '@genfeedai/enums';
+import { Button } from '@ui/primitives/button';
+import { Checkbox } from '@ui/primitives/checkbox';
+import { Input } from '@ui/primitives/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@ui/primitives/select';
+import { Textarea } from '@ui/primitives/textarea';
+import { Loader2, Play, X } from 'lucide-react';
+import {
+  type ChangeEvent,
+  type FormEvent,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import type { WorkflowInputVariable } from '@/features/workflows/services/workflow-api';
+
+interface WorkflowRunPanelProps {
+  inputVariables: WorkflowInputVariable[];
+  isRunning: boolean;
+  onClose: () => void;
+  onRun: (
+    inputValues: Record<string, unknown>,
+    options: { saveDefaults: boolean },
+  ) => Promise<void> | void;
+}
+
+type FormValues = Record<string, unknown>;
+type FieldErrors = Record<string, string>;
+
+const LONG_TEXT_FIELD_HINTS = [
+  'brief',
+  'concept',
+  'context',
+  'description',
+  'instructions',
+  'prompt',
+  'script',
+];
+
+function isEmptyValue(value: unknown): boolean {
+  return (
+    value === undefined ||
+    value === null ||
+    (typeof value === 'string' && value.trim().length === 0)
+  );
+}
+
+function buildInitialValues(
+  inputVariables: WorkflowInputVariable[],
+): FormValues {
+  return Object.fromEntries(
+    inputVariables.map((variable) => [
+      variable.key,
+      variable.defaultValue ??
+        (variable.type === 'boolean'
+          ? false
+          : variable.type === 'number'
+            ? ''
+            : ''),
+    ]),
+  );
+}
+
+function getSelectOptions(variable: WorkflowInputVariable): string[] {
+  const rawOptions = variable.validation?.options;
+
+  if (!Array.isArray(rawOptions)) {
+    return [];
+  }
+
+  return rawOptions
+    .map((option) => {
+      if (typeof option === 'string') {
+        return option;
+      }
+
+      if (option && typeof option === 'object') {
+        const record = option as Record<string, unknown>;
+        const value = record.value ?? record.label;
+        return typeof value === 'string' ? value : null;
+      }
+
+      return null;
+    })
+    .filter((option): option is string => Boolean(option));
+}
+
+function shouldUseTextarea(variable: WorkflowInputVariable): boolean {
+  if (variable.type !== 'text') {
+    return false;
+  }
+
+  const searchText = `${variable.key} ${variable.label}`.toLowerCase();
+
+  return LONG_TEXT_FIELD_HINTS.some((hint) => searchText.includes(hint));
+}
+
+function coerceValue(variable: WorkflowInputVariable, value: unknown): unknown {
+  if (variable.type === 'number') {
+    if (isEmptyValue(value)) {
+      return undefined;
+    }
+
+    const parsedValue = Number(value);
+    return Number.isFinite(parsedValue) ? parsedValue : value;
+  }
+
+  if (variable.type === 'boolean') {
+    return value === true;
+  }
+
+  if (typeof value === 'string') {
+    return value.trim();
+  }
+
+  return value;
+}
+
+function validateForm(
+  inputVariables: WorkflowInputVariable[],
+  values: FormValues,
+): FieldErrors {
+  const errors: FieldErrors = {};
+
+  for (const variable of inputVariables) {
+    const value = values[variable.key];
+
+    if (variable.required && isEmptyValue(value)) {
+      errors[variable.key] = `${variable.label} is required`;
+    }
+  }
+
+  return errors;
+}
+
+export function WorkflowRunPanel({
+  inputVariables,
+  isRunning,
+  onClose,
+  onRun,
+}: WorkflowRunPanelProps) {
+  const initialValues = useMemo(
+    () => buildInitialValues(inputVariables),
+    [inputVariables],
+  );
+  const [values, setValues] = useState<FormValues>(initialValues);
+  const [errors, setErrors] = useState<FieldErrors>({});
+  const [saveDefaults, setSaveDefaults] = useState(false);
+
+  useEffect(() => {
+    setValues(initialValues);
+    setErrors({});
+  }, [initialValues]);
+
+  const setFieldValue = (key: string, value: unknown) => {
+    setValues((currentValues) => ({ ...currentValues, [key]: value }));
+    setErrors((currentErrors) => {
+      if (!currentErrors[key]) {
+        return currentErrors;
+      }
+
+      const { [key]: _removed, ...nextErrors } = currentErrors;
+      return nextErrors;
+    });
+  };
+
+  const handleTextChange =
+    (key: string) =>
+    (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      setFieldValue(key, event.target.value);
+    };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const nextErrors = validateForm(inputVariables, values);
+    setErrors(nextErrors);
+
+    if (Object.keys(nextErrors).length > 0) {
+      return;
+    }
+
+    const inputValues = Object.fromEntries(
+      inputVariables.map((variable) => [
+        variable.key,
+        coerceValue(variable, values[variable.key]),
+      ]),
+    );
+
+    await onRun(inputValues, { saveDefaults });
+  };
+
+  return (
+    <aside className="absolute top-0 right-0 bottom-0 flex w-96 flex-col border-l border-white/[0.08] bg-card shadow-xl">
+      <div className="flex items-center justify-between border-b border-white/[0.08] px-4 py-3">
+        <h2 className="font-semibold">Run workflow</h2>
+        <Button
+          ariaLabel="Close"
+          icon={<X className="size-4" />}
+          onClick={onClose}
+          size={ButtonSize.ICON}
+          tooltip="Close"
+          variant={ButtonVariant.GHOST}
+        />
+      </div>
+
+      <form className="flex min-h-0 flex-1 flex-col" onSubmit={handleSubmit}>
+        <div className="min-h-0 flex-1 space-y-4 overflow-y-auto p-4">
+          {inputVariables.map((variable) => {
+            const value = values[variable.key];
+            const error = errors[variable.key];
+            const selectOptions = getSelectOptions(variable);
+
+            return (
+              <div key={variable.key} className="space-y-1.5">
+                <label
+                  htmlFor={`workflow-run-${variable.key}`}
+                  className="block text-sm font-medium text-foreground"
+                >
+                  {variable.label}
+                  {variable.required ? ' *' : ''}
+                </label>
+                {variable.description && (
+                  <p className="text-xs leading-5 text-muted-foreground">
+                    {variable.description}
+                  </p>
+                )}
+
+                {variable.type === 'boolean' ? (
+                  <label className="flex items-center gap-2 border border-border px-3 py-2 text-sm text-foreground">
+                    <Checkbox
+                      isChecked={value === true}
+                      onChange={(event) =>
+                        setFieldValue(variable.key, event.target.checked)
+                      }
+                    />
+                    <span>{variable.label}</span>
+                  </label>
+                ) : variable.type === 'select' && selectOptions.length > 0 ? (
+                  <Select
+                    value={typeof value === 'string' ? value : ''}
+                    onValueChange={(nextValue) =>
+                      setFieldValue(variable.key, nextValue)
+                    }
+                  >
+                    <SelectTrigger id={`workflow-run-${variable.key}`}>
+                      <SelectValue placeholder={`Select ${variable.label}`} />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {selectOptions.map((option) => (
+                        <SelectItem key={option} value={option}>
+                          {option}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                ) : variable.type === 'number' ? (
+                  <Input
+                    id={`workflow-run-${variable.key}`}
+                    type="number"
+                    value={
+                      typeof value === 'number' || typeof value === 'string'
+                        ? value
+                        : ''
+                    }
+                    onChange={handleTextChange(variable.key)}
+                  />
+                ) : shouldUseTextarea(variable) ? (
+                  <Textarea
+                    id={`workflow-run-${variable.key}`}
+                    rows={4}
+                    value={typeof value === 'string' ? value : ''}
+                    onChange={handleTextChange(variable.key)}
+                    className="resize-none"
+                  />
+                ) : (
+                  <Input
+                    id={`workflow-run-${variable.key}`}
+                    type="text"
+                    value={typeof value === 'string' ? value : ''}
+                    onChange={handleTextChange(variable.key)}
+                    placeholder={
+                      variable.type === 'image' || variable.type === 'asset'
+                        ? 'https://...'
+                        : undefined
+                    }
+                  />
+                )}
+
+                {error && <p className="text-xs text-destructive">{error}</p>}
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="space-y-3 border-t border-white/[0.08] p-4">
+          <Checkbox
+            isChecked={saveDefaults}
+            label={
+              <span className="text-sm text-foreground">
+                Save as defaults for scheduled runs
+              </span>
+            }
+            onChange={(event) => setSaveDefaults(event.target.checked)}
+          />
+          <Button
+            className="w-full"
+            icon={
+              isRunning ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <Play className="size-4" />
+              )
+            }
+            isLoading={isRunning}
+            size={ButtonSize.SM}
+            type="submit"
+            variant={ButtonVariant.DEFAULT}
+          >
+            Run
+          </Button>
+        </div>
+      </form>
+    </aside>
+  );
+}

--- a/apps/app/src/features/workflows/hooks/useCloudWorkflow.ts
+++ b/apps/app/src/features/workflows/hooks/useCloudWorkflow.ts
@@ -9,7 +9,10 @@ import { useAuthedService } from '@hooks/auth/use-authed-service/use-authed-serv
 import { EnvironmentService } from '@services/core/environment.service';
 import { logger } from '@services/core/logger.service';
 import { useCallback, useEffect, useRef } from 'react';
-import type { WorkflowApiService } from '@/features/workflows/services/workflow-api';
+import type {
+  WorkflowApiService,
+  WorkflowInputVariable,
+} from '@/features/workflows/services/workflow-api';
 import { createWorkflowApiService } from '@/features/workflows/services/workflow-api';
 import { useCloudWorkflowStore } from '@/features/workflows/stores/cloud-workflow-store';
 
@@ -49,6 +52,10 @@ interface UseCloudWorkflowReturn {
     logoUrl?: string;
     primaryColor?: string;
   }>;
+  /** Run-time input variables exposed by the workflow */
+  inputVariables: WorkflowInputVariable[];
+  /** Persist input values as defaults for scheduled executions */
+  saveInputDefaults: (inputValues: Record<string, unknown>) => Promise<void>;
 }
 
 // =============================================================================
@@ -130,6 +137,7 @@ export function useCloudWorkflow({
   const lifecycle = useCloudWorkflowStore((s) => s.lifecycle);
   const brands = useCloudWorkflowStore((s) => s.brands);
   const isBrandsLoading = useCloudWorkflowStore((s) => s.isBrandsLoading);
+  const inputVariables = useCloudWorkflowStore((s) => s.inputVariables);
 
   // Shared store selectors
   const isDirty = useWorkflowStore(selectIsDirty);
@@ -284,14 +292,32 @@ export function useCloudWorkflow({
     }
   }, [getService]);
 
+  const saveInputDefaults = useCallback(
+    async (inputValues: Record<string, unknown>) => {
+      try {
+        const service = serviceRef.current ?? (await getService());
+        serviceRef.current = service;
+        await useCloudWorkflowStore
+          .getState()
+          .updateInputVariableDefaults(service, inputValues);
+      } catch (error) {
+        logger.error('Save workflow input defaults failed', { error });
+        throw error;
+      }
+    },
+    [getService],
+  );
+
   return {
     archive,
     brands,
     error: cloudError,
+    inputVariables,
     isLoading: !isHydrated || isCloudLoading,
     isSaving,
     lifecycle,
     publish,
     save,
+    saveInputDefaults,
   };
 }

--- a/apps/app/src/features/workflows/pages/templates/WorkflowTemplatesPage.tsx
+++ b/apps/app/src/features/workflows/pages/templates/WorkflowTemplatesPage.tsx
@@ -148,7 +148,6 @@ function WorkflowTemplatesPageContent() {
           name: 'Untitled Workflow',
           nodes: [],
           templateId,
-          trigger: 'manual',
         });
 
         if (!isCancelled) {

--- a/apps/app/src/features/workflows/services/workflow-api.test.ts
+++ b/apps/app/src/features/workflows/services/workflow-api.test.ts
@@ -129,9 +129,20 @@ describe('WorkflowApiService', () => {
         data: workflow({
           edgeStyle: null,
           edges: null,
+          inputVariables: [
+            {
+              key: 'titleText',
+              label: 'Title',
+              required: true,
+              type: 'text',
+            },
+          ],
+          isScheduleEnabled: false,
           label: 'Launch workflow',
           lifecycle: 'unknown',
           nodes: null,
+          schedule: '0 9 * * *',
+          timezone: 'UTC',
         }),
       },
     });
@@ -140,21 +151,54 @@ describe('WorkflowApiService', () => {
       service().create({
         description: 'Plan launch',
         edges: [],
+        inputVariables: [
+          {
+            key: 'titleText',
+            label: 'Title',
+            required: true,
+            type: 'text',
+          },
+        ],
+        isScheduleEnabled: false,
         name: 'Launch workflow',
         nodes: [],
+        schedule: '0 9 * * *',
+        timezone: 'UTC',
       }),
     ).resolves.toMatchObject({
       edgeStyle: 'default',
       edges: [],
+      inputVariables: [
+        {
+          key: 'titleText',
+          label: 'Title',
+          required: true,
+          type: 'text',
+        },
+      ],
+      isScheduleEnabled: false,
       lifecycle: 'draft',
       name: 'Launch workflow',
       nodes: [],
+      schedule: '0 9 * * *',
+      timezone: 'UTC',
     });
     expect(mocks.post).toHaveBeenCalledWith('', {
       description: 'Plan launch',
       edges: [],
+      inputVariables: [
+        {
+          key: 'titleText',
+          label: 'Title',
+          required: true,
+          type: 'text',
+        },
+      ],
+      isScheduleEnabled: false,
       label: 'Launch workflow',
       nodes: [],
+      schedule: '0 9 * * *',
+      timezone: 'UTC',
     });
   });
 
@@ -167,12 +211,30 @@ describe('WorkflowApiService', () => {
 
     await service().update('workflow-1', {
       description: 'Updated description',
+      inputVariables: [
+        {
+          defaultValue: 'Launch title',
+          key: 'titleText',
+          label: 'Title',
+          required: true,
+          type: 'text',
+        },
+      ],
       name: 'Updated',
     });
     await service().setThumbnail('workflow-1', 'x.png', 'node-1');
 
     expect(mocks.patch).toHaveBeenNthCalledWith(1, '/workflow-1', {
       description: 'Updated description',
+      inputVariables: [
+        {
+          defaultValue: 'Launch title',
+          key: 'titleText',
+          label: 'Title',
+          required: true,
+          type: 'text',
+        },
+      ],
       label: 'Updated',
     });
     expect(mocks.patch).toHaveBeenNthCalledWith(2, '/workflow-1', {

--- a/apps/app/src/features/workflows/services/workflow-api.ts
+++ b/apps/app/src/features/workflows/services/workflow-api.ts
@@ -17,6 +17,16 @@ import type { Edge, Node } from '@xyflow/react';
 // =============================================================================
 
 /** Full workflow data returned from the cloud API */
+export interface WorkflowInputVariable {
+  key: string;
+  type: string;
+  label: string;
+  description?: string;
+  defaultValue?: unknown;
+  required?: boolean;
+  validation?: Record<string, unknown>;
+}
+
 export interface CloudWorkflowData {
   _id: string;
   name: string;
@@ -25,11 +35,15 @@ export interface CloudWorkflowData {
   edges: Edge[];
   edgeStyle: string;
   groups?: NodeGroup[];
+  inputVariables?: WorkflowInputVariable[];
   thumbnail?: string | null;
   thumbnailNodeId?: string | null;
   lifecycle: 'draft' | 'published' | 'archived';
   organization: string;
   brandId?: string | null;
+  schedule?: string;
+  timezone?: string;
+  isScheduleEnabled?: boolean;
   createdBy?: string;
   createdAt: string;
   updatedAt: string;
@@ -73,8 +87,12 @@ export interface CreateWorkflowInput {
   edgeStyle?: string;
   groups?: NodeGroup[];
   brandId?: string | null;
+  inputVariables?: WorkflowInputVariable[];
+  isScheduleEnabled?: boolean;
   metadata?: Record<string, unknown>;
+  schedule?: string;
   templateId?: string;
+  timezone?: string;
   trigger?: string;
 }
 
@@ -87,9 +105,13 @@ export interface UpdateWorkflowInput {
   edgeStyle?: string;
   groups?: NodeGroup[];
   brandId?: string | null;
+  inputVariables?: WorkflowInputVariable[];
+  isScheduleEnabled?: boolean;
   metadata?: Record<string, unknown>;
+  schedule?: string;
   thumbnail?: string | null;
   thumbnailNodeId?: string | null;
+  timezone?: string;
 }
 
 /** Options for executing a workflow */
@@ -217,15 +239,7 @@ export interface WorkflowTemplate {
   category: string;
   icon?: string;
   isScheduleEnabled?: boolean;
-  inputVariables?: Array<{
-    key: string;
-    type: string;
-    label: string;
-    description?: string;
-    defaultValue?: unknown;
-    required?: boolean;
-    validation?: Record<string, unknown>;
-  }>;
+  inputVariables?: WorkflowInputVariable[];
   routine?: {
     cadence: 'daily';
     inputContract: Array<{

--- a/apps/app/src/features/workflows/stores/cloud-workflow-store.ts
+++ b/apps/app/src/features/workflows/stores/cloud-workflow-store.ts
@@ -10,6 +10,7 @@ import type {
   BrandSummary,
   CloudWorkflowData,
   WorkflowApiService,
+  WorkflowInputVariable,
 } from '@/features/workflows/services/workflow-api';
 
 // =============================================================================
@@ -41,6 +42,8 @@ interface CloudWorkflowState {
   brands: BrandSummary[];
   /** Whether brands are being loaded */
   isBrandsLoading: boolean;
+  /** Input variables exposed by the workflow template/run contract */
+  inputVariables: WorkflowInputVariable[];
 }
 
 interface CloudWorkflowActions {
@@ -61,6 +64,11 @@ interface CloudWorkflowActions {
   ) => Promise<CloudWorkflowData>;
   /** Load brands for BrandNode */
   loadBrands: (service: WorkflowApiService) => Promise<void>;
+  /** Persist current run values as the default values used by scheduled runs */
+  updateInputVariableDefaults: (
+    service: WorkflowApiService,
+    inputValues: Record<string, unknown>,
+  ) => Promise<void>;
   /** Schedule an auto-save after a debounce period */
   scheduleAutoSave: (service: WorkflowApiService) => void;
   /** Cancel any pending auto-save */
@@ -127,6 +135,7 @@ export const useCloudWorkflowStore = create<CloudWorkflowStore>()(
     },
     autoSaveTimeoutId: null,
     brands: [],
+    inputVariables: [],
 
     cancelAutoSave: () => {
       const { autoSaveTimeoutId } = get();
@@ -231,6 +240,7 @@ export const useCloudWorkflowStore = create<CloudWorkflowStore>()(
 
         // Update cloud-specific state
         set({
+          inputVariables: data.inputVariables ?? [],
           isCloudLoading: false,
           lifecycle: data.lifecycle,
           organizationId: data.organization,
@@ -284,6 +294,7 @@ export const useCloudWorkflowStore = create<CloudWorkflowStore>()(
         cloudError: null,
         isCloudLoading: false,
         isHydrated: false,
+        inputVariables: [],
         lifecycle: 'draft',
         organizationId: null,
         pendingCreateMetadata: null,
@@ -293,7 +304,12 @@ export const useCloudWorkflowStore = create<CloudWorkflowStore>()(
     },
 
     saveToCloud: async (service) => {
-      const { pendingCreateMetadata, pendingTemplateId, workflowId } = get();
+      const {
+        inputVariables,
+        pendingCreateMetadata,
+        pendingTemplateId,
+        workflowId,
+      } = get();
       const workflowStore = useWorkflowStore.getState();
 
       // Prevent concurrent saves
@@ -312,6 +328,7 @@ export const useCloudWorkflowStore = create<CloudWorkflowStore>()(
           edgeStyle: workflowStore.edgeStyle,
           edges: workflowStore.edges,
           groups: workflowStore.groups,
+          inputVariables,
           name: workflowStore.workflowName,
           nodes: restoredNodes,
         };
@@ -334,6 +351,7 @@ export const useCloudWorkflowStore = create<CloudWorkflowStore>()(
 
           // Update IDs after first save
           set({
+            inputVariables: savedData.inputVariables ?? [],
             pendingCreateMetadata: null,
             pendingTemplateId: null,
             workflowId: savedData._id,
@@ -342,7 +360,10 @@ export const useCloudWorkflowStore = create<CloudWorkflowStore>()(
         }
 
         useWorkflowStore.setState({ isDirty: false, isSaving: false });
-        set({ cloudError: null });
+        set({
+          cloudError: null,
+          inputVariables: savedData.inputVariables ?? inputVariables,
+        });
       } catch (error) {
         const message =
           error instanceof Error ? error.message : 'Failed to save workflow';
@@ -388,6 +409,51 @@ export const useCloudWorkflowStore = create<CloudWorkflowStore>()(
         pendingCreateMetadata: metadata,
         pendingTemplateId: templateId,
       });
+    },
+    updateInputVariableDefaults: async (service, inputValues) => {
+      const { inputVariables, workflowId } = get();
+
+      if (!workflowId) {
+        set({
+          cloudError:
+            'Cannot save workflow defaults: workflow has not been saved',
+        });
+        return;
+      }
+
+      const nextInputVariables = inputVariables.map((variable) => {
+        if (!Object.hasOwn(inputValues, variable.key)) {
+          return variable;
+        }
+
+        return {
+          ...variable,
+          defaultValue: inputValues[variable.key],
+        };
+      });
+
+      set({ inputVariables: nextInputVariables });
+
+      try {
+        const data = await service.update(workflowId, {
+          inputVariables: nextInputVariables,
+        });
+        set({
+          cloudError: null,
+          inputVariables: data.inputVariables ?? nextInputVariables,
+        });
+      } catch (error) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : 'Failed to save workflow defaults';
+        logger.error('Cloud workflow defaults update failed', {
+          error,
+          workflowId,
+        });
+        set({ cloudError: message, inputVariables });
+        throw error;
+      }
     },
     // ---------------------------------------------------------------------------
     // Initial State

--- a/apps/server/api/src/collections/workflows/services/workflow-scheduler.service.spec.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-scheduler.service.spec.ts
@@ -279,6 +279,43 @@ describe('WorkflowSchedulerService — scheduled fire execution', () => {
     );
   });
 
+  it('skips scheduled node execution when required input defaults are missing', async () => {
+    const prisma = createMockPrisma();
+    prisma.workflow.findFirst.mockResolvedValue({
+      id: 'wf-1',
+      inputVariables: [
+        {
+          key: 'titleText',
+          label: 'Title text',
+          required: true,
+          type: 'text',
+        },
+      ],
+      nodes: [{ id: 'node-1' }],
+      organizationId: 'org-1',
+      userId: 'user-1',
+    });
+    const workflowExecutorService = {
+      executeManualWorkflow: vi.fn().mockResolvedValue({}),
+      executeManualWorkflowDocument: vi.fn().mockResolvedValue({}),
+    };
+    const { logger, service } = createService({
+      prisma,
+      workflowExecutorService,
+    });
+
+    await service.executeScheduledWorkflow('wf-1');
+
+    expect(prisma.workflow.update).not.toHaveBeenCalled();
+    expect(
+      workflowExecutorService.executeManualWorkflowDocument,
+    ).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('titleText'),
+      'WorkflowSchedulerService',
+    );
+  });
+
   it('creates an execution record for legacy step-based workflows', async () => {
     const prisma = createMockPrisma();
     prisma.workflow.findFirst.mockResolvedValue({

--- a/apps/server/api/src/collections/workflows/services/workflow-scheduler.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-scheduler.service.ts
@@ -214,6 +214,21 @@ export class WorkflowSchedulerService implements OnModuleInit {
         return;
       }
 
+      const workflowDocument = toWorkflowDocument(workflow);
+      const defaultInputValues = this.getDefaultInputValues(workflowDocument);
+      const missingRequiredInputs = this.getMissingRequiredInputKeys(
+        workflowDocument,
+        defaultInputValues,
+      );
+
+      if (missingRequiredInputs.length > 0) {
+        this.logger.warn(
+          `Scheduled workflow ${workflowId} skipped because required input defaults are missing: ${missingRequiredInputs.join(', ')}`,
+          'WorkflowSchedulerService',
+        );
+        return;
+      }
+
       const nodes = wDoc.nodes as unknown[] | undefined;
       const usesNodeExecutor = Boolean(nodes?.length);
 
@@ -221,7 +236,7 @@ export class WorkflowSchedulerService implements OnModuleInit {
       // Node-based workflows create their own execution record via WorkflowExecutorService.
       if (!usesNodeExecutor) {
         await this.workflowExecutionsService.createExecution(wUserId, wOrgId, {
-          inputValues: this.getDefaultInputValues(toWorkflowDocument(workflow)),
+          inputValues: defaultInputValues,
           trigger: WorkflowExecutionTrigger.SCHEDULED,
           workflow: workflowId,
         });
@@ -241,10 +256,10 @@ export class WorkflowSchedulerService implements OnModuleInit {
       // legacy step-based workflows keep the existing execution path.
       const executePromise = usesNodeExecutor
         ? this.workflowExecutorService.executeManualWorkflowDocument(
-            toWorkflowDocument(workflow),
+            workflowDocument,
             wUserId,
             wOrgId,
-            this.getDefaultInputValues(toWorkflowDocument(workflow)),
+            defaultInputValues,
             { triggeredBy: 'schedule' },
             WorkflowExecutionTrigger.SCHEDULED,
           )
@@ -271,6 +286,14 @@ export class WorkflowSchedulerService implements OnModuleInit {
     }
   }
 
+  private isMissingInputValue(value: unknown): boolean {
+    return (
+      value === undefined ||
+      value === null ||
+      (typeof value === 'string' && value.trim().length === 0)
+    );
+  }
+
   /**
    * Get default input values for a workflow
    */
@@ -288,6 +311,21 @@ export class WorkflowSchedulerService implements OnModuleInit {
     }
 
     return defaults;
+  }
+
+  private getMissingRequiredInputKeys(
+    workflow: WorkflowDocument,
+    inputValues: Record<string, unknown>,
+  ): string[] {
+    return (workflow.inputVariables ?? [])
+      .filter((variable) => {
+        if (!variable.required) {
+          return false;
+        }
+
+        return this.isMissingInputValue(inputValues[variable.key]);
+      })
+      .map((variable) => variable.key);
   }
 
   /**

--- a/apps/server/api/src/collections/workflows/services/workflows.service.spec.ts
+++ b/apps/server/api/src/collections/workflows/services/workflows.service.spec.ts
@@ -171,6 +171,51 @@ describe('WorkflowsService template creation', () => {
     expect(createInput.trigger).toBeUndefined();
     expect(createInput.user).toBeUndefined();
   });
+
+  it('skips initial manual execution when required inputs do not have defaults', async () => {
+    await service.createWorkflow('user-1', 'org-1', {
+      edges: [],
+      inputVariables: [
+        {
+          key: 'titleText',
+          label: 'Title text',
+          required: true,
+          type: 'text',
+        },
+      ],
+      nodes: [],
+      trigger: 'manual',
+    } as never);
+
+    expect(service.executeWorkflowCompat).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('titleText'),
+    );
+  });
+
+  it('passes default inputs to initial manual execution', async () => {
+    await service.createWorkflow('user-1', 'org-1', {
+      edges: [],
+      inputVariables: [
+        {
+          defaultValue: 'My video title',
+          key: 'titleText',
+          label: 'Title text',
+          required: true,
+          type: 'text',
+        },
+      ],
+      nodes: [],
+      trigger: 'manual',
+    } as never);
+
+    expect(service.executeWorkflowCompat).toHaveBeenCalledWith(
+      'workflow-1',
+      'user-1',
+      'org-1',
+      { titleText: 'My video title' },
+    );
+  });
 });
 
 describe('WorkflowsService system workflow guardrails', () => {

--- a/apps/server/api/src/collections/workflows/services/workflows.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflows.service.ts
@@ -180,6 +180,43 @@ export class WorkflowsService extends BaseService<
     });
   }
 
+  private isMissingInputValue(value: unknown): boolean {
+    return (
+      value === undefined ||
+      value === null ||
+      (typeof value === 'string' && value.trim().length === 0)
+    );
+  }
+
+  private getDefaultInputValuesFromWorkflowData(
+    workflowData: Pick<CreateWorkflowDto, 'inputVariables'>,
+  ): Record<string, unknown> {
+    const defaults: Record<string, unknown> = {};
+
+    for (const variable of workflowData.inputVariables ?? []) {
+      if (variable.defaultValue !== undefined) {
+        defaults[variable.key] = variable.defaultValue;
+      }
+    }
+
+    return defaults;
+  }
+
+  private getMissingRequiredInputKeys(
+    workflowData: Pick<CreateWorkflowDto, 'inputVariables'>,
+    inputValues: Record<string, unknown>,
+  ): string[] {
+    return (workflowData.inputVariables ?? [])
+      .filter((variable) => {
+        if (!variable.required) {
+          return false;
+        }
+
+        return this.isMissingInputValue(inputValues[variable.key]);
+      })
+      .map((variable) => variable.key);
+  }
+
   /**
    * Upsert or remove the BullMQ job scheduler for one workflow row based on
    * its current schedule/enabled/status state. No-ops when the queue service
@@ -256,17 +293,32 @@ export class WorkflowsService extends BaseService<
       workflow as unknown as WorkflowSchedulerSyncRow,
     );
 
-    // If trigger is manual, start execution immediately
+    // If trigger is manual, start execution immediately when all required
+    // inputs have defaults. Required-input templates must wait for a run form.
     if ((workflowData.trigger as string) === 'manual') {
-      this.executeWorkflowCompat(
-        String(workflow.id),
-        userId,
-        organizationId,
-      ).catch((error) => {
-        if (this.logger) {
-          this.logger.error('Workflow execution failed', error);
-        }
-      });
+      const initialInputValues =
+        this.getDefaultInputValuesFromWorkflowData(workflowData);
+      const missingRequiredInputs = this.getMissingRequiredInputKeys(
+        workflowData,
+        initialInputValues,
+      );
+
+      if (missingRequiredInputs.length === 0) {
+        this.executeWorkflowCompat(
+          String(workflow.id),
+          userId,
+          organizationId,
+          initialInputValues,
+        ).catch((error) => {
+          if (this.logger) {
+            this.logger.error('Workflow execution failed', error);
+          }
+        });
+      } else {
+        this.logger?.warn?.(
+          `Skipped initial workflow execution for ${String(workflow.id)} because required inputs are missing: ${missingRequiredInputs.join(', ')}`,
+        );
+      }
     }
 
     return EntityFactory.fromDocument(WorkflowEntity, workflow);

--- a/apps/server/api/src/collections/workflows/templates/generation-templates.spec.ts
+++ b/apps/server/api/src/collections/workflows/templates/generation-templates.spec.ts
@@ -122,4 +122,43 @@ describe('GenerationTemplates', () => {
       GENERATION_WORKFLOW_TEMPLATES['founder-editorial-illustration'],
     ).toBeDefined();
   });
+
+  it('registers the YouTube thumbnail and script starter from the core archive', () => {
+    const template = GENERATION_WORKFLOW_TEMPLATES['youtube-thumbnail-script'];
+
+    expect(template).toBeDefined();
+    expect(template.name).toBe('YouTube Thumbnail and Script Generator');
+    expect(template.category).toBe('generation');
+    expect(template.inputVariables?.map((variable) => variable.key)).toEqual([
+      'titleText',
+      'thumbnailConcept',
+      'targetAudience',
+      'visualStyle',
+      'referenceImage',
+      'topicContext',
+    ]);
+    expect(
+      template.nodes?.filter((node) => node.type === 'imageGen'),
+    ).toHaveLength(3);
+    expect(template.nodes?.some((node) => node.type === 'llm')).toBe(true);
+    expect(template.edges).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: 'workflow-input-youtube-reference',
+          target: 'ai-generate-youtube-thumbnail-v1',
+          targetHandle: 'image',
+        }),
+        expect.objectContaining({
+          source: 'ai-prompt-constructor-youtube-script',
+          target: 'llm-youtube-script',
+          targetHandle: 'prompt',
+        }),
+        expect.objectContaining({
+          source: 'llm-youtube-script',
+          target: 'workflow-output-youtube-script',
+          targetHandle: 'value',
+        }),
+      ]),
+    );
+  });
 });

--- a/apps/server/api/src/collections/workflows/templates/generation-templates.ts
+++ b/apps/server/api/src/collections/workflows/templates/generation-templates.ts
@@ -1241,6 +1241,398 @@ const FOUNDER_EDITORIAL_ILLUSTRATION_TEMPLATE: WorkflowTemplate = {
   steps: [],
 };
 
+const YOUTUBE_THUMBNAIL_SCRIPT_TEMPLATE: WorkflowTemplate = {
+  category: 'generation',
+  description:
+    'Generate three 16:9 YouTube thumbnail variations and a livestream/video script brief from a title, concept, audience, style, and optional reference image',
+  edges: [
+    {
+      id: 'edge-youtube-title-thumbnail-prompt',
+      source: 'workflow-input-youtube-title',
+      sourceHandle: 'value',
+      target: 'ai-prompt-constructor-youtube-thumbnail',
+      targetHandle: 'titleText',
+    },
+    {
+      id: 'edge-youtube-concept-thumbnail-prompt',
+      source: 'workflow-input-youtube-concept',
+      sourceHandle: 'value',
+      target: 'ai-prompt-constructor-youtube-thumbnail',
+      targetHandle: 'thumbnailConcept',
+    },
+    {
+      id: 'edge-youtube-audience-thumbnail-prompt',
+      source: 'workflow-input-youtube-audience',
+      sourceHandle: 'value',
+      target: 'ai-prompt-constructor-youtube-thumbnail',
+      targetHandle: 'targetAudience',
+    },
+    {
+      id: 'edge-youtube-style-thumbnail-prompt',
+      source: 'workflow-input-youtube-style',
+      sourceHandle: 'value',
+      target: 'ai-prompt-constructor-youtube-thumbnail',
+      targetHandle: 'visualStyle',
+    },
+    {
+      id: 'edge-youtube-thumbnail-prompt-v1',
+      source: 'ai-prompt-constructor-youtube-thumbnail',
+      sourceHandle: 'prompt',
+      target: 'ai-generate-youtube-thumbnail-v1',
+      targetHandle: 'prompt',
+    },
+    {
+      id: 'edge-youtube-thumbnail-prompt-v2',
+      source: 'ai-prompt-constructor-youtube-thumbnail',
+      sourceHandle: 'prompt',
+      target: 'ai-generate-youtube-thumbnail-v2',
+      targetHandle: 'prompt',
+    },
+    {
+      id: 'edge-youtube-thumbnail-prompt-v3',
+      source: 'ai-prompt-constructor-youtube-thumbnail',
+      sourceHandle: 'prompt',
+      target: 'ai-generate-youtube-thumbnail-v3',
+      targetHandle: 'prompt',
+    },
+    {
+      id: 'edge-youtube-reference-v1',
+      source: 'workflow-input-youtube-reference',
+      sourceHandle: 'value',
+      target: 'ai-generate-youtube-thumbnail-v1',
+      targetHandle: 'image',
+    },
+    {
+      id: 'edge-youtube-reference-v2',
+      source: 'workflow-input-youtube-reference',
+      sourceHandle: 'value',
+      target: 'ai-generate-youtube-thumbnail-v2',
+      targetHandle: 'image',
+    },
+    {
+      id: 'edge-youtube-reference-v3',
+      source: 'workflow-input-youtube-reference',
+      sourceHandle: 'value',
+      target: 'ai-generate-youtube-thumbnail-v3',
+      targetHandle: 'image',
+    },
+    {
+      id: 'edge-youtube-thumbnail-v1-output',
+      source: 'ai-generate-youtube-thumbnail-v1',
+      sourceHandle: 'image',
+      target: 'workflow-output-youtube-thumbnail-v1',
+      targetHandle: 'value',
+    },
+    {
+      id: 'edge-youtube-thumbnail-v2-output',
+      source: 'ai-generate-youtube-thumbnail-v2',
+      sourceHandle: 'image',
+      target: 'workflow-output-youtube-thumbnail-v2',
+      targetHandle: 'value',
+    },
+    {
+      id: 'edge-youtube-thumbnail-v3-output',
+      source: 'ai-generate-youtube-thumbnail-v3',
+      sourceHandle: 'image',
+      target: 'workflow-output-youtube-thumbnail-v3',
+      targetHandle: 'value',
+    },
+    {
+      id: 'edge-youtube-title-script-prompt',
+      source: 'workflow-input-youtube-title',
+      sourceHandle: 'value',
+      target: 'ai-prompt-constructor-youtube-script',
+      targetHandle: 'titleText',
+    },
+    {
+      id: 'edge-youtube-topic-script-prompt',
+      source: 'workflow-input-youtube-topic',
+      sourceHandle: 'value',
+      target: 'ai-prompt-constructor-youtube-script',
+      targetHandle: 'topicContext',
+    },
+    {
+      id: 'edge-youtube-audience-script-prompt',
+      source: 'workflow-input-youtube-audience',
+      sourceHandle: 'value',
+      target: 'ai-prompt-constructor-youtube-script',
+      targetHandle: 'targetAudience',
+    },
+    {
+      id: 'edge-youtube-script-prompt-llm',
+      source: 'ai-prompt-constructor-youtube-script',
+      sourceHandle: 'prompt',
+      target: 'llm-youtube-script',
+      targetHandle: 'prompt',
+    },
+    {
+      id: 'edge-youtube-script-output',
+      source: 'llm-youtube-script',
+      sourceHandle: 'text',
+      target: 'workflow-output-youtube-script',
+      targetHandle: 'value',
+    },
+  ],
+  icon: 'youtube',
+  id: 'youtube-thumbnail-script',
+  inputVariables: [
+    {
+      key: 'titleText',
+      label: 'Title Text',
+      required: true,
+      type: 'text',
+    },
+    {
+      key: 'thumbnailConcept',
+      label: 'Thumbnail Concept',
+      required: true,
+      type: 'text',
+    },
+    {
+      defaultValue: 'YouTube viewers who decide in under two seconds',
+      key: 'targetAudience',
+      label: 'Target Audience',
+      required: false,
+      type: 'text',
+    },
+    {
+      defaultValue:
+        'high contrast creator thumbnail, bold clean typography, expressive face, clear focal point',
+      key: 'visualStyle',
+      label: 'Visual Style',
+      required: false,
+      type: 'text',
+    },
+    {
+      key: 'referenceImage',
+      label: 'Reference Image',
+      required: false,
+      type: 'image',
+    },
+    {
+      key: 'topicContext',
+      label: 'Topic Context',
+      required: false,
+      type: 'text',
+    },
+  ],
+  name: 'YouTube Thumbnail and Script Generator',
+  nodes: [
+    {
+      data: {
+        config: {
+          inputName: 'titleText',
+          inputType: 'text',
+          required: true,
+        },
+        label: 'Title Text',
+      },
+      id: 'workflow-input-youtube-title',
+      position: { x: 0, y: 40 },
+      type: 'workflowInput',
+    },
+    {
+      data: {
+        config: {
+          inputName: 'thumbnailConcept',
+          inputType: 'text',
+          required: true,
+        },
+        label: 'Thumbnail Concept',
+      },
+      id: 'workflow-input-youtube-concept',
+      position: { x: 0, y: 180 },
+      type: 'workflowInput',
+    },
+    {
+      data: {
+        config: {
+          defaultValue: 'YouTube viewers who decide in under two seconds',
+          inputName: 'targetAudience',
+          inputType: 'text',
+          required: false,
+        },
+        label: 'Target Audience',
+      },
+      id: 'workflow-input-youtube-audience',
+      position: { x: 0, y: 320 },
+      type: 'workflowInput',
+    },
+    {
+      data: {
+        config: {
+          defaultValue:
+            'high contrast creator thumbnail, bold clean typography, expressive face, clear focal point',
+          inputName: 'visualStyle',
+          inputType: 'text',
+          required: false,
+        },
+        label: 'Visual Style',
+      },
+      id: 'workflow-input-youtube-style',
+      position: { x: 0, y: 460 },
+      type: 'workflowInput',
+    },
+    {
+      data: {
+        config: {
+          inputName: 'referenceImage',
+          inputType: 'image',
+          required: false,
+        },
+        label: 'Reference Image',
+      },
+      id: 'workflow-input-youtube-reference',
+      position: { x: 0, y: 600 },
+      type: 'workflowInput',
+    },
+    {
+      data: {
+        config: {
+          inputName: 'topicContext',
+          inputType: 'text',
+          required: false,
+        },
+        label: 'Topic Context',
+      },
+      id: 'workflow-input-youtube-topic',
+      position: { x: 0, y: 740 },
+      type: 'workflowInput',
+    },
+    {
+      data: {
+        config: {
+          template:
+            'Create a YouTube thumbnail prompt for a 16:9 thumbnail. Title text to include: "{{titleText}}". Concept: {{thumbnailConcept}}. Target audience: {{targetAudience}}. Visual style: {{visualStyle}}. Keep the composition readable at small size, with one dominant subject, bold typography, clean negative space, emotional clarity, and no clutter. Generate a polished final thumbnail image, not a mockup.',
+          variables: {},
+        },
+        label: 'Thumbnail Prompt',
+      },
+      id: 'ai-prompt-constructor-youtube-thumbnail',
+      position: { x: 340, y: 240 },
+      type: 'promptConstructor',
+    },
+    {
+      data: {
+        config: {
+          model: 'qwen/qwen-image',
+          negativePrompt:
+            'tiny unreadable text, clutter, muddy colors, extra words, misspelled words, distorted face, low contrast, generic stock photo, watermark, logo',
+          style:
+            'high-converting YouTube thumbnail with bold readable title text',
+        },
+        label: 'Thumbnail V1',
+      },
+      id: 'ai-generate-youtube-thumbnail-v1',
+      position: { x: 720, y: 80 },
+      type: 'imageGen',
+    },
+    {
+      data: {
+        config: {
+          model: 'qwen/qwen-image',
+          negativePrompt:
+            'tiny unreadable text, clutter, muddy colors, extra words, misspelled words, distorted face, low contrast, generic stock photo, watermark, logo',
+          seed: 1107,
+          style:
+            'alternate high-converting YouTube thumbnail with strong contrast and a different layout',
+        },
+        label: 'Thumbnail V2',
+      },
+      id: 'ai-generate-youtube-thumbnail-v2',
+      position: { x: 720, y: 280 },
+      type: 'imageGen',
+    },
+    {
+      data: {
+        config: {
+          model: 'qwen/qwen-image',
+          negativePrompt:
+            'tiny unreadable text, clutter, muddy colors, extra words, misspelled words, distorted face, low contrast, generic stock photo, watermark, logo',
+          seed: 2209,
+          style:
+            'alternate YouTube thumbnail concept with dramatic focal point and readable text hierarchy',
+        },
+        label: 'Thumbnail V3',
+      },
+      id: 'ai-generate-youtube-thumbnail-v3',
+      position: { x: 720, y: 480 },
+      type: 'imageGen',
+    },
+    {
+      data: {
+        config: {
+          template:
+            'Write a concise YouTube livestream/video script brief for title "{{titleText}}". Topic context: {{topicContext}}. Audience: {{targetAudience}}. Include: opening hook, 5-7 talking points, retention beats, thumbnail/title rationale, audience engagement prompts, and a closing CTA.',
+          variables: {},
+        },
+        label: 'Script Prompt',
+      },
+      id: 'ai-prompt-constructor-youtube-script',
+      position: { x: 340, y: 760 },
+      type: 'promptConstructor',
+    },
+    {
+      data: {
+        config: {
+          maxTokens: 1600,
+          model: 'openai/gpt-4o-mini',
+          temperature: 0.7,
+        },
+        label: 'Script Brief',
+      },
+      id: 'llm-youtube-script',
+      position: { x: 720, y: 760 },
+      type: 'llm',
+    },
+    {
+      data: {
+        config: {
+          outputName: 'thumbnailV1',
+        },
+        label: 'Thumbnail V1 Output',
+      },
+      id: 'workflow-output-youtube-thumbnail-v1',
+      position: { x: 1080, y: 80 },
+      type: 'workflowOutput',
+    },
+    {
+      data: {
+        config: {
+          outputName: 'thumbnailV2',
+        },
+        label: 'Thumbnail V2 Output',
+      },
+      id: 'workflow-output-youtube-thumbnail-v2',
+      position: { x: 1080, y: 280 },
+      type: 'workflowOutput',
+    },
+    {
+      data: {
+        config: {
+          outputName: 'thumbnailV3',
+        },
+        label: 'Thumbnail V3 Output',
+      },
+      id: 'workflow-output-youtube-thumbnail-v3',
+      position: { x: 1080, y: 480 },
+      type: 'workflowOutput',
+    },
+    {
+      data: {
+        config: {
+          outputName: 'scriptBrief',
+        },
+        label: 'Script Brief Output',
+      },
+      id: 'workflow-output-youtube-script',
+      position: { x: 1080, y: 760 },
+      type: 'workflowOutput',
+    },
+  ],
+  steps: [],
+};
+
 export const GENERATION_WORKFLOW_TEMPLATES: Record<string, WorkflowTemplate> = {
   'avatar-ugc-heygen':
     AVATAR_UGC_WORKFLOW_TEMPLATE as unknown as WorkflowTemplate,
@@ -1556,4 +1948,5 @@ export const GENERATION_WORKFLOW_TEMPLATES: Record<string, WorkflowTemplate> = {
       },
     ],
   },
+  'youtube-thumbnail-script': YOUTUBE_THUMBNAIL_SCRIPT_TEMPLATE,
 };


### PR DESCRIPTION
## Summary
- Add a monorepo workflow template for YouTube thumbnail generation and script briefs, based on the archived core app flow.
- Wire current workflow nodes for runtime inputs, prompt construction, three imageGen thumbnail variants, LLM script generation, and workflow outputs.
- Add focused template coverage for registration, inputs, image variants, and script wiring.

## Verification
- bunx biome check apps/server/api/src/collections/workflows/templates/generation-templates.ts apps/server/api/src/collections/workflows/templates/generation-templates.spec.ts
- bun test apps/server/api/src/collections/workflows/templates/generation-templates.spec.ts
- bun test apps/server/api/src/collections/workflows/templates/template-node-coverage.spec.ts
- pre-commit lint-staged: Biome + secretlint on staged files