### PR TITLE
feat: add platform preview renderers

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/compose/post/posts-write-account-bar.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/compose/post/posts-write-account-bar.tsx
@@ -11,52 +11,14 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@ui/primitives/select';
-
-type GenerationFormat = 'post' | 'thread' | 'x-article';
-
-const PLATFORM_LABELS: Partial<Record<CredentialPlatform, string>> = {
-  [CredentialPlatform.DISCORD]: 'Discord',
-  [CredentialPlatform.FACEBOOK]: 'Facebook',
-  [CredentialPlatform.INSTAGRAM]: 'Instagram',
-  [CredentialPlatform.LINKEDIN]: 'LinkedIn',
-  [CredentialPlatform.MEDIUM]: 'Medium',
-  [CredentialPlatform.PINTEREST]: 'Pinterest',
-  [CredentialPlatform.REDDIT]: 'Reddit',
-  [CredentialPlatform.TELEGRAM]: 'Telegram',
-  [CredentialPlatform.TIKTOK]: 'TikTok',
-  [CredentialPlatform.TWITCH]: 'Twitch',
-  [CredentialPlatform.TWITTER]: 'X',
-  [CredentialPlatform.YOUTUBE]: 'YouTube',
-};
-
-const DESKTOP_PLATFORM_OPTIONS: Array<{
-  label: string;
-  value: DesktopContentPlatform;
-}> = [
-  { label: 'X', value: 'twitter' },
-  { label: 'LinkedIn', value: 'linkedin' },
-  { label: 'Instagram', value: 'instagram' },
-  { label: 'TikTok', value: 'tiktok' },
-  { label: 'YouTube', value: 'youtube' },
-];
-
-const SOCIAL_FORMAT_LABELS: Record<GenerationFormat, string> = {
-  post: 'Post',
-  thread: 'Thread',
-  'x-article': 'X Article',
-};
-
-function getCredentialLabel(credential: ICredential): string {
-  const platform =
-    PLATFORM_LABELS[credential.platform as CredentialPlatform] ??
-    credential.platform;
-  const handle =
-    'externalHandle' in credential && credential.externalHandle
-      ? `@${credential.externalHandle}`
-      : null;
-
-  return handle ? `${platform} ${handle}` : String(platform);
-}
+import {
+  DESKTOP_PLATFORM_OPTIONS,
+  type GenerationFormat,
+  getCharacterLimit,
+  getCredentialLabel,
+  SOCIAL_FORMAT_LABELS,
+  toDesktopPlatform,
+} from './posts-write-page.helpers';
 
 function getFormatConstraintLabel(
   credential: ICredential | undefined,
@@ -72,7 +34,13 @@ function getFormatConstraintLabel(
   }
 
   if (String(platform ?? '').toLowerCase() === CredentialPlatform.TWITTER) {
-    return '280 weighted characters per post';
+    const limit = getCharacterLimit(
+      credential,
+      toDesktopPlatform(credential?.platform),
+    );
+    return limit
+      ? `${limit} weighted characters per post`
+      : 'Weighted characters per post';
   }
 
   if (String(platform ?? '').toLowerCase() === CredentialPlatform.INSTAGRAM) {

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/compose/post/posts-write-page.helpers.ts
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/compose/post/posts-write-page.helpers.ts
@@ -1,3 +1,4 @@
+import { getChannelCapability } from '@api-types/contracts';
 import type {
   DesktopContentPlatform,
   DesktopContentType,
@@ -92,22 +93,7 @@ export function getCharacterLimit(
     ? String(credential.platform).toLowerCase()
     : platform;
 
-  if (
-    activePlatform === CredentialPlatform.TWITTER ||
-    activePlatform === 'twitter'
-  ) {
-    return 280;
-  }
-
-  if (activePlatform === CredentialPlatform.LINKEDIN) {
-    return 3000;
-  }
-
-  if (activePlatform === CredentialPlatform.INSTAGRAM) {
-    return 2200;
-  }
-
-  return null;
+  return getChannelCapability(activePlatform)?.caption.maxLength ?? null;
 }
 
 export function toDesktopPlatform(

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/compose/post/posts-write-page.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/compose/post/posts-write-page.test.tsx
@@ -346,6 +346,30 @@ describe('PostsWritePage', () => {
     expect(generateAccountContentMock).not.toHaveBeenCalled();
   });
 
+  it('renders platform preview limits from channel capabilities', () => {
+    useBrandMock.mockReturnValue({
+      credentials: [
+        {
+          externalHandle: 'genfeed',
+          id: 'cred-1',
+          isConnected: true,
+          platform: 'linkedin',
+        },
+      ],
+    });
+
+    render(<PostsWritePage />);
+
+    fireEvent.change(screen.getByLabelText('Draft content'), {
+      target: { value: 'x'.repeat(3001) },
+    });
+
+    expect(screen.getByText('3001/3000')).toBeInTheDocument();
+    expect(
+      screen.getByText('LinkedIn captions must be 3000 characters or fewer.'),
+    ).toBeInTheDocument();
+  });
+
   it('generates local desktop content when no connected accounts are available', async () => {
     const generateContent = vi.fn().mockResolvedValue({
       content: 'Generated local post',

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/compose/post/posts-write-page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/compose/post/posts-write-page.tsx
@@ -166,11 +166,11 @@ function PostsWritePageContent() {
       </Card>
 
       <PostsWritePreviewPanel
-        characterLimit={characterLimit}
         desktopPlatform={desktopPlatform}
         draftSegments={draftSegments}
         selectedCredential={selectedCredential}
         selectedFormat={selectedFormat}
+        workingTitle={workingTitle}
       />
     </section>
   );

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/compose/post/posts-write-preview-panel.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/compose/post/posts-write-preview-panel.tsx
@@ -2,51 +2,75 @@
 
 import type { ICredential } from '@genfeedai/interfaces';
 import Card from '@ui/card/Card';
-
-type GenerationFormat = 'post' | 'thread' | 'x-article';
-
-const SOCIAL_FORMAT_LABELS: Record<GenerationFormat, string> = {
-  post: 'Post',
-  thread: 'Thread',
-  'x-article': 'X Article',
-};
-
-const DESKTOP_PLATFORM_OPTIONS: Array<{
-  label: string;
-  value: string;
-}> = [
-  { label: 'X', value: 'twitter' },
-  { label: 'LinkedIn', value: 'linkedin' },
-  { label: 'Instagram', value: 'instagram' },
-  { label: 'TikTok', value: 'tiktok' },
-  { label: 'YouTube', value: 'youtube' },
-];
-
-function getCredentialLabel(credential: ICredential): string {
-  const platform = credential.platform;
-  const handle =
-    'externalHandle' in credential && credential.externalHandle
-      ? `@${credential.externalHandle}`
-      : null;
-
-  return handle ? `${platform} ${handle}` : String(platform);
-}
+import PlatformPreview, {
+  type PlatformPreviewTarget,
+} from '@ui/posts/platform-preview/PlatformPreview';
+import {
+  DESKTOP_PLATFORM_OPTIONS,
+  type GenerationFormat,
+  getCredentialLabel,
+  SOCIAL_FORMAT_LABELS,
+} from './posts-write-page.helpers';
 
 interface PostsWritePreviewPanelProps {
-  characterLimit: number | null;
   desktopPlatform: string;
   draftSegments: string[];
   selectedCredential: ICredential | undefined;
   selectedFormat: GenerationFormat;
+  workingTitle: string;
 }
 
-export default function PostsWritePreviewPanel({
-  characterLimit,
+function buildPreviewTarget({
   desktopPlatform,
   draftSegments,
   selectedCredential,
   selectedFormat,
+  workingTitle,
+}: PostsWritePreviewPanelProps): PlatformPreviewTarget {
+  const platform = selectedCredential?.platform ?? desktopPlatform;
+  const platformLabel =
+    DESKTOP_PLATFORM_OPTIONS.find((option) => option.value === desktopPlatform)
+      ?.label ?? 'Desktop';
+  const authorName =
+    selectedCredential?.label?.trim() ||
+    selectedCredential?.externalHandle?.trim() ||
+    platformLabel;
+  const caption = draftSegments.join('\n\n');
+
+  return {
+    author: {
+      handle: selectedCredential?.externalHandle ?? platform,
+      name: authorName,
+    },
+    caption,
+    platform,
+    threadSegments:
+      selectedFormat === 'thread'
+        ? draftSegments.map((segment, index) => ({
+            caption: segment,
+            id: `draft-segment-${index.toString()}`,
+            label: `Post ${index + 1}`,
+          }))
+        : undefined,
+    title: workingTitle,
+  };
+}
+
+export default function PostsWritePreviewPanel({
+  desktopPlatform,
+  draftSegments,
+  selectedCredential,
+  selectedFormat,
+  workingTitle,
 }: PostsWritePreviewPanelProps) {
+  const previewTarget = buildPreviewTarget({
+    desktopPlatform,
+    draftSegments,
+    selectedCredential,
+    selectedFormat,
+    workingTitle,
+  });
+
   return (
     <Card bodyClassName="gap-0 p-6">
       <div className="flex items-start justify-between gap-4">
@@ -66,43 +90,7 @@ export default function PostsWritePreviewPanel({
         </span>
       </div>
 
-      <div className="mt-5 divide-y divide-white/10">
-        {draftSegments.map((segment, index) => {
-          const count = segment.length;
-          const isOverLimit = characterLimit !== null && count > characterLimit;
-
-          return (
-            <div
-              key={`preview-segment-${index.toString()}`}
-              className="py-4 first:pt-0 last:pb-0"
-            >
-              <div className="mb-3 flex items-center justify-between gap-3 text-xs">
-                <span className="font-medium text-foreground/70">
-                  {selectedFormat === 'thread'
-                    ? `Post ${index + 1}`
-                    : SOCIAL_FORMAT_LABELS[selectedFormat]}
-                </span>
-                <span
-                  className={
-                    isOverLimit ? 'text-destructive' : 'text-foreground/40'
-                  }
-                >
-                  {characterLimit ? `${count}/${characterLimit}` : count}
-                </span>
-              </div>
-              {segment.trim() ? (
-                <p className="whitespace-pre-wrap text-sm leading-6 text-foreground/85">
-                  {segment}
-                </p>
-              ) : (
-                <p className="text-sm text-foreground/35">
-                  Draft preview appears here.
-                </p>
-              )}
-            </div>
-          );
-        })}
-      </div>
+      <PlatformPreview className="mt-5" target={previewTarget} />
 
       <div className="mt-5 border-t border-white/10 pt-4 text-sm text-foreground/60">
         <p className="font-medium text-foreground">Agent context</p>

--- a/apps/vitest.config.mts
+++ b/apps/vitest.config.mts
@@ -34,6 +34,10 @@ export default defineConfig({
   resolve: {
     alias: [
       {
+        find: /^@api-types\/(.*)$/,
+        replacement: path.resolve(repoRoot, './packages/api-types/src/$1'),
+      },
+      {
         find: /^@app$/,
         replacement: path.resolve(appRoot, './app'),
       },

--- a/packages/ui/src/components/posts/platform-preview/PlatformPreview.test.tsx
+++ b/packages/ui/src/components/posts/platform-preview/PlatformPreview.test.tsx
@@ -1,0 +1,164 @@
+import {
+  type ChannelCapability,
+  getChannelCapability,
+} from '@api-types/contracts';
+import { CredentialPlatform } from '@genfeedai/enums';
+import { render, screen } from '@testing-library/react';
+import type { ComponentProps } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import PlatformPreview, {
+  countPreviewCharacters,
+  hasDedicatedPlatformPreviewRenderer,
+} from '@ui/posts/platform-preview/PlatformPreview';
+
+type MockImageProps = ComponentProps<'img'> & {
+  fill?: boolean;
+  priority?: boolean;
+  unoptimized?: boolean;
+};
+
+vi.mock('next/image', () => ({
+  default: ({
+    fill: _fill,
+    priority: _priority,
+    unoptimized: _unoptimized,
+    ...props
+  }: MockImageProps) => <img {...props} alt={props.alt ?? ''} />,
+}));
+
+function requireCapability(platform: CredentialPlatform): ChannelCapability {
+  const capability = getChannelCapability(platform);
+  if (!capability) {
+    throw new Error(`Missing capability for ${platform}`);
+  }
+
+  return capability;
+}
+
+describe('PlatformPreview', () => {
+  it('registers dedicated renderers for core platforms only', () => {
+    expect(
+      hasDedicatedPlatformPreviewRenderer(CredentialPlatform.TWITTER),
+    ).toBe(true);
+    expect(
+      hasDedicatedPlatformPreviewRenderer(CredentialPlatform.LINKEDIN),
+    ).toBe(true);
+    expect(
+      hasDedicatedPlatformPreviewRenderer(CredentialPlatform.INSTAGRAM),
+    ).toBe(true);
+    expect(hasDedicatedPlatformPreviewRenderer(CredentialPlatform.TIKTOK)).toBe(
+      true,
+    );
+    expect(
+      hasDedicatedPlatformPreviewRenderer(CredentialPlatform.YOUTUBE),
+    ).toBe(true);
+    expect(hasDedicatedPlatformPreviewRenderer(CredentialPlatform.REDDIT)).toBe(
+      false,
+    );
+  });
+
+  it('uses the capability caption limit for X truncation and validation', () => {
+    const capability = requireCapability(CredentialPlatform.TWITTER);
+    const caption = 'x'.repeat(capability.caption.maxLength + 5);
+
+    render(
+      <PlatformPreview
+        target={{
+          author: { handle: 'genfeed', name: 'Genfeed' },
+          capability,
+          caption,
+          platform: CredentialPlatform.TWITTER,
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        `${countPreviewCharacters(caption)}/${capability.caption.maxLength}`,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        `Truncated after ${capability.caption.maxLength} characters.`,
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        `${capability.label} captions must be ${capability.caption.maxLength} characters or fewer.`,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('renders thread segments with per-post counters', () => {
+    const capability = requireCapability(CredentialPlatform.TWITTER);
+
+    render(
+      <PlatformPreview
+        target={{
+          author: { handle: 'genfeed', name: 'Genfeed' },
+          capability,
+          caption: 'First segment\n\nSecond segment',
+          platform: CredentialPlatform.TWITTER,
+          threadSegments: [
+            { caption: 'First segment #launch', id: 'segment-1' },
+            { caption: 'Second segment @team', id: 'segment-2' },
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.getByText('Post 1')).toBeInTheDocument();
+    expect(screen.getByText('Post 2')).toBeInTheDocument();
+    expect(screen.getByText('#launch')).toBeInTheDocument();
+    expect(screen.getByText('@team')).toBeInTheDocument();
+  });
+
+  it('labels unsupported dedicated layouts as approximate fallback previews', () => {
+    const capability = requireCapability(CredentialPlatform.REDDIT);
+
+    render(
+      <PlatformPreview
+        target={{
+          capability,
+          caption: 'Share this to the community',
+          platform: CredentialPlatform.REDDIT,
+        }}
+      />,
+    );
+
+    expect(screen.getAllByText('Approximate preview').length).toBeGreaterThan(
+      0,
+    );
+    expect(screen.getByText('Reddit')).toBeInTheDocument();
+    expect(
+      screen.getByText('Reddit is hidden from scheduler publishing.'),
+    ).toBeInTheDocument();
+  });
+
+  it('surfaces media count validation from the capability catalog', () => {
+    const capability = requireCapability(CredentialPlatform.INSTAGRAM);
+    const maxItems = capability.media.maxItems ?? 0;
+
+    render(
+      <PlatformPreview
+        target={{
+          capability,
+          caption: 'Carousel launch',
+          media: Array.from({ length: maxItems + 1 }, (_, index) => ({
+            id: `media-${index}`,
+            kind: 'image',
+          })),
+          platform: CredentialPlatform.INSTAGRAM,
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        `${capability.label} allows at most ${maxItems} media item(s).`,
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText('+1 more not shown')).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/posts/platform-preview/PlatformPreview.tsx
+++ b/packages/ui/src/components/posts/platform-preview/PlatformPreview.tsx
@@ -1,220 +1,1132 @@
 'use client';
 
-import { ButtonVariant, CredentialPlatform } from '@genfeedai/enums';
+import {
+  type ChannelCapability,
+  type ChannelMediaKind,
+  type ChannelPublishMode,
+  type ChannelTargetValidationResult,
+  type ChannelValidationIssue,
+  getChannelCapability,
+  PRODUCTIZED_SCHEDULER_PLATFORMS,
+  validateChannelTargetSettings,
+} from '@api-types/contracts';
+import {
+  ButtonVariant,
+  CredentialPlatform,
+  IngredientCategory,
+  TargetValidationState,
+} from '@genfeedai/enums';
+import { cn } from '@genfeedai/helpers/formatting/cn/cn.util';
 import type { IIngredient, IPost } from '@genfeedai/interfaces';
-import Card from '@ui/card/Card';
-import InsetSurface from '@ui/display/inset-surface/InsetSurface';
 import { Button } from '@ui/primitives/button';
 import Image from 'next/image';
-import { useMemo, useState } from 'react';
 import {
-  FaFacebook,
+  type ComponentType,
+  type ReactNode,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import {
   FaInstagram,
   FaLinkedin,
+  FaTiktok,
   FaXTwitter,
+  FaYoutube,
 } from 'react-icons/fa6';
 import {
   HiArrowPath,
   HiBookmark,
   HiChatBubbleOvalLeft,
+  HiHandThumbUp,
   HiHeart,
   HiPaperAirplane,
+  HiPlay,
+  HiSparkles,
 } from 'react-icons/hi2';
 
-type PreviewPlatform = 'instagram' | 'twitter' | 'facebook' | 'linkedin';
+export type PlatformPreviewMedia = {
+  id: string;
+  kind: ChannelMediaKind;
+  url?: string;
+  thumbnailUrl?: string;
+  alt?: string;
+  durationLabel?: string;
+  isAnimated?: boolean;
+};
 
-const PREVIEW_PLATFORMS: {
-  key: PreviewPlatform;
-  label: string;
-  icon: React.ReactNode;
-  forPlatforms: string[];
-}[] = [
-  {
-    forPlatforms: [CredentialPlatform.INSTAGRAM],
-    icon: <FaInstagram className="size-3.5" />,
-    key: 'instagram',
-    label: 'Instagram',
-  },
-  {
-    forPlatforms: [CredentialPlatform.TWITTER],
-    icon: <FaXTwitter className="size-3.5" />,
-    key: 'twitter',
-    label: 'X / Twitter',
-  },
-  {
-    forPlatforms: [CredentialPlatform.FACEBOOK],
-    icon: <FaFacebook className="size-3.5" />,
-    key: 'facebook',
-    label: 'Facebook',
-  },
-  {
-    forPlatforms: [CredentialPlatform.LINKEDIN],
-    icon: <FaLinkedin className="size-3.5" />,
-    key: 'linkedin',
-    label: 'LinkedIn',
-  },
-];
+export type PlatformPreviewAuthor = {
+  name?: string;
+  handle?: string;
+  avatarUrl?: string;
+};
 
-export interface PlatformPreviewProps {
-  post: IPost;
+export type PlatformPreviewLinkCard = {
+  url: string;
+  domain?: string;
+  title?: string;
+  description?: string;
+  imageUrl?: string;
+};
+
+export type PlatformPreviewThreadSegment = {
+  id: string;
+  caption: string;
+  label?: string;
+};
+
+export type PlatformPreviewTarget = {
+  platform: CredentialPlatform | string;
+  caption: string;
+  title?: string;
+  author?: PlatformPreviewAuthor;
+  media?: PlatformPreviewMedia[];
+  settings?: Record<string, unknown>;
+  publishMode?: ChannelPublishMode;
+  capability?: ChannelCapability;
+  validation?: ChannelTargetValidationResult;
+  threadSegments?: PlatformPreviewThreadSegment[];
+  linkPreview?: PlatformPreviewLinkCard | null;
+};
+
+export type PlatformPreviewProps = {
+  post?: IPost;
+  target?: PlatformPreviewTarget;
+  targets?: PlatformPreviewTarget[];
   accountName?: string;
   accountHandle?: string;
+  activePlatform?: CredentialPlatform | string;
+  className?: string;
+  emptyMessage?: string;
+};
+
+export type PlatformPreviewRendererProps = {
+  target: ResolvedPlatformPreviewTarget;
+};
+
+export type PlatformPreviewRenderer =
+  ComponentType<PlatformPreviewRendererProps>;
+
+type CaptionPreviewState = {
+  count: number;
+  maxLength?: number;
+  isOverLimit: boolean;
+  previewText: string;
+};
+
+type ResolvedPlatformPreviewTarget = PlatformPreviewTarget & {
+  capability?: ChannelCapability;
+  validation: ChannelTargetValidationResult;
+  captionState: CaptionPreviewState;
+  platformLabel: string;
+  media: PlatformPreviewMedia[];
+  threadSegments: PlatformPreviewThreadSegment[];
+};
+
+const DEFAULT_AUTHOR_NAME = 'Your Account';
+const DEFAULT_AUTHOR_HANDLE = 'youraccount';
+const ENTITY_PATTERN = /(https?:\/\/[^\s]+|[@#][A-Za-z0-9_]+)/g;
+
+export const PLATFORM_PREVIEW_RENDERERS: Partial<
+  Record<CredentialPlatform, PlatformPreviewRenderer>
+> = {
+  [CredentialPlatform.INSTAGRAM]: InstagramPreviewRenderer,
+  [CredentialPlatform.LINKEDIN]: LinkedInPreviewRenderer,
+  [CredentialPlatform.TIKTOK]: TikTokPreviewRenderer,
+  [CredentialPlatform.TWITTER]: XPreviewRenderer,
+  [CredentialPlatform.YOUTUBE]: YouTubePreviewRenderer,
+};
+
+export function countPreviewCharacters(text: string): number {
+  return Array.from(text).length;
 }
 
-function TwitterPreview({
-  post,
-  accountName,
-  accountHandle,
-}: {
-  post: IPost;
-  accountName: string;
-  accountHandle: string;
-}) {
-  const ingredient = post.ingredients?.[0] as IIngredient | undefined;
+export function getCaptionPreviewState(
+  caption: string,
+  maxLength?: number,
+): CaptionPreviewState {
+  const characters = Array.from(caption);
+  const count = characters.length;
+
+  if (!maxLength || count <= maxLength) {
+    return {
+      count,
+      isOverLimit: false,
+      maxLength,
+      previewText: caption,
+    };
+  }
+
+  return {
+    count,
+    isOverLimit: true,
+    maxLength,
+    previewText: `${characters.slice(0, maxLength).join('')}...`,
+  };
+}
+
+export function hasDedicatedPlatformPreviewRenderer(
+  platform: CredentialPlatform | string,
+): boolean {
+  const normalizedPlatform = normalizePlatform(platform) as CredentialPlatform;
+  return Boolean(PLATFORM_PREVIEW_RENDERERS[normalizedPlatform]);
+}
+
+export function getPlatformPreviewRenderer(
+  platform: CredentialPlatform | string,
+): PlatformPreviewRenderer {
+  const normalizedPlatform = normalizePlatform(platform) as CredentialPlatform;
   return (
-    <InsetSurface density="compact" tone="muted">
-      <div className="flex gap-2">
-        <div className="size-10 rounded-full bg-muted shrink-0" />
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-1">
-            <span className="font-bold text-sm">{accountName}</span>
-            <span className="text-muted-foreground text-sm">
-              @{accountHandle}
-            </span>
-          </div>
-          <p className="text-sm mt-1 whitespace-pre-wrap line-clamp-6">
-            {post.description}
+    PLATFORM_PREVIEW_RENDERERS[normalizedPlatform] ??
+    GenericPlatformPreviewRenderer
+  );
+}
+
+export function resolvePlatformPreviewTarget(
+  target: PlatformPreviewTarget,
+): ResolvedPlatformPreviewTarget {
+  const capability = target.capability ?? getChannelCapability(target.platform);
+  const media = target.media ?? [];
+  const validation =
+    target.validation ?? validatePreviewTarget(target, capability, media);
+  const threadSegments =
+    target.threadSegments && target.threadSegments.length > 0
+      ? target.threadSegments
+      : [{ caption: target.caption, id: 'post-1', label: 'Post' }];
+
+  return {
+    ...target,
+    capability,
+    captionState: getCaptionPreviewState(
+      target.caption,
+      capability?.caption.maxLength,
+    ),
+    media,
+    platformLabel:
+      capability?.label ?? getFallbackPlatformLabel(target.platform),
+    threadSegments,
+    validation,
+  };
+}
+
+function validatePreviewTarget(
+  target: PlatformPreviewTarget,
+  capability: ChannelCapability | undefined,
+  media: PlatformPreviewMedia[],
+): ChannelTargetValidationResult {
+  const mediaPayload = media.map((item) => ({ id: item.id, kind: item.kind }));
+
+  if (!target.threadSegments || target.threadSegments.length <= 1) {
+    return validateChannelTargetSettings({
+      caption: target.caption,
+      media: mediaPayload,
+      platform: target.platform,
+      publishMode: target.publishMode,
+      settings: target.settings,
+    });
+  }
+
+  const segmentResults = target.threadSegments.map((segment) =>
+    validateChannelTargetSettings({
+      caption: segment.caption,
+      media: mediaPayload,
+      platform: target.platform,
+      publishMode: target.publishMode,
+      settings: target.settings,
+    }),
+  );
+  const errors = segmentResults.flatMap((result, index) =>
+    result.errors.map((issue) => ({
+      ...issue,
+      field: `threadSegments.${index}.${issue.field ?? 'caption'}`,
+      message: `Post ${index + 1}: ${issue.message}`,
+    })),
+  );
+  const warnings = segmentResults.flatMap((result, index) =>
+    result.warnings.map((issue) => ({
+      ...issue,
+      field: `threadSegments.${index}.${issue.field ?? 'caption'}`,
+      message: `Post ${index + 1}: ${issue.message}`,
+    })),
+  );
+
+  return {
+    capability,
+    errors,
+    platform: target.platform,
+    valid: errors.length === 0,
+    validationState:
+      errors.length > 0
+        ? TargetValidationState.INVALID
+        : warnings.length > 0
+          ? TargetValidationState.WARNING
+          : TargetValidationState.VALID,
+    warnings,
+  };
+}
+
+function normalizePlatform(platform: CredentialPlatform | string): string {
+  return String(platform).toLowerCase();
+}
+
+function getFallbackPlatformLabel(
+  platform: CredentialPlatform | string,
+): string {
+  const normalizedPlatform = normalizePlatform(platform);
+  if (normalizedPlatform === CredentialPlatform.TWITTER) {
+    return 'X';
+  }
+
+  return normalizedPlatform
+    .split('_')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function getPlatformIcon(platform: CredentialPlatform | string) {
+  const normalizedPlatform = normalizePlatform(platform);
+
+  if (normalizedPlatform === CredentialPlatform.INSTAGRAM) {
+    return FaInstagram;
+  }
+
+  if (normalizedPlatform === CredentialPlatform.LINKEDIN) {
+    return FaLinkedin;
+  }
+
+  if (normalizedPlatform === CredentialPlatform.TIKTOK) {
+    return FaTiktok;
+  }
+
+  if (normalizedPlatform === CredentialPlatform.YOUTUBE) {
+    return FaYoutube;
+  }
+
+  return FaXTwitter;
+}
+
+function formatHandle(handle?: string): string {
+  const normalizedHandle = handle?.trim();
+  if (!normalizedHandle) {
+    return `@${DEFAULT_AUTHOR_HANDLE}`;
+  }
+
+  return normalizedHandle.startsWith('@')
+    ? normalizedHandle
+    : `@${normalizedHandle}`;
+}
+
+function getAuthorName(target: PlatformPreviewTarget): string {
+  return target.author?.name?.trim() || DEFAULT_AUTHOR_NAME;
+}
+
+function inferMediaKind(ingredient: IIngredient): ChannelMediaKind {
+  if (
+    ingredient.category === IngredientCategory.VIDEO ||
+    ingredient.category === IngredientCategory.VIDEO_EDIT
+  ) {
+    return 'video';
+  }
+
+  if (ingredient.category === IngredientCategory.GIF) {
+    return 'image';
+  }
+
+  return 'image';
+}
+
+function formatDuration(seconds?: number): string | undefined {
+  if (!seconds || seconds <= 0) {
+    return undefined;
+  }
+
+  const minutes = Math.floor(seconds / 60);
+  const remainder = Math.floor(seconds % 60)
+    .toString()
+    .padStart(2, '0');
+  return `${minutes}:${remainder}`;
+}
+
+function buildMediaFromIngredients(
+  ingredients: IIngredient[] | undefined,
+): PlatformPreviewMedia[] {
+  return (ingredients ?? []).map((ingredient, index) => ({
+    alt:
+      ingredient.metadataLabel ??
+      ingredient.metadataDescription ??
+      `Media ${index + 1}`,
+    durationLabel: formatDuration(ingredient.metadataDuration),
+    id: ingredient.id ?? `media-${index}`,
+    isAnimated: ingredient.category === IngredientCategory.GIF,
+    kind: inferMediaKind(ingredient),
+    thumbnailUrl: ingredient.thumbnailUrl,
+    url: ingredient.ingredientUrl,
+  }));
+}
+
+function buildPostTargets(
+  post: IPost,
+  accountName: string,
+  accountHandle: string,
+): PlatformPreviewTarget[] {
+  const platforms = post.platform
+    ? [post.platform]
+    : [...PRODUCTIZED_SCHEDULER_PLATFORMS];
+  const media = buildMediaFromIngredients(post.ingredients);
+  const children = post.children ?? [];
+
+  return platforms.map((platform) => ({
+    author: {
+      handle: accountHandle,
+      name: accountName,
+    },
+    caption: post.description ?? '',
+    media,
+    platform,
+    threadSegments:
+      children.length > 0
+        ? [
+            {
+              caption: post.description ?? '',
+              id: post.id ?? 'post-1',
+              label: 'Post 1',
+            },
+            ...children.map((child, index) => ({
+              caption: child.description ?? '',
+              id: child.id ?? `reply-${index + 1}`,
+              label: `Post ${index + 2}`,
+            })),
+          ]
+        : undefined,
+    title: post.label,
+  }));
+}
+
+function getPreviewStatus(target: ResolvedPlatformPreviewTarget): {
+  label: string;
+  className: string;
+} {
+  if (
+    target.validation.validationState === TargetValidationState.INVALID ||
+    target.validation.errors.length > 0
+  ) {
+    return {
+      className: 'border-destructive/30 bg-destructive/10 text-destructive',
+      label: 'Blocked',
+    };
+  }
+
+  if (
+    target.validation.validationState === TargetValidationState.WARNING ||
+    target.validation.warnings.length > 0
+  ) {
+    return {
+      className: 'border-warning/30 bg-warning/10 text-warning',
+      label: 'Warnings',
+    };
+  }
+
+  return {
+    className: 'border-emerald-500/25 bg-emerald-500/10 text-emerald-500',
+    label: 'Valid',
+  };
+}
+
+function extractFirstUrl(text: string): string | null {
+  return text.match(/https?:\/\/[^\s]+/)?.[0] ?? null;
+}
+
+function renderCaptionEntities(text: string): ReactNode[] {
+  return text.split(ENTITY_PATTERN).map((part, index) => {
+    const key = `${part}-${index}`;
+    if (part.match(ENTITY_PATTERN)) {
+      return (
+        <span key={key} className="font-medium text-primary">
+          {part}
+        </span>
+      );
+    }
+
+    return part;
+  });
+}
+
+function CharacterCounter({ state }: { state: CaptionPreviewState }) {
+  return (
+    <span
+      className={cn(
+        'text-xs',
+        state.isOverLimit ? 'text-destructive' : 'text-foreground/45',
+      )}
+    >
+      {state.maxLength ? `${state.count}/${state.maxLength}` : state.count}
+    </span>
+  );
+}
+
+function CaptionText({
+  target,
+  emptyMessage = 'Draft preview appears here.',
+}: {
+  target: ResolvedPlatformPreviewTarget;
+  emptyMessage?: string;
+}) {
+  const text = target.captionState.previewText.trim();
+
+  if (!text) {
+    return <p className="text-sm text-foreground/35">{emptyMessage}</p>;
+  }
+
+  return (
+    <p className="whitespace-pre-wrap text-sm leading-6 text-foreground/85">
+      {renderCaptionEntities(text)}
+    </p>
+  );
+}
+
+function ValidationIssues({
+  target,
+}: {
+  target: ResolvedPlatformPreviewTarget;
+}) {
+  const issues: ChannelValidationIssue[] = [
+    ...target.validation.errors,
+    ...target.validation.warnings,
+  ];
+
+  if (issues.length === 0 && !target.captionState.isOverLimit) {
+    return null;
+  }
+
+  return (
+    <div
+      className="mt-3 border-t border-white/10 pt-3"
+      role={target.validation.errors.length > 0 ? 'alert' : 'status'}
+    >
+      <ul className="grid gap-1 text-xs text-foreground/65">
+        {target.captionState.isOverLimit && target.captionState.maxLength ? (
+          <li className="text-destructive">
+            Truncated after {target.captionState.maxLength} characters.
+          </li>
+        ) : null}
+        {issues.map((issue) => (
+          <li
+            key={`${issue.severity}-${issue.code}-${issue.field ?? 'target'}`}
+            className={
+              issue.severity === 'error' ? 'text-destructive' : 'text-warning'
+            }
+          >
+            {issue.message}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function LinkPreviewCard({
+  target,
+}: {
+  target: ResolvedPlatformPreviewTarget;
+}) {
+  const url = target.linkPreview?.url ?? extractFirstUrl(target.caption);
+
+  if (!url || !target.capability?.media.kinds.includes('link')) {
+    return null;
+  }
+
+  const domain =
+    target.linkPreview?.domain ??
+    (() => {
+      try {
+        return new URL(url).hostname;
+      } catch {
+        return url;
+      }
+    })();
+
+  return (
+    <div className="mt-3 overflow-hidden rounded-lg border border-white/10 bg-black/10">
+      {target.linkPreview?.imageUrl ? (
+        <Image
+          src={target.linkPreview.imageUrl}
+          alt=""
+          width={640}
+          height={320}
+          className="aspect-[2/1] w-full object-cover"
+        />
+      ) : (
+        <div className="flex aspect-[2/1] items-center justify-center bg-muted text-xs text-foreground/45">
+          No link preview available
+        </div>
+      )}
+      <div className="grid gap-1 p-3">
+        <p className="text-xs uppercase text-foreground/45">{domain}</p>
+        <p className="line-clamp-2 text-sm font-medium text-foreground">
+          {target.linkPreview?.title ?? 'Link card pending'}
+        </p>
+        {target.linkPreview?.description ? (
+          <p className="line-clamp-2 text-xs text-foreground/60">
+            {target.linkPreview.description}
           </p>
-          {ingredient?.ingredientUrl && (
-            <div className="mt-2 rounded-xl overflow-hidden border">
-              <Image
-                src={ingredient.ingredientUrl}
-                alt=""
-                width={400}
-                height={225}
-                className="w-full object-cover max-h-48"
-              />
-            </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function MediaTile({
+  item,
+  index,
+  className,
+}: {
+  item: PlatformPreviewMedia;
+  index: number;
+  className?: string;
+}) {
+  const src = item.thumbnailUrl ?? item.url;
+  const label = item.kind.replace('_', ' ');
+
+  return (
+    <div
+      className={cn(
+        'relative flex min-h-24 items-center justify-center overflow-hidden rounded-lg bg-muted text-xs text-foreground/50',
+        className,
+      )}
+    >
+      {src ? (
+        <Image
+          src={src}
+          alt={item.alt ?? `Media ${index + 1}`}
+          fill
+          sizes="(max-width: 768px) 100vw, 360px"
+          className="object-cover"
+        />
+      ) : (
+        <span className="capitalize">{label}</span>
+      )}
+      {item.kind === 'video' || item.kind === 'short_video' ? (
+        <span className="absolute inset-0 flex items-center justify-center bg-black/20 text-white">
+          <HiPlay className="size-6" />
+        </span>
+      ) : null}
+      <div className="absolute bottom-2 left-2 flex flex-wrap gap-1">
+        {item.isAnimated ? (
+          <span className="rounded bg-black/70 px-1.5 py-0.5 text-[10px] font-medium text-white">
+            Animated
+          </span>
+        ) : null}
+        {item.durationLabel ? (
+          <span className="rounded bg-black/70 px-1.5 py-0.5 text-[10px] font-medium text-white">
+            {item.durationLabel}
+          </span>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function MediaGrid({
+  target,
+  variant = 'grid',
+}: {
+  target: ResolvedPlatformPreviewTarget;
+  variant?: 'grid' | 'square' | 'video' | 'vertical';
+}) {
+  const maxItems = target.capability?.media.maxItems;
+  const visibleMedia = maxItems
+    ? target.media.slice(0, maxItems)
+    : target.media;
+  const overflowCount =
+    maxItems && target.media.length > maxItems
+      ? target.media.length - maxItems
+      : 0;
+
+  if (target.media.length === 0) {
+    if ((target.capability?.media.minItems ?? 0) > 0) {
+      return (
+        <div
+          className={cn(
+            'mt-3 flex items-center justify-center rounded-lg border border-dashed border-white/15 bg-muted/40 text-sm text-foreground/45',
+            variant === 'vertical' ? 'aspect-[9/16]' : 'aspect-video',
           )}
-          <div className="flex justify-between mt-3 text-muted-foreground">
+        >
+          Media required
+        </div>
+      );
+    }
+
+    return null;
+  }
+
+  if (variant === 'vertical') {
+    return (
+      <div className="mt-3">
+        <MediaTile
+          item={visibleMedia[0]}
+          index={0}
+          className="aspect-[9/16] min-h-80"
+        />
+      </div>
+    );
+  }
+
+  if (variant === 'video') {
+    return (
+      <div className="mt-3">
+        <MediaTile
+          item={visibleMedia[0]}
+          index={0}
+          className="aspect-video min-h-40"
+        />
+      </div>
+    );
+  }
+
+  const gridClassName =
+    variant === 'square'
+      ? 'grid-cols-1'
+      : visibleMedia.length === 1
+        ? 'grid-cols-1'
+        : 'grid-cols-2';
+
+  return (
+    <div className={cn('mt-3 grid gap-1.5', gridClassName)}>
+      {visibleMedia.map((item, index) => (
+        <MediaTile
+          key={item.id}
+          item={item}
+          index={index}
+          className={variant === 'square' ? 'aspect-square' : 'aspect-video'}
+        />
+      ))}
+      {overflowCount > 0 ? (
+        <div className="flex min-h-20 items-center justify-center rounded-lg bg-muted text-xs font-medium text-foreground/70">
+          +{overflowCount} more not shown
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function PreviewShell({
+  target,
+  eyebrow,
+  isApproximate = false,
+  children,
+  className,
+}: {
+  target: ResolvedPlatformPreviewTarget;
+  eyebrow: string;
+  isApproximate?: boolean;
+  children: ReactNode;
+  className?: string;
+}) {
+  const status = getPreviewStatus(target);
+  const Icon = getPlatformIcon(target.platform);
+
+  return (
+    <article
+      aria-label={`${target.platformLabel} platform preview`}
+      className={cn(
+        'overflow-hidden rounded-lg border border-white/10 bg-background/60',
+        className,
+      )}
+    >
+      <div className="flex items-center justify-between gap-3 border-b border-white/10 px-4 py-3">
+        <div className="flex min-w-0 items-center gap-2">
+          <Icon className="size-4 shrink-0 text-foreground/70" />
+          <div className="min-w-0">
+            <p className="truncate text-sm font-medium text-foreground">
+              {target.platformLabel}
+            </p>
+            <p className="truncate text-xs text-foreground/45">
+              {isApproximate ? 'Approximate preview' : eyebrow}
+            </p>
+          </div>
+        </div>
+        <span
+          className={cn(
+            'shrink-0 rounded-full border px-2 py-0.5 text-xs font-medium',
+            status.className,
+          )}
+        >
+          {status.label}
+        </span>
+      </div>
+      <div className="p-4">{children}</div>
+    </article>
+  );
+}
+
+function AuthorRow({
+  target,
+  meta,
+}: {
+  target: ResolvedPlatformPreviewTarget;
+  meta?: ReactNode;
+}) {
+  const authorName = getAuthorName(target);
+  const handle = formatHandle(target.author?.handle);
+
+  return (
+    <div className="flex items-center gap-3">
+      <div className="relative size-10 shrink-0 overflow-hidden rounded-full bg-muted">
+        {target.author?.avatarUrl ? (
+          <Image
+            src={target.author.avatarUrl}
+            alt=""
+            fill
+            sizes="40px"
+            className="object-cover"
+          />
+        ) : null}
+      </div>
+      <div className="min-w-0">
+        <p className="truncate text-sm font-semibold text-foreground">
+          {authorName}
+        </p>
+        <p className="truncate text-xs text-foreground/45">
+          {handle}
+          {meta ? <> · {meta}</> : null}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function ThreadSegments({ target }: { target: ResolvedPlatformPreviewTarget }) {
+  if (target.threadSegments.length <= 1) {
+    return <CaptionText target={target} />;
+  }
+
+  return (
+    <div className="grid gap-3">
+      {target.threadSegments.map((segment, index) => {
+        const state = getCaptionPreviewState(
+          segment.caption,
+          target.capability?.caption.maxLength,
+        );
+
+        return (
+          <div key={segment.id} className="flex gap-3">
+            <div className="flex flex-col items-center">
+              <span className="flex size-6 items-center justify-center rounded-full bg-muted text-xs font-semibold text-foreground/70">
+                {index + 1}
+              </span>
+              {index < target.threadSegments.length - 1 ? (
+                <span className="mt-2 h-full min-h-8 w-px bg-white/10" />
+              ) : null}
+            </div>
+            <div className="min-w-0 flex-1 rounded-lg border border-white/10 bg-black/10 p-3">
+              <div className="mb-2 flex items-center justify-between gap-2">
+                <span className="text-xs font-medium text-foreground/65">
+                  {segment.label ?? `Post ${index + 1}`}
+                </span>
+                <CharacterCounter state={state} />
+              </div>
+              {segment.caption.trim() ? (
+                <p className="whitespace-pre-wrap text-sm leading-6 text-foreground/85">
+                  {renderCaptionEntities(state.previewText)}
+                </p>
+              ) : (
+                <p className="text-sm text-foreground/35">
+                  Draft preview appears here.
+                </p>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function XPreviewRenderer({ target }: PlatformPreviewRendererProps) {
+  return (
+    <PreviewShell eyebrow="X feed preview" target={target}>
+      <div className="flex gap-3">
+        <div className="size-10 shrink-0 rounded-full bg-muted" />
+        <div className="min-w-0 flex-1">
+          <div className="mb-2 flex items-center justify-between gap-3">
+            <div className="min-w-0">
+              <p className="truncate text-sm font-semibold text-foreground">
+                {getAuthorName(target)}
+              </p>
+              <p className="truncate text-xs text-foreground/45">
+                {formatHandle(target.author?.handle)}
+              </p>
+            </div>
+            <CharacterCounter state={target.captionState} />
+          </div>
+          <ThreadSegments target={target} />
+          <MediaGrid target={target} />
+          <LinkPreviewCard target={target} />
+          <div className="mt-4 flex justify-between text-foreground/45">
             <HiChatBubbleOvalLeft className="size-4" />
             <HiArrowPath className="size-4" />
             <HiHeart className="size-4" />
             <HiBookmark className="size-4" />
           </div>
+          <ValidationIssues target={target} />
         </div>
       </div>
-    </InsetSurface>
+    </PreviewShell>
   );
 }
 
-function InstagramPreview({
-  post,
-  accountName,
-}: {
-  post: IPost;
-  accountName: string;
-}) {
-  const ingredient = post.ingredients?.[0] as IIngredient | undefined;
+function LinkedInPreviewRenderer({ target }: PlatformPreviewRendererProps) {
   return (
-    <InsetSurface className="overflow-hidden" density="compact" tone="muted">
-      <div className="flex items-center gap-2 p-3">
-        <div className="size-8 rounded-full bg-muted" />
-        <span className="font-semibold text-sm">{accountName}</span>
+    <PreviewShell eyebrow="LinkedIn feed preview" target={target}>
+      <AuthorRow target={target} meta="Public" />
+      <div className="mt-3 flex items-center justify-between gap-3">
+        <span className="text-xs font-medium uppercase text-foreground/45">
+          Feed post
+        </span>
+        <CharacterCounter state={target.captionState} />
       </div>
-      {ingredient?.ingredientUrl && (
-        <Image
-          src={ingredient.ingredientUrl}
-          alt=""
-          width={400}
-          height={400}
-          className="w-full object-cover aspect-square"
-        />
-      )}
-      {!ingredient?.ingredientUrl && (
-        <div className="w-full aspect-square bg-muted flex items-center justify-center text-muted-foreground text-sm">
-          No media
-        </div>
-      )}
-      <div className="p-3">
-        <div className="flex gap-4 mb-2">
-          <HiHeart className="size-5" />
-          <HiChatBubbleOvalLeft className="size-5" />
-          <HiPaperAirplane className="size-5" />
-          <HiBookmark className="size-5 ml-auto" />
-        </div>
-        <p className="text-sm">
-          <span className="font-semibold">{accountName}</span>{' '}
-          <span className="line-clamp-2">{post.description}</span>
+      <div className="mt-2">
+        <ThreadSegments target={target} />
+      </div>
+      <MediaGrid target={target} />
+      <LinkPreviewCard target={target} />
+      <div className="mt-4 flex items-center gap-5 border-t border-white/10 pt-3 text-xs text-foreground/45">
+        <span className="inline-flex items-center gap-1">
+          <HiHandThumbUp className="size-4" />
+          Like
+        </span>
+        <span className="inline-flex items-center gap-1">
+          <HiChatBubbleOvalLeft className="size-4" />
+          Comment
+        </span>
+        <span className="inline-flex items-center gap-1">
+          <HiPaperAirplane className="size-4" />
+          Send
+        </span>
+      </div>
+      <ValidationIssues target={target} />
+    </PreviewShell>
+  );
+}
+
+function InstagramPreviewRenderer({ target }: PlatformPreviewRendererProps) {
+  return (
+    <PreviewShell eyebrow="Instagram feed preview" target={target}>
+      <AuthorRow target={target} />
+      <MediaGrid target={target} variant="square" />
+      <div className="mt-3 flex items-center gap-4 text-foreground/70">
+        <HiHeart className="size-5" />
+        <HiChatBubbleOvalLeft className="size-5" />
+        <HiPaperAirplane className="size-5" />
+        <HiBookmark className="ml-auto size-5" />
+      </div>
+      <div className="mt-3 flex items-start justify-between gap-3">
+        <p className="min-w-0 whitespace-pre-wrap text-sm leading-6 text-foreground/85">
+          <span className="font-semibold">{getAuthorName(target)}</span>{' '}
+          {target.captionState.previewText.trim()
+            ? renderCaptionEntities(target.captionState.previewText)
+            : 'Draft preview appears here.'}
         </p>
+        <CharacterCounter state={target.captionState} />
       </div>
-    </InsetSurface>
+      <ValidationIssues target={target} />
+    </PreviewShell>
+  );
+}
+
+function TikTokPreviewRenderer({ target }: PlatformPreviewRendererProps) {
+  return (
+    <PreviewShell eyebrow="TikTok vertical preview" target={target}>
+      <div className="relative mx-auto max-w-72 overflow-hidden rounded-lg border border-white/10 bg-black">
+        <MediaGrid target={target} variant="vertical" />
+        <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/90 to-transparent p-4 text-white">
+          <p className="text-sm font-semibold">
+            {formatHandle(target.author?.handle)}
+          </p>
+          <p className="mt-2 line-clamp-4 whitespace-pre-wrap text-sm leading-5">
+            {target.captionState.previewText.trim() ||
+              'Draft preview appears here.'}
+          </p>
+          <div className="mt-3 flex items-center justify-between text-xs text-white/70">
+            <span>{target.platformLabel}</span>
+            <span>
+              {target.captionState.maxLength
+                ? `${target.captionState.count}/${target.captionState.maxLength}`
+                : target.captionState.count}
+            </span>
+          </div>
+        </div>
+      </div>
+      <ValidationIssues target={target} />
+    </PreviewShell>
+  );
+}
+
+function YouTubePreviewRenderer({ target }: PlatformPreviewRendererProps) {
+  return (
+    <PreviewShell eyebrow="YouTube watch preview" target={target}>
+      <MediaGrid target={target} variant="video" />
+      <div className="mt-3">
+        <h3 className="line-clamp-2 text-base font-semibold text-foreground">
+          {target.title?.trim() || 'Untitled video'}
+        </h3>
+        <div className="mt-2 flex items-center justify-between gap-3 text-xs text-foreground/45">
+          <span>{getAuthorName(target)}</span>
+          <CharacterCounter state={target.captionState} />
+        </div>
+      </div>
+      <div className="mt-3 rounded-lg bg-muted/35 p-3">
+        <CaptionText
+          target={target}
+          emptyMessage="Description preview appears here."
+        />
+      </div>
+      <ValidationIssues target={target} />
+    </PreviewShell>
+  );
+}
+
+function GenericPlatformPreviewRenderer({
+  target,
+}: PlatformPreviewRendererProps) {
+  return (
+    <PreviewShell
+      eyebrow="Generic preview"
+      isApproximate={true}
+      target={target}
+    >
+      <div className="flex items-start gap-3">
+        <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-muted text-foreground/55">
+          <HiSparkles className="size-4" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center justify-between gap-3">
+            <p className="text-sm font-medium text-foreground">
+              Approximate preview
+            </p>
+            <CharacterCounter state={target.captionState} />
+          </div>
+          <div className="mt-2">
+            <CaptionText target={target} />
+          </div>
+          <MediaGrid target={target} />
+          <LinkPreviewCard target={target} />
+          {target.capability ? (
+            <div className="mt-3 grid gap-1 text-xs text-foreground/50">
+              <p>
+                Media: {target.capability.media.kinds.join(', ')}
+                {target.capability.media.maxItems
+                  ? `, up to ${target.capability.media.maxItems} item(s)`
+                  : ''}
+              </p>
+              <p>Status: {target.capability.status}</p>
+            </div>
+          ) : null}
+          <ValidationIssues target={target} />
+        </div>
+      </div>
+    </PreviewShell>
   );
 }
 
 export default function PlatformPreview({
   post,
-  accountName = 'Your Account',
-  accountHandle = 'youraccount',
+  target,
+  targets,
+  accountName = DEFAULT_AUTHOR_NAME,
+  accountHandle = DEFAULT_AUTHOR_HANDLE,
+  activePlatform,
+  className,
+  emptyMessage = 'No platform preview available.',
 }: PlatformPreviewProps) {
-  const relevantPlatforms = useMemo(
-    () =>
-      PREVIEW_PLATFORMS.filter(
-        (p) => !post.platform || p.forPlatforms.includes(post.platform),
-      ),
-    [post.platform],
+  const resolvedTargets = useMemo(() => {
+    const previewTargets =
+      targets ??
+      (target
+        ? [target]
+        : post
+          ? buildPostTargets(post, accountName, accountHandle)
+          : []);
+
+    return previewTargets.map(resolvePlatformPreviewTarget);
+  }, [accountHandle, accountName, post, target, targets]);
+
+  const [selectedPlatform, setSelectedPlatform] = useState<string>(() =>
+    normalizePlatform(activePlatform ?? resolvedTargets[0]?.platform ?? ''),
   );
 
-  const [activePlatform, setActivePlatform] = useState<PreviewPlatform>(
-    () => relevantPlatforms[0]?.key ?? 'twitter',
-  );
+  useEffect(() => {
+    if (resolvedTargets.length === 0) {
+      return;
+    }
 
-  if (relevantPlatforms.length === 0) {
-    return null;
+    const activeKey = activePlatform
+      ? normalizePlatform(activePlatform)
+      : selectedPlatform;
+    const hasActiveTarget = resolvedTargets.some(
+      (item) => normalizePlatform(item.platform) === activeKey,
+    );
+
+    if (!hasActiveTarget || activePlatform) {
+      setSelectedPlatform(
+        normalizePlatform(activePlatform ?? resolvedTargets[0].platform),
+      );
+    }
+  }, [activePlatform, resolvedTargets, selectedPlatform]);
+
+  if (resolvedTargets.length === 0) {
+    return (
+      <section
+        className={cn('rounded-lg border border-white/10 p-4', className)}
+      >
+        <p className="text-sm text-foreground/45">{emptyMessage}</p>
+      </section>
+    );
   }
 
-  return (
-    <Card>
-      <div className="flex items-center justify-between mb-3">
-        <h3 className="font-semibold text-sm">Platform Preview</h3>
-        {relevantPlatforms.length > 1 && (
-          <div className="flex gap-1">
-            {relevantPlatforms.map((p) => (
-              <Button
-                key={p.key}
-                variant={ButtonVariant.GHOST}
-                onClick={() => setActivePlatform(p.key)}
-                className={`p-1.5 rounded ${
-                  activePlatform === p.key
-                    ? 'bg-primary/10 text-primary'
-                    : 'text-muted-foreground hover:text-foreground'
-                }`}
-                tooltip={p.label}
-              >
-                {p.icon}
-              </Button>
-            ))}
-          </div>
-        )}
-      </div>
+  const activeTarget =
+    resolvedTargets.find(
+      (item) => normalizePlatform(item.platform) === selectedPlatform,
+    ) ?? resolvedTargets[0];
+  const Renderer = getPlatformPreviewRenderer(activeTarget.platform);
 
-      {activePlatform === 'twitter' && (
-        <TwitterPreview
-          post={post}
-          accountName={accountName}
-          accountHandle={accountHandle}
-        />
-      )}
-      {activePlatform === 'instagram' && (
-        <InstagramPreview post={post} accountName={accountName} />
-      )}
-      {(activePlatform === 'facebook' || activePlatform === 'linkedin') && (
-        <TwitterPreview
-          post={post}
-          accountName={accountName}
-          accountHandle={accountHandle}
-        />
-      )}
-    </Card>
+  return (
+    <section
+      className={cn('space-y-4', className)}
+      aria-label="Platform preview"
+    >
+      {resolvedTargets.length > 1 ? (
+        <div className="flex flex-wrap gap-1">
+          {resolvedTargets.map((item) => {
+            const itemKey = normalizePlatform(item.platform);
+            const Icon = getPlatformIcon(item.platform);
+            const isSelected =
+              itemKey === normalizePlatform(activeTarget.platform);
+
+            return (
+              <Button
+                key={itemKey}
+                type="button"
+                withWrapper={false}
+                variant={ButtonVariant.UNSTYLED}
+                aria-pressed={isSelected}
+                onClick={() => setSelectedPlatform(itemKey)}
+                className={cn(
+                  'inline-flex h-8 items-center gap-2 rounded-lg border px-2.5 text-xs font-medium transition',
+                  isSelected
+                    ? 'border-primary/35 bg-primary/10 text-primary'
+                    : 'border-white/10 text-foreground/55 hover:bg-white/[0.04] hover:text-foreground',
+                )}
+              >
+                <Icon className="size-3.5" />
+                {item.platformLabel}
+              </Button>
+            );
+          })}
+        </div>
+      ) : null}
+
+      <Renderer target={activeTarget} />
+    </section>
   );
 }

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -12,6 +12,7 @@
     "moduleResolution": "bundler",
     "outDir": "./dist",
     "paths": {
+      "@api-types/*": ["../api-types/src/*"],
       "@genfeedai/client": ["../client/src/index.ts"],
       "@genfeedai/client/*": ["../client/src/*"],
       "@genfeedai/contexts": ["../contexts/index.ts"],

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -21,6 +21,7 @@ const XYFLOW_REACT_MOCK = path.resolve(
   './tests/__mocks__/xyflow-react.tsx',
 );
 const EMPTY_STYLE_MOCK = path.resolve(__dirname, './tests/__mocks__/style.ts');
+const API_TYPES_SRC = path.resolve(__dirname, '../api-types/src');
 const CONSTANTS_SRC = path.resolve(__dirname, '../constants/src');
 const ENUMS_SRC = path.resolve(__dirname, '../enums/src');
 const PRICING_SRC = path.resolve(__dirname, '../pricing/src');
@@ -31,6 +32,10 @@ const PAGES_SRC = path.resolve(__dirname, '../pages');
 export default defineConfig({
   resolve: {
     alias: [
+      {
+        find: /^@api-types\/(.*)$/,
+        replacement: path.resolve(API_TYPES_SRC, '$1'),
+      },
       {
         find: '@genfeedai/client',
         replacement: path.resolve(__dirname, '../client/src'),


### PR DESCRIPTION
## Summary
- Adds a registry-driven PlatformPreview renderer contract with dedicated X, LinkedIn, Instagram, TikTok, and YouTube renderers plus an explicit approximate fallback.
- Drives preview counters, truncation, media-count/type validation, and composer limit labels from the shared channel capability catalog.
- Wires the active post composer preview panel through the registry and adds focused renderer/composer coverage.

## Verification
- bunx biome check --write packages/ui/src/components/posts/platform-preview/PlatformPreview.tsx packages/ui/src/components/posts/platform-preview/PlatformPreview.test.tsx apps/app/app/(protected)/[orgSlug]/[brandSlug]/compose/post/posts-write-preview-panel.tsx apps/app/app/(protected)/[orgSlug]/[brandSlug]/compose/post/posts-write-page.tsx apps/app/app/(protected)/[orgSlug]/[brandSlug]/compose/post/posts-write-page.helpers.ts apps/app/app/(protected)/[orgSlug]/[brandSlug]/compose/post/posts-write-account-bar.tsx apps/app/app/(protected)/[orgSlug]/[brandSlug]/compose/post/posts-write-page.test.tsx packages/ui/tsconfig.json packages/ui/vitest.config.ts apps/vitest.config.mts
- bun run test src/components/posts/platform-preview/PlatformPreview.test.tsx
- bun run test app/(protected)/[orgSlug]/[brandSlug]/compose/post/posts-write-page.test.tsx
- Pre-commit hooks: secretlint, staged Biome, raw HTML check, bespoke-card check

## Notes
- Link-card rendering supports supplied cached metadata and a no-preview fallback; this PR does not add new client-side provider fetching.
- Catalog does not yet expose preview-specific animation/thread strategy flags, so the renderers avoid adding separate hardcoded capability constants.

Refs #1172