### PR TITLE
fix(shell): tighten brand scope controls

### DIFF
--- a/apps/app/src/components/shell/AppProtectedTopbar.test.tsx
+++ b/apps/app/src/components/shell/AppProtectedTopbar.test.tsx
@@ -6,6 +6,9 @@ let mockSearchParams = new URLSearchParams();
 const appSwitcherSpy = vi.hoisted(() => vi.fn());
 const brandSwitcherSpy = vi.hoisted(() => vi.fn());
 const mockPush = vi.hoisted(() => vi.fn());
+const mockPathname = vi.hoisted(() => ({
+  value: '/acme/brand/workspace/overview',
+}));
 const mockAccessState = vi.hoisted(() => ({
   isSuperAdmin: false,
 }));
@@ -122,6 +125,7 @@ vi.mock('@ui/menus/switchers/MenuBrandSwitcher', () => ({
 
 vi.mock('@ui/shell/app-switcher/AppSwitcher', () => ({
   AppSwitcher: (props: {
+    brandAwareSlug?: string;
     brandSlug?: string;
     currentApp?: string;
     orgSlug: string;
@@ -161,7 +165,7 @@ vi.mock('next/link', () => ({
 }));
 
 vi.mock('next/navigation', () => ({
-  usePathname: () => '/acme/brand/workspace/overview',
+  usePathname: () => mockPathname.value,
   useRouter: () => ({ push: mockPush }),
   useSearchParams: () => mockSearchParams,
 }));
@@ -171,6 +175,7 @@ const { default: AppProtectedTopbar } = await import('./AppProtectedTopbar');
 describe('AppProtectedTopbar', () => {
   beforeEach(() => {
     mockSearchParams = new URLSearchParams();
+    mockPathname.value = '/acme/brand/workspace/overview';
     mockAccessState.isSuperAdmin = false;
     appSwitcherSpy.mockClear();
     brandSwitcherSpy.mockClear();
@@ -234,8 +239,24 @@ describe('AppProtectedTopbar', () => {
 
     expect(appSwitcherSpy).toHaveBeenCalledWith(
       expect.objectContaining({
+        brandAwareSlug: 'brand',
         brandSlug: undefined,
         currentApp: 'workspace',
+        orgSlug: 'acme',
+      }),
+    );
+  });
+
+  it('hides the brand switcher on organization settings routes', () => {
+    mockPathname.value = '/acme/~/settings/api-keys';
+
+    render(<AppProtectedTopbar orgSlug="acme" currentApp="workspace" />);
+
+    expect(screen.queryByTestId('brand-switcher')).not.toBeInTheDocument();
+    expect(appSwitcherSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        brandAwareSlug: 'brand',
+        brandSlug: undefined,
         orgSlug: 'acme',
       }),
     );

--- a/apps/app/src/components/shell/AppProtectedTopbar.tsx
+++ b/apps/app/src/components/shell/AppProtectedTopbar.tsx
@@ -98,6 +98,16 @@ function AppProtectedTopbarContent({
   const isOrganizationScopeRoute = hasExplicitOrgScope && !explicitBrandSlug;
   const effectiveBrandId = brandId || getBrandEntityId(selectedBrand);
   const visibleBrandId = isOrganizationScopeRoute ? '' : effectiveBrandId;
+  const selectedBrandForContext = effectiveBrandId
+    ? brands.find((brand) => getBrandEntityId(brand) === effectiveBrandId) ||
+      selectedBrand
+    : undefined;
+  const brandAwareAppSlug =
+    effectiveBrandSlug || selectedBrandForContext?.slug || undefined;
+  const isOrganizationSettingsRoute =
+    Boolean(effectiveOrgSlug) &&
+    isOrganizationScopeRoute &&
+    pathname.startsWith(`/${effectiveOrgSlug}/~/settings`);
 
   const handleBrandChange = useCallback(
     (nextBrandId: string) => {
@@ -197,7 +207,9 @@ function AppProtectedTopbarContent({
             </Button>
           ) : null}
 
-          {!isAdminChrome && brands.length > 0 ? (
+          {!isAdminChrome &&
+          brands.length > 0 &&
+          !isOrganizationSettingsRoute ? (
             <div className="w-36 min-w-0 sm:w-44 md:w-48">
               <MenuBrandSwitcher
                 variant="labeled"
@@ -279,6 +291,7 @@ function AppProtectedTopbarContent({
                 currentApp={effectiveCurrentApp}
                 currentPath={pathname}
                 orgSlug={effectiveOrgSlug}
+                brandAwareSlug={brandAwareAppSlug}
                 brandSlug={effectiveBrandSlug}
                 showAdmin={isAdminChrome || isSuperAdmin}
               />

--- a/packages/props/ui/app-switcher.props.ts
+++ b/packages/props/ui/app-switcher.props.ts
@@ -1,6 +1,8 @@
 import type { AppContext } from '@genfeedai/interfaces';
 
 export interface AppSwitcherProps {
+  /** Selected brand context used by brand-aware apps when the current route is org-scoped. */
+  brandAwareSlug?: string;
   brandSlug?: string;
   currentApp: AppContext;
   currentPath?: string;

--- a/packages/ui/src/components/layouts/app/CollapsedSidebarLogoToggle.tsx
+++ b/packages/ui/src/components/layouts/app/CollapsedSidebarLogoToggle.tsx
@@ -1,10 +1,8 @@
 'use client';
 
 import { ButtonVariant } from '@genfeedai/enums';
-import { useThemeLogo } from '@genfeedai/hooks/ui/use-theme-logo/use-theme-logo';
-import { EnvironmentService } from '@genfeedai/services/core/environment.service';
 import { Button } from '@ui/primitives/button';
-import Image from 'next/image';
+import { HiBars3BottomLeft, HiChevronRight } from 'react-icons/hi2';
 
 type CollapsedSidebarLogoToggleProps = {
   onClick: () => void;
@@ -13,8 +11,6 @@ type CollapsedSidebarLogoToggleProps = {
 export default function CollapsedSidebarLogoToggle({
   onClick,
 }: CollapsedSidebarLogoToggleProps) {
-  const logoUrl = useThemeLogo();
-
   return (
     <Button
       type="button"
@@ -22,21 +18,13 @@ export default function CollapsedSidebarLogoToggle({
       withWrapper={false}
       onClick={onClick}
       ariaLabel="Expand sidebar"
-      className="fixed left-2 z-[60] hidden size-8 items-center justify-center rounded-md border border-border/70 bg-background/95 text-foreground shadow-sm backdrop-blur transition-colors hover:border-foreground/20 hover:bg-background-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 md:flex"
+      className="group fixed left-2 z-[60] hidden size-8 items-center justify-center rounded-md border border-border/70 bg-background/95 text-foreground/72 shadow-sm backdrop-blur transition-colors hover:border-foreground/20 hover:bg-background-secondary hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 md:flex"
       style={{ top: 'calc(var(--desktop-titlebar-height) + 0.5rem)' }}
     >
-      {logoUrl ? (
-        <Image
-          src={logoUrl}
-          alt={EnvironmentService.LOGO_ALT}
-          className="size-4 object-contain dark:invert"
-          width={16}
-          height={16}
-          sizes="16px"
-        />
-      ) : (
-        <span className="text-sm font-bold leading-none">G</span>
-      )}
+      <span className="relative flex size-4 items-center justify-center">
+        <HiBars3BottomLeft className="size-4" />
+        <HiChevronRight className="absolute -right-1 size-3 rounded-full bg-background text-foreground/46 transition-colors group-hover:text-foreground/82" />
+      </span>
     </Button>
   );
 }

--- a/packages/ui/src/components/menus/shared/MenuShared.test.tsx
+++ b/packages/ui/src/components/menus/shared/MenuShared.test.tsx
@@ -321,6 +321,20 @@ describe('MenuShared', () => {
     ).toBeTruthy();
   });
 
+  it('renders an explicit sidebar collapse control separate from the logo', () => {
+    const onToggleCollapse = vi.fn();
+
+    render(<MenuShared config={config} onToggleCollapse={onToggleCollapse} />);
+
+    const collapseButton = screen.getByRole('button', {
+      name: 'Collapse sidebar',
+    });
+
+    expect(collapseButton.querySelector('svg')).not.toBeNull();
+    fireEvent.click(collapseButton);
+    expect(onToggleCollapse).toHaveBeenCalledTimes(1);
+  });
+
   it('omits the org switcher slot when not provided', () => {
     render(<MenuShared config={config} />);
 

--- a/packages/ui/src/components/menus/shared/MenuShared.tsx
+++ b/packages/ui/src/components/menus/shared/MenuShared.tsx
@@ -4,15 +4,17 @@ import { APP_ROUTES } from '@genfeedai/constants';
 import { ButtonVariant } from '@genfeedai/enums';
 import { cn } from '@genfeedai/helpers/formatting/cn/cn.util';
 import type { MenuSharedProps } from '@genfeedai/props/navigation/menu.props';
-import { EnvironmentService } from '@genfeedai/services/core/environment.service';
 import MenuItem from '@ui/menus/item/MenuItem';
 import SidebarNested from '@ui/menus/sidebar-nested/SidebarNested';
 import { useNavigationPrefetch } from '@ui/navigation/prefetch/useNavigationPrefetch';
 import { Button } from '@ui/primitives/button';
-import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { HiOutlineArrowLeft } from 'react-icons/hi2';
+import {
+  HiBars3BottomLeft,
+  HiChevronLeft,
+  HiOutlineArrowLeft,
+} from 'react-icons/hi2';
 import CollapsibleGroup from './CollapsibleGroup';
 import MenuSharedConversations from './MenuSharedConversations';
 import MenuSharedGroupedItems from './MenuSharedGroupedItems';
@@ -45,7 +47,6 @@ export default function MenuShared({
   const { push } = useRouter();
 
   const {
-    logoUrl,
     href,
     orgHref,
     isConversationsCollapsed,
@@ -154,22 +155,12 @@ export default function MenuShared({
       variant={ButtonVariant.UNSTYLED}
       withWrapper={false}
       onClick={onToggleCollapse}
-      className="flex size-7 flex-shrink-0 items-center justify-center rounded-md bg-transparent text-foreground/72 cursor-pointer transition-colors hover:bg-foreground/[0.06] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
+      className="group flex size-7 flex-shrink-0 items-center justify-center rounded-md bg-transparent text-foreground/62 cursor-pointer transition-colors hover:bg-foreground/[0.06] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
       ariaLabel={isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
     >
       <span className="relative flex size-4 items-center justify-center">
-        {logoUrl ? (
-          <Image
-            src={logoUrl}
-            alt={EnvironmentService.LOGO_ALT}
-            className="size-4 object-contain dark:invert"
-            width={16}
-            height={16}
-            sizes="16px"
-          />
-        ) : (
-          <span className="text-sm font-bold leading-none">G</span>
-        )}
+        <HiBars3BottomLeft className="size-4" />
+        <HiChevronLeft className="absolute -right-1 size-3 rounded-full bg-background text-foreground/46 transition-colors group-hover:text-foreground/82" />
       </span>
     </Button>
   ) : null;

--- a/packages/ui/src/components/menus/switcher-dropdown/SwitcherDropdown.tsx
+++ b/packages/ui/src/components/menus/switcher-dropdown/SwitcherDropdown.tsx
@@ -212,7 +212,7 @@ function SwitcherItem({
   return (
     <div
       className={cn(
-        'group mx-1 flex items-center rounded-sm transition-colors duration-150',
+        'group mx-1 flex min-h-9 w-[calc(100%-0.5rem)] items-center rounded-sm transition-colors duration-150',
         'hover:bg-foreground/[0.06] focus-within:bg-foreground/[0.06] has-[[data-selected=true]]:bg-foreground/[0.06]',
         item.isActive && 'bg-foreground/[0.06]',
       )}

--- a/packages/ui/src/components/shell/app-switcher/AppSwitcher.test.tsx
+++ b/packages/ui/src/components/shell/app-switcher/AppSwitcher.test.tsx
@@ -234,6 +234,25 @@ describe('AppSwitcher', () => {
     );
   });
 
+  it('routes the agent tile to the selected brand when the current route is org-scoped', () => {
+    render(
+      <AppSwitcher
+        orgSlug="acme"
+        currentApp="workspace"
+        brandAwareSlug="moonrise"
+      />,
+    );
+
+    expect(screen.getByRole('link', { name: 'Agent' })).toHaveAttribute(
+      'href',
+      '/acme/moonrise/agent',
+    );
+    expect(screen.getByRole('link', { name: 'Workspace' })).toHaveAttribute(
+      'href',
+      '/acme/~/workspace/overview',
+    );
+  });
+
   it('marks messages active when the messages shell is current', () => {
     render(
       <AppSwitcher orgSlug="acme" brandSlug="my-brand" currentApp="messages" />,

--- a/packages/ui/src/components/shell/app-switcher/AppSwitcher.tsx
+++ b/packages/ui/src/components/shell/app-switcher/AppSwitcher.tsx
@@ -521,6 +521,7 @@ function AppSwitcherGridItem({
 }
 
 export function AppSwitcher({
+  brandAwareSlug,
   brandSlug,
   currentApp,
   currentPath,
@@ -533,8 +534,19 @@ export function AppSwitcher({
   const searchInputRef = useRef<HTMLInputElement>(null);
   const [searchQuery, setSearchQuery] = useState('');
 
+  function getRouteBrandSlug(app: AppSwitcherItemConfig) {
+    if (app.id === 'agent') {
+      return brandSlug ?? brandAwareSlug;
+    }
+
+    return brandSlug;
+  }
+
   function getAppHref(app: AppSwitcherItemConfig) {
-    return withPreservedSearch(app.route(orgSlug, brandSlug), preservedSearch);
+    return withPreservedSearch(
+      app.route(orgSlug, getRouteBrandSlug(app)),
+      preservedSearch,
+    );
   }
 
   const handleNavigateStart = () => {


### PR DESCRIPTION
## Summary
- route the app switcher Agent tile through the selected brand when available while leaving org-scope pages org-scoped
- hide the brand dropdown on org settings routes
- replace the sidebar logo-as-collapse control with an explicit sidebar/chevron control
- widen shared switcher dropdown row hover treatment

## Verification
- bun run test src/components/shell/app-switcher/AppSwitcher.test.tsx (packages/ui)
- bun run test src/components/menus/shared/MenuShared.test.tsx (packages/ui)
- bun run test src/components/shell/AppProtectedTopbar.test.tsx (apps/app)
- bunx biome check <touched files>
- bun run design:lint