### PR TITLE
fix(build): resolve api-types alias in server webpack bundles

### DIFF
--- a/webpack.base.config.js
+++ b/webpack.base.config.js
@@ -115,6 +115,7 @@ module.exports = function createWebpackConfig({
         }
       : {}),
     '@genfeedai-types': path.resolve(cloudPackagesRoot, 'types/src'),
+    '@api-types': path.resolve(cloudPackagesRoot, 'api-types/src'),
     '@helpers': path.resolve(cloudPackagesRoot, 'helpers/src'),
     '@integrations': path.resolve(cloudPackagesRoot, 'integrations/src'),
     '@libs': path.resolve(cloudPackagesRoot, 'libs'),
@@ -186,6 +187,7 @@ module.exports = function createWebpackConfig({
           // node_modules package — keep it bundled so the DI fragment is inlined.
           /^@billing-providers$/,
           /^@genfeedai\//,
+          /^@api-types\//,
           /^@cloud\//,
           /^@api\//,
           /^@helpers\//,


### PR DESCRIPTION
## Summary
- add the shared `@api-types` webpack alias for server bundles
- allowlist `@api-types/*` so workers production bundling follows the in-repo API types source

## Deployment blocker
The production deploy QA gate failed in `Build & Boot Check / Build & Boot Check` because `@genfeedai/workers build:prod` could not resolve `@api-types/contracts/publish-webhook-events.contract` from API code pulled into the workers bundle.

## Verification
- `bun --filter @genfeedai/workers build:prod`