### PR TITLE
fix(ui): reduce React Doctor warnings

### DIFF
--- a/packages/ui/src/components/analytics/cards/growth-trends/growth-trends-card.tsx
+++ b/packages/ui/src/components/analytics/cards/growth-trends/growth-trends-card.tsx
@@ -13,6 +13,41 @@ import {
   HiMinus,
 } from 'react-icons/hi2';
 
+function getTrendIcon(direction: TrendDirection) {
+  switch (direction) {
+    case TrendDirection.UP:
+      return <HiArrowTrendingUp className="size-4 text-green-500" />;
+    case TrendDirection.DOWN:
+      return <HiArrowTrendingDown className="size-4 text-red-500" />;
+    default:
+      return <HiMinus className="size-4 text-muted-foreground" />;
+  }
+}
+
+function getTrendColor(direction: TrendDirection): string {
+  switch (direction) {
+    case TrendDirection.UP:
+      return 'text-green-600 dark:text-green-400';
+    case TrendDirection.DOWN:
+      return 'text-red-600 dark:text-red-400';
+    default:
+      return 'text-muted-foreground';
+  }
+}
+
+function getTimeframeLabel(timeframe: Timeframe): string {
+  switch (timeframe) {
+    case Timeframe.D7:
+      return 'Last 7 days';
+    case Timeframe.D30:
+      return 'Last 30 days';
+    case Timeframe.D90:
+      return 'Last 90 days';
+    default:
+      return 'Period';
+  }
+}
+
 export function GrowthTrendsCard({
   growthData,
   timeframe = Timeframe.D30,
@@ -47,41 +82,6 @@ export function GrowthTrendsCard({
       </div>
     );
   }
-
-  const getTrendIcon = (direction: TrendDirection) => {
-    switch (direction) {
-      case TrendDirection.UP:
-        return <HiArrowTrendingUp className="size-4 text-green-500" />;
-      case TrendDirection.DOWN:
-        return <HiArrowTrendingDown className="size-4 text-red-500" />;
-      default:
-        return <HiMinus className="size-4 text-muted-foreground" />;
-    }
-  };
-
-  const getTrendColor = (direction: TrendDirection) => {
-    switch (direction) {
-      case TrendDirection.UP:
-        return 'text-green-600 dark:text-green-400';
-      case TrendDirection.DOWN:
-        return 'text-red-600 dark:text-red-400';
-      default:
-        return 'text-muted-foreground';
-    }
-  };
-
-  const getTimeframeLabel = () => {
-    switch (timeframe) {
-      case Timeframe.D7:
-        return 'Last 7 days';
-      case Timeframe.D30:
-        return 'Last 30 days';
-      case Timeframe.D90:
-        return 'Last 90 days';
-      default:
-        return 'Period';
-    }
-  };
 
   return (
     <div className={cardClassName}>
@@ -215,7 +215,8 @@ export function GrowthTrendsCard({
       </div>
 
       <p className="text-xs text-muted-foreground mt-4">
-        Comparing {getTimeframeLabel().toLowerCase()} vs previous period
+        Comparing {getTimeframeLabel(timeframe).toLowerCase()} vs previous
+        period
       </p>
     </div>
   );

--- a/packages/ui/src/components/analytics/cards/preview/quick-analytics-preview.tsx
+++ b/packages/ui/src/components/analytics/cards/preview/quick-analytics-preview.tsx
@@ -22,12 +22,32 @@ const Area = dynamic(() => import('recharts').then((m) => m.Area), {
   ssr: false,
 });
 
+const TREND_DATA = [
+  { value: 72 },
+  { value: 85 },
+  { value: 63 },
+  { value: 91 },
+  { value: 78 },
+  { value: 54 },
+  { value: 88 },
+];
+
 export interface QuickAnalyticsPreviewProps {
   data: IAnalytics | null;
   isLoading?: boolean;
   moreLink?: string;
   className?: string;
   title?: string;
+}
+
+function getTrendColor(growth: number): string {
+  if (growth > 0) {
+    return 'text-green-600 dark:text-green-400';
+  }
+  if (growth < 0) {
+    return 'text-red-600 dark:text-red-400';
+  }
+  return 'text-muted-foreground';
 }
 
 export function QuickAnalyticsPreview({
@@ -78,27 +98,6 @@ export function QuickAnalyticsPreview({
       </div>
     );
   }
-
-  const getTrendColor = (growth: number) => {
-    if (growth > 0) {
-      return 'text-green-600 dark:text-green-400';
-    }
-    if (growth < 0) {
-      return 'text-red-600 dark:text-red-400';
-    }
-    return 'text-muted-foreground';
-  };
-
-  // Generate simple trend data for mini chart
-  const trendData = [
-    { value: 72 },
-    { value: 85 },
-    { value: 63 },
-    { value: 91 },
-    { value: 78 },
-    { value: 54 },
-    { value: 88 },
-  ];
 
   const quickStats = [
     {
@@ -174,7 +173,7 @@ export function QuickAnalyticsPreview({
           className="border-0 bg-transparent p-0 shadow-none"
           height={80}
         >
-          <AreaChart data={trendData}>
+          <AreaChart data={TREND_DATA}>
             <defs>
               <linearGradient id="colorPreview" x1="0" y1="0" x2="0" y2="1">
                 <stop

--- a/packages/ui/src/components/analytics/charts/brand-performance/brand-performance-chart.tsx
+++ b/packages/ui/src/components/analytics/charts/brand-performance/brand-performance-chart.tsx
@@ -44,6 +44,12 @@ const METRIC_LABELS = {
   views: 'Views',
 };
 
+type BrandMetricKey = keyof typeof METRIC_COLORS;
+
+function formatBrandName(name: string): string {
+  return name.length > 15 ? `${name.substring(0, 15)}…` : name;
+}
+
 export function BrandPerformanceChart({
   data,
   title = 'Top Brands Performance',
@@ -52,7 +58,6 @@ export function BrandPerformanceChart({
   height = 300,
   className = '',
 }: BrandPerformanceChartProps) {
-  type BrandMetricKey = keyof typeof METRIC_COLORS;
   const [activeMetric, setActiveMetric] = useState<BrandMetricKey>(
     String(metric).toLowerCase() as BrandMetricKey,
   );
@@ -76,11 +81,6 @@ export function BrandPerformanceChart({
   const sortedData = data
     .toSorted((a, b) => b[activeMetric] - a[activeMetric])
     .slice(0, 10);
-
-  // Truncate long brand names
-  const formatBrandName = (name: string) => {
-    return name.length > 15 ? `${name.substring(0, 15)}…` : name;
-  };
 
   return (
     <Card className={className}>

--- a/packages/ui/src/components/analytics/charts/platform-breakdown/platform-breakdown-chart.tsx
+++ b/packages/ui/src/components/analytics/charts/platform-breakdown/platform-breakdown-chart.tsx
@@ -49,6 +49,23 @@ type PlatformBreakdownLabelEntry = {
   value: number;
 };
 
+function getColor(platform: string): string {
+  return (
+    PLATFORM_COLORS[platform.toLowerCase()] || 'hsl(var(--muted-foreground))'
+  );
+}
+
+function getLabel(platform: string): string {
+  return PLATFORM_LABELS[platform.toLowerCase()] || platform;
+}
+
+function renderLabel(entry: PieLabelRenderProps): string {
+  const { payload, value } = entry as PlatformBreakdownLabelEntry;
+  const total = payload?.total ?? 0;
+  const percentage = total > 0 ? ((value / total) * 100).toFixed(1) : '0.0';
+  return `${percentage}%`;
+}
+
 export function PlatformBreakdownChart({
   data,
   title = 'Platform Distribution',
@@ -61,24 +78,6 @@ export function PlatformBreakdownChart({
 
   // Filter out platforms with zero values
   const filteredData = chartData.filter((item) => item.value > 0);
-
-  const getColor = (platform: string) => {
-    return (
-      PLATFORM_COLORS[platform.toLowerCase()] || 'hsl(var(--muted-foreground))'
-    );
-  };
-
-  const getLabel = (platform: string) => {
-    return PLATFORM_LABELS[platform.toLowerCase()] || platform;
-  };
-
-  // Custom label renderer with percentage
-  const renderLabel = (entry: PieLabelRenderProps) => {
-    const { payload, value } = entry as PlatformBreakdownLabelEntry;
-    const total = payload?.total ?? 0;
-    const percentage = total > 0 ? ((value / total) * 100).toFixed(1) : '0.0';
-    return `${percentage}%`;
-  };
 
   // Add total to each data point for percentage calculation
   const total = filteredData.reduce((sum, item) => sum + item.value, 0);

--- a/packages/ui/src/components/analytics/charts/platform-comparison/platform-comparison-chart.tsx
+++ b/packages/ui/src/components/analytics/charts/platform-comparison/platform-comparison-chart.tsx
@@ -48,6 +48,10 @@ const METRIC_COLORS = {
   views: 'hsl(var(--foreground))',
 };
 
+function getPlatformLabel(platform: string): string {
+  return PLATFORM_LABELS[platform.toLowerCase()] || platform;
+}
+
 export function PlatformComparisonChart({
   data,
   isLoading = false,
@@ -85,10 +89,6 @@ export function PlatformComparisonChart({
         ? previousMetrics.filter((m) => m !== metric)
         : previousMetrics;
     });
-  };
-
-  const getPlatformLabel = (platform: string) => {
-    return PLATFORM_LABELS[platform.toLowerCase()] || platform;
   };
 
   return (

--- a/packages/ui/src/components/analytics/charts/time-series/time-series-chart.tsx
+++ b/packages/ui/src/components/analytics/charts/time-series/time-series-chart.tsx
@@ -50,6 +50,15 @@ const METRIC_LABELS = {
   views: 'Views',
 };
 
+type TimeSeriesMetric = keyof typeof METRIC_COLORS;
+
+function formatValue(value: number, metric: TimeSeriesMetric): string {
+  if (metric === 'engagementRate') {
+    return formatPercentageSimple(value, 2);
+  }
+  return formatCompactNumberIntl(value);
+}
+
 export function TimeSeriesChart({
   data,
   metrics = [
@@ -61,7 +70,6 @@ export function TimeSeriesChart({
   height = 350,
   className = '',
 }: TimeSeriesChartProps) {
-  type TimeSeriesMetric = keyof typeof METRIC_COLORS;
   const normalizedMetrics = metrics.map(
     (metric) => String(metric) as TimeSeriesMetric,
   );
@@ -121,13 +129,6 @@ export function TimeSeriesChart({
         ? previousMetrics.filter((m) => m !== metric)
         : previousMetrics;
     });
-  };
-
-  const formatValue = (value: number, metric: TimeSeriesMetric) => {
-    if (metric === 'engagementRate') {
-      return formatPercentageSimple(value, 2);
-    }
-    return formatCompactNumberIntl(value);
   };
 
   return (

--- a/packages/ui/src/components/analytics/charts/video-completion-funnel/video-completion-funnel.tsx
+++ b/packages/ui/src/components/analytics/charts/video-completion-funnel/video-completion-funnel.tsx
@@ -20,6 +20,19 @@ export interface VideoCompletionFunnelProps {
   className?: string;
 }
 
+function getBarColor(percentage: number): string {
+  if (percentage >= 75) {
+    return 'bg-success';
+  }
+  if (percentage >= 50) {
+    return 'bg-warning';
+  }
+  if (percentage >= 25) {
+    return 'bg-error';
+  }
+  return 'bg-muted';
+}
+
 export function VideoCompletionFunnel({
   data,
   isLoading = false,
@@ -73,19 +86,6 @@ export function VideoCompletionFunnel({
       to: '100%',
     },
   ];
-
-  const getBarColor = (percentage: number) => {
-    if (percentage >= 75) {
-      return 'bg-success';
-    }
-    if (percentage >= 50) {
-      return 'bg-warning';
-    }
-    if (percentage >= 25) {
-      return 'bg-error';
-    }
-    return 'bg-muted';
-  };
 
   const isEmpty = data.started === 0;
 

--- a/packages/ui/src/components/analytics/trends/trending-sounds.tsx
+++ b/packages/ui/src/components/analytics/trends/trending-sounds.tsx
@@ -14,6 +14,15 @@ import {
   HiOutlinePlay,
 } from 'react-icons/hi2';
 
+function formatDuration(seconds?: number): string {
+  if (!seconds) {
+    return '';
+  }
+  const mins = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return `${mins}:${secs.toString().padStart(2, '0')}`;
+}
+
 export function TrendingSounds({
   sounds,
   isLoading = false,
@@ -50,15 +59,6 @@ export function TrendingSounds({
   }
 
   const sortedSounds = sounds.toSorted((a, b) => b.usageCount - a.usageCount);
-
-  const formatDuration = (seconds?: number) => {
-    if (!seconds) {
-      return '';
-    }
-    const mins = Math.floor(seconds / 60);
-    const secs = seconds % 60;
-    return `${mins}:${secs.toString().padStart(2, '0')}`;
-  };
 
   return (
     <div className={`space-y-4 ${className}`}>

--- a/packages/ui/src/components/display/badge/Badge.tsx
+++ b/packages/ui/src/components/display/badge/Badge.tsx
@@ -38,6 +38,15 @@ const PRIMITIVE_VARIANT_MAP = {
   warning: 'warning',
 } as const;
 
+const BADGE_SIZE_MAP: Record<
+  string,
+  VariantProps<typeof badgeVariants>['size']
+> = {
+  [ComponentSize.LG]: 'lg',
+  [ComponentSize.MD]: 'default',
+  [ComponentSize.SM]: 'sm',
+};
+
 /**
  * Get complete badge configuration from status string
  * Returns variant, icon, label, and animation state
@@ -172,16 +181,9 @@ export default function Badge({
   const effectiveIcon = statusConfig?.icon ?? icon;
   const effectiveLabel = statusConfig?.label ?? children;
 
-  // Map size prop to CVA size
-  const sizeMap: Record<string, VariantProps<typeof badgeVariants>['size']> = {
-    [ComponentSize.LG]: 'lg',
-    [ComponentSize.MD]: 'default',
-    [ComponentSize.SM]: 'sm',
-  };
-
   const badgeClasses = cn(
     badgeVariants({
-      size: sizeMap[size] ?? 'default',
+      size: BADGE_SIZE_MAP[size] ?? 'default',
       variant: effectiveVariant as VariantProps<
         typeof badgeVariants
       >['variant'],

--- a/packages/ui/src/components/display/masonry/Masonry.tsx
+++ b/packages/ui/src/components/display/masonry/Masonry.tsx
@@ -1,14 +1,8 @@
 'use client';
 
 import type { MasonryProps } from '@genfeedai/props/content/masonry.props';
-import {
-  Children,
-  isValidElement,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import { Children, isValidElement, useEffect, useMemo, useRef } from 'react';
+import { useMounted } from '../../../lib/hooks';
 
 const BREAKPOINTS = [
   { key: 'xl' as const, width: 1280 },
@@ -24,16 +18,12 @@ export default function Masonry({
   className = '',
 }: MasonryProps): React.ReactElement {
   const containerRef = useRef<HTMLDivElement>(null);
-  const [mounted, setMounted] = useState(false);
+  const mounted = useMounted();
 
   const childArray = useMemo(
     () => Children.toArray(children).filter(Boolean),
     [children],
   );
-
-  useEffect(() => {
-    setMounted(true);
-  }, []);
 
   useEffect(() => {
     if (!mounted || !containerRef.current) {

--- a/packages/ui/src/components/display/skeleton/skeleton.tsx
+++ b/packages/ui/src/components/display/skeleton/skeleton.tsx
@@ -18,6 +18,16 @@ const VARIANT_CLASSES: Record<SkeletonVariant, string> = {
   text: 'rounded',
 };
 
+const MASONRY_SKELETON_HEIGHTS = [
+  'h-48',
+  'h-60',
+  'h-72',
+  'h-56',
+  'h-64',
+  'h-80',
+  'h-52',
+];
+
 function formatDimension(
   value: number | string | undefined,
 ): string | undefined {
@@ -209,8 +219,6 @@ export function SkeletonMasonryGrid({
   count = 12,
   className,
 }: SkeletonMasonryProps) {
-  const heights = ['h-48', 'h-60', 'h-72', 'h-56', 'h-64', 'h-80', 'h-52'];
-
   return (
     <div
       className={cn(
@@ -219,7 +227,8 @@ export function SkeletonMasonryGrid({
       )}
     >
       {Array.from({ length: count }).map((_, index) => {
-        const height = heights[index % heights.length];
+        const height =
+          MASONRY_SKELETON_HEIGHTS[index % MASONRY_SKELETON_HEIGHTS.length];
         const masonryKey = `masonry-skeleton-${index}`;
 
         return (

--- a/packages/ui/src/components/ingredients/detail-image/IngredientDetailImage.tsx
+++ b/packages/ui/src/components/ingredients/detail-image/IngredientDetailImage.tsx
@@ -37,6 +37,33 @@ type ImageDetailTab =
   | 'sharing'
   | 'evaluation';
 
+const IMAGE_DETAIL_TABS: TabItem[] = [
+  {
+    id: 'info',
+    label: 'info',
+  },
+  {
+    id: 'evaluation',
+    label: 'quality',
+  },
+  {
+    id: 'sharing',
+    label: 'sharing',
+  },
+  {
+    id: 'posts',
+    label: 'posts',
+  },
+  {
+    id: 'metadata',
+    label: 'metadata',
+  },
+  {
+    id: 'prompts',
+    label: 'prompts',
+  },
+];
+
 export default function IngredientDetailImage({
   image,
   // childIngredients,
@@ -127,33 +154,6 @@ export default function IngredientDetailImage({
   const imageHeight = metadata?.height || 1920;
   const isPortrait = imageHeight > imageWidth;
 
-  const tabs: TabItem[] = [
-    {
-      id: 'info',
-      label: 'info',
-    },
-    {
-      id: 'evaluation',
-      label: 'quality',
-    },
-    {
-      id: 'sharing',
-      label: 'sharing',
-    },
-    {
-      id: 'posts',
-      label: 'posts',
-    },
-    {
-      id: 'metadata',
-      label: 'metadata',
-    },
-    {
-      id: 'prompts',
-      label: 'prompts',
-    },
-  ];
-
   return (
     <>
       <div className="space-y-4">
@@ -222,7 +222,7 @@ export default function IngredientDetailImage({
       <div className="col-span-2 space-y-4">
         <IngredientWorkspacePanel
           title="Refine image details"
-          tabs={tabs}
+          tabs={IMAGE_DETAIL_TABS}
           activeTab={tab}
           onTabChange={(nextTab) => setTab(nextTab as ImageDetailTab)}
         >

--- a/packages/ui/src/components/ingredients/tabs/metadata/IngredientTabsMetadata.tsx
+++ b/packages/ui/src/components/ingredients/tabs/metadata/IngredientTabsMetadata.tsx
@@ -13,6 +13,16 @@ import { Button } from '@ui/primitives/button';
 import { useState } from 'react';
 import { HiArrowPath } from 'react-icons/hi2';
 
+function formatValue(
+  value: number,
+  formatter: (val: number) => string,
+): string {
+  if (value === 0) {
+    return '-';
+  }
+  return formatter(value);
+}
+
 export default function IngredientTabsMetadata({
   ingredient,
   onRefresh,
@@ -73,17 +83,6 @@ export default function IngredientTabsMetadata({
     hasZeroOrUnknownHeight ||
     hasZeroOrUnknownDuration ||
     hasZeroOrUnknownSize;
-
-  // Helper function to format value or show '-'
-  const formatValue = (
-    value: number,
-    formatter: (val: number) => string,
-  ): string => {
-    if (value === 0) {
-      return '-';
-    }
-    return formatter(value);
-  };
 
   const metadataRows = [
     // Dimensions: always show, use '-' for zero/unknown, otherwise use getters

--- a/packages/ui/src/components/masonry/grid/MasonryGrid.tsx
+++ b/packages/ui/src/components/masonry/grid/MasonryGrid.tsx
@@ -15,7 +15,14 @@ import {
   LazyMasonryImage,
   LazyMasonryVideo,
 } from '@ui/lazy/masonry/LazyMasonry';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from 'react';
 
 function getColumnsConfig(format?: IngredientFormat): {
   mobile: number;
@@ -37,6 +44,19 @@ function getMediaType(ingredient: IIngredient): MediaType {
 
 const INITIAL_BATCH_SIZE = 24;
 const BATCH_SIZE = 24;
+
+function getViewportWidthSnapshot(): number {
+  return typeof window === 'undefined' ? 0 : window.innerWidth;
+}
+
+function subscribeViewportWidth(onStoreChange: () => void): () => void {
+  if (typeof window === 'undefined') {
+    return () => {};
+  }
+
+  window.addEventListener('resize', onStoreChange);
+  return () => window.removeEventListener('resize', onStoreChange);
+}
 
 export default function MasonryGrid({
   ingredients,
@@ -74,7 +94,11 @@ export default function MasonryGrid({
   onRefresh,
 }: IngredientListProps): React.ReactElement {
   const [visibleCount, setVisibleCount] = useState(INITIAL_BATCH_SIZE);
-  const [viewportWidth, setViewportWidth] = useState(0);
+  const viewportWidth = useSyncExternalStore(
+    subscribeViewportWidth,
+    getViewportWidthSnapshot,
+    () => 0,
+  );
   const loadMoreRef = useRef<HTMLDivElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
 
@@ -98,20 +122,6 @@ export default function MasonryGrid({
     columnsConfig.tablet,
     viewportWidth,
   ]);
-
-  useEffect(() => {
-    if (typeof window === 'undefined') {
-      return;
-    }
-
-    const handleResize = () => {
-      setViewportWidth(window.innerWidth);
-    };
-
-    handleResize();
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, []);
 
   const validIngredients = useMemo(
     () =>

--- a/packages/ui/src/components/modals/brands/instagram/ModalBrandInstagram.tsx
+++ b/packages/ui/src/components/modals/brands/instagram/ModalBrandInstagram.tsx
@@ -20,6 +20,10 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { FaInstagram } from 'react-icons/fa6';
 import { HiCheckCircle } from 'react-icons/hi2';
 
+function closeAccountInstagramModal(): void {
+  closeModal(ModalEnum.BRAND_INSTAGRAM);
+}
+
 export default function ModalBrandInstagram({
   brand,
   credential,
@@ -153,10 +157,6 @@ export default function ModalBrandInstagram({
       setError('Failed to connect Instagram account');
       setIsConnecting(false);
     }
-  };
-
-  const closeAccountInstagramModal = () => {
-    closeModal(ModalEnum.BRAND_INSTAGRAM);
   };
 
   return (

--- a/packages/ui/src/components/modals/gallery/ModalGallery.tsx
+++ b/packages/ui/src/components/modals/gallery/ModalGallery.tsx
@@ -17,6 +17,29 @@ import Modal from '@ui/modals/modal/Modal';
 
 const EMPTY_ARRAY: never[] = [];
 
+function getImageFormat(image: IImage): IngredientFormat | null {
+  if (!image.width || !image.height) {
+    return null;
+  }
+  const aspectRatio = image.width / image.height;
+
+  if (Math.abs(aspectRatio - 16 / 9) < 0.1) {
+    return IngredientFormat.LANDSCAPE;
+  }
+
+  if (Math.abs(aspectRatio - 9 / 16) < 0.1) {
+    return IngredientFormat.PORTRAIT;
+  }
+
+  if (Math.abs(aspectRatio - 1) < 0.1) {
+    return IngredientFormat.SQUARE;
+  }
+
+  return aspectRatio > 1
+    ? IngredientFormat.LANDSCAPE
+    : IngredientFormat.PORTRAIT;
+}
+
 export default function ModalGallery({
   isOpen,
   onClose,
@@ -86,30 +109,6 @@ export default function ModalGallery({
       default:
         return '9:16';
     }
-  };
-
-  // Get format from image dimensions
-  const getImageFormat = (image: IImage): IngredientFormat | null => {
-    if (!image.width || !image.height) {
-      return null;
-    }
-    const aspectRatio = image.width / image.height;
-
-    if (Math.abs(aspectRatio - 16 / 9) < 0.1) {
-      return IngredientFormat.LANDSCAPE;
-    }
-
-    if (Math.abs(aspectRatio - 9 / 16) < 0.1) {
-      return IngredientFormat.PORTRAIT;
-    }
-
-    if (Math.abs(aspectRatio - 1) < 0.1) {
-      return IngredientFormat.SQUARE;
-    }
-
-    return aspectRatio > 1
-      ? IngredientFormat.LANDSCAPE
-      : IngredientFormat.PORTRAIT;
   };
 
   const handleReferenceSelect = (selectedIds: string[]) => {

--- a/packages/ui/src/components/modals/onboarding/OnboardingTrigger.tsx
+++ b/packages/ui/src/components/modals/onboarding/OnboardingTrigger.tsx
@@ -20,6 +20,10 @@ import { useEffect, useRef } from 'react';
  */
 const ONBOARDING_DISMISSED_KEY = 'genfeed:onboarding-dismissed';
 
+function markDismissed(): void {
+  localStorage.setItem(ONBOARDING_DISMISSED_KEY, 'true');
+}
+
 export default function OnboardingTrigger() {
   const { isFirstLogin, isLoading, checkOnboardingStatus } = useOnboarding();
   const hasTriggeredRef = useRef(false);
@@ -41,10 +45,6 @@ export default function OnboardingTrigger() {
       return () => clearTimeout(timer);
     }
   }, [isLoading, isFirstLogin]);
-
-  const markDismissed = () => {
-    localStorage.setItem(ONBOARDING_DISMISSED_KEY, 'true');
-  };
 
   const handleComplete = () => {
     markDismissed();

--- a/packages/ui/src/components/modals/system/error-debug/ModalErrorDebug.tsx
+++ b/packages/ui/src/components/modals/system/error-debug/ModalErrorDebug.tsx
@@ -30,6 +30,10 @@ interface ErrorSectionProps {
   onToggle?: () => void;
 }
 
+function handleCancel(): void {
+  closeModal(ModalEnum.ERROR_DEBUG);
+}
+
 function ErrorSection({
   children,
   title,
@@ -83,11 +87,6 @@ export default function ModalErrorDebug() {
     }
     return subscribe((info) => setErrorInfo(info));
   }, []);
-
-  // Called when Close button is clicked - initiates the close
-  const handleCancel = () => {
-    closeModal(ModalEnum.ERROR_DEBUG);
-  };
 
   // Called by Modal's onClose after modal is closed - cleanup state
   const handleModalClosed = () => {

--- a/packages/ui/src/components/navigation/pagination/Pagination.tsx
+++ b/packages/ui/src/components/navigation/pagination/Pagination.tsx
@@ -9,6 +9,10 @@ import {
   Pagination as PaginationPrimitive,
 } from '@ui/primitives/pagination';
 
+function createPageHref(page: number): string {
+  return `?page=${page}`;
+}
+
 export default function Pagination({
   currentPage = 1,
   totalPages = 1,
@@ -19,7 +23,6 @@ export default function Pagination({
   }
 
   const clampedPage = Math.min(Math.max(currentPage, 1), totalPages);
-  const createPageHref = (page: number) => `?page=${page}`;
 
   const getVisiblePages = () => {
     if (totalPages <= 7) {

--- a/packages/ui/src/components/pages/offline/OfflinePage.tsx
+++ b/packages/ui/src/components/pages/offline/OfflinePage.tsx
@@ -8,12 +8,12 @@ import { PWA_APPS } from '@ui-constants/pwa/pwa-apps.constant';
 /**
  * Offline fallback page displayed when user is disconnected from the internet
  */
+function handleRetry(): void {
+  window.location.reload();
+}
+
 export function OfflinePage({ appName }: OfflinePageProps) {
   const config = PWA_APPS[appName];
-
-  const handleRetry = (): void => {
-    window.location.reload();
-  };
 
   return (
     <div className="flex min-h-screen flex-col items-center justify-center bg-card p-4 text-center">

--- a/packages/ui/src/components/quick-actions/container/QuickActionsContainer.tsx
+++ b/packages/ui/src/components/quick-actions/container/QuickActionsContainer.tsx
@@ -1,22 +1,22 @@
 import type { QuickActionsContainerProps } from '@genfeedai/props/content/quick-actions.props';
 import { memo } from 'react';
 
+const POSITION_CLASSES = {
+  'bottom-left': 'bottom-2 left-2',
+  'bottom-right': 'bottom-2 right-2',
+  'top-left': 'top-2 left-2',
+  'top-right': 'top-2 right-2',
+};
+
 const QuickActionsContainer = memo(
   ({
     children,
     position = 'bottom-right',
     className = '',
   }: QuickActionsContainerProps) => {
-    const positionClasses = {
-      'bottom-left': 'bottom-2 left-2',
-      'bottom-right': 'bottom-2 right-2',
-      'top-left': 'top-2 left-2',
-      'top-right': 'top-2 right-2',
-    };
-
     return (
       <div
-        className={`absolute z-50 ${positionClasses[position]} ${className}`}
+        className={`absolute z-50 ${POSITION_CLASSES[position]} ${className}`}
       >
         {children}
       </div>

--- a/packages/ui/src/components/quick-actions/submenu/QuickActionsSubmenu.tsx
+++ b/packages/ui/src/components/quick-actions/submenu/QuickActionsSubmenu.tsx
@@ -26,6 +26,12 @@ interface SubmenuPortalProps {
   onActionClick: (action: IQuickAction) => void;
 }
 
+const QUICK_ACTION_SIZE_CLASSES = {
+  [ComponentSize.LG]: ButtonSize.LG,
+  [ComponentSize.MD]: ButtonSize.DEFAULT,
+  [ComponentSize.SM]: ButtonSize.SM,
+} as const;
+
 function SubmenuPortal({
   menuRef,
   menuPosition,
@@ -151,12 +157,6 @@ export default function QuickActionsSubmenu({
     };
   }, [isOpen]);
 
-  const sizeClasses = {
-    [ComponentSize.LG]: ButtonSize.LG,
-    [ComponentSize.MD]: ButtonSize.DEFAULT,
-    [ComponentSize.SM]: ButtonSize.SM,
-  } as const;
-
   if (actions.length === 0) {
     return null;
   }
@@ -175,7 +175,7 @@ export default function QuickActionsSubmenu({
             withWrapper={false}
             variant={ButtonVariant.UNSTYLED}
             onClick={() => setIsOpen(!isOpen)}
-            size={sizeClasses[size]}
+            size={QUICK_ACTION_SIZE_CLASSES[size]}
             className={cn(
               'rounded-full transition-all duration-300',
               BG_BLUR,

--- a/packages/ui/src/components/subscription/SubscriptionPlanChanger.tsx
+++ b/packages/ui/src/components/subscription/SubscriptionPlanChanger.tsx
@@ -19,6 +19,10 @@ function getCurrencyFormatter(currency: string): Intl.NumberFormat {
   return formatter;
 }
 
+function formatAmount(amount: number, currency: string = 'usd'): string {
+  return getCurrencyFormatter(currency.toUpperCase()).format(amount / 100);
+}
+
 export default function SubscriptionPlanChanger({
   subscription,
   onPreviewChange,
@@ -73,10 +77,6 @@ export default function SubscriptionPlanChanger({
       logger.error('Failed to change subscription plan:', error);
       setIsLoading(false);
     }
-  };
-
-  const formatAmount = (amount: number, currency: string = 'usd') => {
-    return getCurrencyFormatter(currency.toUpperCase()).format(amount / 100);
   };
 
   return (

--- a/packages/ui/src/components/tags/badge/TagBadge.tsx
+++ b/packages/ui/src/components/tags/badge/TagBadge.tsx
@@ -7,6 +7,12 @@ import { Button } from '@ui/primitives/button';
 import type { MouseEvent } from 'react';
 import { HiXMark } from 'react-icons/hi2';
 
+const SIZE_CLASSES = {
+  [ComponentSize.LG]: 'px-4 py-1.5 text-base',
+  [ComponentSize.MD]: 'px-3 py-1 text-sm',
+  [ComponentSize.SM]: 'px-2 py-0.5 text-xs',
+};
+
 export default function TagBadge({
   tag,
   onRemove,
@@ -14,12 +20,6 @@ export default function TagBadge({
   size = ComponentSize.SM,
   isRemovable = false,
 }: TagBadgeProps) {
-  const sizeClasses = {
-    [ComponentSize.LG]: 'px-4 py-1.5 text-base',
-    [ComponentSize.MD]: 'px-3 py-1 text-sm',
-    [ComponentSize.SM]: 'px-2 py-0.5 text-xs',
-  };
-
   const handleRemove = (e: MouseEvent) => {
     e.stopPropagation();
     if (onRemove && tag.id) {
@@ -31,7 +31,7 @@ export default function TagBadge({
     <span
       className={cn(
         'inline-flex items-center gap-2 rounded-full font-medium transition-all cursor-pointer',
-        sizeClasses[size],
+        SIZE_CLASSES[size],
         isRemovable && 'pr-1',
         className,
       )}

--- a/packages/ui/src/components/topbars/activities/BackgroundTaskRow.tsx
+++ b/packages/ui/src/components/topbars/activities/BackgroundTaskRow.tsx
@@ -13,6 +13,12 @@ type BackgroundTaskStatus = 'processing' | 'completed' | 'failed';
 
 type Preview = { url: string; category: IngredientCategory };
 
+const STATUS_BADGE_CONFIG = {
+  completed: { label: 'Ready', variant: 'success' as const },
+  failed: { label: 'Failed', variant: 'error' as const },
+  processing: { label: 'Processing', variant: 'primary' as const },
+};
+
 type Props = {
   activity: IActivity;
   loadingTaskId: string | null;
@@ -56,13 +62,7 @@ export default function BackgroundTaskRow({
     }
   })();
 
-  const statusBadgeConfig = {
-    completed: { label: 'Ready', variant: 'success' as const },
-    failed: { label: 'Failed', variant: 'error' as const },
-    processing: { label: 'Processing', variant: 'primary' as const },
-  };
-
-  const badgeConfig = statusBadgeConfig[status];
+  const badgeConfig = STATUS_BADGE_CONFIG[status];
   const statusBadge = (
     <Badge variant={badgeConfig.variant} size={ComponentSize.SM}>
       {badgeConfig.label}

--- a/packages/ui/src/components/topbars/public/TopbarPublic.tsx
+++ b/packages/ui/src/components/topbars/public/TopbarPublic.tsx
@@ -7,8 +7,15 @@ import TopbarLogo from '@ui/topbars/logo/TopbarLogo';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import type { ComponentType, ReactNode, SVGProps } from 'react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from 'react';
 import { HiBars3, HiChevronDown, HiXMark } from 'react-icons/hi2';
+import { useMounted } from '../../../lib/hooks';
 import TopbarPublicDesktopDropdown from './TopbarPublicDesktopDropdown';
 import TopbarPublicMobileMenu from './TopbarPublicMobileMenu';
 
@@ -55,6 +62,19 @@ function isLinkActive(pathname: string | null, href: string): boolean {
   return pathname.startsWith(href);
 }
 
+function getScrolledSnapshot(): boolean {
+  return typeof window !== 'undefined' && window.scrollY > 20;
+}
+
+function subscribeScroll(onStoreChange: () => void): () => void {
+  if (typeof window === 'undefined') {
+    return () => {};
+  }
+
+  window.addEventListener('scroll', onStoreChange, { passive: true });
+  return () => window.removeEventListener('scroll', onStoreChange);
+}
+
 export default function TopbarPublic({
   navLinks = EMPTY_ARRAY,
   dropdowns = EMPTY_ARRAY,
@@ -68,30 +88,18 @@ export default function TopbarPublic({
     top: 0,
   });
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
-  const [mounted, setMounted] = useState(false);
+  const mounted = useMounted();
+  const isScrolled = useSyncExternalStore(
+    subscribeScroll,
+    getScrolledSnapshot,
+    () => false,
+  );
   const triggerRefs = useRef<Map<string, HTMLButtonElement> | null>(null);
   const _megaMenuRef = useRef<HTMLDivElement>(null);
   if (triggerRefs.current === null) {
     triggerRefs.current = new Map<string, HTMLButtonElement>();
   }
   const triggerRefsMap = triggerRefs.current;
-
-  // Handle hydration
-  useEffect(() => {
-    setMounted(true);
-  }, []);
-
-  // Lock body scroll when mobile menu is open
-  const [isScrolled, setIsScrolled] = useState(false);
-
-  useEffect(() => {
-    function handleScroll() {
-      setIsScrolled(window.scrollY > 20);
-    }
-    handleScroll();
-    window.addEventListener('scroll', handleScroll, { passive: true });
-    return () => window.removeEventListener('scroll', handleScroll);
-  }, []);
 
   useEffect(() => {
     if (isMobileMenuOpen) {

--- a/packages/ui/src/components/workflow-builder/nodes/TrendSoundInspirationNode.tsx
+++ b/packages/ui/src/components/workflow-builder/nodes/TrendSoundInspirationNode.tsx
@@ -17,6 +17,16 @@ interface TrendSoundInspirationNodeProps {
   onExecute: (id: string) => void;
 }
 
+function formatNumber(num: number): string {
+  if (num >= 1000000) {
+    return `${(num / 1000000).toFixed(1)}M`;
+  }
+  if (num >= 1000) {
+    return `${(num / 1000).toFixed(1)}K`;
+  }
+  return num.toString();
+}
+
 function TrendSoundInspirationNodeComponent({
   id,
   data,
@@ -56,16 +66,6 @@ function TrendSoundInspirationNodeComponent({
   }, [data.soundUrl]);
 
   const isProcessing = data.status === WorkflowNodeStatus.PROCESSING;
-
-  const formatNumber = (num: number) => {
-    if (num >= 1000000) {
-      return `${(num / 1000000).toFixed(1)}M`;
-    }
-    if (num >= 1000) {
-      return `${(num / 1000).toFixed(1)}K`;
-    }
-    return num.toString();
-  };
 
   return (
     <div className="space-y-3">

--- a/packages/ui/src/components/workflow-builder/panels/NodePalette.tsx
+++ b/packages/ui/src/components/workflow-builder/panels/NodePalette.tsx
@@ -45,6 +45,15 @@ const CATEGORY_LABELS: Record<string, string> = {
   processing: 'Processing',
 };
 
+const CATEGORY_ORDER = [
+  'input',
+  'processing',
+  'effects',
+  'ai',
+  'output',
+  'control',
+];
+
 interface CategorySectionProps {
   category: string;
   nodes: Array<[string, NodeDefinition]>;
@@ -124,15 +133,6 @@ export default function NodePalette({
     );
   }
 
-  const categories = [
-    'input',
-    'processing',
-    'effects',
-    'ai',
-    'output',
-    'control',
-  ];
-
   return (
     <div className="flex h-full flex-col">
       {/* Header */}
@@ -150,7 +150,7 @@ export default function NodePalette({
 
       {/* Node Categories */}
       <div className="flex-1 overflow-y-auto">
-        {categories.map((category) => {
+        {CATEGORY_ORDER.map((category) => {
           const nodes =
             nodesByCategory[category as keyof typeof nodesByCategory] || [];
           const nodesWithTypes: Array<[string, NodeDefinition]> = nodes.map(

--- a/packages/ui/src/lib/hooks.ts
+++ b/packages/ui/src/lib/hooks.ts
@@ -1,9 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useSyncExternalStore } from 'react';
 
-export function useMounted() {
-  const [mounted, setMounted] = useState(false);
-  useEffect(() => {
-    setMounted(true);
-  }, []);
-  return mounted;
+const subscribe = () => () => {};
+const getClientSnapshot = () => true;
+const getServerSnapshot = () => false;
+
+export function useMounted(): boolean {
+  return useSyncExternalStore(subscribe, getClientSnapshot, getServerSnapshot);
 }


### PR DESCRIPTION
## Summary

- Replaces effect-initialized mounted/viewport/scroll state in `packages/ui` with `useSyncExternalStore` snapshots for hydration-safe client state.
- Hoists render-independent helpers/static maps out of shared UI components so React Doctor no longer reports pure/static helper rebuild findings.
- Leaves larger state synchronization/API-shape findings for follow-up because they touch prompt-bar and modal behavior contracts.

Fixes part of #338.

## React Doctor Delta

Focused `packages/ui` baseline on this branch:

- Before: score 66, 304 warnings, 0 errors.
- After: score 68, 268 warnings, 0 errors.
- Cleared: all `rendering-hydration-no-flicker`, `prefer-module-scope-pure-function`, and `prefer-module-scope-static-value` findings in `packages/ui`.

Focused `packages/workflow-ui` check was run for issue context only; this branch does not touch it. Current trunk baseline is score 72, 131 warnings, 0 errors, so the issue prior "keep at 100" assumption is stale on current `master`.

## Verification

- `bunx react-doctor@0.5.6 . --project packages/ui --blocking error --json --json-compact --no-color` -> score 68, 268 warnings, 0 errors, 0 remaining hydration/pure/static helper findings.
- `bunx react-doctor@0.5.6 . --project packages/workflow-ui --blocking error --json --json-compact --no-color` -> score 72, 131 warnings, 0 errors, unchanged by this PR.
- `bunx biome check --write $(git diff --name-only)` -> formatted changed files; left one intentional existing `MasonryGrid` dependency warning.
- `bun run design:lint` -> 0 errors, 9 existing token-reference warnings.
- `git diff --check` -> passed.
- Pre-commit hook ran staged Biome, secretlint, no-raw-html, and no-bespoke-card successfully.
- Independent read-only QA sidecar found no blocking regression.

## Not Run / Deferred

- `bun run --cwd packages/ui build` failed before compile because `tsc` is not on PATH in this worktree.
- `bunx tsc --noEmit -p packages/ui/tsconfig.json` could not resolve local dependencies/sibling package dist declarations in this worktree (`react`, Radix, `@shipshitdev/ui`, `packages/helpers/dist`, etc.). PR CI should run dependency-backed gates.
- Full root React Doctor was not run locally per no-heavy-local-suite policy; PR/health CI should cover broad gates.