### PR TITLE
ci: stabilize Fallow health checks

### DIFF
--- a/.agents/memory/project_fallow.md
+++ b/.agents/memory/project_fallow.md
@@ -8,6 +8,6 @@ Fallow (github.com/fallow-rs/fallow) — Rust-native static analysis for TS/JS.
 
 **Why:** Monorepo with 8600+ files, 22% dead files, 99 circular deps, 71 unused deps. Needs automated health tracking.
 
-**How to apply:** Workflow at `.github/workflows/codebase-health.yml` runs weekly Monday 9am UTC. Issue #83 tracks full implementation including .fallowrc.json config and CodeRabbit integration.
+**How to apply:** Workflow at `.github/workflows/codebase-health.yml` runs weekly Monday 9am UTC. It also runs a report-only PR audit for changed code paths. Repo-specific tuning lives in `.fallowrc.json`; operational score/backlog policy lives in `docs/codebase-health.md`.
 
-Initial results (2026-04-05): Score 72/100 (B). Biggest penalties: unused deps (-10), circular deps (-10), dead files (-4.4).
+Initial results (2026-04-05): Score 72/100 (B). Biggest penalties: unused deps (-10), circular deps (-10), dead files (-4.4). A pinned Fallow 2.96.0 local smoke during #83 hardening returned 55.8/C with no node_modules installed, so use the first post-merge weekly CI run with `.fallowrc.json` as the operating baseline.

--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -1,0 +1,76 @@
+{
+  "$schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json",
+  "ignorePatterns": [
+    "**/node_modules/**",
+    "**/.next/**",
+    "**/.turbo/**",
+    "**/dist/**",
+    "**/build/**",
+    "**/coverage/**",
+    "apps/server/clips/**",
+    "artifacts/**",
+    "playwright/artifacts/**",
+    "packages/api-types/src/generated/**",
+    "packages/tools/src/registry/generated/**",
+    "**/*.d.ts"
+  ],
+  "ignoreDependencies": [
+    "@biomejs/biome",
+    "@google/design.md",
+    "@playwright/test",
+    "@types/node",
+    "@types/react",
+    "@types/react-dom",
+    "lint-staged",
+    "secretlint",
+    "turbo",
+    "typescript",
+    "vitest"
+  ],
+  "ignoreExportsUsedInFile": {
+    "type": true,
+    "interface": true
+  },
+  "duplicates": {
+    "mode": "mild",
+    "minTokens": 50,
+    "minLines": 30,
+    "threshold": 0,
+    "ignore": [
+      "**/*.test.*",
+      "**/*.spec.*",
+      "**/*.stories.*",
+      "docs/**",
+      "scripts/**",
+      "packages/api-types/src/generated/**",
+      "packages/tools/src/registry/generated/**"
+    ],
+    "ignoreImports": true
+  },
+  "health": {
+    "maxCyclomatic": 20,
+    "maxCognitive": 15,
+    "maxCrap": 30,
+    "ignore": [
+      "**/*.test.*",
+      "**/*.spec.*",
+      "**/*.stories.*",
+      "docs/**",
+      "scripts/**",
+      "packages/api-types/src/generated/**",
+      "packages/tools/src/registry/generated/**"
+    ],
+    "suggestInlineSuppression": false
+  },
+  "audit": {
+    "gate": "new-only",
+    "css": true,
+    "cssDeep": true,
+    "cacheMaxAgeDays": 14
+  },
+  "production": {
+    "deadCode": false,
+    "health": true,
+    "dupes": false
+  }
+}

--- a/.github/workflows/codebase-health.yml
+++ b/.github/workflows/codebase-health.yml
@@ -1,17 +1,66 @@
 name: Codebase Health Check
 
 on:
+  pull_request:
+    branches: [master]
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - '**/*.cjs'
+      - '**/*.css'
+      - '**/*.cts'
+      - '**/*.js'
+      - '**/*.jsx'
+      - '**/*.json'
+      - '**/*.mjs'
+      - '**/*.mts'
+      - '**/*.ts'
+      - '**/*.tsx'
+      - '.fallowrc.json'
+      - '.github/workflows/codebase-health.yml'
+      - 'bun.lock'
+      - 'package.json'
   schedule:
     - cron: '0 9 * * 1' # Every Monday at 9am UTC
   workflow_dispatch:
+
+permissions:
+  checks: write
+  contents: read
+  pull-requests: write
+  security-events: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  pr-audit:
+    name: Fallow PR Audit
+    if: github.event_name == 'pull_request' && github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: fallow-rs/fallow@v2
+        with:
+          version: '2.96.0'
+          config: .fallowrc.json
+          command: audit
+          gate: new-only
+          format: compact
+          comment: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+          comment-layout: gate-only
+          summary-scope: diff
+          diff-filter: added
+          max-annotations: 30
+          fail-on-issues: false
+
   health:
     name: Health Score
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -27,11 +76,14 @@ jobs:
           # Pinned 2026-06-19 (#684); revisit once the fallow CLI contract is
           # stable, then consider letting it float again or adding Renovate.
           version: '2.96.0'
+          config: .fallowrc.json
           # fallow v2 takes a bare subcommand here; flags moved to dedicated
           # inputs below (the old `health --score --hotspots --min-score 60`
           # string is rejected as an invalid command).
           command: health
+          score: true
           hotspots: true
+          targets: true
           format: sarif
           # Report-only: still produce the SARIF for code scanning, but don't
           # red-line the weekly run on transient complexity findings. Re-enable
@@ -49,6 +101,7 @@ jobs:
 
   dead-code:
     name: Dead Code & Unused Deps
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -60,9 +113,10 @@ jobs:
         with:
           # Keep in sync with the health job's pin above (pinned 2026-06-19, #684).
           version: '2.96.0'
+          config: .fallowrc.json
           command: dead-code
           # The --unused-* / --circular-deps flags are now the issue-types input.
-          issue-types: unused-exports,unused-deps,circular-deps
+          issue-types: unused-files,unused-exports,unused-types,unused-deps,circular-deps
           # `format: annotations` is invalid in fallow v2 (valid: human, json,
           # sarif, compact, markdown, ...). Inline annotations are a separate
           # boolean input.
@@ -74,6 +128,7 @@ jobs:
 
   duplication:
     name: Code Duplication
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -82,6 +137,7 @@ jobs:
       - uses: fallow-rs/fallow@v2
         with:
           version: '2.96.0'
+          config: .fallowrc.json
           command: dupes
           dupes-mode: mild
           annotations: true
@@ -90,6 +146,7 @@ jobs:
 
   skills:
     name: Skills Integrity
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -107,10 +164,11 @@ jobs:
 
   # Full-repo React health gate. The PR job in ci.yml only scans the diff, so
   # pre-existing errors in untouched files never gate it. This scans every
-  # React workspace project (scoped by react-doctor.config.json) and fails on
+  # React workspace project (scoped by doctor.config.json) and fails on
   # any error-severity diagnostic, catching latent regressions repo-wide.
   react-doctor-full:
     name: React Doctor (full repo)
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/docs/audits/00-repo-map.md
+++ b/docs/audits/00-repo-map.md
@@ -216,9 +216,9 @@ image and runs `test:e2e:release`, reporting to a deduped issue.
 
 ### 5.1 CI surface (24 workflows — full table verified)
 
-- **On PR (the only automatic gates):** `ci.yml` (trust-gated: gitleaks, secretlint, react-doctor@0.4.2, architecture guards, format, lint, typecheck, build; heavy test shards only with `run_heavy_tests` or on push) and `link-check.yml` (paths-filtered).
+- **On PR:** `ci.yml` (trust-gated: gitleaks, secretlint, react-doctor@0.5.6, architecture guards, format, lint, typecheck, build; heavy test shards only with `run_heavy_tests` or on push), `link-check.yml` (paths-filtered), and `codebase-health.yml` (Fallow changed-code audit, report-only).
 - **QA gate for releases:** `full-suite.yml` = ci(heavy) + `build-verify.yml` (boots all 12 bundles + EE api bundle) + `e2e.yml` (API e2e with Postgres/Redis service containers + 12-way sharded frontend e2e). Required by both `deploy-ecs.yml` and `docker-publish.yml`.
-- **Scheduled:** nightly e2e (`17 2 * * *`), nightly self-hosted release e2e (`23 5 * * *`), weekly coverage → Codecov (non-blocking), weekly `codebase-health.yml` (fallow 2.96.0 + react-doctor@0.5.6 + skills integrity, report-only), daily Claude pattern miner.
+- **Scheduled:** nightly e2e (`17 2 * * *`), nightly self-hosted release e2e (`23 5 * * *`), weekly coverage → Codecov (non-blocking), weekly `codebase-health.yml` (fallow 2.96.0 + `.fallowrc.json` + react-doctor@0.5.6 + skills integrity, report-only), daily Claude pattern miner.
 - **Manual-only despite their names:** `codeql.yml`, `security-scan.yml` (Trivy), `ide-extension-ci.yml` — no cron, no PR trigger.
 - **Absent:** `dependabot.yml`, `CODEOWNERS` (find: 0 matches repo-wide).
 - OIDC AWS auth in deploy workflows; shared `setup-bun-env` composite (bun/turbo caches, 3× retry install); GHCR registry build cache with provenance/sbom.
@@ -235,7 +235,7 @@ image and runs `test:e2e:release`, reporting to a deduped issue.
 - Pre-commit (`.husky/pre-commit` via `core.hooksPath`): lint-staged → secretlint shim, biome-staged, `scripts/lint-no-raw-html.sh` (raw HTML element ban with primitive-dir whitelist).
 - Architecture guards run in CI: cron boundary, no-API-BullMQ-processors, import cycles, multi-tenancy, serializer drift, package API surface, design system, pages boundary, generated-source artifacts.
 - Knip dead-code config (`knip.config.ts`) — **stale**: declares workspaces `apps/server/fanvue` and `apps/server/llm` (don't exist) and omits `apps/server/images`/`voices` (exist).
-- `doctor.config.json` — most plausibly consumed by react-doctor (used in ci.yml + codebase-health.yml); **UNCLEAR**: codebase-health's comment references `react-doctor.config.json`, a filename that doesn't exist; exact consumer unconfirmed.
+- `doctor.config.json` — consumed by react-doctor in ci.yml + codebase-health.yml.
 
 ---
 

--- a/docs/codebase-health.md
+++ b/docs/codebase-health.md
@@ -1,0 +1,55 @@
+# Codebase Health
+
+Genfeed uses Fallow for codebase-health telemetry. Fallow is not part of the
+runtime path and is not part of the deployment path.
+
+## What Runs
+
+- Pull requests run `Fallow PR Audit` from `.github/workflows/codebase-health.yml`
+  when TypeScript, JavaScript, CSS, package, workflow, or Fallow config files
+  change.
+- The PR audit is scoped to changed code with `gate: new-only`, posts a compact
+  report, and uses `fail-on-issues: false`.
+- The weekly Monday 09:00 UTC workflow runs full-repo `health`, `dead-code`,
+  `dupes`, skills integrity, and full React Doctor checks.
+- Full-repo Fallow jobs are report-only until the backlog is intentionally
+  burned down.
+
+## Health Policy
+
+The original issue #83 baseline was 72/100 with the largest known backlog areas
+in unused dependencies, circular dependencies, and dead files. A local pinned
+Fallow 2.96.0 smoke on this branch returned 55.8/C with 13.0% dead files, 46
+circular dependencies, and 79 unused dependencies, but that run also warned that
+`node_modules` was absent. Treat the first post-merge weekly CI run with this
+config as the operating baseline.
+
+- After the first post-merge baseline, score below 70 opens a follow-up issue
+  for regression triage.
+- After the first post-merge baseline, score below 60, or a drop of 10 or more
+  points from the previous weekly report, is a release-risk investigation before
+  cutting a release.
+- Score 80 or higher for three consecutive weekly runs: consider enabling a
+  blocking PR audit or category-specific gates.
+- Fallow findings do not block deploys unless this policy is changed in a
+  separate PR and the required status checks are updated intentionally.
+
+## Backlog Triage
+
+Triage full-repo findings in this order:
+
+1. Circular dependencies crossing package or server-service boundaries.
+2. Unused dependencies in workspace manifests.
+3. Dead files outside generated, build, fixture, and documentation paths.
+4. Duplicated logic across app/package boundaries.
+5. Localized complexity hotspots that are already touched by product work.
+
+Do not batch-delete dead files from Fallow output alone. Deletions need normal
+review evidence that the file is outside dynamic loading, framework conventions,
+generated artifacts, migrations, or public package API.
+
+## Deployment Impact
+
+This workflow is intentionally separate from ECS, Vercel, Docker publish, and
+release verification workflows. Adding PR-scoped Fallow audit may add a parallel
+PR check and runner minutes, but it does not increase production deployment time.


### PR DESCRIPTION
## Summary
- Add repo-specific Fallow tuning in `.fallowrc.json` for generated/build artifacts, known tool dependencies, duplicate thresholds, health ignores, and PR audit defaults.
- Extend `codebase-health.yml` with a report-only PR-scoped `Fallow PR Audit`, while keeping full health/dead-code/dupes/skills/React Doctor jobs weekly/manual only.
- Turn on weekly health score + refactor targets and expand dead-code tracking to include dead files/types alongside unused deps/cycles.
- Document score policy, backlog triage order, and deployment impact in `docs/codebase-health.md`; refresh repo memory/audit docs.

Closes #83.

## Staleness check
- The issue was stale as a blank-slate CI request: `codebase-health.yml` already exists and the last three weekly master runs succeeded.
- It was not stale as a rollout-hardening task: there was no Fallow config, no PR-scoped decision, and no explicit score/backlog policy.

## Validation
- `ruby -e 'require "json"; JSON.parse(File.read(".fallowrc.json")); puts "json ok"'`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/codebase-health.yml"); puts "yaml ok"'`
- `actionlint .github/workflows/codebase-health.yml`
- `git diff --check -- .fallowrc.json .github/workflows/codebase-health.yml docs/codebase-health.md docs/audits/00-repo-map.md .agents/memory/project_fallow.md`
- `bunx biome check .fallowrc.json .github/workflows/codebase-health.yml docs/codebase-health.md docs/audits/00-repo-map.md .agents/memory/project_fallow.md`
- `bunx fallow@2.96.0 config --config .fallowrc.json`
- `bunx fallow@2.96.0 audit --config .fallowrc.json --changed-since origin/master --format compact --quiet --no-cache`
- `bunx fallow@2.96.0 health --config .fallowrc.json --score --hotspots --targets --format compact --quiet` returned `health-score:55.8:C` in this no-`node_modules` worktree; the first post-merge weekly CI run is documented as the operating baseline.

## Notes
- This does not add Fallow to ECS, Vercel, Docker publish, or release verification workflows, so it should not increase production deployment time.
- The PR audit is report-only (`fail-on-issues: false`) and only comments on same-repo PRs where the token can write.
- Full workspace type-check and heavy suites were not run locally per repo policy; this change is workflow/config/docs scoped.