### PR TITLE
refactor(workers): decouple model schema type

### DIFF
--- a/apps/server/server/src/collections/models/model-record.types.ts
+++ b/apps/server/server/src/collections/models/model-record.types.ts
@@ -1,0 +1,30 @@
+import type { ModelCategory, ModelProvider } from '@genfeedai/enums';
+import type { Model as PrismaModel } from '@genfeedai/prisma';
+
+export type ServerModelDimensions = {
+  height: number;
+  width: number;
+  [key: string]: unknown;
+};
+
+export interface ServerModelRecord
+  extends Omit<PrismaModel, 'category' | 'config'> {
+  _id?: string;
+  capabilities?: string[];
+  category?: ModelCategory | string;
+  config?: Record<string, unknown>;
+  cost?: number;
+  costTier?: 'high' | 'low' | 'medium' | string;
+  description?: string;
+  isDefault?: boolean;
+  isHighlighted?: boolean;
+  key?: string;
+  maxDimensions?: ServerModelDimensions;
+  organization?: string | null;
+  provider?: ModelProvider | string;
+  qualityTier?: 'basic' | 'high' | 'standard' | 'ultra' | string;
+  recommendedFor?: string[];
+  speedTier?: 'fast' | 'medium' | 'slow' | string;
+  supportsFeatures?: string[];
+  [key: string]: unknown;
+}

--- a/apps/server/server/src/index.ts
+++ b/apps/server/server/src/index.ts
@@ -15,6 +15,10 @@ export {
   PerformanceSummaryService,
   type WeeklySummary,
 } from './collections/content-performance/services/performance-summary.service';
+export type {
+  ServerModelDimensions,
+  ServerModelRecord,
+} from './collections/models/model-record.types';
 export {
   SERVER_TOKENS,
   type ServerBrandMemorySync,

--- a/apps/server/workers/src/crons/model-deprecation/cron.model-deprecation.service.ts
+++ b/apps/server/workers/src/crons/model-deprecation/cron.model-deprecation.service.ts
@@ -1,7 +1,7 @@
-import type { ModelDocument } from '@api/collections/models/schemas/model.schema';
 import { ModelsService } from '@api/collections/models/services/models.service';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { WorkflowStatus } from '@genfeedai/enums';
+import type { ServerModelRecord } from '@genfeedai/server';
 import { LoggerService } from '@libs/logger/logger.service';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
 import { Injectable } from '@nestjs/common';
@@ -17,7 +17,7 @@ const MAX_USAGE_PERCENTAGE = 5;
 const USAGE_LOOKBACK_DAYS = 30;
 
 interface DeprecationCandidate {
-  model: ModelDocument;
+  model: ServerModelRecord;
   reason: string;
 }
 
@@ -92,7 +92,7 @@ export class CronModelDeprecationService {
       for (const candidate of candidates) {
         try {
           const deprecationCheck = await this.evaluateCandidate(
-            candidate as ModelDocument,
+            candidate as ServerModelRecord,
           );
 
           if (!deprecationCheck) {
@@ -121,7 +121,7 @@ export class CronModelDeprecationService {
         } catch (error: unknown) {
           this.logger.error(`${url} failed to evaluate candidate`, {
             error,
-            modelKey: (candidate as ModelDocument).key,
+            modelKey: (candidate as ServerModelRecord).key,
           });
         }
       }
@@ -139,7 +139,7 @@ export class CronModelDeprecationService {
    * Returns a DeprecationCandidate with a reason indicating the outcome.
    */
   private async evaluateCandidate(
-    model: ModelDocument,
+    model: ServerModelRecord,
   ): Promise<DeprecationCandidate | null> {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
     if (!model.key || !model.category) {
@@ -162,7 +162,7 @@ export class CronModelDeprecationService {
     }
 
     // 2. Check if successor has been active for 30+ days
-    const successorDoc = successor as ModelDocument;
+    const successorDoc = successor as ServerModelRecord;
     const successorAge = this.getDaysSince(
       successorDoc.createdAt ?? successorDoc.updatedAt,
     );
@@ -297,7 +297,7 @@ export class CronModelDeprecationService {
    * Deactivate a model by setting isActive and isHighlighted to false.
    * Never deletes the model -- only deactivates it.
    */
-  private async deprecateModel(model: ModelDocument): Promise<void> {
+  private async deprecateModel(model: ServerModelRecord): Promise<void> {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
 
     await this.modelsService.patch(model.id, {

--- a/apps/server/workers/src/crons/model-watcher/cron.model-watcher.service.spec.ts
+++ b/apps/server/workers/src/crons/model-watcher/cron.model-watcher.service.spec.ts
@@ -1,7 +1,7 @@
-import type { ModelDocument } from '@api/collections/models/schemas/model.schema';
 import { ModelsService } from '@api/collections/models/services/models.service';
 import { NotificationsService } from '@api/services/notifications/notifications.service';
 import { ModelCategory, ModelProvider } from '@genfeedai/enums';
+import type { ServerModelRecord } from '@genfeedai/server';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@workers/config/config.service';
@@ -42,7 +42,7 @@ describe('CronModelWatcherService', () => {
       label: 'Veo 3',
       provider: ModelProvider.REPLICATE,
     },
-  ] as unknown as ModelDocument[];
+  ] as unknown as ServerModelRecord[];
 
   // Store original fetch
   const originalFetch = globalThis.fetch;
@@ -169,7 +169,7 @@ describe('CronModelWatcherService', () => {
       modelDiscoveryService.createDraftModel.mockResolvedValueOnce({
         _id: 'new-draft-id',
         key: 'google/imagen-5',
-      } as unknown as ModelDocument);
+      } as unknown as ServerModelRecord);
 
       const result = await service.discoverNewModels();
 
@@ -244,7 +244,7 @@ describe('CronModelWatcherService', () => {
         _id: 'draft-id',
         isActive: false,
         key: 'black-forest-labs/flux-3-pro',
-      } as unknown as ModelDocument);
+      } as unknown as ServerModelRecord);
 
       await service.discoverNewModels();
 
@@ -346,7 +346,7 @@ describe('CronModelWatcherService', () => {
 
       modelDiscoveryService.createDraftModel.mockResolvedValue({
         _id: 'draft',
-      } as unknown as ModelDocument);
+      } as unknown as ServerModelRecord);
 
       const result = await service.discoverNewModels();
 
@@ -384,7 +384,7 @@ describe('CronModelWatcherService', () => {
         .mockRejectedValueOnce(new Error('DB error'))
         .mockResolvedValueOnce({
           _id: 'draft',
-        } as unknown as ModelDocument);
+        } as unknown as ServerModelRecord);
 
       const result = await service.discoverNewModels();
 
@@ -421,7 +421,7 @@ describe('CronModelWatcherService', () => {
         _id: 'draft-rep',
         cost: 25,
         key: 'google/rep-model',
-      } as unknown as ModelDocument);
+      } as unknown as ServerModelRecord);
     }
 
     it('should discover new fal.ai models not in DB', async () => {
@@ -501,7 +501,7 @@ describe('CronModelWatcherService', () => {
         _id: 'draft-fal',
         cost: 80,
         key: 'fal-ai/video-gen',
-      } as unknown as ModelDocument);
+      } as unknown as ServerModelRecord);
 
       const result = await service.discoverNewModels();
 
@@ -545,7 +545,7 @@ describe('CronModelWatcherService', () => {
         _id: 'draft-notif',
         cost: 25,
         key: 'meta/notif-model',
-      } as unknown as ModelDocument);
+      } as unknown as ServerModelRecord);
 
       await service.discoverNewModels();
 
@@ -561,7 +561,7 @@ describe('CronModelWatcherService', () => {
         _id: 'draft-notif',
         cost: 25,
         key: 'meta/notif-model',
-      } as unknown as ModelDocument);
+      } as unknown as ServerModelRecord);
 
       notificationsService.sendModelDiscoveryNotification.mockRejectedValueOnce(
         new Error('Discord webhook failed'),
@@ -581,7 +581,7 @@ describe('CronModelWatcherService', () => {
         _id: 'draft-notif',
         cost: 30,
         key: 'meta/notif-model',
-      } as unknown as ModelDocument);
+      } as unknown as ServerModelRecord);
 
       await service.discoverNewModels();
 

--- a/apps/server/workers/src/crons/model-watcher/cron.model-watcher.service.ts
+++ b/apps/server/workers/src/crons/model-watcher/cron.model-watcher.service.ts
@@ -1,7 +1,7 @@
-import type { ModelDocument } from '@api/collections/models/schemas/model.schema';
 import { ModelsService } from '@api/collections/models/services/models.service';
 import { NotificationsService } from '@api/services/notifications/notifications.service';
 import { ModelCategory, ModelProvider } from '@genfeedai/enums';
+import type { ServerModelRecord } from '@genfeedai/server';
 import { LoggerService } from '@libs/logger/logger.service';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
 import { Injectable } from '@nestjs/common';
@@ -103,7 +103,7 @@ export class CronModelWatcherService {
       const allModels = await this.modelsService.find({ isDeleted: false });
       const existingKeys = new Set(
         allModels
-          .map((m: ModelDocument) => m.key)
+          .map((m: ServerModelRecord) => m.key)
           .filter((key): key is string => typeof key === 'string'),
       );
 

--- a/apps/server/workers/src/services/model-discovery.service.spec.ts
+++ b/apps/server/workers/src/services/model-discovery.service.spec.ts
@@ -20,10 +20,6 @@ vi.mock('@genfeedai/enums', async (importOriginal) => {
   };
 });
 
-vi.mock('@api/collections/models/schemas/model.schema', () => ({
-  Model: { name: 'Model' },
-}));
-
 vi.mock('@api/shared/modules/prisma/prisma.service', () => ({
   PrismaService: class PrismaService {},
 }));

--- a/apps/server/workers/src/services/model-discovery.service.ts
+++ b/apps/server/workers/src/services/model-discovery.service.ts
@@ -1,6 +1,6 @@
-import type { ModelDocument } from '@api/collections/models/schemas/model.schema';
 import { ModelsService } from '@api/collections/models/services/models.service';
 import { ModelCategory } from '@genfeedai/enums';
+import type { ServerModelRecord } from '@genfeedai/server';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@workers/config/config.service';
@@ -85,7 +85,7 @@ export class ModelDiscoveryService {
    */
   async createDraftModel(
     modelInfo: IModelDiscoveryInput,
-  ): Promise<ModelDocument | null> {
+  ): Promise<ServerModelRecord | null> {
     const context = 'ModelDiscoveryService createDraftModel';
     const modelKey = `${modelInfo.owner}/${modelInfo.name}`;
 

--- a/apps/server/workers/src/services/model-pricing.service.spec.ts
+++ b/apps/server/workers/src/services/model-pricing.service.spec.ts
@@ -1,5 +1,5 @@
-import type { ModelDocument } from '@api/collections/models/schemas/model.schema';
 import { ModelCategory, ModelProvider, PricingType } from '@genfeedai/enums';
+import type { ServerModelRecord } from '@genfeedai/server';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Test, TestingModule } from '@nestjs/testing';
 import { ModelPricingService } from '@workers/services/model-pricing.service';
@@ -67,7 +67,7 @@ describe('ModelPricingService', () => {
       pricingType: PricingType.FLAT,
       provider: ModelProvider.REPLICATE,
     },
-  ] as unknown as ModelDocument[];
+  ] as unknown as ServerModelRecord[];
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -191,7 +191,7 @@ describe('ModelPricingService', () => {
           pricingType: PricingType.FLAT,
           provider: ModelProvider.REPLICATE,
         },
-      ] as unknown as ModelDocument[];
+      ] as unknown as ServerModelRecord[];
 
       const result = service.estimateCost(
         ModelCategory.IMAGE,

--- a/apps/server/workers/src/services/model-pricing.service.ts
+++ b/apps/server/workers/src/services/model-pricing.service.ts
@@ -1,6 +1,6 @@
-import type { ModelDocument } from '@api/collections/models/schemas/model.schema';
 import { ModelCategory, PricingType } from '@genfeedai/enums';
 import { applyMargin } from '@genfeedai/helpers';
+import type { ServerModelRecord } from '@genfeedai/server';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
 import type { IModelPricingEstimate } from '@workers/interfaces/model-discovery.interface';
@@ -148,7 +148,7 @@ export class ModelPricingService {
   estimateCost(
     category: string,
     creator: string,
-    existingModels: ModelDocument[],
+    existingModels: ServerModelRecord[],
   ): IModelPricingEstimate {
     const context = 'ModelPricingService estimateCost';
     const tierConfig = CATEGORY_TIER_MAP[category] || DEFAULT_TIER_CONFIG;

--- a/scripts/architecture/workers-api-imports.baseline.ts
+++ b/scripts/architecture/workers-api-imports.baseline.ts
@@ -64,7 +64,6 @@ export const WORKERS_API_IMPORT_BASELINE: readonly string[] = [
   '@api/collections/metadata/metadata.module',
   '@api/collections/metadata/services/metadata.service',
   '@api/collections/models/models.module',
-  '@api/collections/models/schemas/model.schema',
   '@api/collections/models/services/models.service',
   '@api/collections/organization-settings/organization-settings.module',
   '@api/collections/organization-settings/services/organization-settings.service',


### PR DESCRIPTION
## Summary
- Add a server-owned `ServerModelRecord` type contract exported from `@genfeedai/server`.
- Replace worker `ModelDocument` type imports from `@api/collections/models/schemas/model.schema`.
- Remove the now-unused model schema specifier from the worker `@api` import ratchet baseline.

## Validation
- `bunx biome check --write apps/server/server/src/collections/models/model-record.types.ts apps/server/server/src/index.ts apps/server/workers/src/services/model-pricing.service.ts apps/server/workers/src/services/model-discovery.service.ts apps/server/workers/src/crons/model-watcher/cron.model-watcher.service.ts apps/server/workers/src/crons/model-deprecation/cron.model-deprecation.service.ts apps/server/workers/src/services/model-pricing.service.spec.ts apps/server/workers/src/services/model-discovery.service.spec.ts apps/server/workers/src/crons/model-watcher/cron.model-watcher.service.spec.ts scripts/architecture/workers-api-imports.baseline.ts`
- `bun run scripts/architecture/check-no-api-imports-in-workers.ts`
- `git diff --check`
- Commit hook: staged Biome + secretlint

## Notes
- Focused Vitest commands for the touched worker specs were attempted, but this detached worktree could not bootstrap the suites before test execution because local dependencies/workspace packages were incomplete (`@genfeedai/prisma`, `ts-jsonapi`). PR CI should provide the full install.

Closes #1503
Refs #1090