### PR TITLE
fix(docker): copy patch files before bun install

### DIFF
--- a/docker/Dockerfile.selfhosted
+++ b/docker/Dockerfile.selfhosted
@@ -123,6 +123,10 @@ RUN --mount=type=bind,source=.,target=/ctx \
 COPY packages/prisma/prisma.config.mjs ./packages/prisma/prisma.config.mjs
 COPY packages/prisma/prisma/ ./packages/prisma/prisma/
 
+# Root patchedDependencies are resolved during bun install, before the full
+# source tree is copied into the builder stage.
+COPY patches/ patches/
+
 # --linker hoisted: bun 1.3 flipped the default workspace linker from hoisted to
 # isolated (per-package node_modules symlinked into a root .bun store). The runtime
 # stage below ships ONLY the root node_modules (and not apps/app/node_modules), yet

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -105,6 +105,10 @@ RUN --mount=type=bind,source=.,target=/ctx \
 COPY packages/prisma/prisma.config.mjs ./packages/prisma/prisma.config.mjs
 COPY packages/prisma/prisma/ ./packages/prisma/prisma/
 
+# Root patchedDependencies are resolved during bun install, before the full
+# source tree is copied into the builder stage.
+COPY patches/ patches/
+
 # Install dependencies (mount cache for bun's global cache to speed up repeat builds).
 # --linker hoisted: bun 1.3 defaults workspaces to isolated installs (per-package
 # node_modules symlink dirs into a root .bun store). The production stage only


### PR DESCRIPTION
## Summary
- copy the root patches directory before Bun installs dependencies in the unified server image
- mirror the same patchedDependencies fix in the self-hosted image

## Verification
- git diff --cached --check
- staged secret scan
- waiting on PR CI and a manual staging Build Server Image run