### PR TITLE
fix(webhooks): harden publish event idempotency

### DIFF
--- a/apps/docs/content/api-reference/webhooks.mdx
+++ b/apps/docs/content/api-reference/webhooks.mdx
@@ -1,3 +1,8 @@
+---
+title: Webhooks
+description: Signed outbound webhook events for scheduled publish outcomes.
+---
+
 # Webhooks
 
 Genfeed can send signed outbound webhooks when scheduled publish work reaches a terminal outcome. Webhooks use the organization webhook endpoint and secret configured in organization settings.
@@ -12,11 +17,13 @@ Each request includes:
 - `X-Genfeed-Delivery`: BullMQ delivery job id
 - `X-Genfeed-Signature`: `sha256=` HMAC over the JSON payload with the endpoint secret
 
-Payloads include `eventId` for consumer idempotency. Delivery is at-least-once, so consumers should store processed `eventId` values.
+Payloads include `eventId` for consumer idempotency. Delivery is at-least-once, so consumers should store processed `eventId` values before running side effects and safely ignore duplicates. The `X-Genfeed-Delivery` header is a transport diagnostic; use the payload `eventId` as the durable idempotency key.
+
+Publish events use stable `eventId` values derived from release, target, event type, and terminal status. If a publish worker retries the same terminal transition, Genfeed enqueues the same webhook job id while the queue record is retained. Consumer endpoints must still be idempotent because delivery retries can resend the same event.
 
 ## Event Catalog
 
-All publish webhook payloads use `schemaVersion: 1`.
+All publish webhook payloads use `schemaVersion: 1`. Breaking payload changes will increment `schemaVersion`; additive fields can appear under the current version, so consumers should tolerate unknown fields and branch parsing by `schemaVersion`.
 
 | Event | When it emits |
 | --- | --- |

--- a/apps/server/api/src/services/webhook-client/publish-event-webhook.service.spec.ts
+++ b/apps/server/api/src/services/webhook-client/publish-event-webhook.service.spec.ts
@@ -101,6 +101,46 @@ describe('PublishEventWebhookService', () => {
     });
   });
 
+  it('uses stable queue ids and retention for retried failed publish emissions', async () => {
+    const input = {
+      errorMessage: 'Provider timeout 503',
+      occurredAt: new Date('2026-07-07T10:00:00.000Z'),
+      post: {
+        credential: 'cred_123',
+        id: 'post_123',
+        organization: 'org_123',
+        platform: 'twitter',
+      },
+      retryable: false,
+    };
+
+    await service.emitLegacyPostFailed(input);
+    await service.emitLegacyPostFailed(input);
+
+    expect(queue.add).toHaveBeenCalledTimes(4);
+    expect(queue.add.mock.calls.map((call) => call[2]?.jobId)).toEqual([
+      'publish:target.failed:post_123:post_123:failed',
+      'publish:release.failed:post_123:release:failed',
+      'publish:target.failed:post_123:post_123:failed',
+      'publish:release.failed:post_123:release:failed',
+    ]);
+
+    for (const call of queue.add.mock.calls) {
+      expect(call[2]).toMatchObject({
+        removeOnComplete: {
+          age: 86_400,
+          count: 10_000,
+        },
+        removeOnFail: {
+          age: 604_800,
+          count: 10_000,
+        },
+      });
+      expect(call[2]).not.toHaveProperty('attempts');
+      expect(call[2]).not.toHaveProperty('backoff');
+    }
+  });
+
   it('derives a partially published release event from terminal grouped posts', async () => {
     postsService.findAll.mockResolvedValue({
       docs: [
@@ -167,6 +207,85 @@ describe('PublishEventWebhookService', () => {
         message: 'Provider rejected access_token=[REDACTED]',
       },
     });
+  });
+
+  it('snapshots failed payloads without secret-bearing source fields', async () => {
+    await service.emitLegacyPostFailed({
+      errorCode: 'provider_503',
+      errorMessage:
+        'Provider timeout 503 with api_key=raw-provider-key, Bearer raw-bearer-token, webhook_secret=raw-webhook-secret',
+      occurredAt: new Date('2026-07-07T10:00:00.000Z'),
+      post: {
+        credential: {
+          accessToken: 'encrypted-access-token',
+          apiKey: 'direct-post-api-key',
+          id: 'cred_123',
+          refreshToken: 'encrypted-refresh-token',
+          webhookSecret: 'direct-post-webhook-secret',
+        },
+        id: 'post_123',
+        organization: 'org_123',
+        platform: 'twitter',
+        scheduledDate: new Date('2026-07-07T09:55:00.000Z'),
+        user: {
+          apiKey: 'user-api-key',
+          token: 'user-token',
+        },
+      },
+      retryable: false,
+    });
+
+    const payload = (queue.add.mock.calls[0][1] as WebhookJobData).payload;
+    const serializedPayload = JSON.stringify(payload);
+
+    expect(serializedPayload).not.toContain('raw-provider-key');
+    expect(serializedPayload).not.toContain('raw-bearer-token');
+    expect(serializedPayload).not.toContain('raw-webhook-secret');
+    expect(serializedPayload).not.toContain('encrypted-access-token');
+    expect(serializedPayload).not.toContain('encrypted-refresh-token');
+    expect(serializedPayload).not.toContain('direct-post-api-key');
+    expect(serializedPayload).not.toContain('direct-post-webhook-secret');
+    expect(serializedPayload).not.toContain('user-api-key');
+    expect(serializedPayload).not.toContain('user-token');
+    expect(payload).toMatchInlineSnapshot(`
+      {
+        "event": "target.failed",
+        "eventId": "publish:target.failed:post_123:post_123:failed",
+        "occurredAt": "2026-07-07T10:00:00.000Z",
+        "release": {
+          "id": "post_123",
+          "publishedAt": null,
+          "scheduledAt": "2026-07-07T09:55:00.000Z",
+          "status": "failed",
+          "targetSummary": {
+            "failed": 1,
+            "published": 0,
+            "total": 1,
+          },
+        },
+        "schemaVersion": 1,
+        "target": {
+          "credential": {
+            "id": "cred_123",
+          },
+          "error": {
+            "class": "provider_outage",
+            "code": "provider_503",
+            "message": "Provider timeout 503 with api_key=[REDACTED], Bearer [REDACTED], webhook_secret=[REDACTED]",
+            "retryable": false,
+          },
+          "externalProviderId": null,
+          "externalShortcode": null,
+          "id": "post_123",
+          "platform": "twitter",
+          "publishedAt": null,
+          "scheduledAt": "2026-07-07T09:55:00.000Z",
+          "status": "failed",
+          "url": null,
+        },
+        "timestamp": "2026-07-07T10:00:00.000Z",
+      }
+    `);
   });
 
   it('does not enqueue when org webhooks are disabled', async () => {

--- a/apps/server/api/src/services/webhook-client/publish-event-webhook.service.ts
+++ b/apps/server/api/src/services/webhook-client/publish-event-webhook.service.ts
@@ -65,6 +65,9 @@ type TerminalTargetResolution =
       reason: 'non-terminal';
     };
 
+const PUBLISH_WEBHOOK_DEDUPE_RETENTION_SECONDS = 24 * 60 * 60;
+const PUBLISH_WEBHOOK_FAILED_RETENTION_SECONDS = 7 * 24 * 60 * 60;
+
 @Injectable()
 export class PublishEventWebhookService {
   private readonly constructorName = 'PublishEventWebhookService';
@@ -386,7 +389,17 @@ export class PublishEventWebhookService {
     };
 
     await this.webhookQueue.add('send-webhook', jobData, {
+      // Retried publish workers must resolve to the same BullMQ jobId long
+      // enough to suppress duplicate terminal events.
       jobId: payload.eventId,
+      removeOnComplete: {
+        age: PUBLISH_WEBHOOK_DEDUPE_RETENTION_SECONDS,
+        count: 10_000,
+      },
+      removeOnFail: {
+        age: PUBLISH_WEBHOOK_FAILED_RETENTION_SECONDS,
+        count: 10_000,
+      },
     });
 
     this.logger.log(`${this.constructorName} publish webhook queued`, {

--- a/apps/server/api/src/services/webhook-client/webhook-client.module.spec.ts
+++ b/apps/server/api/src/services/webhook-client/webhook-client.module.spec.ts
@@ -8,7 +8,10 @@ vi.mock(
   }),
 );
 
-import { WebhookClientModule } from '@api/services/webhook-client/webhook-client.module';
+import {
+  WEBHOOK_CLIENT_DEFAULT_JOB_OPTIONS,
+  WebhookClientModule,
+} from '@api/services/webhook-client/webhook-client.module';
 import { WebhookClientService } from '@api/services/webhook-client/webhook-client.service';
 
 describe('WebhookClientModule', () => {
@@ -24,5 +27,17 @@ describe('WebhookClientModule', () => {
           provider.name === 'WebhookClientProcessor',
       ),
     ).toBe(false);
+  });
+
+  it('keeps webhook delivery retries on the shared queue defaults', () => {
+    expect(WEBHOOK_CLIENT_DEFAULT_JOB_OPTIONS).toEqual({
+      attempts: 5,
+      backoff: {
+        delay: 3000,
+        type: 'exponential',
+      },
+      removeOnComplete: 100,
+      removeOnFail: 200,
+    });
   });
 });

--- a/apps/server/api/src/services/webhook-client/webhook-client.module.ts
+++ b/apps/server/api/src/services/webhook-client/webhook-client.module.ts
@@ -2,11 +2,22 @@ import { OrganizationSettingsModule } from '@api/collections/organization-settin
 import { PostsModule } from '@api/collections/posts/posts.module';
 import { PublishEventWebhookService } from '@api/services/webhook-client/publish-event-webhook.service';
 import { WebhookClientService } from '@api/services/webhook-client/webhook-client.service';
+import { WEBHOOK_CLIENT_QUEUE } from '@genfeedai/queue-contracts';
 import { HttpModule } from '@nestjs/axios';
 import { BullModule } from '@nestjs/bullmq';
 import { forwardRef, Module } from '@nestjs/common';
 
 export { PublishEventWebhookService } from '@api/services/webhook-client/publish-event-webhook.service';
+
+export const WEBHOOK_CLIENT_DEFAULT_JOB_OPTIONS = {
+  attempts: 5,
+  backoff: {
+    delay: 3000,
+    type: 'exponential',
+  },
+  removeOnComplete: 100,
+  removeOnFail: 200,
+} as const;
 
 @Module({
   exports: [PublishEventWebhookService, WebhookClientService],
@@ -15,16 +26,8 @@ export { PublishEventWebhookService } from '@api/services/webhook-client/publish
     forwardRef(() => OrganizationSettingsModule),
     forwardRef(() => PostsModule),
     BullModule.registerQueue({
-      defaultJobOptions: {
-        attempts: 5,
-        backoff: {
-          delay: 3000,
-          type: 'exponential',
-        },
-        removeOnComplete: 100,
-        removeOnFail: 200,
-      },
-      name: 'webhook-client',
+      defaultJobOptions: WEBHOOK_CLIENT_DEFAULT_JOB_OPTIONS,
+      name: WEBHOOK_CLIENT_QUEUE,
     }),
   ],
   providers: [PublishEventWebhookService, WebhookClientService],

--- a/apps/server/workers/src/processors/api/services/webhook-client/webhook-client.processor.spec.ts
+++ b/apps/server/workers/src/processors/api/services/webhook-client/webhook-client.processor.spec.ts
@@ -1,5 +1,5 @@
 import { WebhookClientProcessor } from '@workers/processors/api/services/webhook-client/webhook-client.processor';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 describe('WebhookClientProcessor', () => {
@@ -74,6 +74,42 @@ describe('WebhookClientProcessor', () => {
       expect.any(Object),
       expect.objectContaining({
         maxRedirects: 0,
+      }),
+    );
+  });
+
+  it('rethrows delivery failures so BullMQ retries the webhook job', async () => {
+    const error = new Error('upstream 503');
+    httpService.post.mockReturnValue(throwError(() => error));
+    const job = {
+      attemptsMade: 1,
+      data: {
+        endpoint: 'https://8.8.8.8/webhook',
+        organizationId: 'org-1',
+        payload: {
+          event: 'target.failed',
+          eventId: 'publish:target.failed:release-1:target-1:failed',
+          timestamp: '2026-05-17T10:00:00.000Z',
+        },
+        secret: 'secret',
+      },
+      id: 'publish:target.failed:release-1:target-1:failed',
+      opts: { attempts: 5 },
+      updateProgress: vi.fn(),
+    };
+
+    await expect(processor.process(job as never)).rejects.toThrow(
+      'upstream 503',
+    );
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('webhook delivery failed'),
+      expect.objectContaining({
+        attempt: 2,
+        event: 'target.failed',
+        jobId: 'publish:target.failed:release-1:target-1:failed',
+        maxAttempts: 5,
+        organizationId: 'org-1',
       }),
     );
   });

--- a/packages/api-types/__tests__/publish-webhook-events.contract.test.ts
+++ b/packages/api-types/__tests__/publish-webhook-events.contract.test.ts
@@ -65,6 +65,82 @@ describe('publishWebhookPayloadSchema', () => {
 
     expect(result.success).toBe(false);
   });
+
+  test('accepts a classified target failure payload snapshot', () => {
+    const result = publishWebhookPayloadSchema.safeParse({
+      event: 'target.failed',
+      eventId: 'publish:target.failed:release_123:target_123:failed',
+      occurredAt: '2026-07-07T10:00:00.000Z',
+      release: {
+        id: 'release_123',
+        publishedAt: null,
+        scheduledAt: '2026-07-07T09:55:00.000Z',
+        status: ReleaseStatus.FAILED,
+        targetSummary: {
+          failed: 1,
+          published: 0,
+          total: 1,
+        },
+      },
+      schemaVersion: PUBLISH_WEBHOOK_SCHEMA_VERSION,
+      target: {
+        ...target,
+        error: {
+          class: 'credential',
+          code: 'credential',
+          message: 'Credential expired',
+          retryable: false,
+        },
+        publishedAt: null,
+        status: TargetExecutionState.FAILED,
+      },
+      timestamp: '2026-07-07T10:00:00.000Z',
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      throw new Error('Expected target failure payload to parse');
+    }
+    expect(result.data).toMatchInlineSnapshot(`
+      {
+        "event": "target.failed",
+        "eventId": "publish:target.failed:release_123:target_123:failed",
+        "occurredAt": "2026-07-07T10:00:00.000Z",
+        "release": {
+          "id": "release_123",
+          "publishedAt": null,
+          "scheduledAt": "2026-07-07T09:55:00.000Z",
+          "status": "failed",
+          "targetSummary": {
+            "failed": 1,
+            "published": 0,
+            "total": 1,
+          },
+        },
+        "schemaVersion": 1,
+        "target": {
+          "credential": {
+            "id": "cred_123",
+          },
+          "error": {
+            "class": "credential",
+            "code": "credential",
+            "message": "Credential expired",
+            "retryable": false,
+          },
+          "externalProviderId": "post_123",
+          "externalShortcode": "abc123",
+          "id": "target_123",
+          "platform": "twitter",
+          "publishedAt": null,
+          "scheduledAt": "2026-07-07T09:55:00.000Z",
+          "status": "failed",
+          "url": "https://x.com/example/status/post_123",
+        },
+        "timestamp": "2026-07-07T10:00:00.000Z",
+      }
+    `);
+  });
 });
 
 describe('publish webhook helpers', () => {
@@ -79,14 +155,15 @@ describe('publish webhook helpers', () => {
     ).toBe('publish:target.published:release-123:target-123:published');
   });
 
-  test('classifies common terminal publish errors', () => {
-    expect(classifyPublishWebhookError('Quota exceeded')).toBe('rate_limit');
-    expect(classifyPublishWebhookError('Credential token expired')).toBe(
-      'credential',
-    );
-    expect(classifyPublishWebhookError('Unsupported platform')).toBe(
-      'validation',
-    );
+  test.each([
+    ['missing channel configuration', 'misconfiguration'],
+    ['credential token expired', 'credential'],
+    ['provider timeout with 503', 'provider_outage'],
+    ['quota exceeded', 'rate_limit'],
+    ['unsupported platform', 'validation'],
+    ['unexpected scheduler failure', 'unknown'],
+  ] as const)('classifies "%s" as %s', (message, expectedErrorClass) => {
+    expect(classifyPublishWebhookError(message)).toBe(expectedErrorClass);
   });
 
   test('redacts secret-like text from error messages', () => {


### PR DESCRIPTION
Refs #1169
Builds on #1479, which has now merged into `master`.

## Summary
- Extend publish webhook job retention while keeping delivery retry/backoff on the shared `webhook-client` queue defaults, so retried publish workers reuse stable event IDs/job IDs longer.
- Add focused hardening coverage for duplicate publish emissions, no-secret failed payload snapshots, full failure classification coverage, and worker retry rethrow behavior.
- Polish public webhook docs with metadata, schema versioning rules, and clearer `eventId` idempotency guidance.

## Verification
- `bunx biome check --write apps/server/workers/src/processors/api/services/webhook-client/webhook-client.processor.spec.ts apps/server/api/src/services/webhook-client/webhook-client.module.ts apps/server/api/src/services/webhook-client/webhook-client.module.spec.ts apps/server/api/src/services/webhook-client/publish-event-webhook.service.ts apps/server/api/src/services/webhook-client/publish-event-webhook.service.spec.ts packages/api-types/__tests__/publish-webhook-events.contract.test.ts apps/docs/content/api-reference/webhooks.mdx`
- `bun run --cwd packages/api-types test -- __tests__/publish-webhook-events.contract.test.ts`
- `bun run --cwd apps/server/api test -- src/services/webhook-client/publish-event-webhook.service.spec.ts src/services/webhook-client/webhook-client.module.spec.ts`
- `bun run --cwd apps/server/workers test -- src/processors/api/services/webhook-client/webhook-client.processor.spec.ts`
- `git diff --check origin/master..HEAD`
- Commit hook ran scoped Biome + secretlint on staged files

## Notes
- Full workspace typecheck/build/test intentionally left to PR CI per repo local verification policy.
