### PR TITLE
fix(workflow): wire trend inspiration SaaS nodes

### DIFF
--- a/apps/server/api/src/collections/workflows/services/workflow-trend-publish-executor-registrar.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-trend-publish-executor-registrar.service.ts
@@ -27,7 +27,10 @@ import type {
 import {
   createPublishExecutor,
   createSendEmailExecutor,
+  createTrendHashtagInspirationExecutor,
+  createTrendSoundInspirationExecutor,
   createTrendTriggerExecutor,
+  createTrendVideoInspirationExecutor,
   TrendDigestExecutor,
   type WorkflowEngine,
 } from '@genfeedai/workflow-engine';
@@ -54,6 +57,7 @@ export class WorkflowTrendPublishExecutorRegistrarService {
 
   register(engine: WorkflowEngine): void {
     this.registerTrendTriggerExecutor(engine);
+    this.registerTrendInspirationExecutors(engine);
     this.registerSendEmailExecutor(engine);
     this.registerTrendDigestExecutor(engine);
     this.registerPublishExecutor(engine);
@@ -151,6 +155,165 @@ export class WorkflowTrendPublishExecutorRegistrarService {
       executor.nodeType,
       this.helper.wrapEngineExecutor(executor),
     );
+  }
+
+  private registerTrendInspirationExecutors(engine: WorkflowEngine): void {
+    const trendsService = this.trendsService;
+
+    const hashtagExecutor = createTrendHashtagInspirationExecutor(
+      trendsService
+        ? async ({ platform, hashtag }) => {
+            const hashtags = await trendsService.getTrendingHashtags({
+              limit: 25,
+              platform,
+            });
+            const selected =
+              (hashtag
+                ? hashtags.find(
+                    (item) =>
+                      item.hashtag.replace(/^#/, '').toLowerCase() ===
+                      hashtag.toLowerCase(),
+                  )
+                : undefined) ?? hashtags[0];
+            if (!selected) {
+              return null;
+            }
+
+            return {
+              hashtag: selected.hashtag,
+              platform:
+                typeof selected.platform === 'string'
+                  ? this.normalizeTrendPlatform(selected.platform)
+                  : platform,
+              postCount:
+                typeof selected.postCount === 'number'
+                  ? selected.postCount
+                  : null,
+              relatedHashtags: selected.relatedHashtags ?? [],
+            };
+          }
+        : undefined,
+    );
+    const soundExecutor = createTrendSoundInspirationExecutor(
+      trendsService
+        ? async ({ minUsageCount, maxDuration }) => {
+            const sounds = await trendsService.getTrendingSounds({ limit: 50 });
+            const selected = sounds.find((sound) => {
+              const usageCount =
+                typeof sound.usageCount === 'number' ? sound.usageCount : 0;
+              const duration =
+                typeof sound.duration === 'number' ? sound.duration : null;
+              return (
+                usageCount >= minUsageCount &&
+                (maxDuration === null ||
+                  duration === null ||
+                  duration <= maxDuration)
+              );
+            });
+            if (!selected) {
+              return null;
+            }
+
+            const soundId =
+              selected.soundId ?? selected.externalId ?? selected.id;
+            if (!soundId) {
+              return null;
+            }
+
+            return {
+              authorName: selected.authorName ?? null,
+              coverUrl: selected.coverUrl ?? null,
+              duration:
+                typeof selected.duration === 'number'
+                  ? selected.duration
+                  : null,
+              growthRate:
+                typeof selected.growthRate === 'number'
+                  ? selected.growthRate
+                  : null,
+              soundId,
+              soundName: selected.soundName ?? soundId,
+              soundUrl: selected.playUrl ?? null,
+              usageCount:
+                typeof selected.usageCount === 'number'
+                  ? selected.usageCount
+                  : null,
+            };
+          }
+        : undefined,
+    );
+    const videoExecutor = createTrendVideoInspirationExecutor(
+      trendsService
+        ? async ({ platform, trendId, minViralScore }) => {
+            const videos = await trendsService.getViralVideos({
+              limit: 25,
+              minViralScore,
+              platform,
+            });
+            const selected =
+              (trendId
+                ? videos.find(
+                    (item) =>
+                      item.id === trendId ||
+                      item.externalId === trendId ||
+                      item._id === trendId,
+                  )
+                : undefined) ?? videos[0];
+            if (!selected) {
+              return null;
+            }
+
+            const selectedTrendId =
+              selected.id ?? selected.externalId ?? selected._id;
+            if (!selectedTrendId) {
+              return null;
+            }
+
+            return {
+              description: selected.description ?? null,
+              duration:
+                typeof selected.duration === 'number'
+                  ? selected.duration
+                  : null,
+              hashtags: selected.hashtags ?? [],
+              hook: selected.hook ?? null,
+              platform:
+                typeof selected.platform === 'string'
+                  ? this.normalizeTrendPlatform(selected.platform)
+                  : platform,
+              soundId: selected.soundId ?? null,
+              title: selected.title ?? null,
+              trendId: selectedTrendId,
+              videoUrl: selected.videoUrl ?? selected.playUrl ?? null,
+            };
+          }
+        : undefined,
+    );
+
+    for (const executor of [hashtagExecutor, soundExecutor, videoExecutor]) {
+      engine.registerExecutor(
+        executor.nodeType,
+        this.helper.wrapEngineExecutor(executor),
+      );
+    }
+  }
+
+  private normalizeTrendPlatform(
+    platform: string,
+  ): 'tiktok' | 'instagram' | 'twitter' | 'youtube' | 'reddit' {
+    switch (platform.toLowerCase()) {
+      case 'instagram':
+      case 'twitter':
+      case 'youtube':
+      case 'reddit':
+        return platform.toLowerCase() as
+          | 'instagram'
+          | 'twitter'
+          | 'youtube'
+          | 'reddit';
+      default:
+        return 'tiktok';
+    }
   }
 
   private registerSendEmailExecutor(engine: WorkflowEngine): void {

--- a/packages/workflow-engine/src/executors/executor-registry.spec.ts
+++ b/packages/workflow-engine/src/executors/executor-registry.spec.ts
@@ -18,6 +18,9 @@ describe('executor-registry', () => {
       expect(types).toContain('delay');
       expect(types).toContain('hookGenerator');
       expect(types).toContain('noop');
+      expect(types).toContain('trendHashtagInspiration');
+      expect(types).toContain('trendSoundInspiration');
+      expect(types).toContain('trendVideoInspiration');
     });
   });
 
@@ -109,6 +112,9 @@ describe('executor-registry', () => {
       expect(registry.getKeywordTriggerExecutor()).toBeDefined();
       expect(registry.getEngagementTriggerExecutor()).toBeDefined();
       expect(registry.getCommentTriggerExecutor()).toBeDefined();
+      expect(registry.getTrendHashtagInspirationExecutor()).toBeDefined();
+      expect(registry.getTrendSoundInspirationExecutor()).toBeDefined();
+      expect(registry.getTrendVideoInspirationExecutor()).toBeDefined();
     });
 
     it('allows setting custom executor', () => {

--- a/packages/workflow-engine/src/executors/executor-registry.ts
+++ b/packages/workflow-engine/src/executors/executor-registry.ts
@@ -99,9 +99,21 @@ import {
 import { TextToSpeechExecutor } from '@workflow-engine/executors/saas/text-to-speech-executor';
 import { TrendDigestExecutor } from '@workflow-engine/executors/saas/trend-digest-executor';
 import {
+  createTrendHashtagInspirationExecutor,
+  TrendHashtagInspirationExecutor,
+} from '@workflow-engine/executors/saas/trend-hashtag-inspiration-executor';
+import {
+  createTrendSoundInspirationExecutor,
+  TrendSoundInspirationExecutor,
+} from '@workflow-engine/executors/saas/trend-sound-inspiration-executor';
+import {
   createTrendTriggerExecutor,
   TrendTriggerExecutor,
 } from '@workflow-engine/executors/saas/trend-trigger-executor';
+import {
+  createTrendVideoInspirationExecutor,
+  TrendVideoInspirationExecutor,
+} from '@workflow-engine/executors/saas/trend-video-inspiration-executor';
 import {
   createTweetInputExecutor,
   TweetInputExecutor,
@@ -465,12 +477,33 @@ export const EXECUTOR_REGISTRY: Record<string, ExecutorRegistryEntry> = {
     nodeType: 'trendDigest',
     requiresResolver: true,
   },
+  trendHashtagInspiration: {
+    description: 'Generates a content prompt from a trending hashtag',
+    executorClass: TrendHashtagInspirationExecutor,
+    factory: () => createTrendHashtagInspirationExecutor(),
+    nodeType: 'trendHashtagInspiration',
+    requiresResolver: false,
+  },
+  trendSoundInspiration: {
+    description: 'Selects a trending sound for content inspiration',
+    executorClass: TrendSoundInspirationExecutor,
+    factory: () => createTrendSoundInspirationExecutor(),
+    nodeType: 'trendSoundInspiration',
+    requiresResolver: false,
+  },
   trendTrigger: {
     description: 'Starts workflow when new trend matches criteria',
     executorClass: TrendTriggerExecutor,
     factory: () => createTrendTriggerExecutor(),
     nodeType: 'trendTrigger',
     requiresResolver: true,
+  },
+  trendVideoInspiration: {
+    description: 'Extracts a generation prompt from a trending video',
+    executorClass: TrendVideoInspirationExecutor,
+    factory: () => createTrendVideoInspirationExecutor(),
+    nodeType: 'trendVideoInspiration',
+    requiresResolver: false,
   },
   tweetInput: {
     description: 'Fetches tweet content from URL or accepts text input',
@@ -689,6 +722,30 @@ export class ExecutorRegistryInstance {
   }
 
   /**
+   * Get the trend hashtag inspiration executor for resolver injection
+   */
+  getTrendHashtagInspirationExecutor():
+    | TrendHashtagInspirationExecutor
+    | undefined {
+    const executor = this.executors.get('trendHashtagInspiration');
+    return executor instanceof TrendHashtagInspirationExecutor
+      ? executor
+      : undefined;
+  }
+
+  /**
+   * Get the trend sound inspiration executor for resolver injection
+   */
+  getTrendSoundInspirationExecutor():
+    | TrendSoundInspirationExecutor
+    | undefined {
+    const executor = this.executors.get('trendSoundInspiration');
+    return executor instanceof TrendSoundInspirationExecutor
+      ? executor
+      : undefined;
+  }
+
+  /**
    * Get the sound overlay executor for processor injection
    */
   getSoundOverlayExecutor(): SoundOverlayExecutor | undefined {
@@ -866,6 +923,18 @@ export class ExecutorRegistryInstance {
   getCommentTriggerExecutor(): CommentTriggerExecutor | undefined {
     const executor = this.executors.get('commentTrigger');
     return executor instanceof CommentTriggerExecutor ? executor : undefined;
+  }
+
+  /**
+   * Get the trend video inspiration executor for resolver injection
+   */
+  getTrendVideoInspirationExecutor():
+    | TrendVideoInspirationExecutor
+    | undefined {
+    const executor = this.executors.get('trendVideoInspiration');
+    return executor instanceof TrendVideoInspirationExecutor
+      ? executor
+      : undefined;
   }
 
   /**

--- a/packages/workflow-engine/src/executors/saas/index.ts
+++ b/packages/workflow-engine/src/executors/saas/index.ts
@@ -54,7 +54,10 @@ export * from '@workflow-engine/executors/saas/sound-overlay-executor';
 // Text to speech executor
 export * from '@workflow-engine/executors/saas/text-to-speech-executor';
 export * from '@workflow-engine/executors/saas/trend-digest-executor';
+export * from '@workflow-engine/executors/saas/trend-hashtag-inspiration-executor';
+export * from '@workflow-engine/executors/saas/trend-sound-inspiration-executor';
 export * from '@workflow-engine/executors/saas/trend-trigger-executor';
+export * from '@workflow-engine/executors/saas/trend-video-inspiration-executor';
 export * from '@workflow-engine/executors/saas/tweet-input-executor';
 export * from '@workflow-engine/executors/saas/tweet-remix-executor';
 // Upscale executor

--- a/packages/workflow-engine/src/executors/saas/trend-hashtag-inspiration-executor.ts
+++ b/packages/workflow-engine/src/executors/saas/trend-hashtag-inspiration-executor.ts
@@ -1,0 +1,248 @@
+import {
+  BaseExecutor,
+  type ExecutorInput,
+  type ExecutorOutput,
+} from '@workflow-engine/executors/base-executor';
+import type { ExecutableNode } from '@workflow-engine/types';
+
+export type TrendInspirationPlatform =
+  | 'tiktok'
+  | 'instagram'
+  | 'twitter'
+  | 'youtube'
+  | 'reddit';
+
+export type TrendContentPreference = 'video' | 'image' | 'any';
+export type TrendContentType = 'video' | 'image' | 'carousel' | 'thread';
+
+export interface TrendHashtagInspirationSource {
+  hashtag: string;
+  relatedHashtags: string[];
+  postCount: number | null;
+  platform: TrendInspirationPlatform;
+}
+
+export interface TrendHashtagInspirationOutput {
+  prompt: string;
+  hashtags: string[];
+  contentType: TrendContentType;
+  recommendedPlatform: TrendInspirationPlatform;
+  sourceHashtag: string;
+  hashtagPostCount: number | null;
+}
+
+export type TrendHashtagInspirationResolver = (params: {
+  organizationId: string;
+  platform: TrendInspirationPlatform;
+  hashtag: string | null;
+  auto: boolean;
+}) => Promise<TrendHashtagInspirationSource | null>;
+
+const VALID_PLATFORMS = new Set<TrendInspirationPlatform>([
+  'tiktok',
+  'instagram',
+  'twitter',
+  'youtube',
+  'reddit',
+]);
+
+const VALID_CONTENT_PREFERENCES = new Set<TrendContentPreference>([
+  'video',
+  'image',
+  'any',
+]);
+
+function toNonEmptyString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeHashtag(value: string): string {
+  const normalized = value.replace(/^#/, '').replace(/[^a-zA-Z0-9_]/g, '');
+  return normalized.length > 0 ? normalized : 'trend';
+}
+
+function buildHashtag(value: string): string {
+  return `#${normalizeHashtag(value)}`;
+}
+
+function uniq(values: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const value of values) {
+    const normalized = buildHashtag(value);
+    const key = normalized.toLowerCase();
+    if (seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+    result.push(normalized);
+  }
+
+  return result;
+}
+
+function selectContentType(
+  preference: TrendContentPreference,
+  platform: TrendInspirationPlatform,
+): TrendContentType {
+  if (preference === 'image') {
+    return platform === 'instagram' ? 'carousel' : 'image';
+  }
+
+  if (preference === 'any') {
+    return platform === 'twitter' || platform === 'reddit' ? 'thread' : 'video';
+  }
+
+  return 'video';
+}
+
+function buildPrompt(input: {
+  contentType: TrendContentType;
+  hashtag: string;
+  platform: TrendInspirationPlatform;
+}): string {
+  const topic = input.hashtag.replace(/^#/, '');
+
+  switch (input.contentType) {
+    case 'thread':
+      return `Create a ${input.platform} thread that explains why ${input.hashtag} is gaining traction, opens with a concrete observation, and ends with a practical takeaway.`;
+    case 'carousel':
+      return `Create a carousel concept for ${input.hashtag}: lead with the trend tension, show three visual proof points, and close with a save-worthy takeaway.`;
+    case 'image':
+      return `Create an image concept inspired by ${input.hashtag}, centered on ${topic}, with a bold visual hook and a caption that connects the trend to the audience.`;
+    case 'video':
+      return `Create a short-form video concept for ${input.hashtag}: open with the trend payoff, show the setup in the first three seconds, and land on a repeatable creator insight.`;
+  }
+}
+
+export class TrendHashtagInspirationExecutor extends BaseExecutor {
+  readonly nodeType = 'trendHashtagInspiration';
+  private resolver: TrendHashtagInspirationResolver | null = null;
+
+  setResolver(resolver: TrendHashtagInspirationResolver): void {
+    this.resolver = resolver;
+  }
+
+  validate(node: ExecutableNode): { valid: boolean; errors: string[] } {
+    const baseValidation = super.validate(node);
+    const errors = [...baseValidation.errors];
+
+    const platform = node.config.platform;
+    if (
+      platform !== undefined &&
+      !VALID_PLATFORMS.has(platform as TrendInspirationPlatform)
+    ) {
+      errors.push(
+        'Invalid platform. Must be one of: tiktok, instagram, twitter, youtube, reddit',
+      );
+    }
+
+    const contentPreference = node.config.contentPreference;
+    if (
+      contentPreference !== undefined &&
+      !VALID_CONTENT_PREFERENCES.has(
+        contentPreference as TrendContentPreference,
+      )
+    ) {
+      errors.push('Invalid contentPreference. Must be: video, image, or any');
+    }
+
+    const hashtag = node.config.hashtag;
+    if (
+      hashtag !== undefined &&
+      hashtag !== null &&
+      toNonEmptyString(hashtag) === null
+    ) {
+      errors.push('hashtag must be a non-empty string when provided');
+    }
+
+    return { errors, valid: errors.length === 0 };
+  }
+
+  estimateCost(_node: ExecutableNode): number {
+    return 1;
+  }
+
+  async execute(input: ExecutorInput): Promise<ExecutorOutput> {
+    const { context, inputs, node } = input;
+    const platform = this.getOptionalConfig<TrendInspirationPlatform>(
+      node.config,
+      'platform',
+      'tiktok',
+    );
+    const contentPreference = this.getOptionalConfig<TrendContentPreference>(
+      node.config,
+      'contentPreference',
+      'video',
+    );
+    const auto = this.getOptionalConfig<boolean>(node.config, 'auto', true);
+    const requestedHashtag =
+      toNonEmptyString(inputs.get('hashtag')) ??
+      toNonEmptyString(node.config.hashtag);
+
+    const source =
+      (await this.resolver?.({
+        auto,
+        hashtag: requestedHashtag ? normalizeHashtag(requestedHashtag) : null,
+        organizationId: context.organizationId,
+        platform,
+      })) ??
+      ({
+        hashtag: requestedHashtag
+          ? normalizeHashtag(requestedHashtag)
+          : `${platform}Trend`,
+        platform,
+        postCount: null,
+        relatedHashtags: [],
+      } satisfies TrendHashtagInspirationSource);
+
+    const sourceHashtag = buildHashtag(source.hashtag);
+    const contentType = selectContentType(contentPreference, source.platform);
+    const hashtags = uniq([
+      source.hashtag,
+      ...source.relatedHashtags,
+      source.platform,
+      contentType,
+      'creator',
+    ]).slice(0, 6);
+
+    const data: TrendHashtagInspirationOutput = {
+      contentType,
+      hashtagPostCount: source.postCount,
+      hashtags,
+      prompt: buildPrompt({
+        contentType,
+        hashtag: sourceHashtag,
+        platform: source.platform,
+      }),
+      recommendedPlatform: source.platform,
+      sourceHashtag,
+    };
+
+    return {
+      data,
+      metadata: {
+        auto,
+        contentPreference,
+        resolvedFromSource: Boolean(this.resolver),
+      },
+    };
+  }
+}
+
+export function createTrendHashtagInspirationExecutor(
+  resolver?: TrendHashtagInspirationResolver,
+): TrendHashtagInspirationExecutor {
+  const executor = new TrendHashtagInspirationExecutor();
+  if (resolver) {
+    executor.setResolver(resolver);
+  }
+  return executor;
+}

--- a/packages/workflow-engine/src/executors/saas/trend-inspiration-executors.spec.ts
+++ b/packages/workflow-engine/src/executors/saas/trend-inspiration-executors.spec.ts
@@ -1,0 +1,286 @@
+import type { ExecutionContext } from '@workflow-engine/execution/engine';
+import {
+  createExecutorRegistry,
+  EXECUTOR_REGISTRY,
+} from '@workflow-engine/executors/executor-registry';
+import {
+  createTrendHashtagInspirationExecutor,
+  type TrendHashtagInspirationOutput,
+} from '@workflow-engine/executors/saas/trend-hashtag-inspiration-executor';
+import {
+  createTrendSoundInspirationExecutor,
+  type TrendSoundInspirationOutput,
+} from '@workflow-engine/executors/saas/trend-sound-inspiration-executor';
+import {
+  createTrendVideoInspirationExecutor,
+  type TrendVideoInspirationOutput,
+} from '@workflow-engine/executors/saas/trend-video-inspiration-executor';
+import { DEFAULT_CREDIT_COSTS } from '@workflow-engine/utils/credit-calculator';
+import { describe, expect, it, vi } from 'vitest';
+
+const ctx: ExecutionContext = {
+  organizationId: 'o',
+  runId: 'r',
+  userId: 'u',
+  workflowId: 'w',
+};
+
+const TREND_INSPIRATION_NODE_TYPES = [
+  'trendHashtagInspiration',
+  'trendSoundInspiration',
+  'trendVideoInspiration',
+] as const;
+
+describe('trend inspiration executors', () => {
+  it('registers each implemented trend inspiration node with explicit credits', () => {
+    for (const nodeType of TREND_INSPIRATION_NODE_TYPES) {
+      expect(EXECUTOR_REGISTRY[nodeType]).toBeDefined();
+      expect(DEFAULT_CREDIT_COSTS[nodeType]).toBe(1);
+    }
+
+    const registry = createExecutorRegistry();
+    expect(registry.getTrendHashtagInspirationExecutor()).toBeDefined();
+    expect(registry.getTrendSoundInspirationExecutor()).toBeDefined();
+    expect(registry.getTrendVideoInspirationExecutor()).toBeDefined();
+  });
+
+  describe('TrendHashtagInspirationExecutor', () => {
+    it('validates platform, content preference, and hashtag config', () => {
+      const executor = createTrendHashtagInspirationExecutor();
+      expect(
+        executor.validate({
+          config: { contentPreference: 'video', platform: 'tiktok' },
+          id: 'n1',
+          inputs: [],
+          label: 'Trend Hashtag Inspiration',
+          type: 'trendHashtagInspiration',
+        }).valid,
+      ).toBe(true);
+      expect(
+        executor.validate({
+          config: { contentPreference: 'podcast', platform: 'tiktok' },
+          id: 'n1',
+          inputs: [],
+          label: 'Trend Hashtag Inspiration',
+          type: 'trendHashtagInspiration',
+        }).valid,
+      ).toBe(false);
+    });
+
+    it('generates a deterministic prompt from manual hashtag input', async () => {
+      const result = await createTrendHashtagInspirationExecutor().execute({
+        context: ctx,
+        inputs: new Map<string, unknown>([['hashtag', '#CreatorTips']]),
+        node: {
+          config: { contentPreference: 'any', platform: 'twitter' },
+          id: 'n1',
+          inputs: [],
+          label: 'Trend Hashtag Inspiration',
+          type: 'trendHashtagInspiration',
+        },
+      });
+
+      const data = result.data as TrendHashtagInspirationOutput;
+      expect(data.sourceHashtag).toBe('#CreatorTips');
+      expect(data.contentType).toBe('thread');
+      expect(data.prompt).toContain('#CreatorTips');
+      expect(data.hashtags).toContain('#CreatorTips');
+    });
+
+    it('uses resolver data when available', async () => {
+      const resolver = vi.fn().mockResolvedValue({
+        hashtag: 'AIWorkflow',
+        platform: 'tiktok',
+        postCount: 100000,
+        relatedHashtags: ['automation'],
+      });
+
+      const result = await createTrendHashtagInspirationExecutor(
+        resolver,
+      ).execute({
+        context: ctx,
+        inputs: new Map(),
+        node: {
+          config: { platform: 'tiktok' },
+          id: 'n1',
+          inputs: [],
+          label: 'Trend Hashtag Inspiration',
+          type: 'trendHashtagInspiration',
+        },
+      });
+
+      const data = result.data as TrendHashtagInspirationOutput;
+      expect(resolver).toHaveBeenCalledWith(
+        expect.objectContaining({ organizationId: 'o', platform: 'tiktok' }),
+      );
+      expect(data.sourceHashtag).toBe('#AIWorkflow');
+      expect(data.hashtagPostCount).toBe(100000);
+      expect(data.hashtags).toContain('#automation');
+    });
+  });
+
+  describe('TrendSoundInspirationExecutor', () => {
+    it('validates usage and duration config', () => {
+      const executor = createTrendSoundInspirationExecutor();
+      expect(
+        executor.validate({
+          config: { maxDuration: 30, minUsageCount: 10000 },
+          id: 'n1',
+          inputs: [],
+          label: 'Trend Sound Inspiration',
+          type: 'trendSoundInspiration',
+        }).valid,
+      ).toBe(true);
+      expect(
+        executor.validate({
+          config: { maxDuration: -1 },
+          id: 'n1',
+          inputs: [],
+          label: 'Trend Sound Inspiration',
+          type: 'trendSoundInspiration',
+        }).valid,
+      ).toBe(false);
+    });
+
+    it('completes without a resolver and returns an explicit empty result', async () => {
+      const result = await createTrendSoundInspirationExecutor().execute({
+        context: ctx,
+        inputs: new Map(),
+        node: {
+          config: {},
+          id: 'n1',
+          inputs: [],
+          label: 'Trend Sound Inspiration',
+          type: 'trendSoundInspiration',
+        },
+      });
+
+      const data = result.data as TrendSoundInspirationOutput;
+      expect(data.soundId).toBeNull();
+      expect(result.metadata?.resolvedFromSource).toBe(false);
+    });
+
+    it('returns resolver sound metadata', async () => {
+      const resolver = vi.fn().mockResolvedValue({
+        authorName: 'Creator',
+        coverUrl: 'https://example.com/cover.jpg',
+        duration: 18,
+        growthRate: 24,
+        soundId: 'sound-1',
+        soundName: 'Trending Loop',
+        soundUrl: 'https://example.com/sound.mp3',
+        usageCount: 250000,
+      });
+
+      const result = await createTrendSoundInspirationExecutor(
+        resolver,
+      ).execute({
+        context: ctx,
+        inputs: new Map(),
+        node: {
+          config: { maxDuration: 20, minUsageCount: 10000 },
+          id: 'n1',
+          inputs: [],
+          label: 'Trend Sound Inspiration',
+          type: 'trendSoundInspiration',
+        },
+      });
+
+      const data = result.data as TrendSoundInspirationOutput;
+      expect(resolver).toHaveBeenCalledWith(
+        expect.objectContaining({ maxDuration: 20, minUsageCount: 10000 }),
+      );
+      expect(data.soundId).toBe('sound-1');
+      expect(data.soundName).toBe('Trending Loop');
+    });
+  });
+
+  describe('TrendVideoInspirationExecutor', () => {
+    it('validates platform, style, and viral score config', () => {
+      const executor = createTrendVideoInspirationExecutor();
+      expect(
+        executor.validate({
+          config: {
+            inspirationStyle: 'remix_concept',
+            minViralScore: 80,
+            platform: 'instagram',
+          },
+          id: 'n1',
+          inputs: [],
+          label: 'Trend Video Inspiration',
+          type: 'trendVideoInspiration',
+        }).valid,
+      ).toBe(true);
+      expect(
+        executor.validate({
+          config: { minViralScore: 200 },
+          id: 'n1',
+          inputs: [],
+          label: 'Trend Video Inspiration',
+          type: 'trendVideoInspiration',
+        }).valid,
+      ).toBe(false);
+    });
+
+    it('generates a prompt without a resolver', async () => {
+      const result = await createTrendVideoInspirationExecutor().execute({
+        context: ctx,
+        inputs: new Map<string, unknown>([['trendId', 'trend-1']]),
+        node: {
+          config: { inspirationStyle: 'inspired_by', platform: 'tiktok' },
+          id: 'n1',
+          inputs: [],
+          label: 'Trend Video Inspiration',
+          type: 'trendVideoInspiration',
+        },
+      });
+
+      const data = result.data as TrendVideoInspirationOutput;
+      expect(data.prompt).toContain('tiktok trend');
+      expect(data.aspectRatio).toBe('9:16');
+      expect(result.metadata?.trendId).toBe('trend-1');
+    });
+
+    it('uses resolver video context when available', async () => {
+      const resolver = vi.fn().mockResolvedValue({
+        description: 'A founder documents a launch sprint',
+        duration: 12,
+        hashtags: ['startup', 'buildinpublic'],
+        hook: 'I built this in 24 hours',
+        platform: 'youtube',
+        soundId: 'sound-2',
+        title: '24 hour product launch',
+        trendId: 'trend-2',
+        videoUrl: 'https://example.com/video',
+      });
+
+      const result = await createTrendVideoInspirationExecutor(
+        resolver,
+      ).execute({
+        context: ctx,
+        inputs: new Map(),
+        node: {
+          config: {
+            includeOriginalHook: true,
+            inspirationStyle: 'match_closely',
+            minViralScore: 70,
+            platform: 'youtube',
+          },
+          id: 'n1',
+          inputs: [],
+          label: 'Trend Video Inspiration',
+          type: 'trendVideoInspiration',
+        },
+      });
+
+      const data = result.data as TrendVideoInspirationOutput;
+      expect(resolver).toHaveBeenCalledWith(
+        expect.objectContaining({ platform: 'youtube', trendId: null }),
+      );
+      expect(data.sourceTrendTitle).toBe('24 hour product launch');
+      expect(data.sourceTrendUrl).toBe('https://example.com/video');
+      expect(data.prompt).toContain('I built this in 24 hours');
+      expect(data.hashtags).toContain('#startup');
+    });
+  });
+});

--- a/packages/workflow-engine/src/executors/saas/trend-sound-inspiration-executor.ts
+++ b/packages/workflow-engine/src/executors/saas/trend-sound-inspiration-executor.ts
@@ -1,0 +1,134 @@
+import {
+  BaseExecutor,
+  type ExecutorInput,
+  type ExecutorOutput,
+} from '@workflow-engine/executors/base-executor';
+import type { ExecutableNode } from '@workflow-engine/types';
+
+export interface TrendSoundInspirationSource {
+  soundId: string;
+  soundName: string;
+  soundUrl: string | null;
+  duration: number | null;
+  usageCount: number | null;
+  authorName: string | null;
+  coverUrl: string | null;
+  growthRate: number | null;
+}
+
+export interface TrendSoundInspirationOutput {
+  soundId: string | null;
+  soundName: string | null;
+  soundUrl: string | null;
+  duration: number | null;
+  usageCount: number | null;
+  authorName: string | null;
+  coverUrl: string | null;
+  growthRate: number | null;
+}
+
+export type TrendSoundInspirationResolver = (params: {
+  organizationId: string;
+  minUsageCount: number;
+  maxDuration: number | null;
+}) => Promise<TrendSoundInspirationSource | null>;
+
+function toOptionalPositiveNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+    ? value
+    : null;
+}
+
+export class TrendSoundInspirationExecutor extends BaseExecutor {
+  readonly nodeType = 'trendSoundInspiration';
+  private resolver: TrendSoundInspirationResolver | null = null;
+
+  setResolver(resolver: TrendSoundInspirationResolver): void {
+    this.resolver = resolver;
+  }
+
+  validate(node: ExecutableNode): { valid: boolean; errors: string[] } {
+    const baseValidation = super.validate(node);
+    const errors = [...baseValidation.errors];
+
+    const minUsageCount = node.config.minUsageCount;
+    if (
+      minUsageCount !== undefined &&
+      (typeof minUsageCount !== 'number' || minUsageCount < 0)
+    ) {
+      errors.push('minUsageCount must be a non-negative number');
+    }
+
+    const maxDuration = node.config.maxDuration;
+    if (
+      maxDuration !== undefined &&
+      maxDuration !== null &&
+      (typeof maxDuration !== 'number' || maxDuration <= 0)
+    ) {
+      errors.push('maxDuration must be a positive number when provided');
+    }
+
+    return { errors, valid: errors.length === 0 };
+  }
+
+  estimateCost(_node: ExecutableNode): number {
+    return 1;
+  }
+
+  async execute(input: ExecutorInput): Promise<ExecutorOutput> {
+    const { context, node } = input;
+    const minUsageCount = this.getOptionalConfig<number>(
+      node.config,
+      'minUsageCount',
+      10000,
+    );
+    const maxDuration = toOptionalPositiveNumber(node.config.maxDuration);
+
+    const source = await this.resolver?.({
+      maxDuration,
+      minUsageCount,
+      organizationId: context.organizationId,
+    });
+
+    const data: TrendSoundInspirationOutput = source
+      ? {
+          authorName: source.authorName,
+          coverUrl: source.coverUrl,
+          duration: source.duration,
+          growthRate: source.growthRate,
+          soundId: source.soundId,
+          soundName: source.soundName,
+          soundUrl: source.soundUrl,
+          usageCount: source.usageCount,
+        }
+      : {
+          authorName: null,
+          coverUrl: null,
+          duration: null,
+          growthRate: null,
+          soundId: null,
+          soundName: null,
+          soundUrl: null,
+          usageCount: null,
+        };
+
+    return {
+      data,
+      metadata: {
+        maxDuration,
+        minUsageCount,
+        resolvedFromSource: Boolean(source),
+      },
+    };
+  }
+}
+
+export function createTrendSoundInspirationExecutor(
+  resolver?: TrendSoundInspirationResolver,
+): TrendSoundInspirationExecutor {
+  const executor = new TrendSoundInspirationExecutor();
+  if (resolver) {
+    executor.setResolver(resolver);
+  }
+  return executor;
+}

--- a/packages/workflow-engine/src/executors/saas/trend-video-inspiration-executor.ts
+++ b/packages/workflow-engine/src/executors/saas/trend-video-inspiration-executor.ts
@@ -1,0 +1,283 @@
+import {
+  BaseExecutor,
+  type ExecutorInput,
+  type ExecutorOutput,
+} from '@workflow-engine/executors/base-executor';
+import type { ExecutableNode } from '@workflow-engine/types';
+import type { TrendInspirationPlatform } from './trend-hashtag-inspiration-executor';
+
+export type TrendInspirationStyle =
+  | 'match_closely'
+  | 'inspired_by'
+  | 'remix_concept';
+
+export type TrendContentStyle =
+  | 'cinematic'
+  | 'vlog'
+  | 'tutorial'
+  | 'comedy'
+  | 'aesthetic'
+  | 'educational'
+  | 'storytelling'
+  | 'trend_dance'
+  | 'product'
+  | 'other';
+
+export type TrendAspectRatio = '16:9' | '9:16' | '1:1';
+
+export interface TrendVideoInspirationSource {
+  trendId: string;
+  title: string | null;
+  description: string | null;
+  hook: string | null;
+  hashtags: string[];
+  soundId: string | null;
+  duration: number | null;
+  videoUrl: string | null;
+  platform: TrendInspirationPlatform;
+}
+
+export interface TrendVideoInspirationOutput {
+  prompt: string;
+  hashtags: string[];
+  soundId: string | null;
+  duration: number | null;
+  aspectRatio: TrendAspectRatio;
+  style: TrendContentStyle;
+  sourceTrendTitle: string | null;
+  sourceTrendUrl: string | null;
+}
+
+export type TrendVideoInspirationResolver = (params: {
+  organizationId: string;
+  platform: TrendInspirationPlatform;
+  trendId: string | null;
+  minViralScore: number;
+}) => Promise<TrendVideoInspirationSource | null>;
+
+const VALID_PLATFORMS = new Set<TrendInspirationPlatform>([
+  'tiktok',
+  'instagram',
+  'twitter',
+  'youtube',
+  'reddit',
+]);
+
+const VALID_INSPIRATION_STYLES = new Set<TrendInspirationStyle>([
+  'match_closely',
+  'inspired_by',
+  'remix_concept',
+]);
+
+function toNonEmptyString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function buildHashtag(value: string): string | null {
+  const normalized = value.replace(/^#/, '').replace(/[^a-zA-Z0-9_]/g, '');
+  return normalized.length > 0 ? `#${normalized}` : null;
+}
+
+function uniqHashtags(values: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const value of values) {
+    const hashtag = buildHashtag(value);
+    if (!hashtag) {
+      continue;
+    }
+
+    const key = hashtag.toLowerCase();
+    if (seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+    result.push(hashtag);
+  }
+
+  return result;
+}
+
+function aspectRatioForPlatform(
+  platform: TrendInspirationPlatform,
+): TrendAspectRatio {
+  if (platform === 'youtube' || platform === 'twitter') {
+    return '16:9';
+  }
+
+  return platform === 'instagram' ? '1:1' : '9:16';
+}
+
+function styleForInspiration(
+  inspirationStyle: TrendInspirationStyle,
+): TrendContentStyle {
+  switch (inspirationStyle) {
+    case 'match_closely':
+      return 'trend_dance';
+    case 'remix_concept':
+      return 'storytelling';
+    case 'inspired_by':
+      return 'vlog';
+  }
+}
+
+function buildPrompt(input: {
+  source: TrendVideoInspirationSource | null;
+  inspirationStyle: TrendInspirationStyle;
+  includeOriginalHook: boolean;
+  platform: TrendInspirationPlatform;
+}): string {
+  const title =
+    input.source?.title ??
+    input.source?.description ??
+    `${input.platform} trend`;
+  const hookClause =
+    input.includeOriginalHook && input.source?.hook
+      ? ` Keep the original hook pattern: "${input.source.hook}".`
+      : '';
+
+  switch (input.inspirationStyle) {
+    case 'match_closely':
+      return `Create a generation prompt that closely follows the structure of "${title}" while replacing the subject, setting, and brand details.${hookClause}`;
+    case 'remix_concept':
+      return `Create a generation prompt that remixes the core idea behind "${title}" into a fresh angle with a different setting, stronger story turn, and clear visual payoff.${hookClause}`;
+    case 'inspired_by':
+      return `Create a generation prompt inspired by "${title}" with a similar pacing arc, a distinct concept, and a creator-friendly visual style.${hookClause}`;
+  }
+}
+
+export class TrendVideoInspirationExecutor extends BaseExecutor {
+  readonly nodeType = 'trendVideoInspiration';
+  private resolver: TrendVideoInspirationResolver | null = null;
+
+  setResolver(resolver: TrendVideoInspirationResolver): void {
+    this.resolver = resolver;
+  }
+
+  validate(node: ExecutableNode): { valid: boolean; errors: string[] } {
+    const baseValidation = super.validate(node);
+    const errors = [...baseValidation.errors];
+
+    const platform = node.config.platform;
+    if (
+      platform !== undefined &&
+      !VALID_PLATFORMS.has(platform as TrendInspirationPlatform)
+    ) {
+      errors.push(
+        'Invalid platform. Must be one of: tiktok, instagram, twitter, youtube, reddit',
+      );
+    }
+
+    const inspirationStyle = node.config.inspirationStyle;
+    if (
+      inspirationStyle !== undefined &&
+      !VALID_INSPIRATION_STYLES.has(inspirationStyle as TrendInspirationStyle)
+    ) {
+      errors.push(
+        'Invalid inspirationStyle. Must be: match_closely, inspired_by, or remix_concept',
+      );
+    }
+
+    const minViralScore = node.config.minViralScore;
+    if (
+      minViralScore !== undefined &&
+      (typeof minViralScore !== 'number' ||
+        minViralScore < 0 ||
+        minViralScore > 100)
+    ) {
+      errors.push('minViralScore must be between 0 and 100');
+    }
+
+    return { errors, valid: errors.length === 0 };
+  }
+
+  estimateCost(_node: ExecutableNode): number {
+    return 1;
+  }
+
+  async execute(input: ExecutorInput): Promise<ExecutorOutput> {
+    const { context, inputs, node } = input;
+    const platform = this.getOptionalConfig<TrendInspirationPlatform>(
+      node.config,
+      'platform',
+      'tiktok',
+    );
+    const inspirationStyle = this.getOptionalConfig<TrendInspirationStyle>(
+      node.config,
+      'inspirationStyle',
+      'inspired_by',
+    );
+    const includeOriginalHook = this.getOptionalConfig<boolean>(
+      node.config,
+      'includeOriginalHook',
+      false,
+    );
+    const minViralScore = this.getOptionalConfig<number>(
+      node.config,
+      'minViralScore',
+      70,
+    );
+    const trendId =
+      toNonEmptyString(inputs.get('trendId')) ??
+      toNonEmptyString(node.config.trendId);
+
+    const source =
+      (await this.resolver?.({
+        minViralScore,
+        organizationId: context.organizationId,
+        platform,
+        trendId,
+      })) ?? null;
+
+    const hashtags = uniqHashtags([
+      ...(source?.hashtags ?? []),
+      platform,
+      inspirationStyle,
+      'creator',
+    ]).slice(0, 6);
+    const style = styleForInspiration(inspirationStyle);
+
+    const data: TrendVideoInspirationOutput = {
+      aspectRatio: aspectRatioForPlatform(source?.platform ?? platform),
+      duration: source?.duration ?? 15,
+      hashtags,
+      prompt: buildPrompt({
+        includeOriginalHook,
+        inspirationStyle,
+        platform,
+        source,
+      }),
+      soundId: source?.soundId ?? null,
+      sourceTrendTitle: source?.title ?? null,
+      sourceTrendUrl: source?.videoUrl ?? null,
+      style,
+    };
+
+    return {
+      data,
+      metadata: {
+        inspirationStyle,
+        minViralScore,
+        resolvedFromSource: Boolean(source),
+        trendId: source?.trendId ?? trendId,
+      },
+    };
+  }
+}
+
+export function createTrendVideoInspirationExecutor(
+  resolver?: TrendVideoInspirationResolver,
+): TrendVideoInspirationExecutor {
+  const executor = new TrendVideoInspirationExecutor();
+  if (resolver) {
+    executor.setResolver(resolver);
+  }
+  return executor;
+}

--- a/packages/workflow-engine/src/utils/credit-calculator.ts
+++ b/packages/workflow-engine/src/utils/credit-calculator.ts
@@ -60,6 +60,9 @@ export const DEFAULT_CREDIT_COSTS: CreditCostConfig = {
   postReply: 1, // [ESTIMATED] comparable to caption
   seoRewrite: 3, // [ESTIMATED] LLM rewrite; comparable to generateArticle
   seoScore: 2, // [ESTIMATED] LLM-assisted scoring pass; lighter than a full rewrite
+  trendHashtagInspiration: 1, // [ESTIMATED] lightweight prompt synthesis from trend context
+  trendSoundInspiration: 1, // [ESTIMATED] cached trend lookup / sound selection
+  trendVideoInspiration: 1, // [ESTIMATED] lightweight prompt synthesis from trend context
   tweetRemix: 1,
 
   // ----- image generation / processing -----
@@ -268,6 +271,9 @@ const NODE_CATEGORY_MAP: Record<string, string> = {
   seoRewrite: 'ai',
   seoScore: 'ai',
   textToSpeech: 'ai',
+  trendHashtagInspiration: 'ai',
+  trendSoundInspiration: 'ai',
+  trendVideoInspiration: 'ai',
   videoGen: 'ai',
   voiceChange: 'ai',
 

--- a/packages/workflow-engine/vitest.config.ts
+++ b/packages/workflow-engine/vitest.config.ts
@@ -5,6 +5,22 @@ export default defineConfig({
   resolve: {
     alias: [
       {
+        find: /^@genfeedai\/enums$/,
+        replacement: path.resolve(__dirname, '../enums/src/index.ts'),
+      },
+      {
+        find: /^@genfeedai\/enums\/(.*)$/,
+        replacement: path.resolve(__dirname, '../enums/src/$1'),
+      },
+      {
+        find: /^@genfeedai\/interfaces$/,
+        replacement: path.resolve(__dirname, '../interfaces/src/index.ts'),
+      },
+      {
+        find: /^@genfeedai\/interfaces\/(.*)$/,
+        replacement: path.resolve(__dirname, '../interfaces/src/$1'),
+      },
+      {
         find: '@genfeedai/workflow-engine',
         replacement: path.resolve(__dirname, './src'),
       },

--- a/packages/workflow-ui/src/nodes/BaseNode.tsx
+++ b/packages/workflow-ui/src/nodes/BaseNode.tsx
@@ -35,6 +35,7 @@ import {
   Film,
   GitBranch,
   Grid3X3,
+  Hash,
   Image,
   Layers,
   LayoutGrid,
@@ -44,6 +45,7 @@ import {
   Maximize2,
   MessageSquare,
   Mic,
+  Music,
   Navigation,
   Pencil,
   Puzzle,
@@ -95,6 +97,7 @@ const ICON_MAP: Record<string, typeof Image> = {
   Film,
   GitBranch,
   Grid3X3,
+  Hash,
   Image,
   Layers,
   LayoutGrid,
@@ -102,6 +105,7 @@ const ICON_MAP: Record<string, typeof Image> = {
   Maximize2,
   MessageSquare,
   Mic,
+  Music,
   Navigation,
   Pencil,
   Puzzle,
@@ -121,6 +125,7 @@ const HANDLE_COLORS: Record<string, string> = {
   image: 'var(--handle-image)',
   number: 'var(--handle-number)',
   text: 'var(--handle-text)',
+  'text[]': 'var(--handle-text)',
   video: 'var(--handle-video)',
 };
 
@@ -140,6 +145,13 @@ function StatusIndicator({ status }: { status: NodeStatus }) {
 
 interface BaseNodeProps extends NodeProps {
   children?: ReactNode;
+  nodeDefinition?: {
+    category: string;
+    icon: string;
+    inputs: VisualHandleDefinition[];
+    label?: string;
+    outputs: VisualHandleDefinition[];
+  };
   headerActions?: ReactNode;
   title?: string;
   titleElement?: ReactNode;
@@ -147,6 +159,11 @@ interface BaseNodeProps extends NodeProps {
   hideStatusIndicator?: boolean;
   /** Input handle IDs that should appear disabled (reduced opacity) when model doesn't support them */
   disabledInputs?: string[];
+}
+
+interface VisualHandleDefinition extends Omit<HandleDefinition, 'type'> {
+  type: string;
+  optional?: boolean;
 }
 
 // Hover delay for showing preview tooltip (ms)
@@ -189,8 +206,8 @@ function BaseNodeHandles({
   sortedInputs,
 }: {
   disabledInputs?: string[];
-  outputs: HandleDefinition[];
-  sortedInputs: HandleDefinition[];
+  outputs: VisualHandleDefinition[];
+  sortedInputs: VisualHandleDefinition[];
 }) {
   return (
     <>
@@ -205,7 +222,7 @@ function BaseNodeHandles({
             isConnectableEnd={!isDisabled}
             className={clsx('!w-3 !h-3', isDisabled && 'opacity-30')}
             style={{
-              background: HANDLE_COLORS[input.type],
+              background: HANDLE_COLORS[input.type] ?? HANDLE_COLORS.text,
               top: `${((index + 1) / (sortedInputs.length + 1)) * 100}%`,
             }}
           />
@@ -396,6 +413,7 @@ function BaseNodeComponent({
   width,
   height,
   disabledInputs,
+  nodeDefinition,
 }: BaseNodeProps) {
   // Check if node has been manually resized (has explicit dimensions)
   const isResized = width !== undefined || height !== undefined;
@@ -412,7 +430,7 @@ function BaseNodeComponent({
     (state) => state.stopNodeExecution,
   );
   const updateNodeInternals = useUpdateNodeInternals();
-  const nodeDef = NODE_DEFINITIONS[type as NodeType];
+  const nodeDef = nodeDefinition ?? NODE_DEFINITIONS[type as NodeType];
   const nodeData = data as WorkflowNodeData;
 
   // Hover preview tooltip state
@@ -428,7 +446,10 @@ function BaseNodeComponent({
   const sortedInputs = useMemo(() => {
     const staticInputs = nodeDef?.inputs ?? [];
     if (!selectedModel?.inputSchema) return staticInputs;
-    return generateHandlesFromSchema(selectedModel.inputSchema, staticInputs);
+    return generateHandlesFromSchema(
+      selectedModel.inputSchema,
+      staticInputs as HandleDefinition[],
+    ) as VisualHandleDefinition[];
   }, [nodeDef?.inputs, selectedModel?.inputSchema]);
 
   const _disabledInputsKey = disabledInputs?.join(',') ?? '';
@@ -643,7 +664,6 @@ function BaseNodeComponent({
           <BaseNodeHeader
             Icon={Icon}
             headerActions={normalizedHeaderActions}
-            nodeLabel={nodeData.label}
             onLockToggle={handleLockToggle}
             onStopNode={handleStopNode}
             state={{
@@ -656,6 +676,7 @@ function BaseNodeComponent({
             status={nodeData.status}
             title={title}
             titleElement={titleElement}
+            nodeLabel={nodeData.label ?? nodeDef.label ?? String(type)}
           />
           <BaseNodeContent
             nodeData={nodeData}
@@ -707,6 +728,9 @@ function arePropsEqual(prev: BaseNodeProps, next: BaseNodeProps): boolean {
 
   // Check hideStatusIndicator
   if (prev.hideStatusIndicator !== next.hideStatusIndicator) return false;
+
+  // Check custom node definition
+  if (prev.nodeDefinition !== next.nodeDefinition) return false;
 
   // Check disabledInputs array (shallow compare)
   const prevDisabled = prev.disabledInputs ?? [];

--- a/packages/workflow-ui/src/nodes/index.ts
+++ b/packages/workflow-ui/src/nodes/index.ts
@@ -5,6 +5,7 @@ export * from './input';
 export { NodeDetailModal } from './NodeDetailModal';
 export * from './output';
 export * from './processing';
+export * from './saas';
 
 // Node type mapping for React Flow
 import type { NodeTypes } from '@xyflow/react';
@@ -45,6 +46,7 @@ import {
   VideoStitchNode,
   VideoTrimNode,
 } from './processing';
+import { workflowSaaSNodeTypes } from './saas';
 
 export const nodeTypes: NodeTypes = {
   animation: AnimationNode,
@@ -81,4 +83,5 @@ export const nodeTypes: NodeTypes = {
   workflowInput: WorkflowInputNode,
   workflowOutput: WorkflowOutputNode,
   workflowRef: WorkflowRefNode,
+  ...workflowSaaSNodeTypes,
 };

--- a/packages/workflow-ui/src/nodes/saas/SaaSNode.test.tsx
+++ b/packages/workflow-ui/src/nodes/saas/SaaSNode.test.tsx
@@ -1,0 +1,37 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import {
+  SaaSNode,
+  type WorkflowSaaSNodeType,
+  workflowSaaSNodeDefinitions,
+  workflowSaaSNodeTypes,
+} from './SaaSNode';
+
+describe('workflow SaaS node React Flow mapping', () => {
+  it('exports a React Flow component for every implemented workflow-ui SaaS node type', () => {
+    const nodeTypesToCheck = Object.keys(
+      workflowSaaSNodeDefinitions,
+    ) as WorkflowSaaSNodeType[];
+
+    for (const nodeType of nodeTypesToCheck) {
+      expect(workflowSaaSNodeTypes[nodeType]).toBe(SaaSNode);
+    }
+  });
+
+  it('covers the trend inspiration nodes implemented in the engine', () => {
+    expect(Object.keys(workflowSaaSNodeDefinitions).sort()).toEqual([
+      'trendHashtagInspiration',
+      'trendSoundInspiration',
+      'trendVideoInspiration',
+    ]);
+  });
+
+  it('spreads workflow SaaS node types into the package nodeTypes map', () => {
+    const indexSource = readFileSync('src/nodes/index.ts', 'utf8');
+
+    expect(indexSource).toContain(
+      "import { workflowSaaSNodeTypes } from './saas'",
+    );
+    expect(indexSource).toContain('...workflowSaaSNodeTypes');
+  });
+});

--- a/packages/workflow-ui/src/nodes/saas/SaaSNode.tsx
+++ b/packages/workflow-ui/src/nodes/saas/SaaSNode.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import type { NodeProps } from '@xyflow/react';
+import { memo } from 'react';
+import { BaseNode } from '../BaseNode';
+
+interface WorkflowSaaSHandleDefinition {
+  id: string;
+  label: string;
+  multiple?: boolean;
+  optional?: boolean;
+  required?: boolean;
+  type: string;
+}
+
+interface WorkflowSaaSNodeDefinition {
+  category: string;
+  icon: string;
+  inputs: WorkflowSaaSHandleDefinition[];
+  label: string;
+  outputs: WorkflowSaaSHandleDefinition[];
+}
+
+export const workflowSaaSNodeDefinitions = {
+  trendHashtagInspiration: {
+    category: 'ai',
+    icon: 'Hash',
+    inputs: [{ id: 'hashtag', label: 'Hashtag', optional: true, type: 'text' }],
+    label: 'Trend Hashtag Inspiration',
+    outputs: [
+      { id: 'prompt', label: 'Prompt', type: 'text' },
+      { id: 'hashtags', label: 'Hashtags', type: 'text[]' },
+      { id: 'contentType', label: 'Content Type', type: 'text' },
+      { id: 'platform', label: 'Best Platform', type: 'text' },
+    ],
+  },
+  trendSoundInspiration: {
+    category: 'ai',
+    icon: 'Music',
+    inputs: [],
+    label: 'Trend Sound Inspiration',
+    outputs: [
+      { id: 'soundId', label: 'Sound ID', type: 'text' },
+      { id: 'soundName', label: 'Sound Name', type: 'text' },
+      { id: 'soundUrl', label: 'Sound URL', type: 'text' },
+      { id: 'duration', label: 'Duration (s)', type: 'number' },
+      { id: 'usageCount', label: 'Usage Count', type: 'number' },
+    ],
+  },
+  trendVideoInspiration: {
+    category: 'ai',
+    icon: 'Sparkles',
+    inputs: [
+      { id: 'trendId', label: 'Trend ID', optional: true, type: 'text' },
+    ],
+    label: 'Trend Video Inspiration',
+    outputs: [
+      { id: 'prompt', label: 'Prompt', type: 'text' },
+      { id: 'hashtags', label: 'Hashtags', type: 'text[]' },
+      { id: 'soundId', label: 'Sound ID', type: 'text' },
+      { id: 'duration', label: 'Duration (s)', type: 'number' },
+      { id: 'aspectRatio', label: 'Aspect Ratio', type: 'text' },
+      { id: 'style', label: 'Style', type: 'text' },
+    ],
+  },
+} as const satisfies Record<string, WorkflowSaaSNodeDefinition>;
+
+export type WorkflowSaaSNodeType = keyof typeof workflowSaaSNodeDefinitions;
+
+function SaaSNodeComponent(props: NodeProps) {
+  const definition =
+    workflowSaaSNodeDefinitions[props.type as WorkflowSaaSNodeType];
+
+  return <BaseNode {...props} nodeDefinition={definition} />;
+}
+
+export const SaaSNode = memo(SaaSNodeComponent);
+
+export const workflowSaaSNodeTypes = Object.fromEntries(
+  Object.keys(workflowSaaSNodeDefinitions).map((nodeType) => [
+    nodeType,
+    SaaSNode,
+  ]),
+) as Record<WorkflowSaaSNodeType, typeof SaaSNode>;

--- a/packages/workflow-ui/src/nodes/saas/index.ts
+++ b/packages/workflow-ui/src/nodes/saas/index.ts
@@ -1,0 +1,6 @@
+export {
+  SaaSNode,
+  type WorkflowSaaSNodeType,
+  workflowSaaSNodeDefinitions,
+  workflowSaaSNodeTypes,
+} from './SaaSNode';


### PR DESCRIPTION
## Summary
- Wire the trend inspiration SaaS nodes end-to-end: `trendHashtagInspiration`, `trendSoundInspiration`, and `trendVideoInspiration`.
- Add workflow-engine executors, registry entries, credit cost coverage, package workflow-ui React Flow nodes, and API runtime resolver registration.
- Add focused static/runtime guards so the implemented subset is no longer orphaned.

Refs #481.

## Remaining #481 gaps
Current static executor/credit gaps after this PR:
- `analyticsFeedback`
- `followUser`
- `hookPerformanceTracker`
- `imageTextOverlay`
- `likePost`
- `personaContentPlan`
- `personaPhotoSession`
- `personaVideoContent`
- `slideshowImageBatch`

## Verification
- `bunx @biomejs/biome check --write <touched workflow files>`
- `git diff --check`
- `bun run --cwd packages/workflow-ui test src/nodes/saas/SaaSNode.test.tsx`
- `cd packages/workflow-engine && bun ../../node_modules/.bun/node_modules/vitest/vitest.mjs run --config vitest.config.ts src/executors/saas/trend-inspiration-executors.spec.ts src/executors/executor-registry.spec.ts src/utils/credit-calculator-coverage.spec.ts`

Broad local suites intentionally not run per repo guidance; PR CI should cover the heavier gates.
