### PR TITLE
feat(webhooks): emit publish outcome events

### DIFF
--- a/apps/docs/content/api-reference/_meta.ts
+++ b/apps/docs/content/api-reference/_meta.ts
@@ -2,4 +2,5 @@ export default {
   index: 'Overview',
   mcp: 'MCP Server',
   reference: 'Endpoint Reference',
+  webhooks: 'Webhooks',
 };

--- a/apps/docs/content/api-reference/webhooks.mdx
+++ b/apps/docs/content/api-reference/webhooks.mdx
@@ -1,0 +1,66 @@
+# Webhooks
+
+Genfeed can send signed outbound webhooks when scheduled publish work reaches a terminal outcome. Webhooks use the organization webhook endpoint and secret configured in organization settings.
+
+## Delivery
+
+Webhook delivery is asynchronous and does not block publish execution. Events are queued on the `webhook-client` queue and retried up to five times with exponential backoff. Consumer `5xx` and network failures are retried; `4xx` responses are treated as delivered but rejected by the receiver.
+
+Each request includes:
+
+- `X-Genfeed-Event`: event type
+- `X-Genfeed-Delivery`: BullMQ delivery job id
+- `X-Genfeed-Signature`: `sha256=` HMAC over the JSON payload with the endpoint secret
+
+Payloads include `eventId` for consumer idempotency. Delivery is at-least-once, so consumers should store processed `eventId` values.
+
+## Event Catalog
+
+All publish webhook payloads use `schemaVersion: 1`.
+
+| Event | When it emits |
+| --- | --- |
+| `target.published` | A scheduled publish target reaches a published terminal state. |
+| `target.failed` | A scheduled publish target reaches a permanent failed state. |
+| `release.published` | Every target in the release published. |
+| `release.partially_published` | At least one target published and at least one target failed. |
+| `release.failed` | Every terminal target failed. |
+
+## Payload Shape
+
+```json
+{
+  "event": "target.published",
+  "eventId": "publish:target.published:release_123:target_123:published",
+  "schemaVersion": 1,
+  "timestamp": "2026-07-07T10:00:00.000Z",
+  "occurredAt": "2026-07-07T10:00:00.000Z",
+  "release": {
+    "id": "release_123",
+    "status": "published",
+    "scheduledAt": "2026-07-07T09:55:00.000Z",
+    "publishedAt": "2026-07-07T10:00:00.000Z",
+    "targetSummary": {
+      "total": 1,
+      "published": 1,
+      "failed": 0
+    }
+  },
+  "target": {
+    "id": "target_123",
+    "platform": "twitter",
+    "credential": {
+      "id": "cred_123"
+    },
+    "status": "published",
+    "scheduledAt": "2026-07-07T09:55:00.000Z",
+    "publishedAt": "2026-07-07T10:00:00.000Z",
+    "externalProviderId": "post_123",
+    "externalShortcode": "abc123",
+    "url": "https://x.com/example/status/post_123",
+    "error": null
+  }
+}
+```
+
+Failure payloads include a stable `error.class` value: `misconfiguration`, `credential`, `provider_outage`, `rate_limit`, `validation`, or `unknown`. Provider tokens, webhook secrets, bearer tokens, and API keys are redacted from error messages before delivery.

--- a/apps/server/api/src/services/integrations/youtube/services/modules/youtube-upload-completion.service.spec.ts
+++ b/apps/server/api/src/services/integrations/youtube/services/modules/youtube-upload-completion.service.spec.ts
@@ -1,5 +1,6 @@
 import { PostsService } from '@api/collections/posts/services/posts.service';
 import { YoutubeUploadCompletionService } from '@api/services/integrations/youtube/services/modules/youtube-upload-completion.service';
+import { PublishEventWebhookService } from '@api/services/webhook-client/publish-event-webhook.service';
 import { PostStatus } from '@genfeedai/enums';
 import { RedisService } from '@libs/redis/redis.service';
 import { Test, TestingModule } from '@nestjs/testing';
@@ -8,6 +9,10 @@ describe('YoutubeUploadCompletionService', () => {
   let service: YoutubeUploadCompletionService;
   let redisService: { subscribe: ReturnType<typeof vi.fn> };
   let postsService: { patch: ReturnType<typeof vi.fn> };
+  let publishEventWebhookService: {
+    emitLegacyPostFailed: ReturnType<typeof vi.fn>;
+    emitLegacyPostPublished: ReturnType<typeof vi.fn>;
+  };
   let capturedHandler: (data: unknown) => void;
 
   beforeEach(async () => {
@@ -25,12 +30,20 @@ describe('YoutubeUploadCompletionService', () => {
     postsService = {
       patch: vi.fn().mockResolvedValue(undefined),
     };
+    publishEventWebhookService = {
+      emitLegacyPostFailed: vi.fn().mockResolvedValue(undefined),
+      emitLegacyPostPublished: vi.fn().mockResolvedValue(undefined),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         YoutubeUploadCompletionService,
         { provide: RedisService, useValue: redisService },
         { provide: PostsService, useValue: postsService },
+        {
+          provide: PublishEventWebhookService,
+          useValue: publishEventWebhookService,
+        },
       ],
     }).compile();
 
@@ -78,6 +91,15 @@ describe('YoutubeUploadCompletionService', () => {
         }),
       );
     });
+    expect(
+      publishEventWebhookService.emitLegacyPostPublished,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        externalProviderId: 'yt-vid-1',
+        platform: 'youtube',
+        url: 'https://youtube.com/watch?v=yt-vid-1',
+      }),
+    );
   });
 
   it('should update post status to PRIVATE when status is "private"', async () => {
@@ -185,6 +207,14 @@ describe('YoutubeUploadCompletionService', () => {
         }),
       );
     });
+    expect(
+      publishEventWebhookService.emitLegacyPostFailed,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        errorMessage: 'Upload quota exceeded',
+        platform: 'youtube',
+      }),
+    );
   });
 
   it('should update post status to SCHEDULED when status is "scheduled"', async () => {
@@ -212,6 +242,12 @@ describe('YoutubeUploadCompletionService', () => {
         }),
       );
     });
+    expect(
+      publishEventWebhookService.emitLegacyPostPublished,
+    ).not.toHaveBeenCalled();
+    expect(
+      publishEventWebhookService.emitLegacyPostFailed,
+    ).not.toHaveBeenCalled();
   });
 
   it('should not set publicationDate for scheduled status', async () => {

--- a/apps/server/api/src/services/integrations/youtube/services/modules/youtube-upload-completion.service.ts
+++ b/apps/server/api/src/services/integrations/youtube/services/modules/youtube-upload-completion.service.ts
@@ -1,4 +1,5 @@
 import { PostsService } from '@api/collections/posts/services/posts.service';
+import { PublishEventWebhookService } from '@api/services/webhook-client/publish-event-webhook.service';
 import { PostStatus } from '@genfeedai/enums';
 import { RedisService } from '@libs/redis/redis.service';
 import { Injectable, Logger, type OnModuleInit } from '@nestjs/common';
@@ -83,6 +84,7 @@ export class YoutubeUploadCompletionService implements OnModuleInit {
   constructor(
     private readonly redisService: RedisService,
     private readonly postsService: PostsService,
+    private readonly publishEventWebhookService: PublishEventWebhookService,
   ) {}
 
   async onModuleInit() {
@@ -132,7 +134,27 @@ export class YoutubeUploadCompletionService implements OnModuleInit {
         updateData.publicationDate = new Date();
       }
 
-      await this.postsService.patch(postId, updateData);
+      const patchedPost = await this.postsService.patch(postId, updateData);
+      const webhookPost = buildYoutubeWebhookPostSnapshot(data, patchedPost);
+
+      if (PUBLISHED_STATUSES.includes(status)) {
+        void this.publishEventWebhookService.emitLegacyPostPublished({
+          externalProviderId: result?.externalId ?? null,
+          occurredAt: parseCompletionTimestamp(data.timestamp),
+          platform: 'youtube',
+          post: webhookPost,
+          publishedAt: updateData.publicationDate as Date | undefined,
+          url: result?.videoUrl ?? null,
+        });
+      } else if (status === 'failed') {
+        void this.publishEventWebhookService.emitLegacyPostFailed({
+          errorMessage: error || 'YouTube upload failed',
+          occurredAt: parseCompletionTimestamp(data.timestamp),
+          platform: 'youtube',
+          post: webhookPost,
+          retryable: false,
+        });
+      }
 
       this.logger.log(
         `Updated post ${postId} status to ${status}${result?.externalId ? ` with externalId ${result.externalId}` : ''}`,
@@ -144,4 +166,32 @@ export class YoutubeUploadCompletionService implements OnModuleInit {
       );
     }
   }
+}
+
+function buildYoutubeWebhookPostSnapshot(
+  data: YoutubeUploadCompletionEvent,
+  patchedPost: unknown,
+): Record<string, unknown> {
+  if (isPlainObject(patchedPost)) {
+    return patchedPost;
+  }
+
+  return {
+    externalId: data.result?.externalId,
+    id: data.postId,
+    organization: data.organizationId,
+    organizationId: data.organizationId,
+    platform: 'youtube',
+    publicationDate: PUBLISHED_STATUSES.includes(data.status)
+      ? parseCompletionTimestamp(data.timestamp)
+      : undefined,
+    status: STATUS_MAP[data.status] ?? PostStatus.FAILED,
+    url: data.result?.videoUrl,
+    user: data.userId,
+  };
+}
+
+function parseCompletionTimestamp(timestamp: string): Date {
+  const date = new Date(timestamp);
+  return Number.isNaN(date.getTime()) ? new Date() : date;
 }

--- a/apps/server/api/src/services/integrations/youtube/youtube-upload-completion.module.ts
+++ b/apps/server/api/src/services/integrations/youtube/youtube-upload-completion.module.ts
@@ -1,10 +1,14 @@
 import { PostsModule } from '@api/collections/posts/posts.module';
 import { YoutubeUploadCompletionService } from '@api/services/integrations/youtube/services/modules/youtube-upload-completion.service';
+import { WebhookClientModule } from '@api/services/webhook-client/webhook-client.module';
 import { forwardRef, Module } from '@nestjs/common';
 
 @Module({
   exports: [YoutubeUploadCompletionService],
-  imports: [forwardRef(() => PostsModule)],
+  imports: [
+    forwardRef(() => PostsModule),
+    forwardRef(() => WebhookClientModule),
+  ],
   providers: [YoutubeUploadCompletionService],
 })
 export class YoutubeUploadCompletionModule {}

--- a/apps/server/api/src/services/webhook-client/publish-event-webhook.service.spec.ts
+++ b/apps/server/api/src/services/webhook-client/publish-event-webhook.service.spec.ts
@@ -1,0 +1,190 @@
+import { OrganizationSettingsService } from '@api/collections/organization-settings/services/organization-settings.service';
+import { PostsService } from '@api/collections/posts/services/posts.service';
+import {
+  WEBHOOK_CLIENT_QUEUE,
+  type WebhookJobData,
+} from '@genfeedai/queue-contracts';
+import { LoggerService } from '@libs/logger/logger.service';
+import { getQueueToken } from '@nestjs/bullmq';
+import { Test, TestingModule } from '@nestjs/testing';
+import { describe, expect, it, vi } from 'vitest';
+import { PublishEventWebhookService } from './publish-event-webhook.service';
+
+vi.mock('@api/services/webhook-client/webhook-endpoint.validator', () => ({
+  assertSafeWebhookEndpoint: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe('PublishEventWebhookService', () => {
+  let queue: { add: ReturnType<typeof vi.fn> };
+  let postsService: { findAll: ReturnType<typeof vi.fn> };
+  let service: PublishEventWebhookService;
+  let settingsService: { findOne: ReturnType<typeof vi.fn> };
+
+  beforeEach(async () => {
+    queue = {
+      add: vi.fn().mockResolvedValue({ id: 'job-1' }),
+    };
+    settingsService = {
+      findOne: vi.fn().mockResolvedValue({
+        isWebhookEnabled: true,
+        webhookEndpoint: 'https://example.com/webhook',
+        webhookSecret: 'secret',
+      }),
+    };
+    postsService = {
+      findAll: vi.fn().mockResolvedValue({ docs: [] }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PublishEventWebhookService,
+        {
+          provide: getQueueToken(WEBHOOK_CLIENT_QUEUE),
+          useValue: queue,
+        },
+        {
+          provide: LoggerService,
+          useValue: {
+            error: vi.fn(),
+            log: vi.fn(),
+            warn: vi.fn(),
+          },
+        },
+        {
+          provide: OrganizationSettingsService,
+          useValue: settingsService,
+        },
+        {
+          provide: PostsService,
+          useValue: postsService,
+        },
+      ],
+    }).compile();
+
+    service = module.get(PublishEventWebhookService);
+  });
+
+  it('queues deterministic target and release events for a published post', async () => {
+    const occurredAt = new Date('2026-07-07T10:00:00.000Z');
+
+    await service.emitLegacyPostPublished({
+      externalProviderId: 'post_123',
+      occurredAt,
+      platform: 'twitter',
+      post: {
+        credential: 'cred_123',
+        id: 'post_123',
+        organization: 'org_123',
+        platform: 'twitter',
+        scheduledDate: new Date('2026-07-07T09:55:00.000Z'),
+      },
+      url: 'https://x.com/example/status/post_123',
+    });
+
+    expect(queue.add).toHaveBeenCalledTimes(2);
+    const firstPayload = (queue.add.mock.calls[0][1] as WebhookJobData).payload;
+    expect(firstPayload).toMatchObject({
+      event: 'target.published',
+      eventId: 'publish:target.published:post_123:post_123:published',
+      schemaVersion: 1,
+    });
+    expect(queue.add.mock.calls[0][2]).toMatchObject({
+      jobId: 'publish:target.published:post_123:post_123:published',
+    });
+
+    const secondPayload = (queue.add.mock.calls[1][1] as WebhookJobData)
+      .payload;
+    expect(secondPayload).toMatchObject({
+      event: 'release.published',
+      eventId: 'publish:release.published:post_123:release:published',
+      schemaVersion: 1,
+    });
+  });
+
+  it('derives a partially published release event from terminal grouped posts', async () => {
+    postsService.findAll.mockResolvedValue({
+      docs: [
+        {
+          credential: 'cred_123',
+          groupId: 'group_123',
+          id: 'post_123',
+          organization: 'org_123',
+          platform: 'twitter',
+          status: 'public',
+        },
+        {
+          credential: 'cred_456',
+          groupId: 'group_123',
+          id: 'post_456',
+          organization: 'org_123',
+          platform: 'linkedin',
+          status: 'failed',
+        },
+      ],
+    });
+
+    await service.emitLegacyPostPublished({
+      post: {
+        credential: 'cred_123',
+        groupId: 'group_123',
+        id: 'post_123',
+        organization: 'org_123',
+        platform: 'twitter',
+      },
+    });
+
+    const releasePayload = (queue.add.mock.calls[1][1] as WebhookJobData)
+      .payload;
+    expect(releasePayload).toMatchObject({
+      event: 'release.partially_published',
+      release: {
+        id: 'group_123',
+        status: 'partially-published',
+        targetSummary: {
+          failed: 1,
+          published: 1,
+          total: 2,
+        },
+      },
+    });
+  });
+
+  it('redacts secret material from failed publish payloads', async () => {
+    await service.emitLegacyPostFailed({
+      errorMessage: 'Provider rejected access_token=abc123',
+      post: {
+        credential: 'cred_123',
+        id: 'post_123',
+        organization: 'org_123',
+        platform: 'twitter',
+      },
+    });
+
+    const payload = (queue.add.mock.calls[0][1] as WebhookJobData).payload;
+    expect(payload.target).toMatchObject({
+      error: {
+        class: 'credential',
+        message: 'Provider rejected access_token=[REDACTED]',
+      },
+    });
+  });
+
+  it('does not enqueue when org webhooks are disabled', async () => {
+    settingsService.findOne.mockResolvedValue({
+      isWebhookEnabled: false,
+      webhookEndpoint: 'https://8.8.8.8/webhook',
+      webhookSecret: 'secret',
+    });
+
+    await service.emitLegacyPostPublished({
+      post: {
+        credential: 'cred_123',
+        id: 'post_123',
+        organization: 'org_123',
+        platform: 'twitter',
+      },
+    });
+
+    expect(queue.add).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/api/src/services/webhook-client/publish-event-webhook.service.ts
+++ b/apps/server/api/src/services/webhook-client/publish-event-webhook.service.ts
@@ -1,0 +1,483 @@
+import { OrganizationSettingsService } from '@api/collections/organization-settings/services/organization-settings.service';
+import { PostsService } from '@api/collections/posts/services/posts.service';
+import { customLabels } from '@api/helpers/utils/pagination/pagination.util';
+import { assertSafeWebhookEndpoint } from '@api/services/webhook-client/webhook-endpoint.validator';
+import {
+  classifyPublishWebhookError,
+  createPublishWebhookEventId,
+  PUBLISH_WEBHOOK_SCHEMA_VERSION,
+  type PublishWebhookPayload,
+  type PublishWebhookRelease,
+  type PublishWebhookTarget,
+  publishWebhookPayloadSchema,
+  redactPublishWebhookText,
+} from '@api-types/contracts/publish-webhook-events.contract';
+import { ReleaseStatus, TargetExecutionState } from '@genfeedai/enums';
+import {
+  WEBHOOK_CLIENT_QUEUE,
+  type WebhookJobData,
+} from '@genfeedai/queue-contracts';
+import { LoggerService } from '@libs/logger/logger.service';
+import { InjectQueue } from '@nestjs/bullmq';
+import { Injectable } from '@nestjs/common';
+import type { Queue } from 'bullmq';
+
+type PublishWebhookPostSnapshot = {
+  _id?: unknown;
+  brand?: unknown;
+  credential?: unknown;
+  credentialId?: unknown;
+  externalId?: unknown;
+  externalShortcode?: unknown;
+  groupId?: unknown;
+  id?: unknown;
+  isDeleted?: unknown;
+  organization?: unknown;
+  organizationId?: unknown;
+  platform?: unknown;
+  publicationDate?: unknown;
+  publishedAt?: unknown;
+  scheduledDate?: unknown;
+  status?: unknown;
+  url?: unknown;
+  user?: unknown;
+};
+
+type PublishOutcomeInput = {
+  errorCode?: string | null;
+  errorMessage?: string | null;
+  externalProviderId?: string | null;
+  externalShortcode?: string | null;
+  occurredAt?: Date;
+  platform?: string | null;
+  post: PublishWebhookPostSnapshot;
+  publishedAt?: Date | string | null;
+  retryable?: boolean;
+  url?: string | null;
+};
+
+type TerminalTargetResolution =
+  | {
+      reason: 'terminal';
+      targets: PublishWebhookTarget[];
+    }
+  | {
+      reason: 'non-terminal';
+    };
+
+@Injectable()
+export class PublishEventWebhookService {
+  private readonly constructorName = 'PublishEventWebhookService';
+
+  constructor(
+    @InjectQueue(WEBHOOK_CLIENT_QUEUE)
+    private readonly webhookQueue: Queue<WebhookJobData>,
+    private readonly logger: LoggerService,
+    private readonly organizationSettingsService: OrganizationSettingsService,
+    private readonly postsService: PostsService,
+  ) {}
+
+  async emitLegacyPostPublished(input: PublishOutcomeInput): Promise<void> {
+    await this.emitLegacyPostOutcome(input, TargetExecutionState.PUBLISHED);
+  }
+
+  async emitLegacyPostFailed(input: PublishOutcomeInput): Promise<void> {
+    await this.emitLegacyPostOutcome(input, TargetExecutionState.FAILED);
+  }
+
+  private async emitLegacyPostOutcome(
+    input: PublishOutcomeInput,
+    status: TargetExecutionState.PUBLISHED | TargetExecutionState.FAILED,
+  ): Promise<void> {
+    try {
+      const organizationId = readReferenceId(
+        input.post.organizationId ?? input.post.organization,
+      );
+      const targetId = readReferenceId(input.post.id ?? input.post._id);
+
+      if (!organizationId || !targetId) {
+        this.logger.warn(`${this.constructorName} skipped publish webhook`, {
+          hasOrganizationId: Boolean(organizationId),
+          hasTargetId: Boolean(targetId),
+        });
+        return;
+      }
+
+      const occurredAt = input.occurredAt ?? new Date();
+      const occurredAtIso = occurredAt.toISOString();
+      const releaseId = readReleaseId(input.post, targetId);
+      const target = this.buildTarget(input, targetId, status, occurredAtIso);
+      const targetEvent =
+        status === TargetExecutionState.PUBLISHED
+          ? 'target.published'
+          : 'target.failed';
+      const targetReleaseStatus =
+        status === TargetExecutionState.PUBLISHED
+          ? ReleaseStatus.PUBLISHED
+          : ReleaseStatus.FAILED;
+
+      const targetPayload = publishWebhookPayloadSchema.parse({
+        event: targetEvent,
+        eventId: createPublishWebhookEventId({
+          event: targetEvent,
+          releaseId,
+          status,
+          targetId,
+        }),
+        occurredAt: occurredAtIso,
+        release: this.buildRelease(
+          releaseId,
+          targetReleaseStatus,
+          [target],
+          input.post,
+        ),
+        schemaVersion: PUBLISH_WEBHOOK_SCHEMA_VERSION,
+        target,
+        timestamp: occurredAtIso,
+      });
+
+      await this.queuePublishWebhook(organizationId, targetPayload);
+      await this.emitReleaseOutcomeIfTerminal({
+        currentTarget: target,
+        occurredAtIso,
+        organizationId,
+        post: input.post,
+        releaseId,
+      });
+    } catch (error: unknown) {
+      this.logger.error(
+        `${this.constructorName} failed to emit publish event`,
+        {
+          error: (error as Error)?.message,
+          postId: readReferenceId(input.post.id ?? input.post._id),
+        },
+      );
+    }
+  }
+
+  private async emitReleaseOutcomeIfTerminal(input: {
+    currentTarget: PublishWebhookTarget;
+    occurredAtIso: string;
+    organizationId: string;
+    post: PublishWebhookPostSnapshot;
+    releaseId: string;
+  }): Promise<void> {
+    const targetResolution = await this.resolveTerminalReleaseTargets(
+      input.post,
+      input.currentTarget,
+    );
+
+    if (targetResolution.reason !== 'terminal') {
+      return;
+    }
+
+    const releaseStatus = deriveReleaseStatus(targetResolution.targets);
+    if (!releaseStatus) {
+      return;
+    }
+
+    const releaseEvent =
+      releaseStatus === ReleaseStatus.PUBLISHED
+        ? 'release.published'
+        : releaseStatus === ReleaseStatus.PARTIALLY_PUBLISHED
+          ? 'release.partially_published'
+          : 'release.failed';
+
+    const releasePayload = publishWebhookPayloadSchema.parse({
+      event: releaseEvent,
+      eventId: createPublishWebhookEventId({
+        event: releaseEvent,
+        releaseId: input.releaseId,
+        status: releaseStatus,
+      }),
+      occurredAt: input.occurredAtIso,
+      release: this.buildRelease(
+        input.releaseId,
+        releaseStatus,
+        targetResolution.targets,
+        input.post,
+      ),
+      schemaVersion: PUBLISH_WEBHOOK_SCHEMA_VERSION,
+      targets: targetResolution.targets,
+      timestamp: input.occurredAtIso,
+    });
+
+    await this.queuePublishWebhook(input.organizationId, releasePayload);
+  }
+
+  private async resolveTerminalReleaseTargets(
+    post: PublishWebhookPostSnapshot,
+    currentTarget: PublishWebhookTarget,
+  ): Promise<TerminalTargetResolution> {
+    const groupId = readString(post.groupId);
+    if (!groupId) {
+      return { reason: 'terminal', targets: [currentTarget] };
+    }
+
+    try {
+      const result = (await this.postsService.findAll(
+        {
+          include: { credential: true },
+          where: {
+            groupId,
+            isDeleted: false,
+            parent: null,
+          },
+        },
+        {
+          customLabels,
+          limit: 100,
+          page: 1,
+        },
+      )) as unknown as { docs?: PublishWebhookPostSnapshot[] };
+
+      const targets = new Map<string, PublishWebhookTarget>();
+      for (const groupPost of result.docs ?? []) {
+        const targetId = readReferenceId(groupPost.id ?? groupPost._id);
+        if (!targetId) {
+          return { reason: 'non-terminal' };
+        }
+
+        if (targetId === currentTarget.id) {
+          targets.set(targetId, currentTarget);
+          continue;
+        }
+
+        const terminalState = mapPostStatusToTerminalTargetState(
+          readString(groupPost.status),
+        );
+        if (!terminalState) {
+          return { reason: 'non-terminal' };
+        }
+
+        targets.set(
+          targetId,
+          this.buildTarget(
+            { post: groupPost },
+            targetId,
+            terminalState,
+            toIsoString(groupPost.publicationDate ?? groupPost.publishedAt) ??
+              new Date().toISOString(),
+          ),
+        );
+      }
+
+      if (!targets.has(currentTarget.id)) {
+        targets.set(currentTarget.id, currentTarget);
+      }
+
+      return { reason: 'terminal', targets: [...targets.values()] };
+    } catch (error: unknown) {
+      this.logger.warn(
+        `${this.constructorName} failed to resolve release target group`,
+        {
+          error: (error as Error)?.message,
+          groupId,
+          targetId: currentTarget.id,
+        },
+      );
+      return { reason: 'terminal', targets: [currentTarget] };
+    }
+  }
+
+  private buildTarget(
+    input: PublishOutcomeInput,
+    targetId: string,
+    status: TargetExecutionState.PUBLISHED | TargetExecutionState.FAILED,
+    occurredAtIso: string,
+  ): PublishWebhookTarget {
+    const errorMessage =
+      status === TargetExecutionState.FAILED
+        ? redactPublishWebhookText(input.errorMessage || 'Publish failed')
+        : null;
+    const errorClass = errorMessage
+      ? classifyPublishWebhookError(errorMessage)
+      : null;
+
+    return {
+      credential: {
+        id:
+          readReferenceId(input.post.credentialId ?? input.post.credential) ??
+          'unknown',
+      },
+      error:
+        errorMessage && errorClass
+          ? {
+              class: errorClass,
+              code: input.errorCode ?? errorClass,
+              message: errorMessage,
+              retryable: input.retryable ?? false,
+            }
+          : null,
+      externalProviderId:
+        input.externalProviderId ?? readString(input.post.externalId),
+      externalShortcode:
+        input.externalShortcode ?? readString(input.post.externalShortcode),
+      id: targetId,
+      platform: input.platform ?? readString(input.post.platform) ?? 'unknown',
+      publishedAt:
+        status === TargetExecutionState.PUBLISHED
+          ? (toIsoString(
+              input.publishedAt ??
+                input.post.publicationDate ??
+                input.post.publishedAt,
+            ) ?? occurredAtIso)
+          : null,
+      scheduledAt: toIsoString(input.post.scheduledDate),
+      status,
+      url: input.url ?? readString(input.post.url),
+    };
+  }
+
+  private buildRelease(
+    releaseId: string,
+    releaseStatus:
+      | ReleaseStatus.PUBLISHED
+      | ReleaseStatus.PARTIALLY_PUBLISHED
+      | ReleaseStatus.FAILED,
+    targets: PublishWebhookTarget[],
+    post: PublishWebhookPostSnapshot,
+  ): PublishWebhookRelease {
+    const publishedTargets = targets.filter(
+      (target) => target.status === TargetExecutionState.PUBLISHED,
+    );
+
+    return {
+      id: releaseId,
+      publishedAt:
+        releaseStatus === ReleaseStatus.PUBLISHED
+          ? (publishedTargets[0]?.publishedAt ?? null)
+          : null,
+      scheduledAt: toIsoString(post.scheduledDate),
+      status: releaseStatus,
+      targetSummary: {
+        failed: targets.filter(
+          (target) => target.status === TargetExecutionState.FAILED,
+        ).length,
+        published: publishedTargets.length,
+        total: targets.length,
+      },
+    };
+  }
+
+  private async queuePublishWebhook(
+    organizationId: string,
+    payload: PublishWebhookPayload,
+  ): Promise<void> {
+    const settings = await this.organizationSettingsService.findOne({
+      organization: organizationId,
+    });
+
+    if (
+      !settings?.isWebhookEnabled ||
+      !settings.webhookEndpoint ||
+      !settings.webhookSecret
+    ) {
+      return;
+    }
+
+    await assertSafeWebhookEndpoint(settings.webhookEndpoint);
+
+    const jobData: WebhookJobData = {
+      endpoint: settings.webhookEndpoint,
+      organizationId,
+      payload: payload as WebhookJobData['payload'],
+      secret: settings.webhookSecret,
+    };
+
+    await this.webhookQueue.add('send-webhook', jobData, {
+      jobId: payload.eventId,
+    });
+
+    this.logger.log(`${this.constructorName} publish webhook queued`, {
+      event: payload.event,
+      eventId: payload.eventId,
+      organizationId,
+    });
+  }
+}
+
+function deriveReleaseStatus(
+  targets: PublishWebhookTarget[],
+):
+  | ReleaseStatus.PUBLISHED
+  | ReleaseStatus.PARTIALLY_PUBLISHED
+  | ReleaseStatus.FAILED
+  | null {
+  const published = targets.filter(
+    (target) => target.status === TargetExecutionState.PUBLISHED,
+  ).length;
+  const failed = targets.filter(
+    (target) => target.status === TargetExecutionState.FAILED,
+  ).length;
+
+  if (targets.length === 0 || published + failed !== targets.length) {
+    return null;
+  }
+
+  if (published === targets.length) {
+    return ReleaseStatus.PUBLISHED;
+  }
+
+  if (published > 0) {
+    return ReleaseStatus.PARTIALLY_PUBLISHED;
+  }
+
+  return ReleaseStatus.FAILED;
+}
+
+function mapPostStatusToTerminalTargetState(
+  status: string | null,
+): TargetExecutionState.PUBLISHED | TargetExecutionState.FAILED | null {
+  switch (status) {
+    case 'public':
+    case 'private':
+    case 'unlisted':
+      return TargetExecutionState.PUBLISHED;
+    case 'failed':
+      return TargetExecutionState.FAILED;
+    default:
+      return null;
+  }
+}
+
+function readReleaseId(
+  post: PublishWebhookPostSnapshot,
+  fallbackId: string,
+): string {
+  return readString(post.groupId) ?? fallbackId;
+}
+
+function readReferenceId(value: unknown): string | null {
+  if (typeof value === 'string' && value.trim()) {
+    return value;
+  }
+
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+  return (
+    readString(record.id) ??
+    readString(record._id) ??
+    readString(record.mongoId)
+  );
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value : null;
+}
+
+function toIsoString(value: unknown): string | null {
+  if (value instanceof Date && !Number.isNaN(value.getTime())) {
+    return value.toISOString();
+  }
+
+  if (typeof value === 'string' && value.trim()) {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date.toISOString();
+  }
+
+  return null;
+}

--- a/apps/server/api/src/services/webhook-client/webhook-client.module.ts
+++ b/apps/server/api/src/services/webhook-client/webhook-client.module.ts
@@ -1,14 +1,19 @@
 import { OrganizationSettingsModule } from '@api/collections/organization-settings/organization-settings.module';
+import { PostsModule } from '@api/collections/posts/posts.module';
+import { PublishEventWebhookService } from '@api/services/webhook-client/publish-event-webhook.service';
 import { WebhookClientService } from '@api/services/webhook-client/webhook-client.service';
 import { HttpModule } from '@nestjs/axios';
 import { BullModule } from '@nestjs/bullmq';
 import { forwardRef, Module } from '@nestjs/common';
 
+export { PublishEventWebhookService } from '@api/services/webhook-client/publish-event-webhook.service';
+
 @Module({
-  exports: [WebhookClientService],
+  exports: [PublishEventWebhookService, WebhookClientService],
   imports: [
     forwardRef(() => HttpModule),
     forwardRef(() => OrganizationSettingsModule),
+    forwardRef(() => PostsModule),
     BullModule.registerQueue({
       defaultJobOptions: {
         attempts: 5,
@@ -22,6 +27,6 @@ import { forwardRef, Module } from '@nestjs/common';
       name: 'webhook-client',
     }),
   ],
-  providers: [WebhookClientService],
+  providers: [PublishEventWebhookService, WebhookClientService],
 })
 export class WebhookClientModule {}

--- a/apps/server/workers/src/crons/posts/cron.posts.module.ts
+++ b/apps/server/workers/src/crons/posts/cron.posts.module.ts
@@ -5,6 +5,7 @@ import { PostsModule } from '@api/collections/posts/posts.module';
 import { SystemWorkflowProvenanceService } from '@api/collections/workflows/services/system-workflow-provenance.service';
 import { PublishersModule } from '@api/services/integrations/publishers/publishers.module';
 import { QuotaModule } from '@api/services/quota/quota.module';
+import { WebhookClientModule } from '@api/services/webhook-client/webhook-client.module';
 import { forwardRef, Module } from '@nestjs/common';
 import { CronPostsService } from '@workers/crons/posts/cron.posts.service';
 
@@ -14,6 +15,7 @@ import { CronPostsService } from '@workers/crons/posts/cron.posts.service';
     forwardRef(() => CredentialsModule),
     forwardRef(() => OrganizationsModule),
     forwardRef(() => PostsModule),
+    forwardRef(() => WebhookClientModule),
     PublishersModule,
     QuotaModule,
   ],

--- a/apps/server/workers/src/crons/posts/cron.posts.service.spec.ts
+++ b/apps/server/workers/src/crons/posts/cron.posts.service.spec.ts
@@ -5,16 +5,43 @@ import { PostsService } from '@api/collections/posts/services/posts.service';
 import { SystemWorkflowProvenanceService } from '@api/collections/workflows/services/system-workflow-provenance.service';
 import { PublisherFactoryService } from '@api/services/integrations/publishers/publisher-factory.service';
 import { QuotaService } from '@api/services/quota/quota.service';
+import { PublishEventWebhookService } from '@api/services/webhook-client/webhook-client.module';
+import { CredentialPlatform, PostStatus } from '@genfeedai/enums';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Test, TestingModule } from '@nestjs/testing';
 import { CronPostsService } from '@workers/crons/posts/cron.posts.service';
 
 describe('CronPostsService', () => {
   let service: CronPostsService;
+  let activitiesService: { create: ReturnType<typeof vi.fn> };
+  let credentialsService: { findOne: ReturnType<typeof vi.fn> };
   let postsService: vi.Mocked<PostsService>;
+  let publisherFactory: { getPublisher: ReturnType<typeof vi.fn> };
+  let publishEventWebhookService: {
+    emitLegacyPostFailed: ReturnType<typeof vi.fn>;
+    emitLegacyPostPublished: ReturnType<typeof vi.fn>;
+  };
+  let quotaService: { checkQuota: ReturnType<typeof vi.fn> };
   let loggerService: vi.Mocked<LoggerService>;
 
   beforeEach(async () => {
+    activitiesService = {
+      create: vi.fn().mockResolvedValue(undefined),
+    };
+    credentialsService = {
+      findOne: vi.fn(),
+    };
+    publisherFactory = {
+      getPublisher: vi.fn(),
+    };
+    publishEventWebhookService = {
+      emitLegacyPostFailed: vi.fn().mockResolvedValue(undefined),
+      emitLegacyPostPublished: vi.fn().mockResolvedValue(undefined),
+    };
+    quotaService = {
+      checkQuota: vi.fn(),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         CronPostsService,
@@ -28,20 +55,16 @@ describe('CronPostsService', () => {
         },
         {
           provide: ActivitiesService,
-          useValue: {
-            create: vi.fn(),
-          },
+          useValue: activitiesService,
         },
         {
           provide: CredentialsService,
-          useValue: {
-            findOne: vi.fn(),
-          },
+          useValue: credentialsService,
         },
         {
           provide: OrganizationsService,
           useValue: {
-            findOne: vi.fn(),
+            findOne: vi.fn().mockResolvedValue({ id: 'org-1' }),
           },
         },
         {
@@ -54,15 +77,11 @@ describe('CronPostsService', () => {
         },
         {
           provide: QuotaService,
-          useValue: {
-            checkQuota: vi.fn(),
-          },
+          useValue: quotaService,
         },
         {
           provide: PublisherFactoryService,
-          useValue: {
-            getPublisher: vi.fn(),
-          },
+          useValue: publisherFactory,
         },
         {
           provide: SystemWorkflowProvenanceService,
@@ -86,6 +105,10 @@ describe('CronPostsService', () => {
             ),
           },
         },
+        {
+          provide: PublishEventWebhookService,
+          useValue: publishEventWebhookService,
+        },
       ],
     }).compile();
 
@@ -108,6 +131,111 @@ describe('CronPostsService', () => {
     expect(postsService.findAll).toHaveBeenCalled();
     expect(loggerService.log).toHaveBeenCalledWith(
       expect.stringContaining('no posts to process'),
+    );
+  });
+
+  it('emits publish webhooks after a scheduled post publishes', async () => {
+    const post = {
+      brand: 'brand-1',
+      children: [],
+      credential: 'cred-1',
+      id: 'post-1',
+      ingredients: [],
+      organization: 'org-1',
+      platform: CredentialPlatform.TWITTER,
+      scheduledDate: new Date('2026-07-07T09:55:00.000Z'),
+      status: PostStatus.SCHEDULED,
+      user: 'user-1',
+    };
+    postsService.findAll.mockResolvedValueOnce({
+      docs: [post],
+      total: 1,
+    } as never);
+    credentialsService.findOne.mockResolvedValue({
+      id: 'cred-1',
+      platform: CredentialPlatform.TWITTER,
+    });
+    quotaService.checkQuota.mockResolvedValue({
+      allowed: true,
+      currentCount: 0,
+      dailyLimit: 10,
+    });
+    publisherFactory.getPublisher.mockReturnValue({
+      publish: vi.fn().mockResolvedValue({
+        externalId: 'tweet-1',
+        externalShortcode: 'tweet-short',
+        platform: CredentialPlatform.TWITTER,
+        status: PostStatus.PUBLIC,
+        success: true,
+        url: 'https://x.com/example/status/tweet-1',
+      }),
+      supportsThreads: false,
+    });
+
+    await service.publishScheduledPosts();
+
+    expect(
+      publishEventWebhookService.emitLegacyPostPublished,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        externalProviderId: 'tweet-1',
+        externalShortcode: 'tweet-short',
+        platform: CredentialPlatform.TWITTER,
+        post,
+        url: 'https://x.com/example/status/tweet-1',
+      }),
+    );
+  });
+
+  it('emits failure webhooks only after retries are exhausted', async () => {
+    const post = {
+      brand: 'brand-1',
+      children: [],
+      credential: 'cred-1',
+      id: 'post-1',
+      ingredients: [],
+      organization: 'org-1',
+      platform: CredentialPlatform.TWITTER,
+      retryCount: 3,
+      scheduledDate: new Date('2026-07-07T09:55:00.000Z'),
+      status: PostStatus.SCHEDULED,
+      user: 'user-1',
+    };
+    postsService.findAll.mockResolvedValueOnce({
+      docs: [post],
+      total: 1,
+    } as never);
+    credentialsService.findOne.mockResolvedValue({
+      id: 'cred-1',
+      platform: CredentialPlatform.TWITTER,
+    });
+    quotaService.checkQuota.mockResolvedValue({
+      allowed: true,
+      currentCount: 0,
+      dailyLimit: 10,
+    });
+    publisherFactory.getPublisher.mockReturnValue({
+      publish: vi.fn().mockResolvedValue({
+        error: 'Provider validation failed',
+        externalId: null,
+        platform: CredentialPlatform.TWITTER,
+        status: PostStatus.FAILED,
+        success: false,
+        url: '',
+      }),
+      supportsThreads: false,
+    });
+
+    await service.publishScheduledPosts();
+
+    expect(
+      publishEventWebhookService.emitLegacyPostFailed,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        errorMessage: 'Provider validation failed',
+        platform: CredentialPlatform.TWITTER,
+        post,
+      }),
     );
   });
 });

--- a/apps/server/workers/src/crons/posts/cron.posts.service.ts
+++ b/apps/server/workers/src/crons/posts/cron.posts.service.ts
@@ -16,6 +16,7 @@ import type {
 } from '@api/services/integrations/publishers/interfaces/publisher.interface';
 import { PublisherFactoryService } from '@api/services/integrations/publishers/publisher-factory.service';
 import { QuotaService } from '@api/services/quota/quota.service';
+import { PublishEventWebhookService } from '@api/services/webhook-client/webhook-client.module';
 import {
   ActivityEntityModel,
   ActivityKey,
@@ -60,6 +61,7 @@ export class CronPostsService {
     private readonly quotaService: QuotaService,
     private readonly publisherFactory: PublisherFactoryService,
     private readonly systemWorkflowProvenanceService: SystemWorkflowProvenanceService,
+    private readonly publishEventWebhookService: PublishEventWebhookService,
   ) {}
 
   /**
@@ -209,6 +211,7 @@ export class CronPostsService {
       if (!credential) {
         this.logger.error(`${url} credential not found`, { postId: post.id });
         await this.postsService.patch(post.id, { status: PostStatus.FAILED });
+        this.emitPublishFailedWebhook(post, 'Credential not found');
         return this.createFailedResult('', 'Credential not found');
       }
 
@@ -222,6 +225,7 @@ export class CronPostsService {
           postId: post.id,
         });
         await this.postsService.patch(post.id, { status: PostStatus.FAILED });
+        this.emitPublishFailedWebhook(post, 'Organization not found');
         return this.createFailedResult('', 'Organization not found');
       }
 
@@ -244,6 +248,11 @@ export class CronPostsService {
           quotaCheck,
           credential.platform,
         );
+        this.emitPublishFailedWebhook(
+          post,
+          'Quota exceeded',
+          credential.platform,
+        );
 
         return this.createFailedResult(credential.platform, 'Quota exceeded');
       }
@@ -257,6 +266,7 @@ export class CronPostsService {
           postId: post.id,
         });
         await this.postsService.patch(post.id, { status: PostStatus.FAILED });
+        this.emitPublishFailedWebhook(post, 'Unsupported platform', platform);
         return this.createFailedResult(platform, 'Unsupported platform');
       }
 
@@ -358,6 +368,8 @@ export class CronPostsService {
           }
         }
 
+        this.emitPublishPublishedWebhook(post, result, credential.platform);
+
         this.logger.log(`${url} published post successfully`, {
           childrenCount: children.length,
           externalId: result.externalId,
@@ -443,6 +455,7 @@ export class CronPostsService {
       };
     }
 
+    this.emitPublishFailedWebhook(post, errorMessage, platform);
     return result;
   }
 
@@ -483,7 +496,34 @@ export class CronPostsService {
       };
     }
 
+    this.emitPublishFailedWebhook(post, errorMessage);
     return this.createFailedResult('', errorMessage);
+  }
+
+  private emitPublishPublishedWebhook(
+    post: PostEntity,
+    result: PublishResult,
+    platform: CredentialPlatform | string,
+  ): void {
+    void this.publishEventWebhookService.emitLegacyPostPublished({
+      externalProviderId: result.externalId ?? null,
+      externalShortcode: result.externalShortcode ?? null,
+      platform,
+      post,
+      url: result.url || null,
+    });
+  }
+
+  private emitPublishFailedWebhook(
+    post: PostEntity,
+    errorMessage: string,
+    platform?: CredentialPlatform | string,
+  ): void {
+    void this.publishEventWebhookService.emitLegacyPostFailed({
+      errorMessage,
+      platform,
+      post,
+    });
   }
 
   /**

--- a/apps/server/workers/src/crons/tiktok/cron.tiktok-status.service.spec.ts
+++ b/apps/server/workers/src/crons/tiktok/cron.tiktok-status.service.spec.ts
@@ -5,6 +5,7 @@ import {
   SystemWorkflowProvenanceService,
 } from '@api/collections/workflows/services/system-workflow-provenance.service';
 import { TiktokService } from '@api/services/integrations/tiktok/services/tiktok.service';
+import { PublishEventWebhookService } from '@api/services/webhook-client/webhook-client.module';
 import { PostStatus } from '@genfeedai/enums';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Test, TestingModule } from '@nestjs/testing';
@@ -20,6 +21,10 @@ describe('CronTiktokStatusService', () => {
     getPublishStatus: ReturnType<typeof vi.fn>;
     refreshToken: ReturnType<typeof vi.fn>;
   };
+  let publishEventWebhookService: {
+    emitLegacyPostFailed: ReturnType<typeof vi.fn>;
+    emitLegacyPostPublished: ReturnType<typeof vi.fn>;
+  };
   let provenanceService: { runAction: ReturnType<typeof vi.fn> };
 
   beforeEach(async () => {
@@ -30,6 +35,10 @@ describe('CronTiktokStatusService', () => {
     tiktokService = {
       getPublishStatus: vi.fn(),
       refreshToken: vi.fn(),
+    };
+    publishEventWebhookService = {
+      emitLegacyPostFailed: vi.fn().mockResolvedValue(undefined),
+      emitLegacyPostPublished: vi.fn().mockResolvedValue(undefined),
     };
     provenanceService = {
       runAction: vi.fn(
@@ -73,6 +82,10 @@ describe('CronTiktokStatusService', () => {
           provide: SystemWorkflowProvenanceService,
           useValue: provenanceService,
         },
+        {
+          provide: PublishEventWebhookService,
+          useValue: publishEventWebhookService,
+        },
       ],
     }).compile();
 
@@ -91,9 +104,11 @@ describe('CronTiktokStatusService', () => {
         _id: 'credential-1',
         accessToken: 'encrypted-token',
         externalHandle: 'creator',
+        id: 'credential-1',
         isConnected: true,
       },
       externalId: 'publish-1',
+      id: 'post-1',
       organization: 'org-1',
       updatedAt: new Date().toISOString(),
       user: 'user-1',
@@ -122,6 +137,16 @@ describe('CronTiktokStatusService', () => {
         status: PostStatus.PUBLIC,
       }),
     );
+    expect(
+      publishEventWebhookService.emitLegacyPostPublished,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        externalProviderId: 'tiktok-post-1',
+        platform: 'tiktok',
+        post,
+        url: 'https://www.tiktok.com/@creator/video/tiktok-post-1',
+      }),
+    );
   });
 
   it('marks timed-out pending posts failed inside a provenance execution', async () => {
@@ -131,9 +156,11 @@ describe('CronTiktokStatusService', () => {
       credential: {
         _id: 'credential-1',
         accessToken: 'encrypted-token',
+        id: 'credential-1',
         isConnected: true,
       },
       externalId: 'publish-2',
+      id: 'post-2',
       organization: 'org-1',
       // Became PENDING 48h ago - beyond the 24h max age
       updatedAt: new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString(),
@@ -152,6 +179,15 @@ describe('CronTiktokStatusService', () => {
     expect(postsService.patch).toHaveBeenCalledWith('post-2', {
       status: PostStatus.FAILED,
     });
+    expect(
+      publishEventWebhookService.emitLegacyPostFailed,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        errorMessage: 'TikTok moderation timeout - exceeded 24 hours',
+        platform: 'tiktok',
+        post,
+      }),
+    );
     expect(tiktokService.getPublishStatus).not.toHaveBeenCalled();
   });
 
@@ -162,9 +198,11 @@ describe('CronTiktokStatusService', () => {
       credential: {
         _id: 'credential-1',
         accessToken: 'encrypted-token',
+        id: 'credential-1',
         isConnected: true,
       },
       externalId: 'publish-3',
+      id: 'post-3',
       organization: 'org-1',
       updatedAt: new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString(),
       user: 'user-1',

--- a/apps/server/workers/src/crons/tiktok/cron.tiktok-status.service.ts
+++ b/apps/server/workers/src/crons/tiktok/cron.tiktok-status.service.ts
@@ -7,6 +7,7 @@ import {
 } from '@api/collections/workflows/services/system-workflow-provenance.service';
 import { customLabels } from '@api/helpers/utils/pagination/pagination.util';
 import { TiktokService } from '@api/services/integrations/tiktok/services/tiktok.service';
+import { PublishEventWebhookService } from '@api/services/webhook-client/webhook-client.module';
 import {
   CredentialPlatform,
   PostStatus,
@@ -67,6 +68,7 @@ export class CronTiktokStatusService {
     private readonly tiktokService: TiktokService,
     private readonly credentialsService: CredentialsService,
     private readonly systemWorkflowProvenanceService: SystemWorkflowProvenanceService,
+    private readonly publishEventWebhookService: PublishEventWebhookService,
   ) {}
 
   /**
@@ -233,7 +235,7 @@ export class CronTiktokStatusService {
         const postUrl = `https://www.tiktok.com/@${credential.externalHandle}/video/${postId}`;
 
         // Update post with real post_id and mark as PUBLIC
-        await this.recordStatusTransition(
+        const transitioned = await this.recordStatusTransition(
           post,
           'published',
           `TikTok moderation completed - post ${postId} is live`,
@@ -245,6 +247,15 @@ export class CronTiktokStatusService {
             });
           },
         );
+        if (transitioned) {
+          void this.publishEventWebhookService.emitLegacyPostPublished({
+            externalProviderId: postId,
+            occurredAt: now,
+            platform: CredentialPlatform.TIKTOK,
+            post,
+            url: postUrl,
+          });
+        }
 
         this.logger.log(`${url} post ${post.id} verified and published`, {
           postId,
@@ -340,11 +351,23 @@ export class CronTiktokStatusService {
     post: TiktokPost,
     reason: string,
   ): Promise<void> {
-    await this.recordStatusTransition(post, 'failed', reason, async () => {
-      await this.postsService.patch(String(post.id), {
-        status: PostStatus.FAILED,
+    const transitioned = await this.recordStatusTransition(
+      post,
+      'failed',
+      reason,
+      async () => {
+        await this.postsService.patch(String(post.id), {
+          status: PostStatus.FAILED,
+        });
+      },
+    );
+    if (transitioned) {
+      void this.publishEventWebhookService.emitLegacyPostFailed({
+        errorMessage: reason,
+        platform: CredentialPlatform.TIKTOK,
+        post,
       });
-    });
+    }
 
     this.logger.warn(`Post ${String(post.id)} marked as failed`, {
       reason,
@@ -362,7 +385,7 @@ export class CronTiktokStatusService {
     outcome: 'published' | 'failed',
     detail: string,
     transition: () => Promise<void>,
-  ): Promise<void> {
+  ): Promise<boolean> {
     try {
       await this.systemWorkflowProvenanceService.runAction(
         {
@@ -387,12 +410,14 @@ export class CronTiktokStatusService {
         },
         transition,
       );
+      return true;
     } catch (error: unknown) {
       this.logger.error('Failed to record TikTok status transition', {
         error: (error as Error)?.message,
         outcome,
         postId: String(post.id),
       });
+      return false;
     }
   }
 }

--- a/apps/server/workers/src/crons/tiktok/cron.tiktok.module.ts
+++ b/apps/server/workers/src/crons/tiktok/cron.tiktok.module.ts
@@ -2,6 +2,7 @@ import { CredentialsModule } from '@api/collections/credentials/credentials.modu
 import { PostsModule } from '@api/collections/posts/posts.module';
 import { SystemWorkflowProvenanceService } from '@api/collections/workflows/services/system-workflow-provenance.service';
 import { TiktokModule } from '@api/services/integrations/tiktok/tiktok.module';
+import { WebhookClientModule } from '@api/services/webhook-client/webhook-client.module';
 import { forwardRef, Module } from '@nestjs/common';
 import { CronTiktokStatusService } from '@workers/crons/tiktok/cron.tiktok-status.service';
 
@@ -9,6 +10,7 @@ import { CronTiktokStatusService } from '@workers/crons/tiktok/cron.tiktok-statu
   imports: [
     forwardRef(() => CredentialsModule),
     forwardRef(() => PostsModule),
+    forwardRef(() => WebhookClientModule),
     forwardRef(() => TiktokModule),
   ],
   exports: [CronTiktokStatusService],

--- a/apps/server/workers/src/crons/youtube/cron.youtube-status.service.spec.ts
+++ b/apps/server/workers/src/crons/youtube/cron.youtube-status.service.spec.ts
@@ -4,6 +4,7 @@ import {
   SystemWorkflowProvenanceService,
 } from '@api/collections/workflows/services/system-workflow-provenance.service';
 import { YoutubeService } from '@api/services/integrations/youtube/services/youtube.service';
+import { PublishEventWebhookService } from '@api/services/webhook-client/webhook-client.module';
 import { PostStatus } from '@genfeedai/enums';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Test, TestingModule } from '@nestjs/testing';
@@ -16,6 +17,10 @@ describe('CronYoutubeStatusService', () => {
     patch: ReturnType<typeof vi.fn>;
   };
   let youtubeService: { getVideoStatus: ReturnType<typeof vi.fn> };
+  let publishEventWebhookService: {
+    emitLegacyPostFailed: ReturnType<typeof vi.fn>;
+    emitLegacyPostPublished: ReturnType<typeof vi.fn>;
+  };
   let provenanceService: { runAction: ReturnType<typeof vi.fn> };
 
   beforeEach(async () => {
@@ -25,6 +30,10 @@ describe('CronYoutubeStatusService', () => {
     };
     youtubeService = {
       getVideoStatus: vi.fn(),
+    };
+    publishEventWebhookService = {
+      emitLegacyPostFailed: vi.fn().mockResolvedValue(undefined),
+      emitLegacyPostPublished: vi.fn().mockResolvedValue(undefined),
     };
     provenanceService = {
       runAction: vi.fn(
@@ -62,6 +71,10 @@ describe('CronYoutubeStatusService', () => {
           provide: SystemWorkflowProvenanceService,
           useValue: provenanceService,
         },
+        {
+          provide: PublishEventWebhookService,
+          useValue: publishEventWebhookService,
+        },
       ],
     }).compile();
 
@@ -78,6 +91,7 @@ describe('CronYoutubeStatusService', () => {
       brand: 'brand-1',
       credential: 'credential-1',
       externalId: 'video-1',
+      id: 'post-1',
       organization: 'org-1',
       status: PostStatus.PRIVATE,
       user: 'user-1',
@@ -100,6 +114,16 @@ describe('CronYoutubeStatusService', () => {
       'post-1',
       expect.objectContaining({ status: PostStatus.PUBLIC }),
     );
+    expect(
+      publishEventWebhookService.emitLegacyPostPublished,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        externalProviderId: 'video-1',
+        platform: 'youtube',
+        post,
+        url: 'https://www.youtube.com/watch?v=video-1',
+      }),
+    );
   });
 
   it('does not record an execution when the status is unchanged', async () => {
@@ -108,6 +132,7 @@ describe('CronYoutubeStatusService', () => {
       brand: 'brand-1',
       credential: 'credential-1',
       externalId: 'video-2',
+      id: 'post-2',
       organization: 'org-1',
       status: PostStatus.PRIVATE,
       user: 'user-1',
@@ -129,6 +154,7 @@ describe('CronYoutubeStatusService', () => {
       brand: 'brand-1',
       credential: 'credential-1',
       externalId: 'video-3',
+      id: 'post-3',
       organization: 'org-1',
       status: PostStatus.PRIVATE,
       user: 'user-1',

--- a/apps/server/workers/src/crons/youtube/cron.youtube-status.service.ts
+++ b/apps/server/workers/src/crons/youtube/cron.youtube-status.service.ts
@@ -6,6 +6,7 @@ import {
 } from '@api/collections/workflows/services/system-workflow-provenance.service';
 import { customLabels } from '@api/helpers/utils/pagination/pagination.util';
 import { YoutubeService } from '@api/services/integrations/youtube/services/youtube.service';
+import { PublishEventWebhookService } from '@api/services/webhook-client/webhook-client.module';
 import {
   CredentialPlatform,
   PostStatus,
@@ -30,6 +31,7 @@ export class CronYoutubeStatusService {
     private readonly postsService: PostsService,
     private readonly youtubeService: YoutubeService,
     private readonly systemWorkflowProvenanceService: SystemWorkflowProvenanceService,
+    private readonly publishEventWebhookService: PublishEventWebhookService,
   ) {}
 
   /**
@@ -134,7 +136,7 @@ export class CronYoutubeStatusService {
           updateData.publicationDate = new Date();
         }
 
-        await this.recordStatusTransition(
+        const transitioned = await this.recordStatusTransition(
           post,
           targetStatus,
           `YouTube reports ${videoStatus.privacyStatus} - syncing post from ${post.status} to ${targetStatus}`,
@@ -142,6 +144,19 @@ export class CronYoutubeStatusService {
             await this.postsService.patch(post.id.toString(), updateData);
           },
         );
+        if (
+          transitioned &&
+          [PostStatus.PUBLIC, PostStatus.PRIVATE, PostStatus.UNLISTED].includes(
+            targetStatus,
+          )
+        ) {
+          void this.publishEventWebhookService.emitLegacyPostPublished({
+            externalProviderId: post.externalId,
+            platform: CredentialPlatform.YOUTUBE,
+            post,
+            url: `https://www.youtube.com/watch?v=${post.externalId}`,
+          });
+        }
 
         this.logger.log(
           `${url} YouTube video ${post.externalId} status synced`,
@@ -224,7 +239,7 @@ export class CronYoutubeStatusService {
     outcome: string,
     detail: string,
     transition: () => Promise<void>,
-  ): Promise<void> {
+  ): Promise<boolean> {
     try {
       await this.systemWorkflowProvenanceService.runAction(
         {
@@ -248,12 +263,14 @@ export class CronYoutubeStatusService {
         },
         transition,
       );
+      return true;
     } catch (error: unknown) {
       this.logger.error('Failed to record YouTube status transition', {
         error: (error as Error)?.message,
         outcome,
         postId: String(post._id),
       });
+      return false;
     }
   }
 }

--- a/apps/server/workers/src/crons/youtube/cron.youtube.module.ts
+++ b/apps/server/workers/src/crons/youtube/cron.youtube.module.ts
@@ -2,6 +2,7 @@ import { PostsModule } from '@api/collections/posts/posts.module';
 import { SocialInboxModule } from '@api/collections/social-inbox/social-inbox.module';
 import { SystemWorkflowProvenanceService } from '@api/collections/workflows/services/system-workflow-provenance.service';
 import { YoutubeModule } from '@api/services/integrations/youtube/youtube.module';
+import { WebhookClientModule } from '@api/services/webhook-client/webhook-client.module';
 import { forwardRef, Module } from '@nestjs/common';
 import { CronYoutubeAnalyticsService } from '@workers/crons/youtube/cron.youtube-analytics.service';
 import { CronYoutubeMessagesService } from '@workers/crons/youtube/cron.youtube-messages.service';
@@ -11,6 +12,7 @@ import { WorkersQueuesModule } from '@workers/queues/queues.module';
 @Module({
   imports: [
     forwardRef(() => PostsModule),
+    forwardRef(() => WebhookClientModule),
     forwardRef(() => SocialInboxModule),
     forwardRef(() => WorkersQueuesModule),
     forwardRef(() => YoutubeModule),

--- a/apps/server/workers/vitest.config.ts
+++ b/apps/server/workers/vitest.config.ts
@@ -38,6 +38,13 @@ export default defineConfig({
         replacement: path.resolve(serviceDir, '../server/src/$1'),
       },
       {
+        find: '@billing-providers',
+        replacement: path.resolve(
+          serviceDir,
+          '../api/src/common/subscriptions/billing.providers.oss.ts',
+        ),
+      },
+      {
         find: '@genfeedai/constants',
         replacement: path.resolve(
           serviceDir,

--- a/apps/server/workers/vitest.config.ts
+++ b/apps/server/workers/vitest.config.ts
@@ -119,10 +119,45 @@ export default defineConfig({
         ),
       },
       {
+        find: '@genfeedai/workflow-saas',
+        replacement: path.resolve(
+          serviceDir,
+          '../../../packages/workflow-saas/src',
+        ),
+      },
+      {
+        find: '@genfeedai/workflows',
+        replacement: path.resolve(
+          serviceDir,
+          '../../../packages/workflows/src',
+        ),
+      },
+      {
+        find: /^@genfeedai\/workflows\/(.*)$/,
+        replacement: path.resolve(
+          serviceDir,
+          '../../../packages/workflows/src/$1',
+        ),
+      },
+      {
+        find: /^@genfeedai\/workflow-saas\/(.*)$/,
+        replacement: path.resolve(
+          serviceDir,
+          '../../../packages/workflow-saas/src/$1',
+        ),
+      },
+      {
         find: /^@workflow-engine\/(.*)$/,
         replacement: path.resolve(
           serviceDir,
           '../../../packages/workflow-engine/src/$1',
+        ),
+      },
+      {
+        find: /^@workflow-saas\/(.*)$/,
+        replacement: path.resolve(
+          serviceDir,
+          '../../../packages/workflow-saas/src/$1',
         ),
       },
       {

--- a/apps/server/workers/vitest.config.ts
+++ b/apps/server/workers/vitest.config.ts
@@ -182,6 +182,13 @@ export default defineConfig({
         ),
       },
       {
+        find: /^@api-types\/(.*)$/,
+        replacement: path.resolve(
+          serviceDir,
+          '../../../packages/api-types/src/$1',
+        ),
+      },
+      {
         find: /^@genfeedai\/queue-contracts\/(.*)$/,
         replacement: path.resolve(
           serviceDir,

--- a/apps/server/workers/vitest.cron.config.ts
+++ b/apps/server/workers/vitest.cron.config.ts
@@ -104,6 +104,13 @@ export default defineConfig({
         ),
       },
       {
+        find: /^@api-types\/(.*)$/,
+        replacement: path.resolve(
+          serviceDir,
+          '../../../packages/api-types/src/$1',
+        ),
+      },
+      {
         find: /^@genfeedai\/queue-contracts\/(.*)$/,
         replacement: path.resolve(
           serviceDir,

--- a/ee/packages/billing/tsconfig.json
+++ b/ee/packages/billing/tsconfig.json
@@ -10,6 +10,7 @@
     "noEmit": true,
     "paths": {
       "@api/*": ["../../../apps/server/api/src/*"],
+      "@api-types/*": ["../../../packages/api-types/src/*"],
       "@billing-providers": ["./src/billing.providers.ee.ts"],
       "@config/*": ["../../../packages/config/src/*"],
       "@genfeedai/config": ["../../../packages/config/src/index.ts"],

--- a/packages/api-types/__tests__/publish-webhook-events.contract.test.ts
+++ b/packages/api-types/__tests__/publish-webhook-events.contract.test.ts
@@ -1,0 +1,101 @@
+import {
+  classifyPublishWebhookError,
+  createPublishWebhookEventId,
+  PUBLISH_WEBHOOK_SCHEMA_VERSION,
+  publishWebhookPayloadSchema,
+  redactPublishWebhookText,
+} from '@api-types/contracts/publish-webhook-events.contract';
+import { ReleaseStatus, TargetExecutionState } from '@genfeedai/enums';
+import { describe, expect, test } from 'vitest';
+
+const target = {
+  credential: { id: 'cred_123' },
+  externalProviderId: 'post_123',
+  externalShortcode: 'abc123',
+  id: 'target_123',
+  platform: 'twitter',
+  publishedAt: '2026-07-07T10:00:00.000Z',
+  scheduledAt: '2026-07-07T09:55:00.000Z',
+  status: TargetExecutionState.PUBLISHED,
+  url: 'https://x.com/example/status/post_123',
+};
+
+describe('publishWebhookPayloadSchema', () => {
+  test('accepts a versioned target published payload', () => {
+    const result = publishWebhookPayloadSchema.safeParse({
+      event: 'target.published',
+      eventId: 'publish:target.published:release_123:target_123:published',
+      occurredAt: '2026-07-07T10:00:00.000Z',
+      release: {
+        id: 'release_123',
+        publishedAt: '2026-07-07T10:00:00.000Z',
+        scheduledAt: '2026-07-07T09:55:00.000Z',
+        status: ReleaseStatus.PUBLISHED,
+        targetSummary: {
+          failed: 0,
+          published: 1,
+          total: 1,
+        },
+      },
+      schemaVersion: PUBLISH_WEBHOOK_SCHEMA_VERSION,
+      target,
+      timestamp: '2026-07-07T10:00:00.000Z',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  test('requires targets on release payloads', () => {
+    const result = publishWebhookPayloadSchema.safeParse({
+      event: 'release.published',
+      eventId: 'publish:release.published:release_123:release:published',
+      occurredAt: '2026-07-07T10:00:00.000Z',
+      release: {
+        id: 'release_123',
+        status: ReleaseStatus.PUBLISHED,
+        targetSummary: {
+          failed: 0,
+          published: 1,
+          total: 1,
+        },
+      },
+      schemaVersion: PUBLISH_WEBHOOK_SCHEMA_VERSION,
+      timestamp: '2026-07-07T10:00:00.000Z',
+    });
+
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('publish webhook helpers', () => {
+  test('creates deterministic event ids', () => {
+    expect(
+      createPublishWebhookEventId({
+        event: 'target.published',
+        releaseId: 'Release 123',
+        status: TargetExecutionState.PUBLISHED,
+        targetId: 'Target 123',
+      }),
+    ).toBe('publish:target.published:release-123:target-123:published');
+  });
+
+  test('classifies common terminal publish errors', () => {
+    expect(classifyPublishWebhookError('Quota exceeded')).toBe('rate_limit');
+    expect(classifyPublishWebhookError('Credential token expired')).toBe(
+      'credential',
+    );
+    expect(classifyPublishWebhookError('Unsupported platform')).toBe(
+      'validation',
+    );
+  });
+
+  test('redacts secret-like text from error messages', () => {
+    expect(
+      redactPublishWebhookText(
+        'Provider failed with access_token=abc123 and Bearer xyz987',
+      ),
+    ).toBe(
+      'Provider failed with access_token=[REDACTED] and Bearer [REDACTED]',
+    );
+  });
+});

--- a/packages/api-types/src/contracts/index.ts
+++ b/packages/api-types/src/contracts/index.ts
@@ -11,5 +11,6 @@
 export * from '@api-types/contracts/channel-capabilities.contract';
 export * from '@api-types/contracts/ingredients.contract';
 export * from '@api-types/contracts/posts.contract';
+export * from '@api-types/contracts/publish-webhook-events.contract';
 export * from '@api-types/contracts/publishing-readiness.contract';
 export * from '@api-types/contracts/scheduler.contract';

--- a/packages/api-types/src/contracts/publish-webhook-events.contract.ts
+++ b/packages/api-types/src/contracts/publish-webhook-events.contract.ts
@@ -1,0 +1,204 @@
+import { ReleaseStatus, TargetExecutionState } from '@genfeedai/enums';
+import { z } from 'zod';
+
+export const PUBLISH_WEBHOOK_SCHEMA_VERSION = 1;
+
+export const PUBLISH_WEBHOOK_EVENT_TYPES = [
+  'release.published',
+  'release.partially_published',
+  'release.failed',
+  'target.published',
+  'target.failed',
+] as const;
+
+export const PUBLISH_WEBHOOK_ERROR_CLASSES = [
+  'misconfiguration',
+  'credential',
+  'provider_outage',
+  'rate_limit',
+  'validation',
+  'unknown',
+] as const;
+
+const isoDateTimeSchema = z.string().datetime({ offset: true });
+const nullableStringSchema = z.string().min(1).nullable().optional();
+
+export const publishWebhookEventTypeSchema = z.enum(
+  PUBLISH_WEBHOOK_EVENT_TYPES,
+);
+
+export const publishWebhookErrorClassSchema = z.enum(
+  PUBLISH_WEBHOOK_ERROR_CLASSES,
+);
+
+export const publishWebhookTargetStatusSchema = z.enum([
+  TargetExecutionState.PUBLISHED,
+  TargetExecutionState.FAILED,
+] as const);
+
+export const publishWebhookReleaseStatusSchema = z.enum([
+  ReleaseStatus.PUBLISHED,
+  ReleaseStatus.PARTIALLY_PUBLISHED,
+  ReleaseStatus.FAILED,
+] as const);
+
+export const publishWebhookErrorSchema = z.object({
+  class: publishWebhookErrorClassSchema,
+  code: nullableStringSchema,
+  message: z.string().min(1),
+  retryable: z.boolean(),
+});
+
+export const publishWebhookTargetSchema = z.object({
+  credential: z.object({
+    id: z.string().min(1),
+  }),
+  error: publishWebhookErrorSchema.nullable().optional(),
+  externalProviderId: nullableStringSchema,
+  externalShortcode: nullableStringSchema,
+  id: z.string().min(1),
+  platform: z.string().min(1),
+  publishedAt: nullableStringSchema,
+  scheduledAt: nullableStringSchema,
+  status: publishWebhookTargetStatusSchema,
+  url: nullableStringSchema,
+});
+
+export const publishWebhookReleaseSchema = z.object({
+  id: z.string().min(1),
+  publishedAt: nullableStringSchema,
+  scheduledAt: nullableStringSchema,
+  status: publishWebhookReleaseStatusSchema,
+  targetSummary: z.object({
+    failed: z.number().int().nonnegative(),
+    published: z.number().int().nonnegative(),
+    total: z.number().int().nonnegative(),
+  }),
+});
+
+export const publishWebhookPayloadSchema = z
+  .object({
+    event: publishWebhookEventTypeSchema,
+    eventId: z.string().min(1),
+    occurredAt: isoDateTimeSchema,
+    release: publishWebhookReleaseSchema,
+    schemaVersion: z.literal(PUBLISH_WEBHOOK_SCHEMA_VERSION),
+    target: publishWebhookTargetSchema.optional(),
+    targets: z.array(publishWebhookTargetSchema).min(1).optional(),
+    timestamp: isoDateTimeSchema,
+  })
+  .superRefine((payload, ctx) => {
+    if (payload.event.startsWith('target.') && !payload.target) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'target events require target',
+        path: ['target'],
+      });
+    }
+
+    if (payload.event.startsWith('release.') && !payload.targets) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'release events require targets',
+        path: ['targets'],
+      });
+    }
+  });
+
+export type PublishWebhookEventType = z.infer<
+  typeof publishWebhookEventTypeSchema
+>;
+export type PublishWebhookErrorClass = z.infer<
+  typeof publishWebhookErrorClassSchema
+>;
+export type PublishWebhookTarget = z.infer<typeof publishWebhookTargetSchema>;
+export type PublishWebhookRelease = z.infer<typeof publishWebhookReleaseSchema>;
+export type PublishWebhookPayload = z.infer<typeof publishWebhookPayloadSchema>;
+
+export function createPublishWebhookEventId(input: {
+  event: PublishWebhookEventType;
+  releaseId: string;
+  status: string;
+  targetId?: string | null;
+}): string {
+  return [
+    'publish',
+    input.event,
+    input.releaseId,
+    input.targetId ?? 'release',
+    input.status,
+  ]
+    .map(normalizeEventIdSegment)
+    .join(':');
+}
+
+export function classifyPublishWebhookError(
+  message: string,
+): PublishWebhookErrorClass {
+  const normalized = message.toLowerCase();
+
+  if (
+    normalized.includes('credential') ||
+    normalized.includes('oauth') ||
+    normalized.includes('token') ||
+    normalized.includes('auth') ||
+    normalized.includes('reconnect')
+  ) {
+    return 'credential';
+  }
+
+  if (
+    normalized.includes('rate limit') ||
+    normalized.includes('quota') ||
+    normalized.includes('429')
+  ) {
+    return 'rate_limit';
+  }
+
+  if (
+    normalized.includes('validation') ||
+    normalized.includes('invalid') ||
+    normalized.includes('unsupported')
+  ) {
+    return 'validation';
+  }
+
+  if (
+    normalized.includes('configured') ||
+    normalized.includes('configuration') ||
+    normalized.includes('missing') ||
+    normalized.includes('not found')
+  ) {
+    return 'misconfiguration';
+  }
+
+  if (
+    normalized.includes('provider') ||
+    normalized.includes('timeout') ||
+    normalized.includes('unavailable') ||
+    normalized.includes('502') ||
+    normalized.includes('503') ||
+    normalized.includes('504')
+  ) {
+    return 'provider_outage';
+  }
+
+  return 'unknown';
+}
+
+export function redactPublishWebhookText(value: string): string {
+  return value
+    .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer [REDACTED]')
+    .replace(
+      /\b(access[_-]?token|refresh[_-]?token|api[_-]?key|client[_-]?secret|webhook[_-]?secret|password|secret)(\s*[:=]\s*)([^\s,;]+)/gi,
+      '$1$2[REDACTED]',
+    );
+}
+
+function normalizeEventIdSegment(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}


### PR DESCRIPTION
Refs #1169

## Summary
- Add a versioned publish webhook event catalog and Zod payload schema for release/target terminal outcomes.
- Add a shared publish-event producer on the existing outbound webhook queue/signing/SSRF/org settings path, with deterministic event IDs and payload redaction.
- Emit terminal publish events from scheduled post publishing, TikTok and YouTube reconciliation, and YouTube upload completion; document the webhook catalog.

## Verification
- `bunx biome check --write ...` on changed files
- `bun run --cwd packages/api-types test -- __tests__/publish-webhook-events.contract.test.ts`
- `bun run --cwd apps/server/api test -- src/services/webhook-client/publish-event-webhook.service.spec.ts src/services/integrations/youtube/services/modules/youtube-upload-completion.service.spec.ts src/services/webhook-client/webhook-client.module.spec.ts`
- `bun run --cwd apps/server/workers test:cron -- src/crons/posts/cron.posts.service.spec.ts src/crons/tiktok/cron.tiktok-status.service.spec.ts src/crons/youtube/cron.youtube-status.service.spec.ts`
- `bun scripts/architecture/check-no-api-imports-in-workers.ts`
- `git diff --check`
- Commit hook ran lint-staged Biome + secretlint

## Note
- `bun run --cwd packages/api-types type-check` was attempted, but this fresh worktree is missing `packages/enums/dist/index.d.ts`, so TypeScript exits with TS6305 before checking this contract. Full generated-package/typecheck coverage should run in PR CI.
