### PR TITLE
fix(billing): resolve CodeRabbit pricing follow-ups

### DIFF
--- a/apps/server/api/src/collections/subscriptions/dto/create-subscription.dto.spec.ts
+++ b/apps/server/api/src/collections/subscriptions/dto/create-subscription.dto.spec.ts
@@ -1,4 +1,7 @@
 import { CreateSubscriptionDto } from '@api/collections/subscriptions/dto/create-subscription.dto';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { CreateCheckoutSessionDto } from './create-subscription.dto';
 
 describe('CreateSubscriptionDto', () => {
   it('should be defined', () => {
@@ -17,5 +20,42 @@ describe('CreateSubscriptionDto', () => {
     //   const errors = await validate(dto);
     //   expect(errors.length).toBe(0);
     // });
+  });
+});
+
+describe('CreateCheckoutSessionDto — quantity validation', () => {
+  it('fails validation when quantity is below the minimum', async () => {
+    const instance = plainToInstance(CreateCheckoutSessionDto, {
+      quantity: 500,
+      stripePriceId: 'price_abc123',
+    });
+
+    const errors = await validate(instance);
+    const quantityError = errors.find((error) => error.property === 'quantity');
+
+    expect(quantityError).toBeDefined();
+    expect(Object.keys(quantityError?.constraints ?? {})).toContain('min');
+  });
+
+  it('passes validation when quantity is omitted', async () => {
+    const instance = plainToInstance(CreateCheckoutSessionDto, {
+      stripePriceId: 'price_abc123',
+    });
+
+    const errors = await validate(instance);
+
+    expect(errors.some((error) => error.property === 'quantity')).toBe(false);
+  });
+
+  it('coerces numeric string quantity before validation', async () => {
+    const instance = plainToInstance(CreateCheckoutSessionDto, {
+      quantity: '1500',
+      stripePriceId: 'price_abc123',
+    });
+
+    const errors = await validate(instance);
+
+    expect(errors.some((error) => error.property === 'quantity')).toBe(false);
+    expect(instance.quantity).toBe(1500);
   });
 });

--- a/apps/server/api/src/collections/subscriptions/dto/create-subscription.dto.ts
+++ b/apps/server/api/src/collections/subscriptions/dto/create-subscription.dto.ts
@@ -1,5 +1,6 @@
 import { IsEntityId } from '@api/helpers/validation/entity-id.validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
 import {
   IsBoolean,
   IsDate,
@@ -8,6 +9,7 @@ import {
   IsOptional,
   IsString,
   Matches,
+  Min,
 } from 'class-validator';
 
 export class CreateSubscriptionPreviewDto {
@@ -36,7 +38,9 @@ export class CreateCheckoutSessionDto {
   readonly stripePriceId!: string;
 
   @IsNumber()
+  @Min(1000)
   @IsOptional()
+  @Type(() => Number)
   @ApiProperty({
     default: 1000,
     description: 'The quantity/amount for the checkout session',

--- a/apps/server/api/src/common/subscriptions/oss-subscriptions.service.spec.ts
+++ b/apps/server/api/src/common/subscriptions/oss-subscriptions.service.spec.ts
@@ -27,7 +27,7 @@ describe('OssSubscriptionsService', () => {
         },
         false,
       ),
-    ).resolves.toEqual({ docs: [], total: 0 });
+    ).resolves.toEqual({ docs: [], total: 0, totalDocs: 0 });
   });
 
   it('never throws on always-on webhook paths', async () => {

--- a/apps/server/api/src/common/subscriptions/oss-subscriptions.service.ts
+++ b/apps/server/api/src/common/subscriptions/oss-subscriptions.service.ts
@@ -47,7 +47,7 @@ export class OssSubscriptionsService implements ISubscriptionsService {
     _options: ISubscriptionFindAllOptions,
     _enableCache?: boolean,
   ): Promise<ISubscriptionFindAllResult> {
-    return { docs: [], total: 0 };
+    return { docs: [], total: 0, totalDocs: 0 };
   }
 
   async patch(

--- a/apps/server/api/src/endpoints/analytics/analytics.controller.ts
+++ b/apps/server/api/src/endpoints/analytics/analytics.controller.ts
@@ -22,12 +22,6 @@ import {
   TopContentQueryDto,
   ViralHooksQueryDto,
 } from '@api/endpoints/analytics/dto/leaderboard-query.dto';
-import { AnalyticEntity } from '@api/endpoints/analytics/entities/analytics.entity';
-import {
-  OrgLeaderboardItemEntity,
-  PaginatedBrandsResponse,
-  PaginatedOrgsResponse,
-} from '@api/endpoints/analytics/entities/organization-leaderboard.entity';
 import { EntityLeaderboardService } from '@api/endpoints/analytics/entity-leaderboard.service';
 import { Cache } from '@api/helpers/decorators/cache/cache.decorator';
 import { RolesDecorator } from '@api/helpers/decorators/roles/roles.decorator';
@@ -231,9 +225,18 @@ export class AnalyticsController {
       ),
     ]);
 
-    // Extract count from paginated results - the total property contains the count
-    const extractTotal = (result: unknown): number =>
-      (result as Record<string, number>)?.total || 0;
+    const extractTotal = (result: unknown): number => {
+      if (!result || typeof result !== 'object') {
+        return 0;
+      }
+
+      const counts = result as { total?: unknown; totalDocs?: unknown };
+      if (typeof counts.total === 'number') {
+        return counts.total;
+      }
+
+      return typeof counts.totalDocs === 'number' ? counts.totalDocs : 0;
+    };
 
     const flattenedData = {
       activeBots: extractTotal(activeBots),

--- a/ee/packages/billing/src/subscriptions/services/subscriptions.service.ts
+++ b/ee/packages/billing/src/subscriptions/services/subscriptions.service.ts
@@ -8,8 +8,13 @@ import {
 } from '@api/services/integrations/stripe/services/stripe.service';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { BaseService } from '@api/shared/services/base/base.service';
+import type { AggregatePaginateResult } from '@api/types/aggregate-paginate-result';
 import { SubscriptionPlan, SubscriptionStatus } from '@genfeedai/enums';
-import type { ISubscriptionsService } from '@genfeedai/interfaces/billing';
+import type {
+  ISubscriptionFindAllOptions,
+  ISubscriptionFindAllResult,
+  ISubscriptionsService,
+} from '@genfeedai/interfaces/billing';
 import { ConfigService } from '@libs/config/config.service';
 import { LoggerService } from '@libs/logger/logger.service';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
@@ -32,6 +37,9 @@ type SubscriptionStateSync = {
   stripeSubscriptionId?: string | null;
   status?: string | null;
 };
+
+type SubscriptionsFindAllResult =
+  AggregatePaginateResult<SubscriptionDocument> & ISubscriptionFindAllResult;
 
 /**
  * Enterprise subscriptions service. The OSS-callable surface (`findOne`,
@@ -141,6 +149,20 @@ export class SubscriptionsService
     private readonly creditsUtilsService: CreditsUtilsService,
   ) {
     super(prisma, 'subscription', logger);
+  }
+
+  override async findAll(
+    input: unknown,
+    options: ISubscriptionFindAllOptions,
+    enableCache: boolean = true,
+  ): Promise<SubscriptionsFindAllResult> {
+    const result = await super.findAll(input, options, enableCache);
+
+    return {
+      ...result,
+      total: result.totalDocs,
+      totalDocs: result.totalDocs,
+    };
   }
 
   /**

--- a/packages/interfaces/src/billing/subscriptions-service.contract.ts
+++ b/packages/interfaces/src/billing/subscriptions-service.contract.ts
@@ -63,6 +63,7 @@ export interface ISubscriptionFindAllOptions {
   page?: number;
   limit?: number;
   pagination?: boolean;
+  sort?: Record<string, 1 | -1>;
   [key: string]: unknown;
 }
 
@@ -73,19 +74,22 @@ export interface ISubscriptionFindAllOptions {
  * open.
  *
  * `docs` mirrors `AggregatePaginateResult<T>.docs` on the concrete EE service
- * (`BaseService.findAll`). The webhook reads `data.docs` then guards
- * `length === 0`, so the OSS no-op returns `{ docs: [], total: 0 }`.
+ * (`BaseService.findAll`). `total` is required for OSS-facing consumers, while
+ * `totalDocs` preserves the concrete paginated service shape. The OSS no-op
+ * returns both count fields as zero.
  */
 export interface ISubscriptionFindAllResult {
-  docs?: ISubscriptionOssReadModel[];
-  /**
-   * Optional, not required: the concrete EE `findAll` returns
-   * `AggregatePaginateResult<SubscriptionDocument>`, which exposes `totalDocs`
-   * rather than a statically-guaranteed `total`, while the OSS no-op returns
-   * `{ total: 0 }`. Keeping this optional lets both producers satisfy the
-   * contract without either lying about its shape; OSS reads it defensively.
-   */
-  total?: number;
+  docs: ISubscriptionOssReadModel[];
+  total: number;
+  totalDocs: number;
+  hasNextPage?: boolean;
+  hasPrevPage?: boolean;
+  limit?: number;
+  nextPage?: number | null;
+  page?: number;
+  pagingCounter?: number;
+  prevPage?: number | null;
+  totalPages?: number;
   [key: string]: unknown;
 }
 
@@ -109,7 +113,8 @@ export interface ISubscriptionsService {
   ): Promise<ISubscriptionOssReadModel | null>;
 
   /**
-   * Aggregation query; OSS reads `.total`. OSS no-op returns `{ total: 0 }`.
+   * Aggregation query; OSS reads `.total`. OSS no-op returns
+   * `{ docs: [], total: 0, totalDocs: 0 }`.
    *
    * `options` is required (not optional): the concrete `BaseService.findAll`
    * dereferences `options.pagination` unconditionally, so omitting it would

--- a/packages/pricing/package.json
+++ b/packages/pricing/package.json
@@ -25,7 +25,15 @@
   "license": "MIT",
   "main": "./dist/index.js",
   "name": "@genfeedai/pricing",
-  "private": true,
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "repository": {
+    "directory": "pricing",
+    "type": "git",
+    "url": "git+https://github.com/genfeedai/packages.git"
+  },
   "type": "module",
   "scripts": {
     "build": "tsc --build",


### PR DESCRIPTION
Closes #573.

## Summary
- Make `@genfeedai/pricing` publishable by removing `private: true` and adding the standard public npm `publishConfig` + repository metadata.
- Tighten the subscription `findAll` contract so `total` is required, preserve `totalDocs`, and normalize EE `SubscriptionsService.findAll()` to return both fields.
- Add the missing checkout quantity `@Min(1000)` and `@Type(() => Number)` validation to the OSS subscription DTO copy, plus focused validation coverage.
- Update analytics count extraction to support both `total` and `totalDocs` instead of silently returning 0 for BaseService paginated results.

## #573 checklist
- [x] Pricing interfaces / `PricingConfig` canonical location: already resolved on current master. `PricingConfig` and pricing prop interfaces live in `packages/interfaces/src/billing/pricing.interface.ts`; `packages/pricing/src/pricing-config.ts` only imports/re-exports the type.
- [x] `packages/pricing/package.json` private vs publish intent: resolved by making the package publishable with standard public package metadata.
- [x] `create-subscription.dto` numeric validation + spec: EE billing already had the fix; this PR applies the same validation/spec coverage to the remaining OSS duplicate.
- [x] Subscription service `total?` contract: resolved by requiring `total`, preserving `totalDocs`, and normalizing the EE implementation.
- [x] `build-verify-selfhosted.yml` permissions/action pins: already resolved on current master. The workflow has top-level/job permissions and pinned SHA actions.

## Verification
- `bunx biome check --write packages/pricing/package.json packages/interfaces/src/billing/subscriptions-service.contract.ts ee/packages/billing/src/subscriptions/services/subscriptions.service.ts apps/server/api/src/common/subscriptions/oss-subscriptions.service.ts apps/server/api/src/common/subscriptions/oss-subscriptions.service.spec.ts apps/server/api/src/endpoints/analytics/analytics.controller.ts apps/server/api/src/collections/subscriptions/dto/create-subscription.dto.ts apps/server/api/src/collections/subscriptions/dto/create-subscription.dto.spec.ts`
- `(cd apps/server/api && bunx vitest run --config vitest.config.ts src/collections/subscriptions/dto/create-subscription.dto.spec.ts src/common/subscriptions/oss-subscriptions.service.spec.ts)`
- `(cd ee/packages/billing && bunx vitest run --config vitest.config.ts src/subscriptions/dto/create-subscription.dto.spec.ts)`
- `node scripts/check-public-package-manifests.mjs packages/pricing`

## Notes
- Local package typechecks were not used as completion evidence: `packages/interfaces`, `packages/pricing`, and `ee/packages/billing` typecheck currently require generated/built workspace outputs and fan out into unrelated missing generated package declarations in this fresh worktree. PR CI should run the broad gates.
- Current open PR overlap checked: #1456 only touches `docker/Dockerfile.selfhosted`; it does not edit this PR's workflow/package/billing files.