### PR TITLE
feat(messages): expose action provenance

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/messages/messages-page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/messages/messages-page.tsx
@@ -6,6 +6,7 @@ import { cn } from '@helpers/formatting/cn/cn.util';
 import { useAuthedService } from '@hooks/auth/use-authed-service/use-authed-service';
 import { useOrgUrl } from '@hooks/navigation/use-org-url';
 import type {
+  SocialActionProvenance,
   SocialAutomationState,
   SocialConversationModel,
   SocialConversationStatus,
@@ -90,6 +91,19 @@ const STATUS_STYLES: Record<string, string> = {
   resolved: 'bg-success/10 text-success',
 };
 
+const ACTION_LABELS: Record<string, string> = {
+  draft: 'Draft',
+  post_reply: 'Reply',
+  send_dm: 'DM',
+};
+
+const ACTOR_LABELS: Record<string, string> = {
+  agent: 'Agent',
+  system: 'System',
+  user: 'User',
+  workflow: 'Workflow',
+};
+
 const MESSAGE_TIME = new Intl.DateTimeFormat('en', {
   day: 'numeric',
   hour: '2-digit',
@@ -133,6 +147,92 @@ function getParticipantLabel(conversation: SocialConversationModel): string {
     conversation.participantExternalId ||
     'Unknown sender'
   );
+}
+
+function formatActionLabel(value?: string | null): string | null {
+  if (!value) {
+    return null;
+  }
+
+  return (
+    ACTION_LABELS[value] ??
+    value
+      .split('_')
+      .filter(Boolean)
+      .map((part) => `${part[0]?.toUpperCase() ?? ''}${part.slice(1)}`)
+      .join(' ')
+  );
+}
+
+function getStringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function getMessageProvenanceItems(message: SocialMessageModel): Array<{
+  label: string;
+  value: string;
+}> {
+  const provenance: SocialActionProvenance = message.actionProvenance ?? {};
+  const actionLabel = formatActionLabel(provenance.action);
+  const actorType = getStringValue(provenance.actorType);
+  const actorLabel = actorType
+    ? (ACTOR_LABELS[actorType] ?? formatActionLabel(actorType))
+    : null;
+  const status = getStringValue(provenance.status) ?? message.status;
+  const workflowRunId =
+    getStringValue(provenance.workflowRunId) ??
+    getStringValue(message.workflowRunId);
+  const agentRunId =
+    getStringValue(provenance.agentRunId) ?? getStringValue(message.agentRunId);
+  const userId =
+    getStringValue(provenance.userId) ?? getStringValue(message.userId);
+  const actedAt = getStringValue(provenance.actedAt);
+  const approvedBy = getStringValue(provenance.approvedBy);
+  const rejectedBy = getStringValue(provenance.rejectedBy);
+  const items: Array<{ label: string; value: string }> = [];
+  const hasActionProvenance = Boolean(
+    actionLabel ||
+      actorLabel ||
+      workflowRunId ||
+      agentRunId ||
+      actedAt ||
+      approvedBy ||
+      rejectedBy,
+  );
+
+  if (!hasActionProvenance) {
+    return items;
+  }
+
+  if (actorLabel) {
+    items.push({ label: 'Actor', value: actorLabel });
+  }
+  if (actionLabel) {
+    items.push({ label: 'Action', value: actionLabel });
+  }
+  if (status) {
+    items.push({ label: 'Result', value: status });
+  }
+  if (workflowRunId) {
+    items.push({ label: 'Workflow', value: workflowRunId });
+  }
+  if (agentRunId) {
+    items.push({ label: 'Agent', value: agentRunId });
+  }
+  if (userId) {
+    items.push({ label: 'User', value: userId });
+  }
+  if (actedAt) {
+    items.push({ label: 'When', value: formatTime(actedAt) });
+  }
+  if (approvedBy) {
+    items.push({ label: 'Approved by', value: approvedBy });
+  }
+  if (rejectedBy) {
+    items.push({ label: 'Rejected by', value: rejectedBy });
+  }
+
+  return items;
 }
 
 function StatusPill({ status }: { status: string }) {
@@ -211,6 +311,7 @@ function MessageBubble({
 }) {
   const isOutbound = message.direction === 'outbound';
   const isDraft = isOutbound && message.status === 'draft';
+  const provenanceItems = getMessageProvenanceItems(message);
 
   return (
     <div className={cn('flex', isOutbound ? 'justify-end' : 'justify-start')}>
@@ -230,6 +331,21 @@ function MessageBubble({
         <p className="whitespace-pre-wrap text-sm leading-relaxed">
           {message.body}
         </p>
+        {provenanceItems.length > 0 ? (
+          <dl
+            aria-label="Message provenance"
+            className="mt-3 grid gap-1 border-t border-white/[0.08] pt-2 text-[11px] text-white/46"
+          >
+            {provenanceItems.map((item) => (
+              <div className="flex min-w-0 gap-2" key={item.label}>
+                <dt className="shrink-0 font-medium text-white/36">
+                  {item.label}
+                </dt>
+                <dd className="min-w-0 truncate text-white/62">{item.value}</dd>
+              </div>
+            ))}
+          </dl>
+        ) : null}
         {isDraft ? (
           <div className="mt-3 flex flex-wrap justify-end gap-2">
             <Button

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/messages/page.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/messages/page.test.tsx
@@ -155,6 +155,17 @@ const messages = [
     updatedAt: '2026-07-02T08:00:00.000Z',
   },
   {
+    actionProvenance: {
+      action: 'draft',
+      actedAt: '2026-07-02T08:05:30.000Z',
+      actorType: 'agent',
+      agentRunId: 'agent-run-1',
+      platform: 'youtube',
+      status: 'draft',
+      userId: 'user-1',
+      workflowRunId: 'workflow-run-1',
+    },
+    agentRunId: 'agent-run-1',
     body: 'Here is a drafted answer.',
     conversationId: 'conversation-1',
     createdAt: '2026-07-02T08:05:00.000Z',
@@ -164,6 +175,8 @@ const messages = [
     platform: 'youtube',
     status: 'draft',
     updatedAt: '2026-07-02T08:05:00.000Z',
+    userId: 'user-1',
+    workflowRunId: 'workflow-run-1',
   },
 ];
 
@@ -206,6 +219,10 @@ describe('SocialMessagesPage', () => {
     expect(
       await screen.findByText('Here is a drafted answer.'),
     ).toBeInTheDocument();
+    expect(screen.getByText('workflow-run-1')).toBeInTheDocument();
+    expect(screen.getByText('agent-run-1')).toBeInTheDocument();
+    expect(screen.getByText('user-1')).toBeInTheDocument();
+    expect(screen.getByText('Draft')).toBeInTheDocument();
 
     const automationLink = screen.getByRole('link', { name: /Automation/i });
     expect(automationLink).toHaveAttribute(

--- a/apps/server/api/src/collections/social-inbox/services/social-inbox.service.spec.ts
+++ b/apps/server/api/src/collections/social-inbox/services/social-inbox.service.spec.ts
@@ -398,6 +398,15 @@ describe('SocialInboxService', () => {
       messages.filter((message) => message.direction === 'outbound'),
     ).toHaveLength(1);
     expect(youtubeService.postCommentReply).toHaveBeenCalledTimes(1);
+    expect(first.actionProvenance).toMatchObject({
+      action: 'post_reply',
+      actedAt: expect.any(String),
+      actorType: 'workflow',
+      platform: 'youtube',
+      status: 'sent',
+      userId: 'user-1',
+      workflowRunId: 'workflow-run-1',
+    });
     expect(first.workflowRunId).toBe('workflow-run-1');
     expect(first.status).toBe('sent');
   });
@@ -505,7 +514,12 @@ describe('SocialInboxService', () => {
     expect(draft).toMatchObject({
       actionProvenance: {
         action: 'draft',
+        actedAt: expect.any(String),
+        actorType: 'agent',
         agentRunId: 'agent-run-1',
+        platform: 'youtube',
+        status: 'draft',
+        userId: 'user-1',
         workflowRunId: 'workflow-run-1',
       },
       body: 'Try this answer',
@@ -536,7 +550,12 @@ describe('SocialInboxService', () => {
     expect(sent).toMatchObject({
       actionProvenance: {
         action: 'post_reply',
+        actedAt: expect.any(String),
+        actorType: 'agent',
         agentRunId: 'agent-run-1',
+        platform: 'youtube',
+        status: 'sent',
+        userId: 'user-1',
         workflowRunId: 'workflow-run-1',
       },
       status: 'sent',

--- a/apps/server/api/src/collections/social-inbox/services/social-inbox.service.ts
+++ b/apps/server/api/src/collections/social-inbox/services/social-inbox.service.ts
@@ -292,10 +292,13 @@ export class SocialInboxService {
 
     const message = await this.prisma.socialMessage.create({
       data: {
-        actionProvenance: this.buildActionProvenance(
+        actionProvenance: this.buildActionProvenance({
+          action: 'draft',
+          conversation,
           input,
-          'draft',
-        ) as Prisma.InputJsonValue,
+          scope,
+          status: 'draft',
+        }) as Prisma.InputJsonValue,
         agentRunId: input.agentRunId,
         body,
         brandId: conversation.brandId,
@@ -427,10 +430,13 @@ export class SocialInboxService {
 
     const message = await this.prisma.socialMessage.create({
       data: {
-        actionProvenance: this.buildActionProvenance(
+        actionProvenance: this.buildActionProvenance({
+          action: 'post_reply',
+          conversation,
           input,
-          'post_reply',
-        ) as Prisma.InputJsonValue,
+          scope,
+          status: 'sent',
+        }) as Prisma.InputJsonValue,
         agentRunId: input.agentRunId,
         body,
         brandId: conversation.brandId,
@@ -499,10 +505,13 @@ export class SocialInboxService {
 
     const message = await this.prisma.socialMessage.create({
       data: {
-        actionProvenance: this.buildActionProvenance(
+        actionProvenance: this.buildActionProvenance({
+          action: 'send_dm',
+          conversation,
           input,
-          'send_dm',
-        ) as Prisma.InputJsonValue,
+          scope,
+          status: 'sent',
+        }) as Prisma.InputJsonValue,
         agentRunId: input.agentRunId,
         body,
         brandId: conversation.brandId,
@@ -1089,13 +1098,35 @@ export class SocialInboxService {
     return this.toMessageDocument(draft);
   }
 
-  private buildActionProvenance(
-    input: SocialActionInput,
-    action: string,
-  ): JsonRecord {
+  private buildActionProvenance({
+    action,
+    conversation,
+    input,
+    scope,
+    status,
+  }: {
+    action: string;
+    conversation: SocialConversationDocument;
+    input: SocialActionInput;
+    scope: SocialInboxScope;
+    status: string;
+  }): JsonRecord {
+    const actorType = input.agentRunId
+      ? 'agent'
+      : input.workflowRunId
+        ? 'workflow'
+        : scope.userId
+          ? 'user'
+          : 'system';
+
     return {
       action,
       agentRunId: input.agentRunId,
+      actedAt: new Date().toISOString(),
+      actorType,
+      platform: conversation.platform,
+      status,
+      userId: scope.userId,
       workflowRunId: input.workflowRunId,
     };
   }

--- a/packages/services/social/messages.service.ts
+++ b/packages/services/social/messages.service.ts
@@ -29,6 +29,23 @@ export type SocialAutomationState =
 export type SocialConversationType = 'comment' | 'dm' | 'mention' | 'reply';
 export type SocialMessageDirection = 'inbound' | 'outbound' | 'system';
 export type SocialMessageType = 'comment' | 'dm' | 'draft' | 'note' | 'reply';
+export type SocialActionActorType = 'agent' | 'system' | 'user' | 'workflow';
+
+export interface SocialActionProvenance {
+  action?: string;
+  actedAt?: string;
+  actorType?: SocialActionActorType | string;
+  agentRunId?: string | null;
+  approvedAt?: string;
+  approvedBy?: string | null;
+  approvedMessageId?: string;
+  platform?: SocialPlatform | string;
+  rejectedAt?: string;
+  rejectedBy?: string | null;
+  status?: string;
+  userId?: string | null;
+  workflowRunId?: string | null;
+}
 
 export interface SocialConversationAvailability {
   canPostReply: boolean;
@@ -112,7 +129,7 @@ export interface SocialMessage {
   idempotencyKey?: string | null;
   workflowRunId?: string | null;
   agentRunId?: string | null;
-  actionProvenance?: Record<string, unknown>;
+  actionProvenance?: SocialActionProvenance;
   failureReason?: string | null;
   metadata?: Record<string, unknown>;
   createdAt: string;
@@ -237,7 +254,7 @@ export class SocialMessageModel implements SocialMessage {
   idempotencyKey?: string | null;
   workflowRunId?: string | null;
   agentRunId?: string | null;
-  actionProvenance?: Record<string, unknown>;
+  actionProvenance?: SocialActionProvenance;
   failureReason?: string | null;
   metadata?: Record<string, unknown>;
   createdAt!: string;


### PR DESCRIPTION
## Summary
- enrich social message action provenance with actor type, user id, platform, result status, and action timestamp
- render inspectable action provenance in /messages bubbles for workflow/agent/user actions
- add focused backend and messages-page coverage for provenance persistence and rendering

Closes #1022
Refs #1010

## Validation
- bun install --frozen-lockfile --ignore-scripts
- bun run --cwd packages/prisma db:generate
- bunx biome check --write apps/server/api/src/collections/social-inbox/services/social-inbox.service.ts apps/server/api/src/collections/social-inbox/services/social-inbox.service.spec.ts packages/services/social/messages.service.ts apps/app/app/(protected)/[orgSlug]/[brandSlug]/messages/messages-page.tsx apps/app/app/(protected)/[orgSlug]/[brandSlug]/messages/page.test.tsx
- bun run --cwd apps/app test app/(protected)/[orgSlug]/[brandSlug]/messages/page.test.tsx
- bun run --cwd apps/server/api test:file src/collections/social-inbox/services/social-inbox.service.spec.ts
- git diff --check

## Notes
- Broad workspace type-check/build/full test suites are intentionally left to PR CI per local verification policy.
- Source issue has no Codex queue label; applying codex:automation to this PR because this automation selected the issue.
