### PR TITLE
refactor(agent): extract route rewrite service

### DIFF
--- a/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.module.ts
+++ b/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.module.ts
@@ -34,6 +34,7 @@ import { AgentOrchestratorController } from '@api/services/agent-orchestrator/ag
 import { AgentOrchestratorService } from '@api/services/agent-orchestrator/agent-orchestrator.service';
 import { AgentStreamPublisherModule } from '@api/services/agent-orchestrator/agent-stream-publisher.module';
 import { AgentToolsController } from '@api/services/agent-orchestrator/agent-tools.controller';
+import { AgentRouteRewriteService } from '@api/services/agent-orchestrator/tools/agent-route-rewrite.service';
 import { AgentToolExecutorService } from '@api/services/agent-orchestrator/tools/agent-tool-executor.service';
 import { AgentSpawnModule } from '@api/services/agent-spawn/agent-spawn.module';
 import { AgentThreadingModule } from '@api/services/agent-threading/agent-threading.module';
@@ -94,6 +95,7 @@ import { forwardRef, Module } from '@nestjs/common';
   ],
   providers: [
     AgentOrchestratorService,
+    AgentRouteRewriteService,
     AgentToolExecutorService,
     {
       provide: 'AGENT_BRANDS_SERVICE',

--- a/apps/server/api/src/services/agent-orchestrator/tools/agent-route-rewrite.service.spec.ts
+++ b/apps/server/api/src/services/agent-orchestrator/tools/agent-route-rewrite.service.spec.ts
@@ -1,0 +1,187 @@
+import { AgentRouteRewriteService } from '@api/services/agent-orchestrator/tools/agent-route-rewrite.service';
+import type { AgentToolResult } from '@genfeedai/interfaces';
+
+describe('AgentRouteRewriteService', () => {
+  const loggerService = {
+    warn: vi.fn(),
+  };
+  const brandsService = {
+    findOne: vi.fn(),
+  };
+  const organizationsService = {
+    findOne: vi.fn(),
+  };
+
+  const context = {
+    organizationId: 'org-1',
+    userId: 'user-1',
+  };
+
+  const createService = () =>
+    new AgentRouteRewriteService(
+      loggerService as never,
+      brandsService as never,
+      organizationsService as never,
+    );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    organizationsService.findOne.mockResolvedValue({ slug: 'genfeed-ai' });
+    brandsService.findOne.mockResolvedValue({ slug: 'launch-brand' });
+  });
+
+  it('rewrites nested route hrefs with active organization and brand slugs', async () => {
+    const service = createService();
+    const result: AgentToolResult = {
+      nextActions: [
+        {
+          ctas: [
+            {
+              href: '/analytics/overview?period=30d#top',
+              label: 'Open analytics',
+            },
+            {
+              ctaHref: '/automations/editor/workflow-1',
+              label: 'Open workflow',
+            },
+          ],
+          editorUrl: '/posts/review?filter=ready',
+          title: 'Review',
+          type: 'content_preview_card',
+        },
+      ],
+      success: true,
+    };
+
+    const scoped = await service.scopeToolResultHrefs(result, context);
+
+    expect(scoped.nextActions?.[0]).toMatchObject({
+      ctas: [
+        {
+          href: '/genfeed-ai/launch-brand/analytics/overview?period=30d#top',
+        },
+        {
+          ctaHref: '/genfeed-ai/launch-brand/automations/editor/workflow-1',
+        },
+      ],
+      editorUrl: '/genfeed-ai/launch-brand/posts/review?filter=ready',
+    });
+  });
+
+  it('uses org-level routes when no brand slug is available', async () => {
+    brandsService.findOne.mockResolvedValueOnce(null);
+    const service = createService();
+
+    const scoped = await service.scopeToolResultHrefs(
+      {
+        nextActions: [
+          {
+            ctas: [{ href: '/settings/api-keys', label: 'Settings' }],
+            title: 'Connect',
+            type: 'oauth_connect_card',
+          },
+        ],
+        success: true,
+      },
+      context,
+    );
+
+    expect(scoped.nextActions?.[0].ctas?.[0]).toMatchObject({
+      href: '/genfeed-ai/~/settings/api-keys',
+    });
+  });
+
+  it('preserves already scoped, admin, external, and protocol-relative hrefs', async () => {
+    const service = createService();
+
+    const scoped = await service.scopeToolResultHrefs(
+      {
+        nextActions: [
+          {
+            ctas: [
+              { href: '/genfeed-ai/launch-brand/analytics', label: 'Scoped' },
+              { href: '/admin/agent', label: 'Admin' },
+              { href: 'https://genfeed.ai/docs', label: 'External' },
+              { href: '//cdn.example.com/image.png', label: 'Protocol' },
+            ],
+            title: 'Links',
+            type: 'content_preview_card',
+          },
+        ],
+        success: true,
+      },
+      context,
+    );
+
+    expect(scoped.nextActions?.[0].ctas).toEqual([
+      { href: '/genfeed-ai/launch-brand/analytics', label: 'Scoped' },
+      { href: '/admin/agent', label: 'Admin' },
+      { href: 'https://genfeed.ai/docs', label: 'External' },
+      { href: '//cdn.example.com/image.png', label: 'Protocol' },
+    ]);
+  });
+
+  it('does not rewrite url fields', async () => {
+    const service = createService();
+
+    const scoped = await service.scopeToolResultHrefs(
+      {
+        data: {
+          href: '/posts/review',
+          url: '/media/generated-image.png',
+        },
+        success: true,
+      },
+      context,
+    );
+
+    expect(scoped.data).toEqual({
+      href: '/genfeed-ai/launch-brand/posts/review',
+      url: '/media/generated-image.png',
+    });
+  });
+
+  it('preserves the original result when organization slug resolution fails', async () => {
+    organizationsService.findOne.mockResolvedValueOnce({ id: 'org-1' });
+    const service = createService();
+    const result: AgentToolResult = {
+      nextActions: [
+        {
+          ctas: [{ href: '/settings/api-keys', label: 'Settings' }],
+          title: 'Connect',
+          type: 'oauth_connect_card',
+        },
+      ],
+      success: true,
+    };
+
+    const scoped = await service.scopeToolResultHrefs(result, context);
+
+    expect(scoped).toBe(result);
+    expect(brandsService.findOne).not.toHaveBeenCalled();
+  });
+
+  it('uses the explicit context brand before selected-brand fallback', async () => {
+    const service = createService();
+
+    await service.scopeToolResultHrefs(
+      {
+        nextActions: [
+          {
+            ctas: [{ href: '/analytics', label: 'Analytics' }],
+            title: 'Analytics',
+            type: 'analytics_card',
+          },
+        ],
+        success: true,
+      },
+      { ...context, brandId: 'brand-1' },
+    );
+
+    expect(brandsService.findOne).toHaveBeenCalledWith({
+      _id: 'brand-1',
+      isDeleted: false,
+      organization: 'org-1',
+    });
+  });
+});

--- a/apps/server/api/src/services/agent-orchestrator/tools/agent-route-rewrite.service.ts
+++ b/apps/server/api/src/services/agent-orchestrator/tools/agent-route-rewrite.service.ts
@@ -1,0 +1,222 @@
+import { OrganizationsService } from '@api/collections/organizations/services/organizations.service';
+import type { ToolExecutionContext } from '@api/services/agent-orchestrator/tools/agent-tool-executor.service';
+import type { AgentToolResult } from '@genfeedai/interfaces';
+import { LoggerService } from '@libs/logger/logger.service';
+import { Inject, Injectable, Optional } from '@nestjs/common';
+
+interface AgentBrandsServiceLike {
+  findOne: (
+    query: Record<string, unknown>,
+  ) => Promise<Record<string, unknown> | null>;
+}
+
+interface ToolRouteSlugs {
+  brandSlug?: string;
+  orgSlug: string;
+}
+
+const ROUTE_HREF_KEYS = new Set(['href', 'ctaHref', 'editorUrl']);
+const ORG_LEVEL_ROUTE_PREFIXES = new Set([
+  'agent',
+  'chat',
+  'overview',
+  'settings',
+]);
+const UNSCOPED_ROUTE_PREFIXES = new Set([
+  'admin',
+  'login',
+  'logout',
+  'oauth',
+  'onboarding',
+  'playwright-ready',
+  'request-access',
+  'sign-up',
+]);
+
+@Injectable()
+export class AgentRouteRewriteService {
+  constructor(
+    private readonly loggerService: LoggerService,
+    @Inject('AGENT_BRANDS_SERVICE')
+    private readonly brandsService: AgentBrandsServiceLike,
+    @Optional()
+    private readonly organizationsService?: OrganizationsService,
+  ) {}
+
+  async scopeToolResultHrefs(
+    result: AgentToolResult,
+    ctx: ToolExecutionContext,
+  ): Promise<AgentToolResult> {
+    if (!this.hasScopeableHref(result)) {
+      return result;
+    }
+
+    const routeSlugs = await this.resolveToolRouteSlugs(ctx);
+    if (!routeSlugs) {
+      return result;
+    }
+
+    return this.scopeHrefFields(result, routeSlugs) as AgentToolResult;
+  }
+
+  private async resolveToolRouteSlugs(
+    ctx: ToolExecutionContext,
+  ): Promise<ToolRouteSlugs | null> {
+    if (!this.organizationsService) {
+      return null;
+    }
+
+    try {
+      const organization = await this.organizationsService.findOne({
+        _id: ctx.organizationId,
+        isDeleted: false,
+      });
+      const orgSlug = this.readRecordString(organization, 'slug');
+
+      if (!orgSlug) {
+        return null;
+      }
+
+      const brand = await this.resolveToolRouteBrand(ctx);
+      const brandSlug = this.readRecordString(brand, 'slug');
+
+      return {
+        ...(brandSlug ? { brandSlug } : {}),
+        orgSlug,
+      };
+    } catch (error: unknown) {
+      this.loggerService.warn('Failed to resolve tool route slugs', {
+        error: error instanceof Error ? error.message : String(error),
+        organizationId: ctx.organizationId,
+      });
+      return null;
+    }
+  }
+
+  private async resolveToolRouteBrand(
+    ctx: ToolExecutionContext,
+  ): Promise<Record<string, unknown> | null> {
+    if (ctx.brandId) {
+      return this.brandsService.findOne({
+        _id: ctx.brandId,
+        isDeleted: false,
+        organization: ctx.organizationId,
+      });
+    }
+
+    return this.brandsService.findOne({
+      isDeleted: false,
+      isSelected: true,
+      organization: ctx.organizationId,
+      user: ctx.userId,
+    });
+  }
+
+  private hasScopeableHref(value: unknown): boolean {
+    if (Array.isArray(value)) {
+      return value.some((item) => this.hasScopeableHref(item));
+    }
+
+    if (!this.isPlainRecord(value)) {
+      return false;
+    }
+
+    return Object.entries(value).some(([key, nestedValue]) => {
+      if (
+        ROUTE_HREF_KEYS.has(key) &&
+        typeof nestedValue === 'string' &&
+        this.isScopeableInternalHref(nestedValue)
+      ) {
+        return true;
+      }
+
+      return this.hasScopeableHref(nestedValue);
+    });
+  }
+
+  private scopeHrefFields(value: unknown, slugs: ToolRouteSlugs): unknown {
+    if (Array.isArray(value)) {
+      return value.map((item) => this.scopeHrefFields(item, slugs));
+    }
+
+    if (!this.isPlainRecord(value)) {
+      return value;
+    }
+
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nestedValue]) => {
+        if (ROUTE_HREF_KEYS.has(key) && typeof nestedValue === 'string') {
+          return [key, this.scopeInternalHref(nestedValue, slugs)];
+        }
+
+        return [key, this.scopeHrefFields(nestedValue, slugs)];
+      }),
+    );
+  }
+
+  private scopeInternalHref(href: string, slugs: ToolRouteSlugs): string {
+    if (!this.isScopeableInternalHref(href)) {
+      return href;
+    }
+
+    const { path, suffix } = this.splitHrefSuffix(href);
+    const firstSegment = path.split('/').filter(Boolean)[0];
+
+    if (!firstSegment || UNSCOPED_ROUTE_PREFIXES.has(firstSegment)) {
+      return href;
+    }
+
+    if (path.startsWith(`/${slugs.orgSlug}/`)) {
+      return href;
+    }
+
+    if (ORG_LEVEL_ROUTE_PREFIXES.has(firstSegment)) {
+      return `/${slugs.orgSlug}/~${path}${suffix}`;
+    }
+
+    if (slugs.brandSlug) {
+      return `/${slugs.orgSlug}/${slugs.brandSlug}${path}${suffix}`;
+    }
+
+    return `/${slugs.orgSlug}/~${path}${suffix}`;
+  }
+
+  private isScopeableInternalHref(href: string): boolean {
+    return href.startsWith('/') && !href.startsWith('//');
+  }
+
+  private splitHrefSuffix(href: string): { path: string; suffix: string } {
+    const suffixStart = href.search(/[?#]/);
+
+    if (suffixStart === -1) {
+      return { path: href, suffix: '' };
+    }
+
+    return {
+      path: href.slice(0, suffixStart),
+      suffix: href.slice(suffixStart),
+    };
+  }
+
+  private isPlainRecord(value: unknown): value is Record<string, unknown> {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+      return false;
+    }
+
+    const prototype = Object.getPrototypeOf(value);
+    return prototype === Object.prototype || prototype === null;
+  }
+
+  private readRecordString(
+    value: Record<string, unknown> | null | undefined,
+    key: string,
+  ): string | undefined {
+    return value ? this.readOptionalString(value[key]) : undefined;
+  }
+
+  private readOptionalString(value: unknown): string | undefined {
+    return typeof value === 'string' && value.trim().length > 0
+      ? value.trim()
+      : undefined;
+  }
+}

--- a/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.spec.ts
+++ b/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.spec.ts
@@ -7,6 +7,7 @@ vi.mock(
 
 import 'reflect-metadata';
 import { AiActionType } from '@api/endpoints/ai-actions/dto/ai-action.dto';
+import { AgentRouteRewriteService } from '@api/services/agent-orchestrator/tools/agent-route-rewrite.service';
 import { AgentToolExecutorService } from '@api/services/agent-orchestrator/tools/agent-tool-executor.service';
 import { PostStatus } from '@genfeedai/enums';
 import { AgentToolName } from '@genfeedai/interfaces';
@@ -284,6 +285,11 @@ describe('AgentToolExecutorService', () => {
       findOne: vi.fn().mockResolvedValue({ onboardingCompleted: false }),
       patch: vi.fn().mockResolvedValue({}),
     };
+    const routeRewriteService = new AgentRouteRewriteService(
+      loggerService,
+      brandsService as never,
+      organizationsService as never,
+    );
     const organizationSettingsService = {
       findOne: vi.fn().mockResolvedValue({
         id: 'settings-1',
@@ -608,6 +614,7 @@ describe('AgentToolExecutorService', () => {
       httpService as never,
       postsService as never,
       brandsService as never,
+      routeRewriteService,
       botsService as never,
       botsLivestreamService as never,
       campaignsService as never,
@@ -3084,6 +3091,11 @@ describe('AgentToolExecutorService', () => {
       {} as never,
       postsService as never,
       brandsService as never,
+      new AgentRouteRewriteService(
+        loggerService,
+        brandsService as never,
+        organizationsService as never,
+      ),
       {} as never,
       {} as never,
       {} as never,

--- a/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts
+++ b/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts
@@ -45,6 +45,7 @@ import { EntityIdUtil } from '@api/helpers/utils/entity-id/entity-id.util';
 import { MarketplaceApiClient } from '@api/marketplace-integration/marketplace-api-client';
 import { MarketplaceInstallService } from '@api/marketplace-integration/marketplace-install.service';
 import { AgentStreamPublisherService } from '@api/services/agent-orchestrator/agent-stream-publisher.service';
+import { AgentRouteRewriteService } from '@api/services/agent-orchestrator/tools/agent-route-rewrite.service';
 import { AgentSpawnService } from '@api/services/agent-spawn/agent-spawn.service';
 import { BatchGenerationService } from '@api/services/batch-generation/batch-generation.service';
 import { ContentQualityScorerService } from '@api/services/content-quality/content-quality-scorer.service';
@@ -141,11 +142,6 @@ export interface ToolExecutionContext {
   streamBatchToUser?: boolean;
 }
 
-interface ToolRouteSlugs {
-  brandSlug?: string;
-  orgSlug: string;
-}
-
 interface DashboardHydrationState {
   status?: 'idle' | 'loading' | 'ready';
   staggerMs?: number;
@@ -194,7 +190,6 @@ type RecurringTaskContentType = 'image' | 'video' | 'post' | 'newsletter';
 type ToolCatalogSurface = 'agent' | 'mcp' | 'cli' | 'all';
 
 const LIVESTREAM_BOT_CATEGORY = 'livestream_chat';
-const ROUTE_HREF_KEYS = new Set(['href', 'ctaHref', 'editorUrl']);
 const TOOL_CATALOG_SURFACES = ['agent', 'mcp', 'cli'] as const;
 const TOOL_CATALOG_CATEGORIES: ToolCategory[] = [
   'ads',
@@ -213,22 +208,6 @@ const TOOL_CATALOG_CATEGORIES: ToolCategory[] = [
   'workflow',
 ];
 const TOOL_CATALOG_ROLES: ToolRequiredRole[] = ['user', 'admin', 'superadmin'];
-const ORG_LEVEL_ROUTE_PREFIXES = new Set([
-  'agent',
-  'chat',
-  'overview',
-  'settings',
-]);
-const UNSCOPED_ROUTE_PREFIXES = new Set([
-  'admin',
-  'login',
-  'logout',
-  'oauth',
-  'onboarding',
-  'playwright-ready',
-  'request-access',
-  'sign-up',
-]);
 
 interface AgentLivestreamBotRecord {
   id: unknown;
@@ -371,6 +350,7 @@ export class AgentToolExecutorService {
     private readonly postsService: PostsService,
     @Inject('AGENT_BRANDS_SERVICE')
     private readonly brandsService: AgentBrandsServiceLike,
+    private readonly routeRewriteService: AgentRouteRewriteService,
     @Optional()
     @Inject('AGENT_BOTS_SERVICE')
     private readonly botsService: AgentBotsServiceLike | undefined,
@@ -748,7 +728,10 @@ export class AgentToolExecutorService {
 
     try {
       const result = await this.dispatch(toolName, parameters, context);
-      const scopedResult = await this.scopeToolResultHrefs(result, context);
+      const scopedResult = await this.routeRewriteService.scopeToolResultHrefs(
+        result,
+        context,
+      );
       const durationMs = Date.now() - startTime;
 
       this.loggerService.log(
@@ -775,161 +758,6 @@ export class AgentToolExecutorService {
     }
   }
 
-  private async scopeToolResultHrefs(
-    result: AgentToolResult,
-    ctx: ToolExecutionContext,
-  ): Promise<AgentToolResult> {
-    if (!this.hasScopeableHref(result)) {
-      return result;
-    }
-
-    const routeSlugs = await this.resolveToolRouteSlugs(ctx);
-    if (!routeSlugs) {
-      return result;
-    }
-
-    return this.scopeHrefFields(result, routeSlugs) as AgentToolResult;
-  }
-
-  private async resolveToolRouteSlugs(
-    ctx: ToolExecutionContext,
-  ): Promise<ToolRouteSlugs | null> {
-    if (!this.organizationsService) {
-      return null;
-    }
-
-    try {
-      const organization = await this.organizationsService.findOne({
-        _id: ctx.organizationId,
-        isDeleted: false,
-      });
-      const orgSlug = this.readRecordString(organization, 'slug');
-
-      if (!orgSlug) {
-        return null;
-      }
-
-      const brand = await this.resolveToolRouteBrand(ctx);
-      const brandSlug = this.readRecordString(brand, 'slug');
-
-      return {
-        ...(brandSlug ? { brandSlug } : {}),
-        orgSlug,
-      };
-    } catch (error: unknown) {
-      this.loggerService.warn('Failed to resolve tool route slugs', {
-        error: error instanceof Error ? error.message : String(error),
-        organizationId: ctx.organizationId,
-      });
-      return null;
-    }
-  }
-
-  private async resolveToolRouteBrand(
-    ctx: ToolExecutionContext,
-  ): Promise<Record<string, unknown> | null> {
-    if (ctx.brandId) {
-      return this.brandsService.findOne({
-        _id: ctx.brandId,
-        isDeleted: false,
-        organization: ctx.organizationId,
-      });
-    }
-
-    return this.brandsService.findOne({
-      isDeleted: false,
-      isSelected: true,
-      organization: ctx.organizationId,
-      user: ctx.userId,
-    });
-  }
-
-  private hasScopeableHref(value: unknown): boolean {
-    if (Array.isArray(value)) {
-      return value.some((item) => this.hasScopeableHref(item));
-    }
-
-    if (!this.isPlainRecord(value)) {
-      return false;
-    }
-
-    return Object.entries(value).some(([key, nestedValue]) => {
-      if (
-        ROUTE_HREF_KEYS.has(key) &&
-        typeof nestedValue === 'string' &&
-        this.isScopeableInternalHref(nestedValue)
-      ) {
-        return true;
-      }
-
-      return this.hasScopeableHref(nestedValue);
-    });
-  }
-
-  private scopeHrefFields(value: unknown, slugs: ToolRouteSlugs): unknown {
-    if (Array.isArray(value)) {
-      return value.map((item) => this.scopeHrefFields(item, slugs));
-    }
-
-    if (!this.isPlainRecord(value)) {
-      return value;
-    }
-
-    return Object.fromEntries(
-      Object.entries(value).map(([key, nestedValue]) => {
-        if (ROUTE_HREF_KEYS.has(key) && typeof nestedValue === 'string') {
-          return [key, this.scopeInternalHref(nestedValue, slugs)];
-        }
-
-        return [key, this.scopeHrefFields(nestedValue, slugs)];
-      }),
-    );
-  }
-
-  private scopeInternalHref(href: string, slugs: ToolRouteSlugs): string {
-    if (!this.isScopeableInternalHref(href)) {
-      return href;
-    }
-
-    const { path, suffix } = this.splitHrefSuffix(href);
-    const firstSegment = path.split('/').filter(Boolean)[0];
-
-    if (!firstSegment || UNSCOPED_ROUTE_PREFIXES.has(firstSegment)) {
-      return href;
-    }
-
-    if (path.startsWith(`/${slugs.orgSlug}/`)) {
-      return href;
-    }
-
-    if (ORG_LEVEL_ROUTE_PREFIXES.has(firstSegment)) {
-      return `/${slugs.orgSlug}/~${path}${suffix}`;
-    }
-
-    if (slugs.brandSlug) {
-      return `/${slugs.orgSlug}/${slugs.brandSlug}${path}${suffix}`;
-    }
-
-    return `/${slugs.orgSlug}/~${path}${suffix}`;
-  }
-
-  private isScopeableInternalHref(href: string): boolean {
-    return href.startsWith('/') && !href.startsWith('//');
-  }
-
-  private splitHrefSuffix(href: string): { path: string; suffix: string } {
-    const suffixStart = href.search(/[?#]/);
-
-    if (suffixStart === -1) {
-      return { path: href, suffix: '' };
-    }
-
-    return {
-      path: href.slice(0, suffixStart),
-      suffix: href.slice(suffixStart),
-    };
-  }
-
   private isPlainRecord(value: unknown): value is Record<string, unknown> {
     if (typeof value !== 'object' || value === null || Array.isArray(value)) {
       return false;
@@ -937,13 +765,6 @@ export class AgentToolExecutorService {
 
     const prototype = Object.getPrototypeOf(value);
     return prototype === Object.prototype || prototype === null;
-  }
-
-  private readRecordString(
-    value: Record<string, unknown> | null | undefined,
-    key: string,
-  ): string | undefined {
-    return value ? this.readOptionalString(value[key]) : undefined;
   }
 
   private readResponseEnvelopeString(


### PR DESCRIPTION
## Summary
- Extracts agent tool-result route href scoping into `AgentRouteRewriteService` registered in `AgentOrchestratorModule`
- Keeps current rewrite behavior limited to `href`, `ctaHref`, and `editorUrl` fields while preserving external, protocol-relative, admin, and already-scoped links
- Adds focused service coverage plus preserves existing executor route rewrite coverage

## Validation
- `bun install --frozen-lockfile --ignore-scripts`
- `bun run --cwd packages/prisma db:generate`
- `bun run --cwd packages/tools build`
- `bun run --cwd apps/server/api test:file src/services/agent-orchestrator/tools/agent-route-rewrite.service.spec.ts src/services/agent-orchestrator/tools/agent-tool-executor.service.spec.ts`
- `bunx biome check --write apps/server/api/src/services/agent-orchestrator/tools/agent-route-rewrite.service.ts apps/server/api/src/services/agent-orchestrator/tools/agent-route-rewrite.service.spec.ts apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.spec.ts apps/server/api/src/services/agent-orchestrator/agent-orchestrator.module.ts --max-diagnostics=30` (exits 0; reports pre-existing warnings in the large executor/spec)
- `bunx secretlint apps/server/api/src/services/agent-orchestrator/tools/agent-route-rewrite.service.ts apps/server/api/src/services/agent-orchestrator/tools/agent-route-rewrite.service.spec.ts apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.spec.ts apps/server/api/src/services/agent-orchestrator/agent-orchestrator.module.ts`
- `git diff --check`
- `git diff --cached --check`

Closes #1501
Refs #519