### PR TITLE
fix(app): redirect keyless self-hosted root

### DIFF
--- a/apps/app/app/(protected)/page.test.ts
+++ b/apps/app/app/(protected)/page.test.ts
@@ -9,6 +9,8 @@ describe('ProtectedRootPage', () => {
       'utf8',
     );
 
+    expect(source).toContain("import { redirect } from 'next/navigation'");
+    expect(source).toContain('NEXT_PUBLIC_BETTER_AUTH_ENABLED');
     expect(source).toContain('ProtectedRootResolver');
     expect(source).toContain('return <ProtectedRootResolver />');
   });

--- a/apps/app/app/(protected)/page.test.tsx
+++ b/apps/app/app/(protected)/page.test.tsx
@@ -1,17 +1,54 @@
 import { runPageModuleTests } from '@shared/pages/pageTestUtils';
 import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, expect, vi } from 'vitest';
 import ProtectedRootPage, * as PageModule from './page';
+
+const mocks = vi.hoisted(() => ({
+  redirect: vi.fn((url: string) => {
+    throw new Error(`NEXT_REDIRECT:${url}`);
+  }),
+}));
 
 vi.mock('@app/(protected)/root-resolver-client', () => ({
   default: () => <div data-testid="protected-root-resolver" />,
 }));
 
+vi.mock('next/navigation', () => ({
+  redirect: mocks.redirect,
+}));
+
 runPageModuleTests('app/(protected)/page', PageModule);
 
 describe('ProtectedRootPage', () => {
+  const originalBetterAuthEnabled = process.env.NEXT_PUBLIC_BETTER_AUTH_ENABLED;
+
+  beforeEach(() => {
+    delete process.env.NEXT_PUBLIC_BETTER_AUTH_ENABLED;
+    mocks.redirect.mockClear();
+  });
+
+  afterEach(() => {
+    if (originalBetterAuthEnabled === undefined) {
+      delete process.env.NEXT_PUBLIC_BETTER_AUTH_ENABLED;
+    } else {
+      process.env.NEXT_PUBLIC_BETTER_AUTH_ENABLED = originalBetterAuthEnabled;
+    }
+  });
+
   it('renders the protected root resolver', () => {
     render(<ProtectedRootPage />);
 
     expect(screen.getByTestId('protected-root-resolver')).toBeInTheDocument();
+  });
+
+  it('redirects keyless self-hosted root to the seeded workspace', () => {
+    process.env.NEXT_PUBLIC_BETTER_AUTH_ENABLED = 'false';
+
+    expect(() => ProtectedRootPage()).toThrow(
+      'NEXT_REDIRECT:/default/default/workspace/overview',
+    );
+    expect(mocks.redirect).toHaveBeenCalledWith(
+      '/default/default/workspace/overview',
+    );
   });
 });

--- a/apps/app/app/(protected)/page.tsx
+++ b/apps/app/app/(protected)/page.tsx
@@ -1,5 +1,12 @@
 import ProtectedRootResolver from '@app/(protected)/root-resolver-client';
+import { redirect } from 'next/navigation';
+
+const SEEDED_WORKSPACE_PATH = '/default/default/workspace/overview';
 
 export default function ProtectedRootPage() {
+  if (process.env.NEXT_PUBLIC_BETTER_AUTH_ENABLED === 'false') {
+    redirect(SEEDED_WORKSPACE_PATH);
+  }
+
   return <ProtectedRootResolver />;
 }

--- a/apps/app/proxy.ts
+++ b/apps/app/proxy.ts
@@ -153,20 +153,6 @@ function isSeededWorkspaceEntrypoint(pathname: string): boolean {
   );
 }
 
-function isScopedWorkspacePath(pathname: string): boolean {
-  const parts = pathname.split('/').filter(Boolean);
-
-  // Only the org-root workspace scope (/:orgSlug/~/...) gates onboarding here.
-  // Brand-scoped (/:orgSlug/:brandSlug/...) and bare protected paths are
-  // handled by their own branches above, so matching them here would fire a
-  // redundant bootstrap fetch on every authenticated navigation.
-  if (parts.length < 2 || parts[0] === 'admin') {
-    return false;
-  }
-
-  return parts[1] === '~';
-}
-
 type WorkspaceSlugs = {
   brandCount: number;
   brandSlug?: string;
@@ -633,7 +619,7 @@ function isPlaywrightBypassRequest(req: NextRequest): boolean {
   return isPlaywrightTestBuild && hasPlaywrightBypassCookie;
 }
 
-export default async function proxy(req: NextRequest) {
+export async function proxy(req: NextRequest) {
   if (req.nextUrl.pathname === '/playwright-ready') {
     return NextResponse.next();
   }
@@ -829,6 +815,8 @@ export default async function proxy(req: NextRequest) {
 
   return NextResponse.next();
 }
+
+export default proxy;
 
 export const config = {
   matcher: [

--- a/docker/Dockerfile.selfhosted
+++ b/docker/Dockerfile.selfhosted
@@ -146,10 +146,12 @@ COPY apps/server/ apps/server/
 
 # Build the shared packages that downstream project references resolve through
 # package exports before the parallel batch. A clean Docker context has no host
-# dist output, so this must mirror docker/Dockerfile.server's dependency order:
-# enums -> constants -> interfaces -> pricing -> client, then config can build.
+# dist output, so this follows docker/Dockerfile.server's dependency order and
+# includes api-types because the self-hosted image also builds the Next.js app:
+# enums -> api-types -> constants -> interfaces -> pricing -> client, then config can build.
 RUN set -e; \
     bun --filter @genfeedai/enums build; \
+    bun --filter @genfeedai/api-types build; \
     bun --filter @genfeedai/constants build; \
     bun --filter @genfeedai/interfaces build; \
     bun --filter @genfeedai/pricing build; \


### PR DESCRIPTION
## Summary
- redirect the protected root server page to the seeded workspace when Better Auth is explicitly disabled
- expose the Next 16 proxy handler as both named `proxy` and default export
- build `@genfeedai/api-types` in the self-hosted Docker image before the Next app build so `@genfeedai/api-types/contracts` resolves in a clean Docker context
- cover the keyless self-hosted root fallback in focused app tests

Refs #1450.

## Verification
- `bunx biome check docker/Dockerfile.selfhosted apps/app/app/'(protected)'/page.tsx apps/app/app/'(protected)'/page.test.tsx apps/app/app/'(protected)'/page.test.ts apps/app/proxy.ts`
- `bun --cwd apps/app test 'app/(protected)/page.test.tsx' 'app/(protected)/page.test.ts' proxy.test.ts`
- PR CI: https://github.com/genfeedai/genfeed.ai/actions/runs/28935080368
- Build Verify (Self-Hosted): https://github.com/genfeedai/genfeed.ai/actions/runs/28935082031
- pre-commit: secretlint, staged Biome write, raw HTML guard, bespoke card guard

## Notes
The failing scheduled workflow tests `ghcr.io/genfeedai/genfeed.ai:latest`. This patch fixes the next self-hosted image built from the merged code; the current published `latest` image will stay red until republished.
