### PR TITLE
feat(scheduler): add publishing readiness contract

### DIFF
--- a/packages/api-types/__tests__/channel-capabilities.contract.test.ts
+++ b/packages/api-types/__tests__/channel-capabilities.contract.test.ts
@@ -1,4 +1,5 @@
 import {
+  channelTargetValidationResultSchema,
   getChannelCapability,
   listChannelCapabilities,
   PRODUCTIZED_SCHEDULER_PLATFORMS,
@@ -87,6 +88,47 @@ describe('validateChannelTargetSettings', () => {
     expect(result.valid).toBe(true);
     expect(result.validationState).toBe(TargetValidationState.VALID);
     expect(result.errors).toEqual([]);
+  });
+
+  test('allows provider readiness to travel with validation results', () => {
+    const result = channelTargetValidationResultSchema.parse({
+      errors: [
+        {
+          code: 'channel_target.provider_blocked',
+          message: 'Instagram cannot publish until app review is complete.',
+          severity: 'error',
+        },
+      ],
+      platform: CredentialPlatform.INSTAGRAM,
+      readiness: {
+        appReviewStatus: 'fail',
+        callbackUrlStatus: 'pass',
+        canSchedule: false,
+        diagnostics: [
+          {
+            classification: 'missing_provider_approval',
+            code: 'meta_app_review_required',
+            correctiveAction: 'Move the Meta app out of development mode.',
+            isRetryable: false,
+            message: 'Meta app review is required before publishing.',
+            severity: 'error',
+          },
+        ],
+        isRetryable: false,
+        permissionScopeStatus: 'pass',
+        providerKey: CredentialPlatform.INSTAGRAM,
+        quotaStatus: 'unknown',
+        requiredAction: 'Move the Meta app out of development mode.',
+        state: 'blocked',
+        tokenFreshness: 'pass',
+      },
+      valid: false,
+      validationState: TargetValidationState.INVALID,
+      warnings: [],
+    });
+
+    expect(result.readiness?.state).toBe('blocked');
+    expect(result.readiness?.canSchedule).toBe(false);
   });
 
   test('returns the same required-setting failure shape for YouTube privacy', () => {

--- a/packages/api-types/__tests__/publishing-readiness.contract.test.ts
+++ b/packages/api-types/__tests__/publishing-readiness.contract.test.ts
@@ -1,0 +1,104 @@
+import {
+  publishingDiagnosticSchema,
+  publishingProviderReadinessSchema,
+  publishingSetupChecklistSchema,
+} from '@api-types/contracts/publishing-readiness.contract';
+import { CredentialPlatform } from '@genfeedai/enums';
+import { describe, expect, test } from 'vitest';
+
+describe('publishing readiness contract', () => {
+  test('accepts a blocked provider readiness payload with actionable diagnostics', () => {
+    const readiness = publishingProviderReadinessSchema.parse({
+      appReviewStatus: 'fail',
+      callbackUrlStatus: 'pass',
+      canSchedule: false,
+      credentialId: 'cred_123',
+      diagnostics: [
+        {
+          checkedAt: '2026-07-03T10:00:00.000Z',
+          classification: 'missing_provider_approval',
+          code: 'meta_app_review_required',
+          correctiveAction: 'Move the Meta app out of development mode.',
+          isRetryable: false,
+          message: 'Meta app review is required before publishing.',
+          scope: 'app_review',
+          severity: 'error',
+        },
+      ],
+      isRetryable: false,
+      lastSuccessfulValidationAt: null,
+      lastValidationAttemptAt: '2026-07-03T10:00:00.000Z',
+      permissionScopeStatus: 'pass',
+      providerKey: CredentialPlatform.INSTAGRAM,
+      quotaStatus: 'unknown',
+      requiredAction: 'Move the Meta app out of development mode.',
+      state: 'blocked',
+      tokenFreshness: 'pass',
+    });
+
+    expect(readiness.state).toBe('blocked');
+    expect(readiness.canSchedule).toBe(false);
+    expect(readiness.diagnostics[0]?.classification).toBe(
+      'missing_provider_approval',
+    );
+  });
+
+  test('keeps diagnostic details as bounded non-secret evidence', () => {
+    const diagnostic = publishingDiagnosticSchema.parse({
+      classification: 'misconfiguration',
+      code: 'oauth_redirect_uri_mismatch',
+      correctiveAction:
+        'Add https://app.example.com/integrations/instagram/callback to the provider app.',
+      details: {
+        callbackUrl: 'https://app.example.com/integrations/instagram/callback',
+        providerErrorCode: 'redirect_uri_mismatch',
+      },
+      isRetryable: false,
+      message: 'OAuth callback URL is not registered in the provider app.',
+      scope: 'callback',
+      severity: 'error',
+    });
+
+    expect(diagnostic.details).toEqual({
+      callbackUrl: 'https://app.example.com/integrations/instagram/callback',
+      providerErrorCode: 'redirect_uri_mismatch',
+    });
+  });
+
+  test('accepts a self-host setup checklist for core runtime checks', () => {
+    const checklist = publishingSetupChecklistSchema.parse({
+      checks: [
+        {
+          diagnostics: [],
+          key: 'redis.reachability',
+          label: 'Redis reachability',
+          scope: 'core_runtime',
+          status: 'pass',
+        },
+        {
+          diagnostics: [
+            {
+              classification: 'misconfiguration',
+              code: 'public_url_missing',
+              correctiveAction:
+                'Set the public application URL used by OAuth callbacks.',
+              isRetryable: false,
+              message: 'Public URL is required for provider callbacks.',
+              scope: 'callback',
+              severity: 'error',
+            },
+          ],
+          key: 'public_url',
+          label: 'Public callback URL',
+          scope: 'callback',
+          status: 'fail',
+        },
+      ],
+      generatedAt: '2026-07-03T10:00:00.000Z',
+      state: 'blocked',
+    });
+
+    expect(checklist.checks).toHaveLength(2);
+    expect(checklist.state).toBe('blocked');
+  });
+});

--- a/packages/api-types/src/contracts/channel-capabilities.contract.ts
+++ b/packages/api-types/src/contracts/channel-capabilities.contract.ts
@@ -7,6 +7,7 @@
  * Foundation for epic #1123, issue #1125.
  */
 
+import { publishingProviderReadinessSchema } from '@api-types/contracts/publishing-readiness.contract';
 import { CredentialPlatform, TargetValidationState } from '@genfeedai/enums';
 import { z } from 'zod';
 
@@ -130,6 +131,7 @@ export const channelTargetValidationMediaSchema = z.object({
 
 export const validateChannelTargetSettingsInputSchema = z.object({
   caption: z.string().optional(),
+  credentialId: z.string().min(1).optional(),
   media: z.array(channelTargetValidationMediaSchema).optional(),
   platform: z.union([z.nativeEnum(CredentialPlatform), z.string().min(1)]),
   publishMode: channelPublishModeSchema.optional(),
@@ -147,6 +149,7 @@ export const channelTargetValidationResultSchema = z.object({
   capability: channelCapabilitySchema.optional(),
   errors: z.array(channelValidationIssueSchema),
   platform: z.union([z.nativeEnum(CredentialPlatform), z.string().min(1)]),
+  readiness: publishingProviderReadinessSchema.optional(),
   valid: z.boolean(),
   validationState: z.nativeEnum(TargetValidationState),
   warnings: z.array(channelValidationIssueSchema),

--- a/packages/api-types/src/contracts/index.ts
+++ b/packages/api-types/src/contracts/index.ts
@@ -11,4 +11,5 @@
 export * from '@api-types/contracts/channel-capabilities.contract';
 export * from '@api-types/contracts/ingredients.contract';
 export * from '@api-types/contracts/posts.contract';
+export * from '@api-types/contracts/publishing-readiness.contract';
 export * from '@api-types/contracts/scheduler.contract';

--- a/packages/api-types/src/contracts/publishing-readiness.contract.ts
+++ b/packages/api-types/src/contracts/publishing-readiness.contract.ts
@@ -1,0 +1,138 @@
+/**
+ * Publishing setup/readiness API contract.
+ *
+ * Shared observable states for self-host scheduler setup, provider credential
+ * readiness, sanitized diagnostics, and schedule-blocking decisions. This is
+ * intentionally provider-agnostic; individual integrations can add evidence in
+ * `details`, but exports must redact secrets before exposing diagnostics.
+ *
+ * Foundation for issue #1144.
+ */
+
+import { CredentialPlatform } from '@genfeedai/enums';
+import { z } from 'zod';
+
+export const publishingReadinessStateValues = [
+  'publish_capable',
+  'degraded',
+  'blocked',
+  'unknown',
+] as const;
+
+export const publishingSetupFailureClassificationValues = [
+  'misconfiguration',
+  'missing_provider_approval',
+  'expired_credential',
+  'missing_permission_scope',
+  'provider_outage',
+  'quota_or_rate_limit',
+  'unsupported_self_host_mode',
+  'unknown',
+] as const;
+
+export const publishingDiagnosticSeverityValues = [
+  'info',
+  'warning',
+  'error',
+] as const;
+
+export const publishingSetupCheckStatusValues = [
+  'pass',
+  'warn',
+  'fail',
+  'unknown',
+] as const;
+
+export const publishingSetupCheckScopeValues = [
+  'core_runtime',
+  'auth',
+  'provider',
+  'callback',
+  'credential',
+  'permission',
+  'app_review',
+  'quota',
+] as const;
+
+export const publishingReadinessStateSchema = z.enum(
+  publishingReadinessStateValues,
+);
+export const publishingSetupFailureClassificationSchema = z.enum(
+  publishingSetupFailureClassificationValues,
+);
+export const publishingDiagnosticSeveritySchema = z.enum(
+  publishingDiagnosticSeverityValues,
+);
+export const publishingSetupCheckStatusSchema = z.enum(
+  publishingSetupCheckStatusValues,
+);
+export const publishingSetupCheckScopeSchema = z.enum(
+  publishingSetupCheckScopeValues,
+);
+
+export const publishingDiagnosticSchema = z.object({
+  checkedAt: z.string().datetime().optional(),
+  classification: publishingSetupFailureClassificationSchema,
+  code: z.string().min(1),
+  correctiveAction: z.string().min(1).optional(),
+  details: z.record(z.string(), z.unknown()).optional(),
+  isRetryable: z.boolean(),
+  message: z.string().min(1),
+  scope: publishingSetupCheckScopeSchema.optional(),
+  severity: publishingDiagnosticSeveritySchema,
+});
+
+export const publishingSetupCheckSchema = z.object({
+  diagnostics: z.array(publishingDiagnosticSchema),
+  key: z.string().min(1),
+  label: z.string().min(1),
+  scope: publishingSetupCheckScopeSchema,
+  status: publishingSetupCheckStatusSchema,
+});
+
+export const publishingSetupChecklistSchema = z.object({
+  checks: z.array(publishingSetupCheckSchema),
+  generatedAt: z.string().datetime(),
+  state: publishingReadinessStateSchema,
+});
+
+export const publishingProviderReadinessSchema = z.object({
+  appReviewStatus: publishingSetupCheckStatusSchema,
+  callbackUrlStatus: publishingSetupCheckStatusSchema,
+  canSchedule: z.boolean(),
+  credentialId: z.string().min(1).nullable().optional(),
+  diagnostics: z.array(publishingDiagnosticSchema),
+  isRetryable: z.boolean(),
+  lastSuccessfulValidationAt: z.string().datetime().nullable().optional(),
+  lastValidationAttemptAt: z.string().datetime().nullable().optional(),
+  permissionScopeStatus: publishingSetupCheckStatusSchema,
+  providerKey: z.union([z.nativeEnum(CredentialPlatform), z.string().min(1)]),
+  quotaStatus: publishingSetupCheckStatusSchema,
+  requiredAction: z.string().min(1).nullable().optional(),
+  state: publishingReadinessStateSchema,
+  tokenFreshness: publishingSetupCheckStatusSchema,
+});
+
+export type PublishingReadinessState = z.infer<
+  typeof publishingReadinessStateSchema
+>;
+export type PublishingSetupFailureClassification = z.infer<
+  typeof publishingSetupFailureClassificationSchema
+>;
+export type PublishingDiagnosticSeverity = z.infer<
+  typeof publishingDiagnosticSeveritySchema
+>;
+export type PublishingSetupCheckStatus = z.infer<
+  typeof publishingSetupCheckStatusSchema
+>;
+export type PublishingSetupCheckScope = z.infer<
+  typeof publishingSetupCheckScopeSchema
+>;
+export type PublishingDiagnostic = z.infer<typeof publishingDiagnosticSchema>;
+export type PublishingSetupCheck = z.infer<typeof publishingSetupCheckSchema>;
+export type PublishingSetupChecklist = z.infer<
+  typeof publishingSetupChecklistSchema
+>;
+export type PublishingProviderReadiness = z.infer<
+  typeof publishingProviderReadinessSchema
+>;

--- a/packages/api-types/src/contracts/scheduler.contract.ts
+++ b/packages/api-types/src/contracts/scheduler.contract.ts
@@ -28,6 +28,7 @@
  * The mapping is backward-compatible: no legacy field is dropped, only relocated.
  */
 
+import { publishingProviderReadinessSchema } from '@api-types/contracts/publishing-readiness.contract';
 import {
   dateStringSchema,
   daysOfWeekSchema,
@@ -162,6 +163,7 @@ export const updateChannelTargetSchema = z.object({
   lastAttemptAt: dateStringSchema.optional(),
   order: nonNegativeIntSchema.optional(),
   publishedAt: dateStringSchema.optional(),
+  readiness: publishingProviderReadinessSchema.nullable().optional(),
   retryCount: nonNegativeIntSchema.optional(),
   scheduledDate: dateStringSchema.optional(),
   settings: channelTargetSettingsSchema.optional(),

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -13,6 +13,7 @@ export * from './generation-controls.helper';
 export * from './generation-eta.helper';
 export * from './media/provenance/provenance.helper';
 export * from './model-capability.helper';
+export * from './publisher/publishing-diagnostics.helper';
 export * from './quality-routing.helper';
 export * from './serializer.helper';
 export * from './social-url.helper';

--- a/packages/helpers/src/publisher/publishing-diagnostics.helper.test.ts
+++ b/packages/helpers/src/publisher/publishing-diagnostics.helper.test.ts
@@ -1,0 +1,177 @@
+import type { IPublishingDiagnostic } from '@genfeedai/interfaces';
+import {
+  buildPublishingProviderReadiness,
+  canScheduleWithPublishingReadiness,
+  classifyPublishingDiagnostic,
+  classifyPublishingReadiness,
+  redactPublishingDiagnosticValue,
+  sanitizePublishingDiagnostic,
+} from '@helpers/publisher/publishing-diagnostics.helper';
+
+function diagnostic(
+  overrides: Partial<IPublishingDiagnostic> = {},
+): IPublishingDiagnostic {
+  return {
+    classification: 'unknown',
+    code: 'provider_unknown',
+    isRetryable: true,
+    message: 'Provider returned an unknown response.',
+    severity: 'warning',
+    ...overrides,
+  };
+}
+
+describe('publishing diagnostics helpers', () => {
+  it('classifies common provider setup failures into stable buckets', () => {
+    expect(
+      classifyPublishingDiagnostic({
+        code: 'redirect_uri_mismatch',
+        message: 'OAuth redirect URI is not allowed',
+      }),
+    ).toBe('misconfiguration');
+
+    expect(
+      classifyPublishingDiagnostic({
+        message: 'App review required before publishing',
+      }),
+    ).toBe('missing_provider_approval');
+
+    expect(
+      classifyPublishingDiagnostic({
+        message: 'Missing instagram_content_publish scope',
+      }),
+    ).toBe('missing_permission_scope');
+
+    expect(
+      classifyPublishingDiagnostic({
+        statusCode: 401,
+      }),
+    ).toBe('expired_credential');
+
+    expect(
+      classifyPublishingDiagnostic({
+        message: 'Provider quota exceeded',
+      }),
+    ).toBe('quota_or_rate_limit');
+
+    expect(
+      classifyPublishingDiagnostic({
+        statusCode: 503,
+      }),
+    ).toBe('provider_outage');
+
+    expect(
+      classifyPublishingDiagnostic({
+        message: 'Managed provider keys are not available in self-host mode',
+      }),
+    ).toBe('unsupported_self_host_mode');
+  });
+
+  it('redacts nested secrets without removing non-secret evidence', () => {
+    const redacted = redactPublishingDiagnosticValue({
+      callbackUrl:
+        'https://example.com/oauth/callback?code=visible&access_token=secret-token',
+      headers: {
+        Authorization: 'Bearer abc.def.ghi',
+        requestId: 'req_123',
+      },
+      nested: [
+        {
+          clientSecret: 'client-secret',
+          providerStatus: 'pending_review',
+        },
+      ],
+    });
+
+    expect(redacted).toEqual({
+      callbackUrl:
+        'https://example.com/oauth/callback?code=visible&access_token=[REDACTED]',
+      headers: {
+        Authorization: '[REDACTED]',
+        requestId: 'req_123',
+      },
+      nested: [
+        {
+          clientSecret: '[REDACTED]',
+          providerStatus: 'pending_review',
+        },
+      ],
+    });
+  });
+
+  it('sanitizes diagnostic detail before export', () => {
+    const sanitized = sanitizePublishingDiagnostic(
+      diagnostic({
+        details: {
+          apiKey: 'sk-test-secret',
+          errorCode: 'redirect_uri_mismatch',
+        },
+      }),
+    );
+
+    expect(sanitized.details).toEqual({
+      apiKey: '[REDACTED]',
+      errorCode: 'redirect_uri_mismatch',
+    });
+  });
+
+  it('marks non-retryable setup errors as blocked for scheduling', () => {
+    const state = classifyPublishingReadiness([
+      diagnostic({
+        classification: 'missing_permission_scope',
+        isRetryable: false,
+        severity: 'error',
+      }),
+    ]);
+
+    expect(state).toBe('blocked');
+    expect(canScheduleWithPublishingReadiness(state)).toBe(false);
+  });
+
+  it('keeps retryable provider errors degraded instead of blocked', () => {
+    const state = classifyPublishingReadiness([
+      diagnostic({
+        classification: 'provider_outage',
+        isRetryable: true,
+        severity: 'error',
+      }),
+    ]);
+
+    expect(state).toBe('degraded');
+    expect(canScheduleWithPublishingReadiness(state)).toBe(true);
+  });
+
+  it('builds sanitized provider readiness with inferred schedule gate', () => {
+    const readiness = buildPublishingProviderReadiness({
+      appReviewStatus: 'fail',
+      callbackUrlStatus: 'pass',
+      diagnostics: [
+        diagnostic({
+          classification: 'missing_provider_approval',
+          correctiveAction: 'Move the Meta app out of development mode.',
+          details: {
+            accessToken: 'secret-token',
+            appMode: 'development',
+          },
+          isRetryable: false,
+          severity: 'error',
+        }),
+      ],
+      permissionScopeStatus: 'pass',
+      providerKey: 'instagram',
+      quotaStatus: 'unknown',
+      tokenFreshness: 'pass',
+    });
+
+    expect(readiness.state).toBe('blocked');
+    expect(readiness.canSchedule).toBe(false);
+    expect(readiness.isRetryable).toBe(false);
+    expect(readiness.requiredAction).toBe(
+      'Move the Meta app out of development mode.',
+    );
+    expect(readiness.diagnostics[0]?.details).toEqual({
+      accessToken: '[REDACTED]',
+      appMode: 'development',
+    });
+  });
+});

--- a/packages/helpers/src/publisher/publishing-diagnostics.helper.ts
+++ b/packages/helpers/src/publisher/publishing-diagnostics.helper.ts
@@ -1,0 +1,258 @@
+import type {
+  IPublishingDiagnostic,
+  IPublishingProviderReadiness,
+  PublishingReadinessState,
+  PublishingSetupCheckStatus,
+  PublishingSetupFailureClassification,
+} from '@genfeedai/interfaces';
+
+const REDACTED_VALUE = '[REDACTED]';
+
+const SENSITIVE_KEY_PATTERN =
+  /(^|[_-])(access[_-]?token|api[_-]?key|authorization|bearer|client[_-]?secret|cookie|id[_-]?token|password|private[_-]?key|refresh[_-]?token|secret|session|token)([_-]|$)/i;
+
+const SENSITIVE_QUERY_PARAM_PATTERN =
+  /([?&][^=&#]*(?:access[_-]?token|api[_-]?key|client[_-]?secret|id[_-]?token|password|refresh[_-]?token|secret|session|token)[^=&#]*=)[^&#]*/gi;
+
+const AUTH_HEADER_PATTERN = /\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]+/gi;
+const PRIVATE_KEY_BLOCK_PATTERN =
+  /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g;
+
+const BLOCKING_CLASSIFICATIONS = new Set<PublishingSetupFailureClassification>([
+  'expired_credential',
+  'missing_permission_scope',
+  'missing_provider_approval',
+  'misconfiguration',
+  'unsupported_self_host_mode',
+]);
+
+export interface PublishingDiagnosticClassificationInput {
+  code?: string | null;
+  message?: string | null;
+  statusCode?: number | null;
+}
+
+export type PublishingReadinessInput = Omit<
+  IPublishingProviderReadiness,
+  | 'appReviewStatus'
+  | 'callbackUrlStatus'
+  | 'canSchedule'
+  | 'diagnostics'
+  | 'isRetryable'
+  | 'permissionScopeStatus'
+  | 'quotaStatus'
+  | 'state'
+  | 'tokenFreshness'
+> & {
+  appReviewStatus?: PublishingSetupCheckStatus;
+  callbackUrlStatus?: PublishingSetupCheckStatus;
+  diagnostics?: IPublishingDiagnostic[];
+  permissionScopeStatus?: PublishingSetupCheckStatus;
+  quotaStatus?: PublishingSetupCheckStatus;
+  tokenFreshness?: PublishingSetupCheckStatus;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function redactString(value: string): string {
+  return value
+    .replace(PRIVATE_KEY_BLOCK_PATTERN, REDACTED_VALUE)
+    .replace(AUTH_HEADER_PATTERN, (_match, scheme: string) => {
+      return `${scheme} ${REDACTED_VALUE}`;
+    })
+    .replace(SENSITIVE_QUERY_PARAM_PATTERN, `$1${REDACTED_VALUE}`);
+}
+
+export function redactPublishingDiagnosticValue(value: unknown): unknown {
+  if (typeof value === 'string') {
+    return redactString(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => redactPublishingDiagnosticValue(item));
+  }
+
+  if (!isRecord(value)) {
+    return value;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entry]) => [
+      key,
+      SENSITIVE_KEY_PATTERN.test(key)
+        ? REDACTED_VALUE
+        : redactPublishingDiagnosticValue(entry),
+    ]),
+  );
+}
+
+export function sanitizePublishingDiagnostic(
+  diagnostic: IPublishingDiagnostic,
+): IPublishingDiagnostic {
+  return {
+    ...diagnostic,
+    details: diagnostic.details
+      ? (redactPublishingDiagnosticValue(diagnostic.details) as Record<
+          string,
+          unknown
+        >)
+      : undefined,
+  };
+}
+
+export function sanitizePublishingDiagnostics(
+  diagnostics: readonly IPublishingDiagnostic[],
+): IPublishingDiagnostic[] {
+  return diagnostics.map((diagnostic) =>
+    sanitizePublishingDiagnostic(diagnostic),
+  );
+}
+
+export function classifyPublishingDiagnostic(
+  input: PublishingDiagnosticClassificationInput,
+): PublishingSetupFailureClassification {
+  const haystack = [input.code, input.message]
+    .filter((value): value is string => typeof value === 'string')
+    .join(' ')
+    .toLowerCase();
+
+  if (
+    /\b(self[-_ ]?host|hosted[-_ ]?key|managed[-_ ]?provider)\b/.test(haystack)
+  ) {
+    return 'unsupported_self_host_mode';
+  }
+
+  if (
+    /\b(app[-_ ]?review|approval|not[-_ ]?approved|developer[-_ ]?mode)\b/.test(
+      haystack,
+    )
+  ) {
+    return 'missing_provider_approval';
+  }
+
+  if (
+    /\b(scope|permission|permissions|insufficient[_-]?scope|forbidden)\b/.test(
+      haystack,
+    ) ||
+    input.statusCode === 403
+  ) {
+    return 'missing_permission_scope';
+  }
+
+  if (
+    /\b(expired|invalid[_-]?token|refresh[_-]?token|revoked|reauth)\b/.test(
+      haystack,
+    ) ||
+    input.statusCode === 401
+  ) {
+    return 'expired_credential';
+  }
+
+  if (/\b(rate[-_ ]?limit|quota|too many requests)\b/.test(haystack)) {
+    return 'quota_or_rate_limit';
+  }
+
+  if (
+    /\b(timeout|unavailable|outage|econnreset|econnrefused|5\d\d)\b/.test(
+      haystack,
+    ) ||
+    (typeof input.statusCode === 'number' && input.statusCode >= 500)
+  ) {
+    return 'provider_outage';
+  }
+
+  if (
+    /\b(callback|redirect[_-]?uri|redirect uri|webhook|public url|env|missing config|missing secret)\b/.test(
+      haystack,
+    )
+  ) {
+    return 'misconfiguration';
+  }
+
+  return 'unknown';
+}
+
+export function classifyPublishingReadiness(
+  diagnostics: readonly IPublishingDiagnostic[],
+): PublishingReadinessState {
+  if (diagnostics.length === 0) {
+    return 'publish_capable';
+  }
+
+  if (
+    diagnostics.some(
+      (diagnostic) =>
+        diagnostic.severity === 'error' &&
+        (!diagnostic.isRetryable ||
+          BLOCKING_CLASSIFICATIONS.has(diagnostic.classification)),
+    )
+  ) {
+    return 'blocked';
+  }
+
+  if (
+    diagnostics.some(
+      (diagnostic) =>
+        diagnostic.severity === 'warning' || diagnostic.severity === 'error',
+    )
+  ) {
+    return 'degraded';
+  }
+
+  return 'publish_capable';
+}
+
+export function canScheduleWithPublishingReadiness(
+  state: PublishingReadinessState,
+): boolean {
+  return state === 'publish_capable' || state === 'degraded';
+}
+
+function inferRetryability(
+  state: PublishingReadinessState,
+  diagnostics: readonly IPublishingDiagnostic[],
+): boolean {
+  if (state === 'publish_capable') {
+    return false;
+  }
+
+  return diagnostics.some((diagnostic) => diagnostic.isRetryable);
+}
+
+function getFirstRequiredAction(
+  diagnostics: readonly IPublishingDiagnostic[],
+): string | null {
+  return (
+    diagnostics.find((diagnostic) => diagnostic.correctiveAction)
+      ?.correctiveAction ?? null
+  );
+}
+
+function defaultStatus(
+  status: PublishingSetupCheckStatus | undefined,
+): PublishingSetupCheckStatus {
+  return status ?? 'unknown';
+}
+
+export function buildPublishingProviderReadiness(
+  input: PublishingReadinessInput,
+): IPublishingProviderReadiness {
+  const diagnostics = sanitizePublishingDiagnostics(input.diagnostics ?? []);
+  const state = classifyPublishingReadiness(diagnostics);
+
+  return {
+    ...input,
+    appReviewStatus: defaultStatus(input.appReviewStatus),
+    callbackUrlStatus: defaultStatus(input.callbackUrlStatus),
+    canSchedule: canScheduleWithPublishingReadiness(state),
+    diagnostics,
+    isRetryable: inferRetryability(state, diagnostics),
+    permissionScopeStatus: defaultStatus(input.permissionScopeStatus),
+    quotaStatus: defaultStatus(input.quotaStatus),
+    requiredAction: input.requiredAction ?? getFirstRequiredAction(diagnostics),
+    state,
+    tokenFreshness: defaultStatus(input.tokenFreshness),
+  };
+}

--- a/packages/interfaces/src/index.ts
+++ b/packages/interfaces/src/index.ts
@@ -177,6 +177,7 @@ export * from './organization/organization-setting.interface';
 export * from './organization/quota-status.interface';
 export * from './providers/providers.interface';
 export * from './publisher/publisher.interface';
+export * from './publisher/publishing-readiness.interface';
 export * from './scheduler/channel-target.interface';
 export * from './scheduler/recurrence-rule.interface';
 export * from './scheduler/release-attachment.interface';

--- a/packages/interfaces/src/publisher/index.ts
+++ b/packages/interfaces/src/publisher/index.ts
@@ -1,1 +1,2 @@
 export * from './publisher.interface';
+export * from './publishing-readiness.interface';

--- a/packages/interfaces/src/publisher/publishing-readiness.interface.ts
+++ b/packages/interfaces/src/publisher/publishing-readiness.interface.ts
@@ -1,0 +1,82 @@
+import type { CredentialPlatform } from '@genfeedai/enums';
+
+export type PublishingReadinessState =
+  | 'publish_capable'
+  | 'degraded'
+  | 'blocked'
+  | 'unknown';
+
+export type PublishingSetupFailureClassification =
+  | 'misconfiguration'
+  | 'missing_provider_approval'
+  | 'expired_credential'
+  | 'missing_permission_scope'
+  | 'provider_outage'
+  | 'quota_or_rate_limit'
+  | 'unsupported_self_host_mode'
+  | 'unknown';
+
+export type PublishingDiagnosticSeverity = 'info' | 'warning' | 'error';
+
+export type PublishingSetupCheckStatus = 'pass' | 'warn' | 'fail' | 'unknown';
+
+export type PublishingSetupCheckScope =
+  | 'core_runtime'
+  | 'auth'
+  | 'provider'
+  | 'callback'
+  | 'credential'
+  | 'permission'
+  | 'app_review'
+  | 'quota';
+
+export interface IPublishingDiagnostic {
+  /** Stable machine-readable code for API/MCP/CLI consumers. */
+  code: string;
+  /** Safe user-facing summary of the failed or degraded check. */
+  message: string;
+  classification: PublishingSetupFailureClassification;
+  severity: PublishingDiagnosticSeverity;
+  /** Whether retrying the provider/setup validation could recover this state. */
+  isRetryable: boolean;
+  scope?: PublishingSetupCheckScope;
+  /** Specific next action a self-host operator or channel owner can take. */
+  correctiveAction?: string;
+  /** ISO 8601 timestamp for the diagnostic observation. */
+  checkedAt?: string;
+  /** Non-secret provider/setup evidence. Values must be redacted before export. */
+  details?: Record<string, unknown>;
+}
+
+export interface IPublishingSetupCheck {
+  key: string;
+  label: string;
+  status: PublishingSetupCheckStatus;
+  scope: PublishingSetupCheckScope;
+  diagnostics: IPublishingDiagnostic[];
+}
+
+export interface IPublishingSetupChecklist {
+  state: PublishingReadinessState;
+  generatedAt: string;
+  checks: IPublishingSetupCheck[];
+}
+
+export interface IPublishingProviderReadiness {
+  providerKey: CredentialPlatform | string;
+  credentialId?: string | null;
+  state: PublishingReadinessState;
+  /** False only for states that must block schedule mutation before queueing. */
+  canSchedule: boolean;
+  /** Whether a later validation attempt can reasonably recover the state. */
+  isRetryable: boolean;
+  requiredAction?: string | null;
+  callbackUrlStatus: PublishingSetupCheckStatus;
+  permissionScopeStatus: PublishingSetupCheckStatus;
+  tokenFreshness: PublishingSetupCheckStatus;
+  appReviewStatus: PublishingSetupCheckStatus;
+  quotaStatus: PublishingSetupCheckStatus;
+  lastValidationAttemptAt?: string | null;
+  lastSuccessfulValidationAt?: string | null;
+  diagnostics: IPublishingDiagnostic[];
+}

--- a/packages/interfaces/src/scheduler/channel-target.interface.ts
+++ b/packages/interfaces/src/scheduler/channel-target.interface.ts
@@ -5,6 +5,7 @@ import type {
 } from '@genfeedai/enums';
 import type { IBaseEntity } from '../core/base.interface';
 import type { ICredential } from '../organization/credential.interface';
+import type { IPublishingProviderReadiness } from '../publisher/publishing-readiness.interface';
 import type { IReleaseAttachment } from './release-attachment.interface';
 import type { IScheduleStatusTransition } from './status-transition.interface';
 
@@ -56,6 +57,12 @@ export interface IChannelTarget extends IBaseEntity {
   validationState: TargetValidationState;
   /** Non-empty when `validationState` is `WARNING` or `INVALID`. */
   validationIssues: string[];
+  /**
+   * Provider credential/setup readiness surfaced before scheduling. This
+   * contains only sanitized diagnostics; raw provider payloads stay out of the
+   * public scheduler response.
+   */
+  readiness?: IPublishingProviderReadiness | null;
   executionState: TargetExecutionState;
   /** Provider's ID for the published item (used for analytics reconciliation). */
   externalProviderId?: string | null;

--- a/packages/serializers/__tests__/scheduler-serializers.test.ts
+++ b/packages/serializers/__tests__/scheduler-serializers.test.ts
@@ -169,6 +169,48 @@ describe('Channel target serialization', () => {
       isRetryable: false,
     });
   });
+
+  test('serializes sanitized provider readiness for scheduling surfaces', () => {
+    const result = ChannelTargetSerializer.serialize({
+      id: 'tgt_ready',
+      executionState: 'scheduled',
+      platform: 'instagram',
+      readiness: {
+        appReviewStatus: 'fail',
+        callbackUrlStatus: 'pass',
+        canSchedule: false,
+        diagnostics: [
+          {
+            classification: 'missing_provider_approval',
+            code: 'meta_app_review_required',
+            correctiveAction: 'Move the Meta app out of development mode.',
+            details: { appMode: 'development' },
+            isRetryable: false,
+            message: 'Meta app review is required before publishing.',
+            severity: 'error',
+          },
+        ],
+        isRetryable: false,
+        permissionScopeStatus: 'pass',
+        providerKey: 'instagram',
+        quotaStatus: 'unknown',
+        requiredAction: 'Move the Meta app out of development mode.',
+        state: 'blocked',
+        tokenFreshness: 'pass',
+      },
+    });
+
+    expect(result.data.attributes.readiness).toMatchObject({
+      appReviewStatus: 'fail',
+      canSchedule: false,
+      providerKey: 'instagram',
+      state: 'blocked',
+    });
+    expect(result.data.attributes.readiness.diagnostics[0]).toMatchObject({
+      classification: 'missing_provider_approval',
+      code: 'meta_app_review_required',
+    });
+  });
 });
 
 describe('Recurrence + attachment serialization', () => {

--- a/packages/serializers/src/attributes/content/channel-target.attributes.ts
+++ b/packages/serializers/src/attributes/content/channel-target.attributes.ts
@@ -14,6 +14,7 @@ export const channelTargetAttributes = createEntityAttributes([
   'settings',
   'validationState',
   'validationIssues',
+  'readiness',
   'executionState',
   'externalProviderId',
   'externalShortcode',


### PR DESCRIPTION
## Summary
- add a Zod-backed publishing readiness contract for provider/setup diagnostics, schedule gating state, and self-host setup checklist payloads
- add shared publishing diagnostic helpers for failure classification, recursive redaction, readiness state derivation, and schedule eligibility
- expose sanitized provider readiness on scheduler channel targets and serializer output

Refs #1144.

## Remaining #1144 scope
- wire a read endpoint/service that composes preflight, onboarding, credential/account health, channel capabilities, and scheduler liveness into this contract
- add provider-specific readiness probes for promoted scheduler platforms
- enforce blocked readiness in schedule mutations/composer/calendar/API/MCP after the #1127/#1129 scheduler mutation/read-model work lands
- add self-host docs and diagnostic export/copy UX around the sanitized payload

## Verification
- `bunx biome check --write <touched readiness/helper/serializer files>`
- `bunx vitest run --config packages/api-types/vitest.config.ts __tests__/publishing-readiness.contract.test.ts __tests__/channel-capabilities.contract.test.ts`
- `bunx vitest run --config packages/helpers/vitest.config.ts src/publisher/publishing-diagnostics.helper.test.ts --environment node`
- `bunx vitest run --config packages/serializers/vitest.config.ts __tests__/scheduler-serializers.test.ts`
- `bun run --cwd packages/api-types type-check`
- `bun run --cwd packages/helpers type-check`
- `bun run --cwd packages/serializers type-check`
- `git diff --check`
- `bunx secretlint $(git diff --cached --name-only)` plus pre-commit staged secretlint

## Notes
- Local workspace setup required `bun install --frozen-lockfile --ignore-scripts` and building package references (`auth-client`, `enums`, `constants`, `interfaces`, `pricing`, `helpers`) so focused package tests/type-checks could resolve local workspace exports.
- Full workspace type-check/build and full test suites were intentionally not run locally per repo policy; PR CI owns broad gates.