### PR TITLE
Add Beehiiv publishing fixes and expiry-aware social token refresh

### DIFF
--- a/apps/server/api/src/services/integrations/beehiiv/controllers/beehiiv.controller.spec.ts
+++ b/apps/server/api/src/services/integrations/beehiiv/controllers/beehiiv.controller.spec.ts
@@ -64,6 +64,13 @@ describe('BeehiivController', () => {
     name: 'My Newsletter',
     url: 'https://newsletter.beehiiv.com',
   };
+  const alternatePublication = {
+    created: 1_700_000_002,
+    description: 'Second newsletter',
+    id: 'pub_selected',
+    name: 'Selected Newsletter',
+    url: 'https://selected.beehiiv.com',
+  };
 
   beforeEach(async () => {
     beehiivService = {
@@ -124,6 +131,49 @@ describe('BeehiivController', () => {
         },
       );
       expect(result).toHaveProperty('data');
+    });
+
+    it('should connect to the selected publication when publicationId is provided', async () => {
+      brandsService.findOne.mockResolvedValue(mockBrand);
+      beehiivService.listPublications.mockResolvedValue([
+        mockPublication,
+        alternatePublication,
+      ]);
+      credentialsService.saveCredentials.mockResolvedValue({
+        _id: 'test-object-id',
+        platform: CredentialPlatform.BEEHIIV,
+      });
+
+      await controller.connect(mockRequest, mockUser, {
+        apiKey: 'test-api-key',
+        brandId: '507f191e810c19729de860ea',
+        publicationId: 'pub_selected',
+      });
+
+      expect(credentialsService.saveCredentials).toHaveBeenCalledWith(
+        mockBrand,
+        CredentialPlatform.BEEHIIV,
+        {
+          accessToken: 'test-api-key',
+          externalHandle: alternatePublication.name,
+          externalId: alternatePublication.id,
+          isConnected: true,
+        },
+      );
+    });
+
+    it('should return bad request when selected publication is not available', async () => {
+      brandsService.findOne.mockResolvedValue(mockBrand);
+      beehiivService.listPublications.mockResolvedValue([mockPublication]);
+
+      const result = await controller.connect(mockRequest, mockUser, {
+        apiKey: 'test-api-key',
+        brandId: '507f191e810c19729de860ea',
+        publicationId: 'pub_missing',
+      });
+
+      expect(result).toHaveProperty('errors');
+      expect(credentialsService.saveCredentials).not.toHaveBeenCalled();
     });
 
     it('should return bad request when apiKey is missing', async () => {

--- a/apps/server/api/src/services/integrations/beehiiv/controllers/beehiiv.controller.ts
+++ b/apps/server/api/src/services/integrations/beehiiv/controllers/beehiiv.controller.ts
@@ -32,20 +32,23 @@ export class BeehiivController {
   /**
    * Connect Beehiiv by verifying API key and storing credential.
    * Lists publications to verify the key, then stores the credential
-   * with the first publication's ID and name.
+   * with the selected publication's ID and name.
    */
   @Post('connect')
   async connect(
     @Req() request: Request,
     @CurrentUser() user: User,
-    @Body() body: { apiKey: string; brandId: string },
+    @Body() body: { apiKey: string; brandId: string; publicationId?: string },
   ) {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
     this.loggerService.log(url, { brandId: body.brandId });
 
     const publicMetadata = getPublicMetadata(user);
+    const apiKey = body.apiKey?.trim();
+    const brandId = body.brandId?.trim();
+    const publicationId = body.publicationId?.trim();
 
-    if (!body.apiKey || !body.brandId) {
+    if (!apiKey || !brandId) {
       return returnBadRequest({
         detail: 'API key and brand ID are required',
         title: 'Invalid payload',
@@ -53,7 +56,7 @@ export class BeehiivController {
     }
 
     const brand = await this.brandsService.findOne({
-      _id: body.brandId,
+      _id: brandId,
       isDeleted: false,
       organization: publicMetadata.organization,
     });
@@ -67,9 +70,7 @@ export class BeehiivController {
 
     try {
       // Verify API key by listing publications
-      const publications = await this.beehiivService.listPublications(
-        body.apiKey,
-      );
+      const publications = await this.beehiivService.listPublications(apiKey);
 
       if (!publications || publications.length === 0) {
         return returnBadRequest({
@@ -79,15 +80,24 @@ export class BeehiivController {
         });
       }
 
-      // Use the first publication by default
-      const publication = publications[0];
+      const publication = publicationId
+        ? publications.find((item) => item.id === publicationId)
+        : publications[0];
+
+      if (!publication) {
+        return returnBadRequest({
+          detail:
+            'The selected Beehiiv publication was not found for this API key.',
+          title: 'Invalid publication',
+        });
+      }
 
       // Store credential with API key as accessToken
       const credential = await this.credentialsService.saveCredentials(
         brand,
         CredentialPlatform.BEEHIIV,
         {
-          accessToken: body.apiKey,
+          accessToken: apiKey,
           externalHandle: publication.name,
           externalId: publication.id,
           isConnected: true,

--- a/apps/server/api/src/services/integrations/beehiiv/services/beehiiv.service.spec.ts
+++ b/apps/server/api/src/services/integrations/beehiiv/services/beehiiv.service.spec.ts
@@ -241,7 +241,7 @@ describe('BeehiivService', () => {
       expect(result).toEqual(mockPost);
       expect(httpPostMock).toHaveBeenCalledWith(
         'https://api.beehiiv.com/v2/publications/pub_abc123/posts',
-        { content_html: '<p>Hello</p>', status: 'draft', title: 'Test Post' },
+        { body_content: '<p>Hello</p>', status: 'draft', title: 'Test Post' },
         expect.any(Object),
       );
     });

--- a/apps/server/api/src/services/integrations/beehiiv/services/beehiiv.service.ts
+++ b/apps/server/api/src/services/integrations/beehiiv/services/beehiiv.service.ts
@@ -210,7 +210,7 @@ export class BeehiivService {
         this.httpService.post<BeehiivCreatePostResponse>(
           `${this.apiBase}/publications/${publicationId}/posts`,
           {
-            content_html: contentHtml,
+            body_content: contentHtml,
             status,
             title,
           },

--- a/apps/server/api/src/services/integrations/instagram/services/instagram.service.spec.ts
+++ b/apps/server/api/src/services/integrations/instagram/services/instagram.service.spec.ts
@@ -11,6 +11,7 @@ describe('InstagramService', () => {
 
   const credentialsMock = {
     findOne: vi.fn(),
+    patch: vi.fn(),
   } as CredentialsService;
 
   const httpServiceMock = {
@@ -45,7 +46,8 @@ describe('InstagramService', () => {
 
   describe('sendCommentReplyDm', () => {
     it('sends a direct message to commenter', async () => {
-      vi.spyOn(service, 'refreshToken').mockResolvedValue({
+      vi.spyOn(service, 'getValidCredential').mockResolvedValue({
+        _id: 'credential-id',
         accessToken: 'tok',
         externalId: 'acc',
       });
@@ -73,6 +75,50 @@ describe('InstagramService', () => {
       );
 
       expect(result).toBe('msg');
+    });
+  });
+
+  describe('getValidCredential', () => {
+    it('returns stored credential when access token is not near expiry', async () => {
+      credentialsMock.findOne = vi.fn().mockResolvedValue({
+        accessToken: 'fresh-token',
+        accessTokenExpiry: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+        externalId: 'ig-account-id',
+        id: 'credential-id',
+        isConnected: true,
+      });
+      const refreshSpy = vi.spyOn(service, 'refreshToken');
+
+      const result = await service.getValidCredential('org-id', 'brand-id');
+
+      expect(result).toEqual({
+        _id: 'credential-id',
+        accessToken: 'fresh-token',
+        externalId: 'ig-account-id',
+        isConnected: true,
+      });
+      expect(refreshSpy).not.toHaveBeenCalled();
+    });
+
+    it('refreshes when access token is inside the refresh buffer', async () => {
+      credentialsMock.findOne = vi.fn().mockResolvedValue({
+        accessToken: 'stale-token',
+        accessTokenExpiry: new Date(Date.now() + 24 * 60 * 60 * 1000),
+        externalId: 'ig-account-id',
+        id: 'credential-id',
+        isConnected: true,
+      });
+      const refreshSpy = vi.spyOn(service, 'refreshToken').mockResolvedValue({
+        _id: 'credential-id',
+        accessToken: 'new-token',
+        externalId: 'ig-account-id',
+        isConnected: true,
+      });
+
+      const result = await service.getValidCredential('org-id', 'brand-id');
+
+      expect(refreshSpy).toHaveBeenCalledWith('org-id', 'brand-id');
+      expect(result.accessToken).toBe('new-token');
     });
   });
 

--- a/apps/server/api/src/services/integrations/instagram/services/instagram.service.ts
+++ b/apps/server/api/src/services/integrations/instagram/services/instagram.service.ts
@@ -30,6 +30,8 @@ function requireString(
   return value;
 }
 
+const INSTAGRAM_TOKEN_REFRESH_BUFFER_MS = 7 * 24 * 60 * 60 * 1000;
+
 // NOTE: `accessToken` here is the stored (encrypted-at-rest) value. Callers must
 // run it through `EncryptionUtil.decrypt()` before using it against the Graph API.
 function toInstagramCredentialResponse(
@@ -70,6 +72,49 @@ export class InstagramService {
     return `${caption}\n\n${hashtags.map((tag) => `#${tag}`).join(' ')}`;
   }
 
+  private shouldRefreshAccessToken(expiresAt?: Date | string | null): boolean {
+    if (!expiresAt) {
+      return true;
+    }
+
+    const expiresAtMs = new Date(expiresAt).getTime();
+    if (!Number.isFinite(expiresAtMs)) {
+      return true;
+    }
+
+    return expiresAtMs <= Date.now() + INSTAGRAM_TOKEN_REFRESH_BUFFER_MS;
+  }
+
+  public async getValidCredential(
+    organizationId: string,
+    brandId: string,
+  ): Promise<InstagramCredentialResponse> {
+    const credential = await this.credentialsService.findOne({
+      brand: brandId,
+      organization: organizationId,
+      platform: CredentialPlatform.INSTAGRAM,
+    });
+
+    if (!credential) {
+      throw new Error('Instagram credential not found');
+    }
+
+    if (!credential.accessToken) {
+      await this.credentialsService.patch(credential.id, {
+        isConnected: false,
+      });
+      throw new Error(
+        'Instagram access token not found. Please reconnect your account.',
+      );
+    }
+
+    if (this.shouldRefreshAccessToken(credential.accessTokenExpiry)) {
+      return this.refreshToken(organizationId, brandId);
+    }
+
+    return toInstagramCredentialResponse(credential);
+  }
+
   public async getAccountDetails(
     accessToken: string,
   ): Promise<InstagramAccountDetails> {
@@ -101,7 +146,7 @@ export class InstagramService {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
 
     try {
-      const credential = await this.refreshToken(organizationId, brandId);
+      const credential = await this.getValidCredential(organizationId, brandId);
 
       const accessToken = EncryptionUtil.decrypt(credential.accessToken);
 
@@ -243,6 +288,10 @@ export class InstagramService {
 
       const { access_token, expires_in } = response.data || {};
 
+      if (!access_token) {
+        throw new Error('Instagram refresh response missing access token');
+      }
+
       this.loggerService.log(`${url} succeeded`, response.data);
 
       const updatedCredential = await this.credentialsService.patch(
@@ -295,13 +344,12 @@ export class InstagramService {
       // If user has connected brand, fetch personalized trends
       if (organizationId && brandId) {
         try {
-          const credential = await this.credentialsService.findOne({
-            brand: brandId,
-            organization: organizationId,
-            platform: CredentialPlatform.INSTAGRAM,
-          });
+          const credential = await this.getValidCredential(
+            organizationId,
+            brandId,
+          );
 
-          if (credential?.accessToken && credential.externalId) {
+          if (credential.externalId) {
             // Decrypt access token before use
             const decryptedAccessToken = EncryptionUtil.decrypt(
               credential.accessToken,
@@ -395,7 +443,7 @@ export class InstagramService {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
 
     try {
-      const credential = await this.refreshToken(organizationId, brandId);
+      const credential = await this.getValidCredential(organizationId, brandId);
       const accessToken = EncryptionUtil.decrypt(credential.accessToken);
       const externalId = requireString(credential.externalId, 'externalId');
 
@@ -430,7 +478,7 @@ export class InstagramService {
   ): Promise<{ mediaId: string; shortcode: string }> {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
 
-    const credential = await this.refreshToken(organizationId, brandId);
+    const credential = await this.getValidCredential(organizationId, brandId);
     const externalId = requireString(credential.externalId, 'externalId');
     const accessToken = EncryptionUtil.decrypt(credential.accessToken);
     const fullCaption = this.formatCaption(caption, hashtags);
@@ -495,7 +543,7 @@ export class InstagramService {
   ): Promise<{ mediaId: string; shortcode: string }> {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
 
-    const credential = await this.refreshToken(organizationId, brandId);
+    const credential = await this.getValidCredential(organizationId, brandId);
     const externalId = requireString(credential.externalId, 'externalId');
     const accessToken = EncryptionUtil.decrypt(credential.accessToken);
     const fullCaption = this.formatCaption(caption, hashtags);
@@ -562,7 +610,7 @@ export class InstagramService {
   ): Promise<{ mediaId: string; shortcode: string }> {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
 
-    const credential = await this.refreshToken(organizationId, brandId);
+    const credential = await this.getValidCredential(organizationId, brandId);
     const externalId = requireString(credential.externalId, 'externalId');
     const accessToken = EncryptionUtil.decrypt(credential.accessToken);
     const fullCaption = this.formatCaption(caption, hashtags);
@@ -757,7 +805,7 @@ export class InstagramService {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
 
     try {
-      const credential = await this.refreshToken(organizationId, brandId);
+      const credential = await this.getValidCredential(organizationId, brandId);
 
       // Decrypt access token before use
       const decryptedAccessToken = EncryptionUtil.decrypt(
@@ -811,15 +859,7 @@ export class InstagramService {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
 
     try {
-      const credential = await this.credentialsService.findOne({
-        brand: brandId,
-        organization: organizationId,
-        platform: CredentialPlatform.INSTAGRAM,
-      });
-
-      if (!credential?.accessToken) {
-        throw new Error('Instagram credential not found');
-      }
+      const credential = await this.getValidCredential(organizationId, brandId);
 
       // Decrypt access token before use
       const decryptedAccessToken = EncryptionUtil.decrypt(
@@ -905,7 +945,7 @@ export class InstagramService {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
 
     try {
-      const credential = await this.refreshToken(organizationId, brandId);
+      const credential = await this.getValidCredential(organizationId, brandId);
       const decryptedAccessToken = EncryptionUtil.decrypt(
         credential.accessToken,
       );

--- a/apps/server/api/src/services/integrations/tiktok/controllers/tiktok.controller.spec.ts
+++ b/apps/server/api/src/services/integrations/tiktok/controllers/tiktok.controller.spec.ts
@@ -127,9 +127,12 @@ describe('TiktokController', () => {
         url: string;
       };
       const url = new URL(result.url);
-      const state = JSON.parse(
-        decodeURIComponent(url.searchParams.get('state')!),
-      ) as { brandId: string; organizationId: string };
+      const stateParam = url.searchParams.get('state');
+      expect(stateParam).toBeTruthy();
+      const state = JSON.parse(decodeURIComponent(stateParam ?? '')) as {
+        brandId: string;
+        organizationId: string;
+      };
       expect(state.brandId).toBe(brandId.toString());
       expect(state.organizationId).toBe(orgId.toString());
     });
@@ -148,8 +151,8 @@ describe('TiktokController', () => {
           data: {
             access_token: 'tt_access',
             expires_in: 86400,
+            refresh_expires_in: 2592000,
             refresh_token: 'tt_refresh',
-            refresh_token_expires_in: 2592000,
           },
         }),
       );

--- a/apps/server/api/src/services/integrations/tiktok/controllers/tiktok.controller.ts
+++ b/apps/server/api/src/services/integrations/tiktok/controllers/tiktok.controller.ts
@@ -164,9 +164,11 @@ export class TiktokController {
       const {
         access_token,
         expires_in,
+        refresh_expires_in,
         refresh_token,
         refresh_token_expires_in,
       } = tokenRes.data || {};
+      const refreshExpiresIn = refresh_expires_in ?? refresh_token_expires_in;
 
       // Find and update the existing credential
       const existingCredential = await this.credentialsService.findOne({
@@ -197,8 +199,8 @@ export class TiktokController {
           isConnected: true,
           isDeleted: false, // Reactivate if previously disconnected
           refreshToken: refresh_token,
-          refreshTokenExpiry: refresh_token_expires_in
-            ? new Date(Date.now() + refresh_token_expires_in * 1000)
+          refreshTokenExpiry: refreshExpiresIn
+            ? new Date(Date.now() + refreshExpiresIn * 1000)
             : undefined,
         },
       );

--- a/apps/server/api/src/services/integrations/tiktok/services/tiktok.service.spec.ts
+++ b/apps/server/api/src/services/integrations/tiktok/services/tiktok.service.spec.ts
@@ -75,8 +75,8 @@ describe('TiktokService', () => {
     it('sends request and returns data', async () => {
       const mockPost = { label: 'Test video' };
 
-      // Mock the refreshToken call
-      vi.spyOn(service, 'refreshToken').mockResolvedValue({
+      // Mock credential selection to avoid token refresh during publish flow.
+      vi.spyOn(service, 'getValidCredential').mockResolvedValue({
         accessToken: 'test-token',
       } as unknown as import('@api/collections/credentials/entities/credential.entity').CredentialEntity);
 
@@ -120,8 +120,8 @@ describe('TiktokService', () => {
     it('throws on non-200 response', async () => {
       const mockPost = { label: 'Test video' };
 
-      // Mock the refreshToken call
-      vi.spyOn(service, 'refreshToken').mockResolvedValue({
+      // Mock credential selection to avoid token refresh during publish flow.
+      vi.spyOn(service, 'getValidCredential').mockResolvedValue({
         accessToken: 'test-token',
       } as unknown as import('@api/collections/credentials/entities/credential.entity').CredentialEntity);
 
@@ -170,7 +170,7 @@ describe('TiktokService', () => {
             access_token: 'nac',
             expires_in: 10,
             refresh_token: 'nref',
-            refresh_token_expires_in: 20,
+            refresh_expires_in: 20,
           },
         }),
       );
@@ -218,6 +218,48 @@ describe('TiktokService', () => {
     });
   });
 
+  describe('getValidCredential', () => {
+    it('returns stored credential when access token is not near expiry', async () => {
+      (credentialsMock.findOne as vi.Mock).mockResolvedValue({
+        accessToken: 'fresh-access',
+        accessTokenExpiry: new Date(Date.now() + 60 * 60 * 1000),
+        id: 'credential-id',
+        oauthTokenHash: '',
+        refreshToken: 'refresh-token',
+      });
+
+      const refreshSpy = vi.spyOn(service, 'refreshToken');
+
+      const result = await service.getValidCredential('org-id', 'brand-id');
+
+      expect(result).toBeInstanceOf(CredentialEntity);
+      expect(result.accessToken).toBe('fresh-access');
+      expect(refreshSpy).not.toHaveBeenCalled();
+    });
+
+    it('refreshes when access token is inside the refresh buffer', async () => {
+      (credentialsMock.findOne as vi.Mock).mockResolvedValue({
+        accessToken: 'stale-access',
+        accessTokenExpiry: new Date(Date.now() + 5 * 60 * 1000),
+        id: 'credential-id',
+        refreshToken: 'refresh-token',
+      });
+      const refreshedCredential = new CredentialEntity({
+        accessToken: 'new-access',
+        id: 'credential-id',
+        oauthTokenHash: '',
+      });
+      const refreshSpy = vi
+        .spyOn(service, 'refreshToken')
+        .mockResolvedValue(refreshedCredential);
+
+      const result = await service.getValidCredential('org-id', 'brand-id');
+
+      expect(refreshSpy).toHaveBeenCalledWith('org-id', 'brand-id', undefined);
+      expect(result.accessToken).toBe('new-access');
+    });
+  });
+
   describe('getTrends', () => {
     it('returns trending hashtags without credentials', async () => {
       (httpService.get as vi.Mock).mockReturnValue(of({ data: {} }));
@@ -235,6 +277,9 @@ describe('TiktokService', () => {
     it('returns stats', async () => {
       (credentialsMock.findOne as vi.Mock).mockResolvedValue({
         accessToken: 'tok',
+        accessTokenExpiry: new Date(Date.now() + 60 * 60 * 1000),
+        id: 'credential-id',
+        oauthTokenHash: '',
       });
 
       (httpService.get as vi.Mock).mockReturnValue(

--- a/apps/server/api/src/services/integrations/tiktok/services/tiktok.service.ts
+++ b/apps/server/api/src/services/integrations/tiktok/services/tiktok.service.ts
@@ -25,6 +25,16 @@ import { Injectable } from '@nestjs/common';
 import { AxiosError } from 'axios';
 import { firstValueFrom } from 'rxjs';
 
+const TIKTOK_TOKEN_REFRESH_BUFFER_MS = 15 * 60 * 1000;
+
+interface TikTokTokenResponse {
+  access_token?: string;
+  expires_in?: number;
+  refresh_expires_in?: number;
+  refresh_token?: string;
+  refresh_token_expires_in?: number;
+}
+
 @Injectable()
 export class TiktokService {
   private readonly constructorName: string = String(this.constructor.name);
@@ -117,6 +127,61 @@ export class TiktokService {
         patchError,
       );
     }
+  }
+
+  private async findCredential(
+    organizationId: string,
+    brandId: string,
+    credentialId?: string,
+  ): Promise<CredentialDocument | null> {
+    return credentialId
+      ? this.credentialsService.findOne({ _id: credentialId })
+      : this.credentialsService.findOne({
+          brand: brandId,
+          organization: organizationId,
+          platform: CredentialPlatform.TIKTOK,
+        });
+  }
+
+  private shouldRefreshAccessToken(expiresAt?: Date | string | null): boolean {
+    if (!expiresAt) {
+      return true;
+    }
+
+    const expiresAtMs = new Date(expiresAt).getTime();
+    if (!Number.isFinite(expiresAtMs)) {
+      return true;
+    }
+
+    return expiresAtMs <= Date.now() + TIKTOK_TOKEN_REFRESH_BUFFER_MS;
+  }
+
+  public async getValidCredential(
+    organizationId: string,
+    brandId: string,
+    credentialId?: string,
+  ): Promise<CredentialEntity> {
+    const credential = await this.findCredential(
+      organizationId,
+      brandId,
+      credentialId,
+    );
+
+    if (!credential) {
+      throw new Error('TikTok credential not found');
+    }
+
+    if (
+      !credential.accessToken ||
+      this.shouldRefreshAccessToken(credential.accessTokenExpiry)
+    ) {
+      return this.refreshToken(organizationId, brandId, credentialId);
+    }
+
+    return new CredentialEntity({
+      ...credential,
+      oauthTokenHash: credential.oauthTokenHash ?? '',
+    });
   }
 
   /**
@@ -240,17 +305,13 @@ export class TiktokService {
     this.loggerService.log(`${url} started`);
 
     try {
-      // If credentialId is provided, fetch by ID directly (more reliable)
-      // Otherwise fall back to org+brand+platform lookup
-      const credential = credentialId
-        ? await this.credentialsService.findOne({ _id: credentialId })
-        : await this.credentialsService.findOne({
-            brand: brandId,
-            organization: organizationId,
-            platform: CredentialPlatform.TIKTOK,
-          });
+      const credential = await this.findCredential(
+        organizationId,
+        brandId,
+        credentialId,
+      );
 
-      if (!credential || !credential.refreshToken) {
+      if (!credential?.refreshToken) {
         throw new Error('No refresh token available');
       }
 
@@ -281,9 +342,15 @@ export class TiktokService {
       const {
         access_token,
         expires_in,
+        refresh_expires_in,
         refresh_token,
         refresh_token_expires_in,
-      } = tokenRes.data || {};
+      } = (tokenRes.data || {}) as TikTokTokenResponse;
+      const refreshExpiresIn = refresh_expires_in ?? refresh_token_expires_in;
+
+      if (!access_token) {
+        throw new Error('TikTok refresh response missing access token');
+      }
 
       const updatedCredential = await this.credentialsService.patch(
         credential.id,
@@ -294,8 +361,8 @@ export class TiktokService {
             : undefined,
           isConnected: true,
           refreshToken: refresh_token,
-          refreshTokenExpiry: refresh_token_expires_in
-            ? new Date(Date.now() + refresh_token_expires_in * 1000)
+          refreshTokenExpiry: refreshExpiresIn
+            ? new Date(Date.now() + refreshExpiresIn * 1000)
             : undefined,
         },
       );
@@ -310,13 +377,11 @@ export class TiktokService {
 
       // If auth error, mark credential as disconnected
       if (this.isAuthError(error)) {
-        const credential = credentialId
-          ? await this.credentialsService.findOne({ _id: credentialId })
-          : await this.credentialsService.findOne({
-              brand: brandId,
-              organization: organizationId,
-              platform: CredentialPlatform.TIKTOK,
-            });
+        const credential = await this.findCredential(
+          organizationId,
+          brandId,
+          credentialId,
+        );
         if (credential) {
           await this.handleAuthError(
             credential.id,
@@ -369,13 +434,9 @@ export class TiktokService {
 
       // If user has connected brand, fetch personalized trends
       if (organizationId && brandId) {
-        let credential = null;
+        let credential: CredentialEntity | null = null;
         try {
-          credential = await this.credentialsService.findOne({
-            brand: brandId,
-            organization: organizationId,
-            platform: CredentialPlatform.TIKTOK,
-          });
+          credential = await this.getValidCredential(organizationId, brandId);
 
           if (credential?.accessToken) {
             // Decrypt the access token
@@ -462,7 +523,7 @@ export class TiktokService {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
     this.loggerService.log(`${url} started`);
 
-    let credential: CredentialDocument | null = null;
+    let credential: CredentialDocument | CredentialEntity | null = null;
 
     try {
       let decryptedAccessToken: string;
@@ -471,13 +532,9 @@ export class TiktokService {
       if (accessToken) {
         decryptedAccessToken = EncryptionUtil.decrypt(accessToken);
       } else {
-        credential = await this.credentialsService.findOne({
-          brand: brandId,
-          organization: organizationId,
-          platform: CredentialPlatform.TIKTOK,
-        });
+        credential = await this.getValidCredential(organizationId, brandId);
 
-        if (!credential || !credential.accessToken) {
+        if (!credential.accessToken) {
           throw new Error('TikTok credential not found or invalid');
         }
 
@@ -587,7 +644,7 @@ export class TiktokService {
     try {
       this.loggerService.log(`${url} started`, { videoUrl });
 
-      const credential = await this.refreshToken(organizationId, brandId);
+      const credential = await this.getValidCredential(organizationId, brandId);
 
       if (!credential?.accessToken) {
         throw new Error('TikTok credential not found or invalid');
@@ -664,7 +721,7 @@ export class TiktokService {
         throw new Error('Maximum 35 images allowed per post');
       }
 
-      const credential = await this.refreshToken(organizationId, brandId);
+      const credential = await this.getValidCredential(organizationId, brandId);
 
       if (!credential?.accessToken) {
         throw new Error('TikTok credential not found or invalid');
@@ -824,16 +881,12 @@ export class TiktokService {
     mediaId: string,
   ): Promise<ITikTokMediaAnalytics> {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
-    let credential: CredentialDocument | null = null;
+    let credential: CredentialDocument | CredentialEntity | null = null;
 
     try {
-      credential = await this.credentialsService.findOne({
-        brand: brandId,
-        organization: organizationId,
-        platform: CredentialPlatform.TIKTOK,
-      });
+      credential = await this.getValidCredential(organizationId, brandId);
 
-      if (!credential?.accessToken) {
+      if (!credential.accessToken) {
         throw new Error('TikTok credential not found');
       }
 


### PR DESCRIPTION
## Summary
- update Beehiiv post creation to use Beehiiv's current body_content payload and allow connecting a selected publication
- add expiry-aware Instagram credential selection so Graph tokens are refreshed near expiry instead of on every action
- fix TikTok refresh token expiry handling to use refresh_expires_in, and reuse fresh access tokens before refreshing

## Verification
- bunx biome check --write apps/server/api/src/services/integrations/beehiiv/controllers/beehiiv.controller.spec.ts apps/server/api/src/services/integrations/beehiiv/controllers/beehiiv.controller.ts apps/server/api/src/services/integrations/beehiiv/services/beehiiv.service.spec.ts apps/server/api/src/services/integrations/beehiiv/services/beehiiv.service.ts apps/server/api/src/services/integrations/instagram/services/instagram.service.spec.ts apps/server/api/src/services/integrations/instagram/services/instagram.service.ts apps/server/api/src/services/integrations/tiktok/controllers/tiktok.controller.spec.ts apps/server/api/src/services/integrations/tiktok/controllers/tiktok.controller.ts apps/server/api/src/services/integrations/tiktok/services/tiktok.service.spec.ts apps/server/api/src/services/integrations/tiktok/services/tiktok.service.ts
- bun run --cwd apps/server/api test:file src/services/integrations/beehiiv/services/beehiiv.service.spec.ts src/services/integrations/beehiiv/controllers/beehiiv.controller.spec.ts src/services/integrations/publishers/beehiiv-publisher.service.spec.ts src/services/integrations/tiktok/services/tiktok.service.spec.ts src/services/integrations/tiktok/controllers/tiktok.controller.spec.ts src/services/integrations/instagram/services/instagram.service.spec.ts