### PR TITLE
fix(e2e): classify password reset routes in smoke discovery

### DIFF
--- a/playwright/e2e/tests/smoke/all-app-pages.spec.ts
+++ b/playwright/e2e/tests/smoke/all-app-pages.spec.ts
@@ -68,10 +68,12 @@ const routes = listPageFiles(appRoot)
 
 const publicRoutes = routes.filter(
   (route) =>
+    route.startsWith('/forgot-password') ||
     route.startsWith('/login') ||
     route.startsWith('/logout') ||
     route.startsWith('/managed-credits') ||
     route.startsWith('/request-access') ||
+    route.startsWith('/reset-password') ||
     route.startsWith('/sign-up'),
 );
 


### PR DESCRIPTION
## Summary
- Mark `/forgot-password` and `/reset-password` as public app routes in the all-pages smoke route discovery test.
- Unblocks the production deploy QA gate after the password reset pages were merged.

## Verification
- `bunx biome check --config-path=biome-staged.json --no-errors-on-unmatched playwright/e2e/tests/smoke/all-app-pages.spec.ts` warning only: existing `GENFEED_E2E_ROUTE_FILTER` turbo env warning.
- `bun --eval "const fs = require('node:fs'); const file = 'playwright/e2e/tests/smoke/all-app-pages.spec.ts'; const source = fs.readFileSync(file, 'utf8'); const required = ['route.startsWith(\'/forgot-password\')', 'route.startsWith(\'/reset-password\')']; const missing = required.filter((needle) => !source.includes(needle)); if (missing.length) { console.error(missing.join('\n')); process.exit(1); } console.log('password reset routes are classified as public smoke routes');"`

## Note
- Focused local Playwright invocation could not run because the local Chromium cache is missing; PR CI will run the smoke gate.
