### PR TITLE
fix(telegram): wire workflow media inputs

### DIFF
--- a/apps/server/api/src/services/telegram-bot/__tests__/telegram-message-handler.service.spec.ts
+++ b/apps/server/api/src/services/telegram-bot/__tests__/telegram-message-handler.service.spec.ts
@@ -1,12 +1,16 @@
 import type { FilesClientService } from '@api/services/files-microservice/client/files-client.service';
+import { TELEGRAM_BOT_CONSTANTS } from '@api/services/telegram-bot/telegram-bot.constants';
 import type {
   ConversationState,
   WorkflowInput,
+  WorkflowJson,
 } from '@api/services/telegram-bot/telegram-bot.types';
-import type { TelegramConversationService } from '@api/services/telegram-bot/telegram-conversation.service';
+import { TelegramConversationService } from '@api/services/telegram-bot/telegram-conversation.service';
 import { TelegramMessageHandlerService } from '@api/services/telegram-bot/telegram-message-handler.service';
 import type { TelegramRunCommandsService } from '@api/services/telegram-bot/telegram-run-commands.service';
+import type { TelegramWorkflowRunnerService } from '@api/services/telegram-bot/telegram-workflow-runner.service';
 import { FileInputType } from '@genfeedai/enums';
+import type { WorkflowEngine } from '@genfeedai/workflow-engine';
 import type { LoggerService } from '@libs/logger/logger.service';
 import type { Context } from 'grammy';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -23,6 +27,25 @@ type ContextFixture = {
   getFile: ReturnType<typeof vi.fn>;
   reply: ReturnType<typeof vi.fn>;
 };
+
+type CallbackContextFixture = {
+  answerCallbackQuery: ReturnType<typeof vi.fn>;
+  ctx: Context;
+  reply: ReturnType<typeof vi.fn>;
+};
+
+function createCallbackContextFixture(data: string): CallbackContextFixture {
+  const answerCallbackQuery = vi.fn();
+  const reply = vi.fn().mockResolvedValue({ message_id: 99 });
+  const ctx = {
+    answerCallbackQuery,
+    callbackQuery: { data },
+    chat: { id: 42 },
+    reply,
+  } as unknown as Context;
+
+  return { answerCallbackQuery, ctx, reply };
+}
 
 function createState(input: WorkflowInput): ConversationState {
   return {
@@ -62,15 +85,104 @@ function createContextFixture(
   return { ctx, getFile, reply };
 }
 
-function stubFetch(contentType: string | null): ReturnType<typeof vi.fn> {
-  const fetchMock = vi.fn().mockResolvedValue({
+function createFetchResponse(contentType: string | null) {
+  return {
     arrayBuffer: vi.fn().mockResolvedValue(Uint8Array.from([1, 2, 3]).buffer),
     headers: { get: vi.fn().mockReturnValue(contentType) },
     ok: true,
     status: 200,
-  });
+  };
+}
+
+function stubFetch(contentType: string | null): ReturnType<typeof vi.fn> {
+  const fetchMock = vi.fn().mockResolvedValue(createFetchResponse(contentType));
   vi.stubGlobal('fetch', fetchMock);
   return fetchMock;
+}
+
+function stubFetchSequence(
+  contentTypes: Array<string | null>,
+): ReturnType<typeof vi.fn> {
+  const fetchMock = vi.fn();
+  for (const contentType of contentTypes) {
+    fetchMock.mockResolvedValueOnce(createFetchResponse(contentType));
+  }
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+function lastReplyText(reply: ReturnType<typeof vi.fn>): string {
+  const [message] = reply.mock.calls.at(-1) ?? [];
+  return typeof message === 'string' ? message : '';
+}
+
+function createMediaWorkflow(): WorkflowJson {
+  return {
+    description: 'Collects audio and video media inputs.',
+    edges: [
+      {
+        id: 'e1',
+        source: 'audio-node',
+        sourceHandle: 'value',
+        target: 'output-node',
+        targetHandle: 'audio',
+      },
+      {
+        id: 'e2',
+        source: 'video-node',
+        sourceHandle: 'value',
+        target: 'output-node',
+        targetHandle: 'video',
+      },
+    ],
+    inputVariables: [
+      {
+        key: 'audioUrl',
+        label: 'Narration',
+        required: true,
+        type: 'audio',
+      },
+      {
+        key: 'videoUrl',
+        label: 'Reference Video',
+        required: true,
+        type: 'video',
+      },
+    ],
+    name: 'Media Workflow',
+    nodes: [
+      {
+        data: {
+          config: {
+            inputName: 'audioUrl',
+            inputType: 'audio',
+            required: true,
+          },
+          label: 'Narration',
+        },
+        id: 'audio-node',
+        type: 'workflowInput',
+      },
+      {
+        data: {
+          config: {
+            inputName: 'videoUrl',
+            inputType: 'video',
+            required: true,
+          },
+          label: 'Reference Video',
+        },
+        id: 'video-node',
+        type: 'workflowInput',
+      },
+      {
+        data: { label: 'Final Output' },
+        id: 'output-node',
+        type: 'output',
+      },
+    ],
+    version: 1,
+  };
 }
 
 describe('TelegramMessageHandlerService media inputs', () => {
@@ -219,6 +331,97 @@ describe('TelegramMessageHandlerService media inputs', () => {
     );
     expect(state.collectedInputs.get('audio-node')).toBe(
       'https://cdn.genfeed.ai/telegram-media',
+    );
+  });
+
+  it('drives a selected audio/video workflow through collection and run confirmation', async () => {
+    const execute = vi.fn().mockResolvedValue(undefined);
+    const runner = {
+      execute,
+    } as unknown as TelegramWorkflowRunnerService;
+    conversation = new TelegramConversationService(logger, runner);
+    conversation.attachEngine({} as WorkflowEngine);
+    conversation.setWorkflows(
+      new Map<string, WorkflowJson>([
+        ['media-workflow', createMediaWorkflow()],
+      ]),
+    );
+    uploadToS3
+      .mockResolvedValueOnce({
+        publicUrl: 'https://cdn.genfeed.ai/audio.mp3',
+      })
+      .mockResolvedValueOnce({
+        publicUrl: 'https://cdn.genfeed.ai/video.mp4',
+      });
+    const service = new TelegramMessageHandlerService(
+      logger,
+      conversation,
+      {} as unknown as TelegramRunCommandsService,
+      filesClientService,
+    );
+    service.setBotToken('bot-token');
+    stubFetchSequence(['audio/mpeg', 'video/mp4']);
+
+    const select = createCallbackContextFixture(
+      `${TELEGRAM_BOT_CONSTANTS.CALLBACK_PREFIX.WORKFLOW_SELECT}media-workflow`,
+    );
+    await conversation.handleCallbackQuery(select.ctx);
+
+    expect(select.answerCallbackQuery).toHaveBeenCalled();
+    expect(lastReplyText(select.reply)).toContain('Please send an audio file.');
+
+    const audio = createContextFixture(
+      {
+        audio: {
+          file_id: 'audio-file',
+          file_name: 'audio.mp3',
+          mime_type: 'audio/mpeg',
+        },
+      },
+      'telegram/audio.mp3',
+    );
+    await service.handleAudio(audio.ctx);
+
+    expect(lastReplyText(audio.reply)).toContain('Please send a video.');
+
+    const video = createContextFixture(
+      {
+        video: {
+          file_id: 'video-file',
+          file_name: 'video.mp4',
+          mime_type: 'video/mp4',
+        },
+      },
+      'telegram/video.mp4',
+    );
+    await service.handleVideo(video.ctx);
+
+    expect(lastReplyText(video.reply)).toContain(
+      'Ready to run: Media Workflow',
+    );
+    expect(lastReplyText(video.reply)).toContain('Audio received');
+    expect(lastReplyText(video.reply)).toContain('Video received');
+
+    const confirm = createCallbackContextFixture(
+      TELEGRAM_BOT_CONSTANTS.CALLBACK_PREFIX.CONFIRM_RUN,
+    );
+    await conversation.handleCallbackQuery(confirm.ctx);
+
+    const stateArg = execute.mock.calls[0]?.[2] as
+      | ConversationState
+      | undefined;
+    expect(execute).toHaveBeenCalledOnce();
+    expect(stateArg?.collectedInputs.get('audio-node')).toBe(
+      'https://cdn.genfeed.ai/audio.mp3',
+    );
+    expect(stateArg?.collectedInputs.get('audioUrl')).toBe(
+      'https://cdn.genfeed.ai/audio.mp3',
+    );
+    expect(stateArg?.collectedInputs.get('video-node')).toBe(
+      'https://cdn.genfeed.ai/video.mp4',
+    );
+    expect(stateArg?.collectedInputs.get('videoUrl')).toBe(
+      'https://cdn.genfeed.ai/video.mp4',
     );
   });
 });

--- a/apps/server/api/src/services/telegram-bot/__tests__/telegram-workflow-loader.spec.ts
+++ b/apps/server/api/src/services/telegram-bot/__tests__/telegram-workflow-loader.spec.ts
@@ -28,6 +28,69 @@ const workflow: WorkflowJson = {
   version: 1,
 };
 
+const runtimeInputWorkflow: WorkflowJson = {
+  description: 'runtime desc',
+  edges: [
+    {
+      id: 'e1',
+      source: 'workflow-input-audio',
+      sourceHandle: 'value',
+      target: 'output',
+      targetHandle: 'audio',
+    },
+    {
+      id: 'e2',
+      source: 'workflow-input-video',
+      sourceHandle: 'value',
+      target: 'output',
+      targetHandle: 'video',
+    },
+  ],
+  inputVariables: [
+    {
+      key: 'audioUrl',
+      label: 'Narration',
+      required: true,
+      type: 'audio',
+    },
+    {
+      key: 'videoUrl',
+      label: 'Reference video',
+      required: true,
+      type: 'video',
+    },
+  ],
+  name: 'Runtime Inputs',
+  nodes: [
+    {
+      data: {
+        config: {
+          inputName: 'audioUrl',
+          inputType: 'audio',
+          required: true,
+        },
+        label: 'Narration',
+      },
+      id: 'workflow-input-audio',
+      type: 'workflowInput',
+    },
+    {
+      data: {
+        config: {
+          inputName: 'videoUrl',
+          inputType: 'video',
+          required: true,
+        },
+        label: 'Reference video',
+      },
+      id: 'workflow-input-video',
+      type: 'workflow-input',
+    },
+    { data: { label: 'Output' }, id: 'output', type: 'output' },
+  ],
+  version: 1,
+};
+
 describe('extractWorkflowInputs', () => {
   it('extracts only input nodes with the correct kinds and labels', () => {
     const inputs = extractWorkflowInputs(workflow);
@@ -50,6 +113,29 @@ describe('extractWorkflowInputs', () => {
     expect(byId.v).toMatchObject({ inputType: 'video', label: 'Video' });
     // Only the prompt (text) input carries a default value.
     expect(byId.img.defaultValue).toBeUndefined();
+  });
+
+  it('extracts canonical workflow input variables for audio and video steps', () => {
+    const inputs = extractWorkflowInputs(runtimeInputWorkflow);
+
+    expect(inputs).toEqual([
+      expect.objectContaining({
+        inputKey: 'audioUrl',
+        inputType: 'audio',
+        label: 'Narration',
+        nodeId: 'workflow-input-audio',
+        nodeType: 'workflowInput',
+        required: true,
+      }),
+      expect.objectContaining({
+        inputKey: 'videoUrl',
+        inputType: 'video',
+        label: 'Reference video',
+        nodeId: 'workflow-input-video',
+        nodeType: 'workflow-input',
+        required: true,
+      }),
+    ]);
   });
 });
 
@@ -76,5 +162,34 @@ describe('toExecutableWorkflow', () => {
     expect(byId.gen.inputs).toEqual(['img']);
     expect(executable.id).toBe('wid');
     expect(executable.organizationId).toBe('telegram-bot');
+  });
+
+  it('locks canonical workflow input nodes with collected runtime values', () => {
+    const executable = toExecutableWorkflow(
+      runtimeInputWorkflow,
+      new Map<string, string>([
+        ['audioUrl', 'audio-url'],
+        ['videoUrl', 'video-url'],
+      ]),
+      'runtime-workflow',
+    );
+    const byId = Object.fromEntries(executable.nodes.map((n) => [n.id, n]));
+
+    expect(executable.lockedNodeIds.sort()).toEqual([
+      'workflow-input-audio',
+      'workflow-input-video',
+    ]);
+    expect(byId['workflow-input-audio']).toMatchObject({
+      cachedOutput: 'audio-url',
+      isLocked: true,
+    });
+    expect(byId['workflow-input-video']).toMatchObject({
+      cachedOutput: 'video-url',
+      isLocked: true,
+    });
+    expect(byId.output.inputs).toEqual([
+      'workflow-input-audio',
+      'workflow-input-video',
+    ]);
   });
 });

--- a/apps/server/api/src/services/telegram-bot/telegram-bot.types.ts
+++ b/apps/server/api/src/services/telegram-bot/telegram-bot.types.ts
@@ -13,6 +13,7 @@ export interface WorkflowJson {
   version: number;
   name: string;
   description: string;
+  inputVariables?: WorkflowInputVariable[];
   nodes: Array<{
     id: string;
     type: string;
@@ -28,9 +29,20 @@ export interface WorkflowJson {
   }>;
 }
 
+export interface WorkflowInputVariable {
+  key: string;
+  type: string;
+  label: string;
+  description?: string;
+  defaultValue?: unknown;
+  required?: boolean;
+  validation?: Record<string, unknown>;
+}
+
 /** Input requirement derived from workflow nodes */
 export interface WorkflowInput {
   nodeId: string;
+  inputKey?: string;
   nodeType: string;
   label: string;
   inputType: 'image' | 'text' | 'audio' | 'video';

--- a/apps/server/api/src/services/telegram-bot/telegram-message-handler.service.ts
+++ b/apps/server/api/src/services/telegram-bot/telegram-message-handler.service.ts
@@ -65,7 +65,7 @@ export class TelegramMessageHandlerService {
     const photos = ctx.message.photo;
     const bestPhoto = photos[photos.length - 1];
 
-    if (!state || state.step !== 'collecting_inputs') {
+    if (state?.step !== 'collecting_inputs') {
       try {
         const { imageUrl } = await this.downloadPhotoFromTelegram(
           ctx,
@@ -94,7 +94,7 @@ export class TelegramMessageHandlerService {
     }
 
     const currentInput = state.requiredInputs[state.currentInputIndex];
-    if (!currentInput || currentInput.inputType !== 'image') {
+    if (currentInput?.inputType !== 'image') {
       await ctx.reply(this.getExpectedInputMessage(currentInput?.inputType));
       return;
     }
@@ -108,7 +108,7 @@ export class TelegramMessageHandlerService {
       );
 
       // Store the re-hosted, token-free image URL; Replicate fetches from it.
-      state.collectedInputs.set(currentInput.nodeId, imageUrl);
+      this.collectInputValue(state, currentInput, imageUrl);
       state.currentInputIndex++;
 
       this.loggerService.log(
@@ -153,7 +153,7 @@ export class TelegramMessageHandlerService {
     }
 
     const state = this.conversation.getState(chatId);
-    if (!state || state.step !== 'collecting_inputs') {
+    if (state?.step !== 'collecting_inputs') {
       return;
     }
 
@@ -216,7 +216,7 @@ export class TelegramMessageHandlerService {
     }
 
     const currentInput = state.requiredInputs[state.currentInputIndex];
-    if (!currentInput || currentInput.inputType !== 'text') {
+    if (currentInput?.inputType !== 'text') {
       await ctx.reply(this.getExpectedInputMessage(currentInput?.inputType));
       return;
     }
@@ -227,7 +227,7 @@ export class TelegramMessageHandlerService {
       text = currentInput.defaultValue;
     }
 
-    state.collectedInputs.set(currentInput.nodeId, text);
+    this.collectInputValue(state, currentInput, text);
     state.currentInputIndex++;
 
     await this.conversation.promptNextInput(ctx, chatId);
@@ -306,7 +306,7 @@ export class TelegramMessageHandlerService {
     }
 
     const state = this.conversation.getState(chatId);
-    if (!state || state.step !== 'collecting_inputs') {
+    if (state?.step !== 'collecting_inputs') {
       return;
     }
 
@@ -338,7 +338,7 @@ export class TelegramMessageHandlerService {
         currentInput.inputType,
       );
 
-      state.collectedInputs.set(currentInput.nodeId, mediaUrl);
+      this.collectInputValue(state, currentInput, mediaUrl);
       state.currentInputIndex++;
 
       this.loggerService.log(
@@ -371,6 +371,17 @@ export class TelegramMessageHandlerService {
         return "I'm expecting video right now. Please send a video.";
       default:
         return "I'm not expecting a file right now. Send /workflows to start.";
+    }
+  }
+
+  private collectInputValue(
+    state: ConversationState,
+    input: WorkflowInput,
+    value: string,
+  ): void {
+    state.collectedInputs.set(input.nodeId, value);
+    if (input.inputKey) {
+      state.collectedInputs.set(input.inputKey, value);
     }
   }
 

--- a/apps/server/api/src/services/telegram-bot/telegram-workflow-loader.ts
+++ b/apps/server/api/src/services/telegram-bot/telegram-workflow-loader.ts
@@ -16,6 +16,7 @@ import { fileURLToPath } from 'node:url';
 import type {
   TelegramWorkflowName,
   WorkflowInput,
+  WorkflowInputVariable,
   WorkflowJson,
 } from '@api/services/telegram-bot/telegram-bot.types';
 import type {
@@ -60,6 +61,8 @@ const TELEGRAM_INPUT_NODE_TYPES: Record<
   },
 };
 
+const WORKFLOW_INPUT_NODE_TYPES = new Set(['workflowInput', 'workflow-input']);
+
 const TELEGRAM_WORKFLOW_FILES: TelegramWorkflowName[] = [
   'single-image',
   'image-series',
@@ -68,6 +71,109 @@ const TELEGRAM_WORKFLOW_FILES: TelegramWorkflowName[] = [
   'full-pipeline',
   'ugc-factory',
 ];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function readString(
+  source: Record<string, unknown> | undefined,
+  key: string,
+): string | undefined {
+  const value = source?.[key];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function readBoolean(
+  source: Record<string, unknown> | undefined,
+  key: string,
+): boolean | undefined {
+  const value = source?.[key];
+  return typeof value === 'boolean' ? value : undefined;
+}
+
+function toSupportedInputType(
+  value: unknown,
+): WorkflowInput['inputType'] | undefined {
+  return value === 'audio' ||
+    value === 'image' ||
+    value === 'text' ||
+    value === 'video'
+    ? value
+    : undefined;
+}
+
+function getNodeConfig(
+  node: WorkflowJson['nodes'][number],
+): Record<string, unknown> {
+  return isRecord(node.data.config) ? node.data.config : node.data;
+}
+
+function isWorkflowInputNode(nodeType: string): boolean {
+  return WORKFLOW_INPUT_NODE_TYPES.has(nodeType);
+}
+
+function workflowInputKey(node: WorkflowJson['nodes'][number]): string {
+  return readString(getNodeConfig(node), 'inputName') ?? node.id;
+}
+
+function findWorkflowInputNode(
+  workflow: WorkflowJson,
+  inputKey: string,
+): WorkflowJson['nodes'][number] | undefined {
+  return workflow.nodes.find(
+    (node) =>
+      isWorkflowInputNode(node.type) && workflowInputKey(node) === inputKey,
+  );
+}
+
+function createRuntimeWorkflowInput(
+  variable: WorkflowInputVariable,
+  node: WorkflowJson['nodes'][number] | undefined,
+): WorkflowInput | undefined {
+  const inputType = toSupportedInputType(variable.type);
+  if (!inputType) {
+    return undefined;
+  }
+
+  const nodeConfig = node ? getNodeConfig(node) : undefined;
+  const defaultValue =
+    typeof variable.defaultValue === 'string'
+      ? variable.defaultValue
+      : readString(nodeConfig, 'defaultValue');
+
+  return {
+    defaultValue,
+    inputKey: variable.key,
+    inputType,
+    label: variable.label || readString(node?.data, 'label') || variable.key,
+    nodeId: node?.id ?? variable.key,
+    nodeType: node?.type ?? 'workflowInput',
+    required: variable.required ?? readBoolean(nodeConfig, 'required') ?? true,
+  };
+}
+
+function createWorkflowInputNodeInput(
+  node: WorkflowJson['nodes'][number],
+): WorkflowInput | undefined {
+  const nodeConfig = getNodeConfig(node);
+  const inputType = toSupportedInputType(nodeConfig.inputType);
+  if (!inputType) {
+    return undefined;
+  }
+
+  const inputKey = workflowInputKey(node);
+
+  return {
+    defaultValue: readString(nodeConfig, 'defaultValue'),
+    inputKey,
+    inputType,
+    label: readString(node.data, 'label') ?? inputKey,
+    nodeId: node.id,
+    nodeType: node.type,
+    required: readBoolean(nodeConfig, 'required') ?? false,
+  };
+}
 
 /**
  * Load workflow JSONs from the core workflows package into a name → JSON map.
@@ -139,7 +245,29 @@ export function resolveWorkflowFallbackPath(name: string): string | null {
 export function extractWorkflowInputs(workflow: WorkflowJson): WorkflowInput[] {
   const inputs: WorkflowInput[] = [];
 
+  if (workflow.inputVariables && workflow.inputVariables.length > 0) {
+    for (const variable of workflow.inputVariables) {
+      const input = createRuntimeWorkflowInput(
+        variable,
+        findWorkflowInputNode(workflow, variable.key),
+      );
+      if (input) {
+        inputs.push(input);
+      }
+    }
+
+    return inputs;
+  }
+
   for (const node of workflow.nodes) {
+    if (isWorkflowInputNode(node.type)) {
+      const input = createWorkflowInputNodeInput(node);
+      if (input) {
+        inputs.push(input);
+      }
+      continue;
+    }
+
     const descriptor = TELEGRAM_INPUT_NODE_TYPES[node.type];
     if (!descriptor) {
       continue;
@@ -174,15 +302,51 @@ export function toExecutableWorkflow(
   organizationId?: string,
   userId?: string,
 ): ExecutableWorkflow {
+  const inputDefaultsByKey = new Map(
+    (workflow.inputVariables ?? []).map((variable) => [
+      variable.key,
+      variable.defaultValue,
+    ]),
+  );
+  const lockedNodeIds = new Set<string>();
+
   const nodes: ExecutableNode[] = workflow.nodes.map((node) => {
-    const config = { ...node.data };
+    const config = { ...getNodeConfig(node) };
 
     // Inject collected inputs into node config
     const collectedValue = collectedInputs.get(node.id);
-    if (collectedValue) {
+    if (isWorkflowInputNode(node.type)) {
+      const inputKey = workflowInputKey(node);
+      const runtimeValue =
+        collectedInputs.get(inputKey) ??
+        collectedValue ??
+        inputDefaultsByKey.get(inputKey) ??
+        config.defaultValue;
+      if (runtimeValue !== undefined) {
+        lockedNodeIds.add(node.id);
+        config.value = runtimeValue;
+      }
+    } else if (collectedValue) {
       const descriptor = TELEGRAM_INPUT_NODE_TYPES[node.type];
       if (descriptor) {
         config[descriptor.configField] = collectedValue;
+      }
+    }
+
+    const inputVariableKeys = Array.isArray(node.data.inputVariableKeys)
+      ? node.data.inputVariableKeys.filter(
+          (key): key is string => typeof key === 'string',
+        )
+      : Array.isArray(config.inputVariableKeys)
+        ? config.inputVariableKeys.filter(
+            (key): key is string => typeof key === 'string',
+          )
+        : [];
+    for (const inputKey of inputVariableKeys) {
+      const runtimeValue =
+        collectedInputs.get(inputKey) ?? inputDefaultsByKey.get(inputKey);
+      if (runtimeValue !== undefined) {
+        config[inputKey] = runtimeValue;
       }
     }
 
@@ -192,8 +356,10 @@ export function toExecutableWorkflow(
 
     return {
       config,
+      cachedOutput: lockedNodeIds.has(node.id) ? config.value : undefined,
       id: node.id,
       inputs,
+      isLocked: lockedNodeIds.has(node.id),
       label: (node.data.label as string) || node.type,
       type: node.type,
     };
@@ -210,7 +376,7 @@ export function toExecutableWorkflow(
   return {
     edges,
     id: workflowId,
-    lockedNodeIds: [],
+    lockedNodeIds: Array.from(lockedNodeIds),
     nodes,
     // Execute under the connected chat's real tenant when available; fall back
     // to the bot sentinel only for unauthenticated (no /connect) chats.


### PR DESCRIPTION
## Summary
- support canonical `inputVariables` / `workflowInput` runtime inputs in the Telegram workflow loader, including `audio` and `video` types
- store collected Telegram media by both workflow node id and runtime input key so confirmed runs receive the uploaded media URLs
- add focused regression coverage for selecting an audio/video workflow, collecting both uploads, and confirming execution

Closes #862
Parent context: #715, #851

## Verification
- `bun install --frozen-lockfile --ignore-scripts`
- `bun run test:file src/services/telegram-bot/__tests__/telegram-workflow-loader.spec.ts` from `apps/server/api`
- `bun run test:file src/services/telegram-bot/__tests__/telegram-message-handler.service.spec.ts` from `apps/server/api`
- `bunx biome check apps/server/api/src/services/telegram-bot/telegram-bot.types.ts apps/server/api/src/services/telegram-bot/telegram-workflow-loader.ts apps/server/api/src/services/telegram-bot/telegram-message-handler.service.ts apps/server/api/src/services/telegram-bot/__tests__/telegram-workflow-loader.spec.ts apps/server/api/src/services/telegram-bot/__tests__/telegram-message-handler.service.spec.ts`
- pre-commit hook: Secretlint + staged Biome passed

## Notes
- Existing handler registration from the closed-but-unmerged #910 later reached `master` via integration; this PR covers the remaining canonical workflow-input reachability path and closes the still-open issue.
- Project #12 status updates are blocked until the GitHub GraphQL rate limit resets.