### PR TITLE
fix(api): bill Fleet voice clones on completion

### DIFF
--- a/apps/server/api/openapi/openapi.json
+++ b/apps/server/api/openapi/openapi.json
@@ -49581,6 +49581,21 @@
         ]
       }
     },
+    "/webhooks/fleet/voice-clone": {
+      "post": {
+        "operationId": "FleetWebhookController.handleVoiceCloneCompletion",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "summary": "handleVoiceCloneCompletion",
+        "tags": [
+          "webhooks/fleet"
+        ]
+      }
+    },
     "/webhooks/heygen/callback": {
       "post": {
         "operationId": "HeygenWebhookController.handleCallback",

--- a/apps/server/api/src/collections/credits/services/credits.utils.service.spec.ts
+++ b/apps/server/api/src/collections/credits/services/credits.utils.service.spec.ts
@@ -26,6 +26,7 @@ describe('CreditsUtilsService', () => {
   };
   const creditTransactionsService = {
     createTransactionEntry: vi.fn(),
+    findOne: vi.fn(),
   };
   const organizationSettingsService = {
     findOne: vi.fn(),
@@ -69,6 +70,7 @@ describe('CreditsUtilsService', () => {
     creditBalanceService.findByOrganization.mockResolvedValue({ balance: 100 });
     creditBalanceService.updateBalance.mockResolvedValue({ balance: 60 });
     creditTransactionsService.createTransactionEntry.mockResolvedValue({});
+    creditTransactionsService.findOne.mockResolvedValue(null);
     organizationSettingsService.findOne.mockResolvedValue(null);
   });
 
@@ -147,6 +149,37 @@ describe('CreditsUtilsService', () => {
         60,
         undefined,
       );
+    });
+
+    it('skips an idempotent deduction when the ledger reference already exists', async () => {
+      const service = buildService(false);
+      creditTransactionsService.findOne.mockResolvedValue({
+        id: 'txn_existing',
+      });
+
+      await service.deductCreditsFromOrganization(
+        'org_1',
+        'user_1',
+        40,
+        'Fleet voice clone compute',
+        undefined,
+        {
+          referenceId: 'fleet-job-1',
+          referenceType: 'fleet:voice-clone',
+        },
+      );
+
+      expect(creditTransactionsService.findOne).toHaveBeenCalledWith({
+        category: expect.anything(),
+        isDeleted: false,
+        organizationId: 'org_1',
+        referenceId: 'fleet-job-1',
+        referenceType: 'fleet:voice-clone',
+      });
+      expect(creditBalanceService.updateBalance).not.toHaveBeenCalled();
+      expect(
+        creditTransactionsService.createTransactionEntry,
+      ).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/server/api/src/collections/credits/services/credits.utils.service.ts
+++ b/apps/server/api/src/collections/credits/services/credits.utils.service.ts
@@ -80,7 +80,12 @@ export class CreditsUtilsService implements ICreditsUtilsService {
     creditsToDeduct: number,
     description: string,
     source: ActivitySource = ActivitySource.SCRIPT,
-    options?: { maxOverdraftCredits?: number },
+    options?: {
+      maxOverdraftCredits?: number;
+      metadata?: Record<string, unknown>;
+      referenceId?: string;
+      referenceType?: string;
+    },
   ): Promise<void> {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
 
@@ -104,6 +109,38 @@ export class CreditsUtilsService implements ICreditsUtilsService {
 
       // Core deduction logic — runs atomically inside a transaction when available
       const deductCore = async (tx?: PrismaTransactionClient) => {
+        if (options?.referenceId && options.referenceType) {
+          const existingTransaction = tx
+            ? await tx.creditTransaction.findFirst({
+                where: {
+                  category: CreditTransactionCategory.DEDUCT,
+                  isDeleted: false,
+                  organizationId,
+                  referenceId: options.referenceId,
+                  referenceType: options.referenceType,
+                },
+              })
+            : await this.creditTransactionsService.findOne({
+                category: CreditTransactionCategory.DEDUCT,
+                isDeleted: false,
+                organizationId,
+                referenceId: options.referenceId,
+                referenceType: options.referenceType,
+              });
+
+          if (existingTransaction) {
+            this.loggerService.log(
+              `${url} credit deduction already recorded for reference`,
+              {
+                organizationId,
+                referenceId: options.referenceId,
+                referenceType: options.referenceType,
+              },
+            );
+            return this.getOrganizationCreditsBalance(organizationId, tx);
+          }
+        }
+
         const currentBalance = await this.getOrganizationCreditsBalance(
           organizationId,
           tx,
@@ -126,17 +163,45 @@ export class CreditsUtilsService implements ICreditsUtilsService {
           newBalance,
           tx,
         );
-        await this.creditTransactionsService.createTransactionEntry(
-          organizationId,
-          CreditTransactionCategory.DEDUCT,
-          creditsToDeduct,
-          currentBalance,
-          newBalance,
-          source,
-          description,
-          undefined,
-          tx,
-        );
+        const transactionOptions =
+          options?.referenceId || options?.referenceType || options?.metadata
+            ? {
+                ...(options.metadata ? { metadata: options.metadata } : {}),
+                ...(options.referenceId
+                  ? { referenceId: options.referenceId }
+                  : {}),
+                ...(options.referenceType
+                  ? { referenceType: options.referenceType }
+                  : {}),
+              }
+            : undefined;
+
+        if (transactionOptions) {
+          await this.creditTransactionsService.createTransactionEntry(
+            organizationId,
+            CreditTransactionCategory.DEDUCT,
+            creditsToDeduct,
+            currentBalance,
+            newBalance,
+            source,
+            description,
+            undefined,
+            tx,
+            transactionOptions,
+          );
+        } else {
+          await this.creditTransactionsService.createTransactionEntry(
+            organizationId,
+            CreditTransactionCategory.DEDUCT,
+            creditsToDeduct,
+            currentBalance,
+            newBalance,
+            source,
+            description,
+            undefined,
+            tx,
+          );
+        }
 
         return newBalance;
       };

--- a/apps/server/api/src/collections/voices/controllers/voices.controller.spec.ts
+++ b/apps/server/api/src/collections/voices/controllers/voices.controller.spec.ts
@@ -13,7 +13,12 @@ import { FleetService } from '@api/services/integrations/fleet/fleet.service';
 import { HeyGenService } from '@api/services/integrations/heygen/services/heygen.service';
 import { NotificationsPublisherService } from '@api/services/notifications/publisher/notifications-publisher.service';
 import { SharedService } from '@api/shared/services/shared/shared.service';
-import { IngredientCategory, VoiceProvider } from '@genfeedai/enums';
+import {
+  ActivitySource,
+  IngredientCategory,
+  VoiceCloneStatus,
+  VoiceProvider,
+} from '@genfeedai/enums';
 import { VoiceProvider as DbVoiceProvider } from '@genfeedai/prisma';
 import { LoggerService } from '@libs/logger/logger.service';
 import { HttpException, HttpStatus } from '@nestjs/common';
@@ -559,14 +564,19 @@ describe('VoicesController', () => {
       expect(deferred).toBe(true);
     });
 
-    it('charges a fixed 17-credit @Credits config for voice cloning', () => {
+    it('defers voice clone credits so the handler can branch by provider', () => {
       const config = reflector.get<{ amount?: number }>(
         CREDITS_KEY,
         controller.cloneVoice,
       );
+      const deferred = reflector.get(
+        CREDITS_DEFER_MODEL_RESOLUTION_KEY,
+        controller.cloneVoice,
+      );
 
       expect(config).toBeDefined();
-      expect(config.amount).toBe(17);
+      expect(config.amount).toBeUndefined();
+      expect(deferred).toBe(true);
     });
   });
 
@@ -634,6 +644,108 @@ describe('VoicesController', () => {
       expect(voicesService.patchAll).toHaveBeenCalledWith(
         expect.objectContaining({ OR: expect.any(Array) }),
         expect.objectContaining({ voiceProvider: VoiceProvider.ELEVENLABS }),
+      );
+    });
+
+    it('settles the flat 17-credit charge for ElevenLabs clones', async () => {
+      const user = createMockUser();
+      const request = {
+        ...createMockRequest(),
+        creditsConfig: {
+          amount: 0,
+          deferred: true,
+          description: 'Voice cloning',
+          source: ActivitySource.VOICE_GENERATION,
+        },
+      };
+      const ingredientId = '507f191e810c19729de860ee';
+
+      byokService.resolveApiKey.mockResolvedValue({ apiKey: 'test-key' });
+      elevenLabsService.cloneVoice.mockResolvedValue({ voiceId: 'el_cloned' });
+      sharedService.saveDocuments.mockResolvedValue({
+        ingredientData: { id: ingredientId },
+      });
+      voicesService.patchAll.mockResolvedValue({});
+      voicesService.findOne.mockResolvedValue({
+        id: ingredientId,
+        isCloned: true,
+      });
+      notificationsService.publishAssetStatus.mockResolvedValue(undefined);
+
+      await controller.cloneVoice(
+        request as never,
+        user as never,
+        {
+          audioUrl: 'https://example.com/audio.mp3',
+          name: 'My Voice',
+          provider: VoiceProvider.ELEVENLABS,
+        } as never,
+        undefined,
+      );
+
+      expect(
+        creditsUtilsService.checkOrganizationCreditsAvailable,
+      ).toHaveBeenCalledWith(user.publicMetadata.organization, 17);
+      expect(request.creditsConfig).toMatchObject({
+        amount: 17,
+        deferred: false,
+      });
+    });
+
+    it('does not finalize request credits when accepting a Fleet clone job', async () => {
+      const user = createMockUser();
+      const request = {
+        ...createMockRequest(),
+        creditsConfig: {
+          amount: 0,
+          deferred: true,
+          description: 'Voice cloning',
+          source: ActivitySource.VOICE_GENERATION,
+        },
+      };
+      const ingredientId = '507f191e810c19729de860ee';
+
+      fleetService.isAvailable.mockResolvedValue(true);
+      fleetService.cloneVoice.mockResolvedValue({ jobId: 'fleet-job-1' });
+      sharedService.saveDocuments.mockResolvedValue({
+        ingredientData: { id: ingredientId },
+      });
+      voicesService.patchAll.mockResolvedValue({});
+      voicesService.findOne.mockResolvedValue({
+        cloneStatus: VoiceCloneStatus.CLONING,
+        id: ingredientId,
+        isCloned: true,
+      });
+      notificationsService.publishAssetStatus.mockResolvedValue(undefined);
+
+      await controller.cloneVoice(
+        request as never,
+        user as never,
+        {
+          audioUrl: 'https://example.com/audio.mp3',
+          name: 'My Voice',
+          provider: VoiceProvider.GENFEED_AI,
+        } as never,
+        undefined,
+      );
+
+      expect(request.creditsConfig).toMatchObject({
+        amount: 0,
+        deferred: true,
+      });
+      expect(voicesService.patchAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          OR: expect.any(Array),
+          organizationId: user.publicMetadata.organization,
+        }),
+        expect.objectContaining({
+          providerData: {
+            fleet: {
+              jobId: 'fleet-job-1',
+              jobKind: 'voice-clone',
+            },
+          },
+        }),
       );
     });
   });

--- a/apps/server/api/src/collections/voices/controllers/voices.controller.ts
+++ b/apps/server/api/src/collections/voices/controllers/voices.controller.ts
@@ -158,10 +158,9 @@ function toWireFormat(voice: ExternalVoice): VoiceCatalogEntryDocument {
 const VOICE_CREDITS_PER_MINUTE = 17;
 
 /**
- * Flat credit charge for a one-time voice clone (ElevenLabs synchronous, or
- * Genfeed Fleet asynchronous). Fleet clones are billed at job acceptance today;
- * true compute-time metering (Replicate/Fal-style, on job completion) is tracked
- * as a follow-up — see #1354.
+ * Flat credit charge for a synchronous ElevenLabs one-time voice clone. Fleet
+ * clones are asynchronous and billed from measured compute time by the Fleet
+ * completion webhook instead.
  */
 const VOICE_CLONE_CREDITS = 17;
 
@@ -176,9 +175,9 @@ export class VoicesController {
     private readonly elevenLabsService: ElevenLabsService,
     private readonly externalVoiceCatalogService: ExternalVoiceCatalogService,
     private readonly fleetService: FleetService,
-    private readonly heygenService: HeyGenService,
+    _heygenService: HeyGenService,
     private readonly loggerService: LoggerService,
-    private readonly metadataService: MetadataService,
+    _metadataService: MetadataService,
     private readonly notificationsPublisherService: NotificationsPublisherService,
     private readonly sharedService: SharedService,
     private readonly voicesService: VoicesService,
@@ -547,15 +546,11 @@ export class VoicesController {
     CreditsInterceptor,
     FileInterceptor('file', { limits: { fileSize: 25 * 1024 * 1024 } }),
   )
-  // Flat per-clone charge. Cloning creates a one-time reusable voice (not
-  // duration-priced output), so a fixed `amount` is checked up-front by
-  // CreditsGuard and deducted by CreditsInterceptor on success — replacing the
-  // previous amount-less config that fell through to
-  // `throw InsufficientCreditsException(0,0)` on every call (#1354). Fleet
-  // (async) clones are billed here at acceptance; compute-time metering on job
-  // completion is a follow-up (see #1354).
+  @DeferCreditsUntilModelResolution()
+  // Provider-specific charge: ElevenLabs keeps the flat synchronous clone charge,
+  // while Fleet async clones finalize credits from measured process time in the
+  // Fleet completion webhook.
   @Credits({
-    amount: VOICE_CLONE_CREDITS,
     description: 'Voice cloning',
     source: ActivitySource.VOICE_GENERATION,
   })
@@ -600,6 +595,12 @@ export class VoicesController {
 
     try {
       if (provider === VoiceProvider.ELEVENLABS) {
+        await this.assertOrganizationCanAfford(
+          publicMetadata.organization,
+          VOICE_CLONE_CREDITS,
+        );
+        this.settleVoiceCloneCredits(request);
+
         return await this.cloneVoiceElevenLabs(
           request,
           user,
@@ -812,6 +813,24 @@ export class VoicesController {
     }
   }
 
+  private settleVoiceCloneCredits(request: Request): void {
+    const requestWithCredits = request as unknown as {
+      creditsConfig?: {
+        amount?: number;
+        deferred?: boolean;
+        [key: string]: unknown;
+      };
+    };
+
+    if (requestWithCredits.creditsConfig) {
+      requestWithCredits.creditsConfig = {
+        ...requestWithCredits.creditsConfig,
+        amount: VOICE_CLONE_CREDITS,
+        deferred: false,
+      };
+    }
+  }
+
   private parseSingleProvider(value?: string): SyncableDbProvider | undefined {
     if (!value) {
       return undefined;
@@ -1012,6 +1031,7 @@ export class VoicesController {
           { id: String(ingredientData.id) },
           { mongoId: String(ingredientData.id) },
         ],
+        organizationId: publicMetadata.organization,
       },
       {
         cloneStatus: VoiceCloneStatus.CLONING,
@@ -1048,6 +1068,7 @@ export class VoicesController {
             { id: String(ingredientData.id) },
             { mongoId: String(ingredientData.id) },
           ],
+          organizationId: publicMetadata.organization,
         },
         {
           cloneStatus: VoiceCloneStatus.FAILED,
@@ -1074,6 +1095,24 @@ export class VoicesController {
         HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
+
+    await this.voicesService.patchAll(
+      {
+        OR: [
+          { id: String(ingredientData.id) },
+          { mongoId: String(ingredientData.id) },
+        ],
+        organizationId: publicMetadata.organization,
+      },
+      {
+        providerData: {
+          fleet: {
+            jobId: result.jobId,
+            jobKind: 'voice-clone',
+          },
+        },
+      },
+    );
 
     this.loggerService.log(`${url} Genfeed AI voice clone initiated`, {
       jobId: result.jobId,

--- a/apps/server/api/src/endpoints/webhooks/fleet/webhooks.fleet.controller.ts
+++ b/apps/server/api/src/endpoints/webhooks/fleet/webhooks.fleet.controller.ts
@@ -1,0 +1,49 @@
+import type { FleetVoiceCloneWebhookPayload } from '@api/endpoints/webhooks/fleet/webhooks.fleet.service';
+import { FleetWebhookService } from '@api/endpoints/webhooks/fleet/webhooks.fleet.service';
+import { assertWebhookToken } from '@api/endpoints/webhooks/webhook-token.util';
+import { AutoSwagger } from '@api/helpers/decorators/swagger/auto-swagger.decorator';
+import { ConfigService } from '@libs/config/config.service';
+import { Public } from '@libs/decorators/public.decorator';
+import { LoggerService } from '@libs/logger/logger.service';
+import { CallerUtil } from '@libs/utils/caller/caller.util';
+import { Body, Controller, HttpCode, Post, Req } from '@nestjs/common';
+import type { Request } from 'express';
+
+@AutoSwagger()
+@Public()
+@Controller('webhooks/fleet')
+export class FleetWebhookController {
+  private readonly constructorName = String(this.constructor.name);
+
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly loggerService: LoggerService,
+    private readonly fleetWebhookService: FleetWebhookService,
+  ) {}
+
+  @HttpCode(200)
+  @Post('voice-clone')
+  async handleVoiceCloneCompletion(
+    @Req() request: Request,
+    @Body() payload: FleetVoiceCloneWebhookPayload,
+  ) {
+    const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
+
+    assertWebhookToken({
+      configuredSecret: this.configService.get('FLEET_WEBHOOK_SECRET') as
+        | string
+        | undefined,
+      loggerService: this.loggerService,
+      request,
+      url,
+    });
+
+    this.loggerService.log(`${url} received`, {
+      handle: payload.handle,
+      jobId: payload.jobId ?? payload.job_id,
+      status: payload.status ?? payload.state,
+    });
+
+    return await this.fleetWebhookService.handleVoiceCloneCompletion(payload);
+  }
+}

--- a/apps/server/api/src/endpoints/webhooks/fleet/webhooks.fleet.service.spec.ts
+++ b/apps/server/api/src/endpoints/webhooks/fleet/webhooks.fleet.service.spec.ts
@@ -1,0 +1,116 @@
+import { FleetWebhookService } from '@api/endpoints/webhooks/fleet/webhooks.fleet.service';
+import {
+  ActivitySource,
+  IngredientStatus,
+  VoiceCloneStatus,
+} from '@genfeedai/enums';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('FleetWebhookService', () => {
+  let service: FleetWebhookService;
+  let voicesService: {
+    findOne: ReturnType<typeof vi.fn>;
+    patchAll: ReturnType<typeof vi.fn>;
+  };
+  let creditDeductionQueueService: {
+    queueDeduction: ReturnType<typeof vi.fn>;
+  };
+  let notificationsPublisherService: {
+    publishAssetStatus: ReturnType<typeof vi.fn>;
+  };
+
+  const voice = {
+    _id: 'voice-asset-1',
+    id: 'voice-asset-1',
+    organizationId: 'org-1',
+    providerData: { fleet: { jobId: 'old-job' } },
+    userId: 'user-1',
+  };
+
+  beforeEach(() => {
+    voicesService = {
+      findOne: vi.fn().mockResolvedValue(voice),
+      patchAll: vi.fn().mockResolvedValue({ modifiedCount: 1 }),
+    };
+    creditDeductionQueueService = {
+      queueDeduction: vi.fn().mockResolvedValue(undefined),
+    };
+    notificationsPublisherService = {
+      publishAssetStatus: vi.fn().mockResolvedValue(undefined),
+    };
+
+    service = new FleetWebhookService(
+      voicesService as never,
+      creditDeductionQueueService as never,
+      notificationsPublisherService as never,
+    );
+  });
+
+  it('deducts Fleet voice clone credits from measured process time on completion', async () => {
+    const result = await service.handleVoiceCloneCompletion({
+      handle: 'voice-asset-1',
+      job_id: 'fleet-job-1',
+      output: {
+        sample_audio_url: 'https://cdn.example.com/sample.wav',
+        voice_id: 'fleet-voice-1',
+      },
+      process_time: 61,
+      status: 'completed',
+    });
+
+    expect(result).toMatchObject({
+      chargedCredits: 18,
+      jobId: 'fleet-job-1',
+      processTimeSeconds: 61,
+      status: 'charged',
+    });
+    expect(voicesService.patchAll).toHaveBeenCalledWith(
+      expect.objectContaining({
+        OR: [{ id: 'voice-asset-1' }, { mongoId: 'voice-asset-1' }],
+        organizationId: 'org-1',
+      }),
+      expect.objectContaining({
+        cloneStatus: VoiceCloneStatus.READY,
+        externalVoiceId: 'fleet-voice-1',
+        sampleAudioUrl: 'https://cdn.example.com/sample.wav',
+        status: IngredientStatus.GENERATED,
+      }),
+    );
+    expect(creditDeductionQueueService.queueDeduction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        amount: 18,
+        idempotencyKey: 'fleet-voice-clone-fleet-job-1',
+        organizationId: 'org-1',
+        referenceId: 'fleet-job-1',
+        referenceType: 'fleet:voice-clone',
+        source: ActivitySource.VOICE_GENERATION,
+        type: 'deduct-credits',
+        userId: 'user-1',
+      }),
+    );
+  });
+
+  it('does not charge failed or cancelled Fleet clone jobs', async () => {
+    const result = await service.handleVoiceCloneCompletion({
+      error: 'cancelled by provider',
+      handle: 'voice-asset-1',
+      jobId: 'fleet-job-2',
+      processTimeSeconds: 42,
+      status: 'cancelled',
+    });
+
+    expect(result).toMatchObject({
+      chargedCredits: 0,
+      jobId: 'fleet-job-2',
+      status: 'failed',
+    });
+    expect(voicesService.patchAll).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({
+        cloneStatus: VoiceCloneStatus.FAILED,
+        status: IngredientStatus.FAILED,
+      }),
+    );
+    expect(creditDeductionQueueService.queueDeduction).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/api/src/endpoints/webhooks/fleet/webhooks.fleet.service.ts
+++ b/apps/server/api/src/endpoints/webhooks/fleet/webhooks.fleet.service.ts
@@ -1,0 +1,446 @@
+import type { IngredientDocument } from '@api/collections/ingredients/schemas/ingredient.schema';
+import { VoicesService } from '@api/collections/voices/services/voices.service';
+import { NotFoundException } from '@api/helpers/exceptions/http/not-found.exception';
+import { CreditDeductionQueueService } from '@api/queues/credit-deduction/credit-deduction-queue.service';
+import {
+  calculateFleetComputeCredits,
+  FLEET_COMPUTE_CREDIT_RATES,
+} from '@api/services/integrations/fleet/fleet-compute-billing.util';
+import { NotificationsPublisherService } from '@api/services/notifications/publisher/notifications-publisher.service';
+import {
+  ActivitySource,
+  IngredientCategory,
+  IngredientStatus,
+  VoiceCloneStatus,
+  VoiceProvider,
+} from '@genfeedai/enums';
+import { BadRequestException, Injectable } from '@nestjs/common';
+
+export interface FleetVoiceCloneWebhookPayload {
+  assetId?: string;
+  duration?: number;
+  durationSeconds?: number;
+  duration_seconds?: number;
+  error?: unknown;
+  handle?: string;
+  id?: string;
+  ingredientId?: string;
+  job_id?: string;
+  jobId?: string;
+  metrics?: Record<string, unknown>;
+  output?: Record<string, unknown>;
+  process_time?: number;
+  process_time_seconds?: number;
+  processTime?: number;
+  processTimeMs?: number;
+  processTimeSeconds?: number;
+  processing_time?: number;
+  processingTime?: number;
+  result?: Record<string, unknown>;
+  sampleAudioUrl?: string;
+  sample_audio_url?: string;
+  state?: string;
+  status?: string;
+  voice_id?: string;
+  voiceId?: string;
+}
+
+type FleetWebhookOutcome = {
+  chargedCredits: number;
+  jobId?: string;
+  processTimeSeconds?: number;
+  status: 'charged' | 'failed' | 'ignored';
+};
+
+const FLEET_VOICE_CLONE_REFERENCE_TYPE = 'fleet:voice-clone';
+
+@Injectable()
+export class FleetWebhookService {
+  constructor(
+    private readonly voicesService: VoicesService,
+    private readonly creditDeductionQueueService: CreditDeductionQueueService,
+    private readonly notificationsPublisherService: NotificationsPublisherService,
+  ) {}
+
+  async handleVoiceCloneCompletion(
+    payload: FleetVoiceCloneWebhookPayload,
+  ): Promise<FleetWebhookOutcome> {
+    const status = this.normalizeTerminalStatus(
+      payload.status ?? payload.state,
+    );
+
+    if (status === 'pending') {
+      return {
+        chargedCredits: 0,
+        jobId: this.readJobId(payload),
+        status: 'ignored',
+      };
+    }
+
+    const ingredientId = this.readIngredientId(payload);
+    if (!ingredientId) {
+      throw new BadRequestException(
+        'Fleet voice clone callback missing handle',
+      );
+    }
+
+    const voice = await this.findFleetVoice(ingredientId);
+    if (!voice) {
+      throw new NotFoundException({
+        message: 'Fleet voice clone asset not found',
+      });
+    }
+    this.organizationId(voice);
+    this.userId(voice);
+
+    if (status === 'failed') {
+      await this.markVoiceCloneFailed(voice, payload);
+      return {
+        chargedCredits: 0,
+        jobId: this.readJobId(payload),
+        status: 'failed',
+      };
+    }
+
+    const processTimeSeconds = this.readProcessTimeSeconds(payload);
+    if (!processTimeSeconds) {
+      throw new BadRequestException(
+        'Fleet voice clone completion missing process time',
+      );
+    }
+
+    const chargedCredits = calculateFleetComputeCredits({
+      jobKind: 'voice-clone',
+      processTimeSeconds,
+    });
+
+    await this.markVoiceCloneReady(voice, payload, processTimeSeconds);
+    await this.queueVoiceCloneDeduction(voice, payload, {
+      chargedCredits,
+      processTimeSeconds,
+    });
+
+    return {
+      chargedCredits,
+      jobId: this.readJobId(payload),
+      processTimeSeconds,
+      status: 'charged',
+    };
+  }
+
+  private async findFleetVoice(
+    ingredientId: string,
+  ): Promise<IngredientDocument | null> {
+    return await this.voicesService.findOne({
+      OR: [{ id: ingredientId }, { mongoId: ingredientId }],
+      category: IngredientCategory.VOICE,
+      isDeleted: false,
+      voiceProvider: VoiceProvider.GENFEED_AI,
+    });
+  }
+
+  private async markVoiceCloneReady(
+    voice: IngredientDocument,
+    payload: FleetVoiceCloneWebhookPayload,
+    processTimeSeconds: number,
+  ): Promise<void> {
+    const voiceId = this.readVoiceId(payload);
+    const sampleAudioUrl = this.readSampleAudioUrl(payload);
+    const update: Record<string, unknown> = {
+      cloneStatus: VoiceCloneStatus.READY,
+      providerData: this.buildProviderData(voice, payload, {
+        processTimeSeconds,
+        status: 'completed',
+      }),
+      status: IngredientStatus.GENERATED,
+    };
+
+    if (voiceId) {
+      update.externalVoiceId = voiceId;
+    }
+
+    if (sampleAudioUrl) {
+      update.sampleAudioUrl = sampleAudioUrl;
+    }
+
+    await this.patchVoice(voice, update);
+    await this.publishVoiceStatus(voice, VoiceCloneStatus.READY, {
+      chargedCredits: calculateFleetComputeCredits({
+        jobKind: 'voice-clone',
+        processTimeSeconds,
+      }),
+      cloneStatus: VoiceCloneStatus.READY,
+      jobId: this.readJobId(payload),
+      processTimeSeconds,
+      provider: VoiceProvider.GENFEED_AI,
+    });
+  }
+
+  private async markVoiceCloneFailed(
+    voice: IngredientDocument,
+    payload: FleetVoiceCloneWebhookPayload,
+  ): Promise<void> {
+    await this.patchVoice(voice, {
+      cloneStatus: VoiceCloneStatus.FAILED,
+      providerData: this.buildProviderData(voice, payload, {
+        error: this.readError(payload),
+        status: 'failed',
+      }),
+      status: IngredientStatus.FAILED,
+    });
+
+    await this.publishVoiceStatus(voice, VoiceCloneStatus.FAILED, {
+      cloneStatus: VoiceCloneStatus.FAILED,
+      error: this.readError(payload),
+      jobId: this.readJobId(payload),
+      provider: VoiceProvider.GENFEED_AI,
+    });
+  }
+
+  private async patchVoice(
+    voice: IngredientDocument,
+    update: Record<string, unknown>,
+  ): Promise<void> {
+    const ingredientId = this.voiceId(voice);
+    await this.voicesService.patchAll(
+      {
+        OR: [{ id: ingredientId }, { mongoId: ingredientId }],
+        organizationId: voice.organizationId,
+      },
+      update,
+    );
+  }
+
+  private async publishVoiceStatus(
+    voice: IngredientDocument,
+    status: VoiceCloneStatus,
+    metadata: Record<string, unknown>,
+  ): Promise<void> {
+    await this.notificationsPublisherService.publishAssetStatus(
+      this.voiceId(voice),
+      status,
+      this.userId(voice),
+      metadata,
+    );
+  }
+
+  private async queueVoiceCloneDeduction(
+    voice: IngredientDocument,
+    payload: FleetVoiceCloneWebhookPayload,
+    params: { chargedCredits: number; processTimeSeconds: number },
+  ): Promise<void> {
+    const jobId = this.readJobId(payload) ?? this.voiceId(voice);
+    const idempotencyKey = this.toQueueKey(`fleet-voice-clone-${jobId}`);
+
+    await this.creditDeductionQueueService.queueDeduction({
+      amount: params.chargedCredits,
+      description: `Fleet voice clone compute (${params.processTimeSeconds.toFixed(2)}s)`,
+      idempotencyKey,
+      metadata: {
+        fleetJobId: this.readJobId(payload),
+        jobKind: 'voice-clone',
+        processTimeSeconds: params.processTimeSeconds,
+        rateCreditsPerSecond:
+          FLEET_COMPUTE_CREDIT_RATES['voice-clone'].creditsPerSecond,
+        voiceId: this.voiceId(voice),
+      },
+      organizationId: this.organizationId(voice),
+      referenceId: jobId,
+      referenceType: FLEET_VOICE_CLONE_REFERENCE_TYPE,
+      source: ActivitySource.VOICE_GENERATION,
+      type: 'deduct-credits',
+      userId: this.userId(voice),
+    });
+  }
+
+  private buildProviderData(
+    voice: IngredientDocument,
+    payload: FleetVoiceCloneWebhookPayload,
+    update: Record<string, unknown>,
+  ): Record<string, unknown> {
+    const providerData = this.toRecord(voice.providerData);
+    const fleetData = this.toRecord(providerData.fleet);
+
+    return {
+      ...providerData,
+      fleet: {
+        ...fleetData,
+        jobId: this.readJobId(payload),
+        jobKind: 'voice-clone',
+        ...update,
+      },
+    };
+  }
+
+  private normalizeTerminalStatus(
+    value: string | undefined,
+  ): 'completed' | 'failed' | 'pending' {
+    const status = value?.trim().toLowerCase();
+
+    if (
+      status === 'completed' ||
+      status === 'succeeded' ||
+      status === 'success' ||
+      status === 'ready'
+    ) {
+      return 'completed';
+    }
+
+    if (
+      status === 'failed' ||
+      status === 'error' ||
+      status === 'errored' ||
+      status === 'cancelled' ||
+      status === 'canceled'
+    ) {
+      return 'failed';
+    }
+
+    return 'pending';
+  }
+
+  private readIngredientId(
+    payload: FleetVoiceCloneWebhookPayload,
+  ): string | null {
+    return (
+      this.readString(payload.handle) ??
+      this.readString(payload.ingredientId) ??
+      this.readString(payload.assetId)
+    );
+  }
+
+  private readJobId(
+    payload: FleetVoiceCloneWebhookPayload,
+  ): string | undefined {
+    return (
+      this.readString(payload.jobId) ??
+      this.readString(payload.job_id) ??
+      this.readString(payload.id)
+    );
+  }
+
+  private readVoiceId(
+    payload: FleetVoiceCloneWebhookPayload,
+  ): string | undefined {
+    const output = this.toRecord(payload.output);
+    const result = this.toRecord(payload.result);
+
+    return (
+      this.readString(payload.voiceId) ??
+      this.readString(payload.voice_id) ??
+      this.readString(output.voiceId) ??
+      this.readString(output.voice_id) ??
+      this.readString(result.voiceId) ??
+      this.readString(result.voice_id)
+    );
+  }
+
+  private readSampleAudioUrl(
+    payload: FleetVoiceCloneWebhookPayload,
+  ): string | undefined {
+    const output = this.toRecord(payload.output);
+    const result = this.toRecord(payload.result);
+
+    return (
+      this.readString(payload.sampleAudioUrl) ??
+      this.readString(payload.sample_audio_url) ??
+      this.readString(output.sampleAudioUrl) ??
+      this.readString(output.sample_audio_url) ??
+      this.readString(result.sampleAudioUrl) ??
+      this.readString(result.sample_audio_url)
+    );
+  }
+
+  private readProcessTimeSeconds(
+    payload: FleetVoiceCloneWebhookPayload,
+  ): number | null {
+    const metrics = this.toRecord(payload.metrics);
+    const seconds =
+      this.readPositiveNumber(payload.processTimeSeconds) ??
+      this.readPositiveNumber(payload.process_time_seconds) ??
+      this.readPositiveNumber(payload.processTime) ??
+      this.readPositiveNumber(payload.process_time) ??
+      this.readPositiveNumber(payload.processingTime) ??
+      this.readPositiveNumber(payload.processing_time) ??
+      this.readPositiveNumber(payload.durationSeconds) ??
+      this.readPositiveNumber(payload.duration_seconds) ??
+      this.readPositiveNumber(payload.duration) ??
+      this.readPositiveNumber(metrics.processTimeSeconds) ??
+      this.readPositiveNumber(metrics.process_time_seconds) ??
+      this.readPositiveNumber(metrics.processTime) ??
+      this.readPositiveNumber(metrics.process_time) ??
+      this.readPositiveNumber(metrics.processingTime) ??
+      this.readPositiveNumber(metrics.processing_time) ??
+      this.readPositiveNumber(metrics.predict_time) ??
+      this.readPositiveNumber(metrics.total_time);
+
+    if (seconds) {
+      return seconds;
+    }
+
+    const milliseconds =
+      this.readPositiveNumber(payload.processTimeMs) ??
+      this.readPositiveNumber(metrics.processTimeMs) ??
+      this.readPositiveNumber(metrics.process_time_ms);
+
+    return milliseconds ? milliseconds / 1000 : null;
+  }
+
+  private readError(
+    payload: FleetVoiceCloneWebhookPayload,
+  ): string | undefined {
+    if (typeof payload.error === 'string') {
+      return payload.error;
+    }
+
+    const error = this.toRecord(payload.error);
+    return this.readString(error.message) ?? this.readString(error.detail);
+  }
+
+  private readString(value: unknown): string | undefined {
+    return typeof value === 'string' && value.trim().length > 0
+      ? value.trim()
+      : undefined;
+  }
+
+  private readPositiveNumber(value: unknown): number | undefined {
+    const numberValue = Number(value);
+    return Number.isFinite(numberValue) && numberValue > 0
+      ? numberValue
+      : undefined;
+  }
+
+  private toRecord(value: unknown): Record<string, unknown> {
+    return value && typeof value === 'object' && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {};
+  }
+
+  private toQueueKey(value: string): string {
+    return value.replace(/[^A-Za-z0-9_-]/g, '_');
+  }
+
+  private voiceId(voice: IngredientDocument): string {
+    return String(voice.id ?? voice._id);
+  }
+
+  private organizationId(voice: IngredientDocument): string {
+    if (!voice.organizationId) {
+      throw new BadRequestException(
+        'Fleet voice clone asset is missing organizationId',
+      );
+    }
+
+    return voice.organizationId;
+  }
+
+  private userId(voice: IngredientDocument): string {
+    if (!voice.userId) {
+      throw new BadRequestException(
+        'Fleet voice clone asset is missing userId',
+      );
+    }
+
+    return voice.userId;
+  }
+}

--- a/apps/server/api/src/endpoints/webhooks/fleet/webhooks.fleet.service.ts
+++ b/apps/server/api/src/endpoints/webhooks/fleet/webhooks.fleet.service.ts
@@ -305,7 +305,8 @@ export class FleetWebhookService {
     return (
       this.readString(payload.handle) ??
       this.readString(payload.ingredientId) ??
-      this.readString(payload.assetId)
+      this.readString(payload.assetId) ??
+      null
     );
   }
 

--- a/apps/server/api/src/endpoints/webhooks/webhooks.module.ts
+++ b/apps/server/api/src/endpoints/webhooks/webhooks.module.ts
@@ -21,9 +21,12 @@ import { TrainingsModule } from '@api/collections/trainings/trainings.module';
 import { UserSubscriptionsModule } from '@api/collections/user-subscriptions/user-subscriptions.module';
 import { UserSetupModule } from '@api/collections/users/user-setup.module';
 import { UsersModule } from '@api/collections/users/users.module';
+import { VoicesModule } from '@api/collections/voices/voices.module';
 import { CommonModule } from '@api/common/common.module';
 import { ChromaticWebhookController } from '@api/endpoints/webhooks/chromatic/webhooks.chromatic.controller';
 import { ChromaticWebhookService } from '@api/endpoints/webhooks/chromatic/webhooks.chromatic.service';
+import { FleetWebhookController } from '@api/endpoints/webhooks/fleet/webhooks.fleet.controller';
+import { FleetWebhookService } from '@api/endpoints/webhooks/fleet/webhooks.fleet.service';
 import { GitHubWebhookController } from '@api/endpoints/webhooks/github/webhooks.github.controller';
 import { GitHubWebhookService } from '@api/endpoints/webhooks/github/webhooks.github.service';
 import { HeygenWebhookController } from '@api/endpoints/webhooks/heygen/webhooks.heygen.controller';
@@ -58,6 +61,7 @@ import { forwardRef, Module } from '@nestjs/common';
 @Module({
   controllers: [
     ChromaticWebhookController,
+    FleetWebhookController,
     GitHubWebhookController,
     HeygenWebhookController,
     KlingWebhookController,
@@ -100,11 +104,13 @@ import { forwardRef, Module } from '@nestjs/common';
     forwardRef(() => UserSubscriptionsModule),
     forwardRef(() => UserSetupModule),
     forwardRef(() => UsersModule),
+    forwardRef(() => VoicesModule),
   ],
   providers: [
     ActivityUpdateService,
     AutoMergeService,
     ChromaticWebhookService,
+    FleetWebhookService,
     ModelRegistrationService,
     GitHubWebhookService,
     HeygenWebhookService,

--- a/apps/server/api/src/queues/credit-deduction/credit-deduction-queue.service.spec.ts
+++ b/apps/server/api/src/queues/credit-deduction/credit-deduction-queue.service.spec.ts
@@ -100,6 +100,28 @@ describe('CreditDeductionQueueService', () => {
         .jobId as string;
       expect(call1).not.toBe(call2);
     });
+
+    it('should use a deterministic job ID when an idempotency key is supplied', async () => {
+      const jobData: CreditDeductionJobData = {
+        amount: 18,
+        description: 'Fleet voice clone compute',
+        idempotencyKey: 'fleet-voice-clone-job-1',
+        organizationId: 'org-123',
+        source: 'video-generation',
+        type: 'deduct-credits',
+        userId: 'user-456',
+      };
+
+      await service.queueDeduction(jobData);
+
+      expect(queue.add).toHaveBeenCalledWith(
+        'deduct-credits',
+        jobData,
+        expect.objectContaining({
+          jobId: 'credit-deduct-org-123-fleet-voice-clone-job-1',
+        }),
+      );
+    });
   });
 
   describe('queueByokUsage', () => {

--- a/apps/server/api/src/queues/credit-deduction/credit-deduction-queue.service.ts
+++ b/apps/server/api/src/queues/credit-deduction/credit-deduction-queue.service.ts
@@ -18,11 +18,14 @@ export class CreditDeductionQueueService {
 
   async queueDeduction(data: CreditDeductionJobData): Promise<void> {
     await this.queue.add('deduct-credits', data, {
-      jobId: `credit-deduct-${data.organizationId}-${Date.now()}`,
+      jobId: data.idempotencyKey
+        ? `credit-deduct-${data.organizationId}-${data.idempotencyKey}`
+        : `credit-deduct-${data.organizationId}-${Date.now()}`,
     });
 
     this.logger.log(`${this.constructorName} credit deduction job queued`, {
       amount: data.amount,
+      idempotencyKey: data.idempotencyKey,
       organizationId: data.organizationId,
       type: data.type,
     });

--- a/apps/server/api/src/services/integrations/fleet/fleet-compute-billing.util.ts
+++ b/apps/server/api/src/services/integrations/fleet/fleet-compute-billing.util.ts
@@ -1,0 +1,27 @@
+import { INTERNAL_CREDIT_COSTS } from '@genfeedai/pricing';
+
+export type FleetComputeJobKind = 'voice-clone';
+
+export const FLEET_COMPUTE_CREDIT_RATES: Record<
+  FleetComputeJobKind,
+  { creditsPerSecond: number; description: string }
+> = {
+  'voice-clone': {
+    creditsPerSecond: INTERNAL_CREDIT_COSTS.voicePerMinute / 60,
+    description: 'Fleet voice clone compute',
+  },
+};
+
+export function calculateFleetComputeCredits(params: {
+  jobKind: FleetComputeJobKind;
+  processTimeSeconds: number;
+}): number {
+  const seconds = Number(params.processTimeSeconds);
+
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    return 0;
+  }
+
+  const rate = FLEET_COMPUTE_CREDIT_RATES[params.jobKind].creditsPerSecond;
+  return Math.max(1, Math.ceil(seconds * rate));
+}

--- a/apps/server/api/src/services/integrations/fleet/fleet.service.spec.ts
+++ b/apps/server/api/src/services/integrations/fleet/fleet.service.spec.ts
@@ -12,7 +12,7 @@ const mockedAxios = vi.mocked(axios, true);
 
 describe('FleetService', () => {
   let service: FleetService;
-  let configService: vi.Mocked<ConfigService>;
+  let _configService: vi.Mocked<ConfigService>;
   let loggerService: vi.Mocked<LoggerService>;
   let customerInstancesService: {
     findRunningForOrg: ReturnType<typeof vi.fn>;
@@ -60,7 +60,7 @@ describe('FleetService', () => {
     }).compile();
 
     service = module.get<FleetService>(FleetService);
-    configService = module.get(ConfigService);
+    _configService = module.get(ConfigService);
     loggerService = module.get(LoggerService);
   };
 
@@ -447,6 +447,31 @@ describe('FleetService', () => {
           audio_url: 'https://example.com/sample.wav',
           handle: 'aria',
           label: 'Aria Voice',
+        }),
+        expect.any(Object),
+      );
+    });
+
+    it('sends a Fleet voice clone completion callback URL when configured', async () => {
+      await createModule({
+        FLEET_WEBHOOK_SECRET: 'fleet-secret',
+        GENFEEDAI_WEBHOOKS_URL: 'https://webhooks.test',
+      });
+      mockedAxios.post = vi
+        .fn()
+        .mockResolvedValue({ data: { job_id: 'clone_1' } });
+
+      await service.cloneVoice({
+        audioUrl: 'https://example.com/sample.wav',
+        handle: 'aria',
+        label: 'Aria Voice',
+      });
+
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        'http://voices.fleet.local/voices/clone',
+        expect.objectContaining({
+          callback_url:
+            'https://webhooks.test/v1/webhooks/fleet/voice-clone?token=fleet-secret',
         }),
         expect.any(Object),
       );

--- a/apps/server/api/src/services/integrations/fleet/fleet.service.ts
+++ b/apps/server/api/src/services/integrations/fleet/fleet.service.ts
@@ -1,4 +1,5 @@
 import { CustomerInstancesService } from '@api/collections/customer-instances/services/customer-instances.service';
+import { appendWebhookToken } from '@api/endpoints/webhooks/webhook-token.util';
 import type {
   IFleetHealthResponse,
   IFleetInstance,
@@ -215,6 +216,22 @@ export class FleetService {
    */
   getVoicesUrl(): string | null {
     return this.getInstanceUrl('voices');
+  }
+
+  private getWebhookUrl(
+    path: string,
+    secretKey: 'FLEET_WEBHOOK_SECRET',
+  ): string | undefined {
+    const baseUrl = this.configService.get('GENFEEDAI_WEBHOOKS_URL');
+
+    if (!baseUrl) {
+      return undefined;
+    }
+
+    return appendWebhookToken(
+      `${baseUrl}/v1/${path}`,
+      this.configService.get(secretKey) as string | undefined,
+    );
   }
 
   /**
@@ -488,6 +505,10 @@ export class FleetService {
         `${url}/voices/clone`,
         {
           audio_url: params.audioUrl,
+          callback_url: this.getWebhookUrl(
+            'webhooks/fleet/voice-clone',
+            'FLEET_WEBHOOK_SECRET',
+          ),
           handle: params.handle,
           label: params.label,
         },

--- a/apps/server/workers/src/processors/api/queues/credit-deduction/credit-deduction.processor.spec.ts
+++ b/apps/server/workers/src/processors/api/queues/credit-deduction/credit-deduction.processor.spec.ts
@@ -1,29 +1,77 @@
-import { describe, expect, it } from 'vitest';
+import { ActivitySource } from '@genfeedai/enums';
+import type { CreditDeductionJobData } from '@genfeedai/queue-contracts';
+import { CreditDeductionProcessor } from '@workers/processors/api/queues/credit-deduction/credit-deduction.processor';
+import type { Job } from 'bullmq';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-/**
- * CreditDeductionProcessor Test
- * Note: Full integration tests require complex module resolution.
- * This file ensures the processor spec is present for coverage tracking.
- */
 describe('CreditDeductionProcessor', () => {
-  describe('processor logic', () => {
-    it('should handle credit deductions', () => {
-      // The processor handles two job types:
-      // 1. deduct-credits - deducts credits from organization
-      // 2. record-byok-usage - records BYOK usage without deduction
-      expect(true).toBe(true);
-    });
+  let processor: CreditDeductionProcessor;
+  let creditsUtilsService: {
+    deductCreditsFromOrganization: ReturnType<typeof vi.fn>;
+    getOrganizationCreditsBalance: ReturnType<typeof vi.fn>;
+  };
 
-    it('should validate organizationId', () => {
-      // Processor requires valid organizationId
-      const isValid = (id: string) => Boolean(id && id.length > 0);
-      expect(isValid('org-123')).toBe(true);
-      expect(isValid('')).toBe(false);
-    });
+  beforeEach(() => {
+    creditsUtilsService = {
+      deductCreditsFromOrganization: vi.fn().mockResolvedValue(undefined),
+      getOrganizationCreditsBalance: vi.fn().mockResolvedValue(5000),
+    };
 
-    it('should handle errors gracefully', () => {
-      // Processor should catch and log errors
-      expect(true).toBe(true);
-    });
+    processor = new CreditDeductionProcessor(
+      creditsUtilsService as never,
+      { createTransactionEntry: vi.fn() } as never,
+      { sendLowCreditsAlert: vi.fn() } as never,
+      { getPublisher: vi.fn() } as never,
+      {
+        debug: vi.fn(),
+        error: vi.fn(),
+        log: vi.fn(),
+        warn: vi.fn(),
+      } as never,
+    );
+  });
+
+  it('passes completion billing references into the credit utility', async () => {
+    const data: CreditDeductionJobData = {
+      amount: 18,
+      description: 'Fleet voice clone compute',
+      idempotencyKey: 'fleet-voice-clone-job-1',
+      metadata: {
+        fleetJobId: 'job-1',
+        processTimeSeconds: 61,
+      },
+      organizationId: 'org-1',
+      referenceId: 'job-1',
+      referenceType: 'fleet:voice-clone',
+      source: ActivitySource.VOICE_GENERATION,
+      type: 'deduct-credits',
+      userId: 'user-1',
+    };
+
+    await processor.process({
+      attemptsMade: 0,
+      data,
+      id: 'credit-deduct-org-1-fleet-voice-clone-job-1',
+      opts: { attempts: 3 },
+    } as Job<CreditDeductionJobData>);
+
+    expect(
+      creditsUtilsService.deductCreditsFromOrganization,
+    ).toHaveBeenCalledWith(
+      'org-1',
+      'user-1',
+      18,
+      'Fleet voice clone compute',
+      ActivitySource.VOICE_GENERATION,
+      {
+        maxOverdraftCredits: undefined,
+        metadata: {
+          fleetJobId: 'job-1',
+          processTimeSeconds: 61,
+        },
+        referenceId: 'job-1',
+        referenceType: 'fleet:voice-clone',
+      },
+    );
   });
 });

--- a/apps/server/workers/src/processors/api/queues/credit-deduction/credit-deduction.processor.ts
+++ b/apps/server/workers/src/processors/api/queues/credit-deduction/credit-deduction.processor.ts
@@ -42,13 +42,22 @@ export class CreditDeductionProcessor extends WorkerHost {
 
     try {
       if (type === 'deduct-credits') {
+        if (!userId) {
+          throw new UnrecoverableError('Credit deduction job missing userId');
+        }
+
         await this.creditsUtilsService.deductCreditsFromOrganization(
           organizationId,
-          userId!,
+          userId,
           amount,
           description,
           source,
-          { maxOverdraftCredits: job.data.maxOverdraftCredits },
+          {
+            maxOverdraftCredits: job.data.maxOverdraftCredits,
+            metadata: job.data.metadata,
+            referenceId: job.data.referenceId,
+            referenceType: job.data.referenceType,
+          },
         );
 
         await this.checkLowCredits(organizationId);

--- a/packages/queue-contracts/src/job-data/credit-deduction-job.interface.ts
+++ b/packages/queue-contracts/src/job-data/credit-deduction-job.interface.ts
@@ -8,4 +8,8 @@ export interface CreditDeductionJobData {
   description: string;
   source: ActivitySource;
   maxOverdraftCredits?: number;
+  idempotencyKey?: string;
+  metadata?: Record<string, unknown>;
+  referenceId?: string;
+  referenceType?: string;
 }


### PR DESCRIPTION
Closes #1376

## Summary
- Defers Genfeed/Fleet voice clone credits at acceptance and preserves the ElevenLabs flat synchronous charge.
- Adds a Fleet voice-clone webhook that bills completed jobs from measured process time, marks failed/cancelled jobs without charging, and publishes status updates.
- Adds idempotent credit deduction metadata/reference support through the queue and worker.

## Verification
- bunx biome check --write <16 touched files>
- bun run --cwd apps/server/api test:file src/collections/voices/controllers/voices.controller.spec.ts src/endpoints/webhooks/fleet/webhooks.fleet.service.spec.ts src/services/integrations/fleet/fleet.service.spec.ts src/queues/credit-deduction/credit-deduction-queue.service.spec.ts src/collections/credits/services/credits.utils.service.spec.ts
- bun run --cwd apps/server/workers test src/processors/api/queues/credit-deduction/credit-deduction.processor.spec.ts
- git diff --check