### PR TITLE
fix(docs): patch nextra layout schema

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1353,6 +1353,9 @@
       },
     },
   },
+  "patchedDependencies": {
+    "nextra-theme-docs@4.6.1": "patches/nextra-theme-docs@4.6.1.patch",
+  },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.5.0", "", {}, "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q=="],
 

--- a/package.json
+++ b/package.json
@@ -307,5 +307,8 @@
     "winston": "3.19.0",
     "yet-another-react-lightbox": "3.32.0",
     "zod": "4.4.3"
+  },
+  "patchedDependencies": {
+    "nextra-theme-docs@4.6.1": "patches/nextra-theme-docs@4.6.1.patch"
   }
 }

--- a/patches/nextra-theme-docs@4.6.1.patch
+++ b/patches/nextra-theme-docs@4.6.1.patch
@@ -1,0 +1,25 @@
+diff --git a/dist/schemas.d.mts b/dist/schemas.d.mts
+index ab0104e9095be0d138c9b04d84f3a4e0d821c0fa..e0c6d34184b5bfe8a6284ef5c0ebf11c0b779c87 100644
+--- a/dist/schemas.d.mts
++++ b/dist/schemas.d.mts
+@@ -5,6 +5,6 @@
+ declare const LayoutPropsSchema: z.ZodObject<{
+     banner: z.ZodOptional<z.ZodCustom<react.ReactNode, react.ReactNode>>;
+-    children: z.ZodCustom<react.ReactNode, react.ReactNode>;
++    children: z.ZodOptional<z.ZodCustom<react.ReactNode, react.ReactNode>>;
+     copyPageButton: z.ZodDefault<z.ZodBoolean>;
+     darkMode: z.ZodDefault<z.ZodBoolean>;
+     docsRepositoryBase: z.ZodDefault<z.ZodString>;
+diff --git a/dist/schemas.js b/dist/schemas.js
+index 060d0b98b76515e4f0a1cd9edb3c3f5d31597540..f17054ec71086d81f8242282a5e0bb42adbcb657 100644
+--- a/dist/schemas.js
++++ b/dist/schemas.js
+@@ -65,7 +65,7 @@ const LayoutPropsSchema = z.strictObject({
+   banner: reactNode.optional().meta({
+     description: "Rendered [`<Banner>` component](/docs/built-ins/banner). E.g. `<Banner {...bannerProps} />`"
+   }),
+-  children: reactNode,
++  children: reactNode.optional(),
+   copyPageButton: z.boolean().default(true).meta({
+     description: "Hide/show copy page content button."
+   }),


### PR DESCRIPTION
## Summary
- add a Bun patch for nextra-theme-docs@4.6.1 so LayoutPropsSchema.children is optional
- fixes production docs prerender failures caused by Layout validating theme config after destructuring children out

## Verification
- NEXT_TELEMETRY_DISABLED=1 bun run --cwd apps/docs build
- git apply --reverse --check --directory=node_modules/nextra-theme-docs patches/nextra-theme-docs@4.6.1.patch
- staged diff check + staged secret scan
- pre-commit lint-staged checks