### PR TITLE
fix(workflows): protect system workflow deletion

### DIFF
--- a/apps/server/api/src/collections/workflows/controllers/workflow-crud.controller.spec.ts
+++ b/apps/server/api/src/collections/workflows/controllers/workflow-crud.controller.spec.ts
@@ -7,6 +7,7 @@ import { WorkflowsService } from '@api/collections/workflows/services/workflows.
 import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
 import { WorkflowStatus } from '@genfeedai/enums';
 import { LoggerService } from '@libs/logger/logger.service';
+import { ForbiddenException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import type { Request } from 'express';
 
@@ -143,6 +144,19 @@ describe('WorkflowCrudController', () => {
       const result = await controller.findAll(mockRequest, mockUser, {});
 
       expect(service.findAll).toHaveBeenCalled();
+      const [aggregateArg] =
+        mockWorkflowsService.findAll.mock.calls[
+          mockWorkflowsService.findAll.mock.calls.length - 1
+        ];
+      expect(aggregateArg.where.OR).toEqual([
+        { user: mockUser.publicMetadata.user },
+        {
+          metadata: {
+            equals: 'organization',
+            path: ['systemWorkflow', 'visibility'],
+          },
+        },
+      ]);
       expect(result).toBeDefined();
     });
   });
@@ -332,6 +346,25 @@ describe('WorkflowCrudController', () => {
       });
       expect(service.remove).toHaveBeenCalledWith(id);
       expect(result).toBeDefined();
+    });
+
+    it('should reject deleting immutable system workflows', async () => {
+      const id = '507f1f77bcf86cd799439014';
+      mockWorkflowsService.findMutableOwnedOrThrow.mockRejectedValue(
+        new ForbiddenException(
+          'System workflows are immutable. Duplicate the workflow before editing or deleting it.',
+        ),
+      );
+
+      await expect(
+        controller.remove(mockRequest, id, mockUser),
+      ).rejects.toThrow('System workflows are immutable');
+
+      expect(service.findMutableOwnedOrThrow).toHaveBeenCalledWith(id, {
+        organization: mockUser.publicMetadata.organization,
+        user: mockUser.publicMetadata.user,
+      });
+      expect(service.remove).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/server/api/src/collections/workflows/services/workflow-template-seeder.service.spec.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-template-seeder.service.spec.ts
@@ -16,6 +16,7 @@ describe('WorkflowTemplateSeederService seeded livestream bot workflows', () => 
     workflow: {
       create: vi.fn(),
       findFirst: vi.fn(),
+      update: vi.fn(),
     },
   };
   const prisma = {
@@ -52,6 +53,7 @@ describe('WorkflowTemplateSeederService seeded livestream bot workflows', () => 
     );
     tx.workflow.findFirst.mockResolvedValue(null);
     tx.workflow.create.mockResolvedValue({});
+    tx.workflow.update.mockResolvedValue({});
     prisma.$transaction.mockImplementation(
       async (
         callback: (transactionClient: typeof tx) => Promise<void>,
@@ -108,11 +110,96 @@ describe('WorkflowTemplateSeederService seeded livestream bot workflows', () => 
   });
 
   it('does not seed a duplicate livestream bot workflow', async () => {
-    prisma.workflow.findFirst.mockResolvedValue({ id: 'workflow-1' });
+    prisma.workflow.findFirst.mockResolvedValue({
+      id: 'workflow-1',
+      metadata: {
+        sourceIssue: 793,
+        sourceTemplateChangeSummary: SYSTEM_WORKFLOW_TEMPLATE_CHANGE_SUMMARY,
+        sourceTemplateId: 'livestream-bot-session-processing',
+        sourceTemplateVersion: SYSTEM_WORKFLOW_TEMPLATE_VERSION,
+        sourceType: 'seeded-template',
+        systemWorkflow: buildSystemWorkflowMetadata({
+          canonicalId: 'livestream-bot-session-processing',
+          sourceIssue: 793,
+        }),
+      },
+    });
 
     await service.ensureLivestreamBotWorkflows('user-1', 'org-1');
 
     expect(prisma.$transaction).not.toHaveBeenCalled();
+    expect(prisma.workflow.update).not.toHaveBeenCalled();
+    expect(tx.workflow.create).not.toHaveBeenCalled();
+  });
+
+  it('repairs legacy seeded workflow metadata without creating a duplicate', async () => {
+    prisma.workflow.findFirst.mockResolvedValue({
+      id: 'workflow-1',
+      metadata: {
+        legacyFlag: true,
+        sourceTemplateId: 'livestream-bot-session-processing',
+      },
+    });
+
+    await service.ensureLivestreamBotWorkflows('user-1', 'org-1');
+
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+    expect(prisma.workflow.update).toHaveBeenCalledWith({
+      data: {
+        metadata: expect.objectContaining({
+          legacyFlag: true,
+          sourceIssue: 793,
+          sourceTemplateChangeSummary: SYSTEM_WORKFLOW_TEMPLATE_CHANGE_SUMMARY,
+          sourceTemplateId: 'livestream-bot-session-processing',
+          sourceTemplateVersion: SYSTEM_WORKFLOW_TEMPLATE_VERSION,
+          sourceType: 'seeded-template',
+          systemWorkflow: expect.objectContaining({
+            canonicalId: 'livestream-bot-session-processing',
+            immutable: true,
+            owner: 'genfeed',
+            version: SYSTEM_WORKFLOW_TEMPLATE_VERSION,
+            visibility: 'organization',
+          }),
+        }),
+      },
+      where: { id: 'workflow-1' },
+    });
+    expect(tx.workflow.create).not.toHaveBeenCalled();
+  });
+
+  it('repairs legacy daily trends metadata while preserving the enabled repair', async () => {
+    prisma.workflow.findFirst.mockResolvedValue({
+      id: 'workflow-1',
+      isScheduleEnabled: false,
+      metadata: {
+        sourceTemplateId: 'daily-trends-digest',
+      },
+    });
+
+    await service.ensureDailyTrendsDigestWorkflow('user-1', 'org-1');
+
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+    expect(prisma.workflow.update).toHaveBeenCalledWith({
+      data: {
+        isScheduleEnabled: true,
+        metadata: expect.objectContaining({
+          sourceIssue: 1011,
+          sourceTemplateChangeSummary:
+            'Initial daily trend digest system workflow with trend assembly and owner email delivery.',
+          sourceTemplateId: 'daily-trends-digest',
+          sourceTemplateVersion: 1,
+          sourceType: 'seeded-template',
+          systemWorkflow: expect.objectContaining({
+            canonicalId: 'daily-trends-digest',
+            immutable: true,
+            owner: 'genfeed',
+            version: 1,
+            visibility: 'organization',
+          }),
+        }),
+      },
+      where: { id: 'workflow-1' },
+    });
     expect(tx.workflow.create).not.toHaveBeenCalled();
   });
 

--- a/apps/server/api/src/collections/workflows/services/workflow-template-seeder.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-template-seeder.service.ts
@@ -3,6 +3,8 @@ import { SYSTEM_WORKFLOW_ACTION_DEFINITIONS } from '@api/collections/workflows/s
 import { WorkflowExecutionQueueService } from '@api/collections/workflows/services/workflow-execution-queue.service';
 import {
   buildSystemWorkflowMetadata,
+  getMetadataRecord,
+  getSystemWorkflowMetadata,
   SYSTEM_WORKFLOW_METADATA_KEY,
   SYSTEM_WORKFLOW_TEMPLATE_CHANGE_SUMMARY,
   SYSTEM_WORKFLOW_TEMPLATE_VERSION,
@@ -89,6 +91,104 @@ export class WorkflowTemplateSeederService {
     };
   }
 
+  private buildSeededWorkflowMetadataPatch(input: {
+    desiredMetadata: unknown;
+    existingMetadata: unknown;
+  }): Record<string, unknown> | null {
+    const desiredMetadata = getMetadataRecord(input.desiredMetadata);
+    const desiredSystemWorkflow = getSystemWorkflowMetadata(desiredMetadata);
+
+    if (!desiredSystemWorkflow) {
+      return null;
+    }
+
+    const existingMetadata = getMetadataRecord(input.existingMetadata);
+    const existingSystemWorkflow = getSystemWorkflowMetadata(existingMetadata);
+    const repairedMetadata = { ...existingMetadata, ...desiredMetadata };
+
+    if (!existingSystemWorkflow) {
+      return repairedMetadata;
+    }
+
+    const existingSourceVersion = this.normalizeSeededWorkflowVersion(
+      existingMetadata.sourceTemplateVersion,
+    );
+    const desiredSourceVersion = this.normalizeSeededWorkflowVersion(
+      desiredMetadata.sourceTemplateVersion,
+    );
+    const existingSystemVersion = this.normalizeSeededWorkflowVersion(
+      existingSystemWorkflow.version,
+    );
+    const desiredSystemVersion = this.normalizeSeededWorkflowVersion(
+      desiredSystemWorkflow.version,
+    );
+
+    if (
+      existingSourceVersion < desiredSourceVersion ||
+      existingSystemVersion < desiredSystemVersion
+    ) {
+      return repairedMetadata;
+    }
+
+    for (const [key, value] of Object.entries(desiredMetadata)) {
+      if (!this.areSeededMetadataValuesEqual(existingMetadata[key], value)) {
+        return repairedMetadata;
+      }
+    }
+
+    return null;
+  }
+
+  private normalizeSeededWorkflowVersion(version: unknown): number {
+    return typeof version === 'number' &&
+      Number.isInteger(version) &&
+      version > 0
+      ? version
+      : 0;
+  }
+
+  private areSeededMetadataValuesEqual(left: unknown, right: unknown): boolean {
+    if (left === right) {
+      return true;
+    }
+
+    if (Array.isArray(left) || Array.isArray(right)) {
+      if (!Array.isArray(left) || !Array.isArray(right)) {
+        return false;
+      }
+
+      return (
+        left.length === right.length &&
+        left.every((item, index) =>
+          this.areSeededMetadataValuesEqual(item, right[index]),
+        )
+      );
+    }
+
+    if (this.isMetadataRecord(left) || this.isMetadataRecord(right)) {
+      if (!this.isMetadataRecord(left) || !this.isMetadataRecord(right)) {
+        return false;
+      }
+
+      const leftKeys = Object.keys(left);
+      const rightKeys = Object.keys(right);
+      return (
+        leftKeys.length === rightKeys.length &&
+        leftKeys.every(
+          (key) =>
+            Object.hasOwn(right, key) &&
+            this.areSeededMetadataValuesEqual(left[key], right[key]),
+        )
+      );
+    }
+
+    return false;
+  }
+
+  private isMetadataRecord(value: unknown): value is Record<string, unknown> {
+    return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+  }
+
   /**
    * Race-safe idempotent insert keyed on `metadata.sourceTemplateId` within an
    * organization. Fast-path read first; otherwise a SERIALIZABLE re-check +
@@ -112,11 +212,22 @@ export class WorkflowTemplateSeederService {
     };
 
     const preCheck = await this.prisma.workflow.findFirst({
-      select: { id: true },
+      select: { id: true, metadata: true },
       where,
     });
 
     if (preCheck) {
+      const metadataPatch = this.buildSeededWorkflowMetadataPatch({
+        desiredMetadata: input.createData.metadata,
+        existingMetadata: preCheck.metadata,
+      });
+
+      if (metadataPatch) {
+        await this.prisma.workflow.update({
+          data: { metadata: metadataPatch } as never,
+          where: { id: preCheck.id },
+        });
+      }
       return;
     }
 
@@ -124,11 +235,22 @@ export class WorkflowTemplateSeederService {
       await this.prisma.$transaction(
         async (tx) => {
           const existing = await tx.workflow.findFirst({
-            select: { id: true },
+            select: { id: true, metadata: true },
             where,
           });
 
           if (existing) {
+            const metadataPatch = this.buildSeededWorkflowMetadataPatch({
+              desiredMetadata: input.createData.metadata,
+              existingMetadata: existing.metadata,
+            });
+
+            if (metadataPatch) {
+              await tx.workflow.update({
+                data: { metadata: metadataPatch } as never,
+                where: { id: existing.id },
+              });
+            }
             return;
           }
 
@@ -238,16 +360,28 @@ export class WorkflowTemplateSeederService {
       organizationId,
     };
 
+    const createData = this.buildDailyTrendsDigestCreateData(
+      userId,
+      organizationId,
+    );
+
     // Fast path: most calls hit an already-seeded org.
     const preCheck = await this.prisma.workflow.findFirst({
-      select: { id: true, isScheduleEnabled: true },
+      select: { id: true, isScheduleEnabled: true, metadata: true },
       where,
     });
 
     if (preCheck) {
-      if (!preCheck.isScheduleEnabled) {
+      const metadataPatch = this.buildSeededWorkflowMetadataPatch({
+        desiredMetadata: createData.metadata,
+        existingMetadata: preCheck.metadata,
+      });
+      if (!preCheck.isScheduleEnabled || metadataPatch) {
         await this.prisma.workflow.update({
-          data: { isScheduleEnabled: true },
+          data: {
+            ...(metadataPatch ? { metadata: metadataPatch } : {}),
+            ...(!preCheck.isScheduleEnabled ? { isScheduleEnabled: true } : {}),
+          } as never,
           where: { id: preCheck.id },
         });
       }
@@ -258,14 +392,23 @@ export class WorkflowTemplateSeederService {
       await this.prisma.$transaction(
         async (tx) => {
           const existing = await tx.workflow.findFirst({
-            select: { id: true, isScheduleEnabled: true },
+            select: { id: true, isScheduleEnabled: true, metadata: true },
             where,
           });
 
           if (existing) {
-            if (!existing.isScheduleEnabled) {
+            const metadataPatch = this.buildSeededWorkflowMetadataPatch({
+              desiredMetadata: createData.metadata,
+              existingMetadata: existing.metadata,
+            });
+            if (!existing.isScheduleEnabled || metadataPatch) {
               await tx.workflow.update({
-                data: { isScheduleEnabled: true },
+                data: {
+                  ...(metadataPatch ? { metadata: metadataPatch } : {}),
+                  ...(!existing.isScheduleEnabled
+                    ? { isScheduleEnabled: true }
+                    : {}),
+                } as never,
                 where: { id: existing.id },
               });
             }
@@ -273,10 +416,7 @@ export class WorkflowTemplateSeederService {
           }
 
           await tx.workflow.create({
-            data: this.buildDailyTrendsDigestCreateData(
-              userId,
-              organizationId,
-            ) as never,
+            data: createData as never,
           });
         },
         { isolationLevel: 'Serializable' },

--- a/apps/server/api/src/collections/workflows/services/workflows.service.spec.ts
+++ b/apps/server/api/src/collections/workflows/services/workflows.service.spec.ts
@@ -253,6 +253,45 @@ describe('WorkflowsService system workflow guardrails', () => {
     ).rejects.toThrow('System workflows are immutable');
   });
 
+  it('rejects direct deletion of protected system workflows', async () => {
+    const prisma = {
+      workflow: {
+        findFirst: vi.fn().mockResolvedValue({
+          id: 'system-workflow-1',
+          isDeleted: false,
+          metadata: {
+            systemWorkflow: buildSystemWorkflowMetadata({
+              canonicalId: 'daily-trends-digest',
+              changeSummary: 'Initial daily digest version.',
+              sourceIssue: 1011,
+              version: 2,
+            }),
+          },
+        }),
+        update: vi.fn(),
+      },
+    };
+    const workflowExecutionQueueService = {
+      syncWorkflowScheduler: vi.fn(),
+    };
+    const guardedService = new WorkflowsService(
+      prisma as never,
+      logger as never,
+      undefined,
+      undefined,
+      workflowExecutionQueueService as never,
+    );
+
+    await expect(guardedService.remove('system-workflow-1')).rejects.toThrow(
+      'System workflows are immutable',
+    );
+
+    expect(prisma.workflow.update).not.toHaveBeenCalled();
+    expect(
+      workflowExecutionQueueService.syncWorkflowScheduler,
+    ).not.toHaveBeenCalled();
+  });
+
   it('duplicates protected system workflows as editable user drafts', async () => {
     vi.spyOn(service, 'findVisibleOrThrow').mockResolvedValue({
       _id: 'system-workflow-1',

--- a/apps/server/api/src/collections/workflows/services/workflows.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflows.service.ts
@@ -233,6 +233,14 @@ export class WorkflowsService extends BaseService<
    * stops firing immediately.
    */
   override async remove(id: string): Promise<WorkflowDocument | null> {
+    const workflow = await this.findOne({
+      _id: id,
+      isDeleted: false,
+    });
+    if (workflow) {
+      this.assertWorkflowMutable(workflow);
+    }
+
     const removed = await super.remove(id);
 
     if (removed) {


### PR DESCRIPTION
## Summary
- Repair legacy seeded workflow metadata during idempotent seeding so existing canonical rows gain `systemWorkflow` visibility/immutability without duplicate creation.
- Enforce immutable system workflow protection inside `WorkflowsService.remove` before any soft-delete or scheduler cleanup can run.
- Add focused seeder, workflow service, and CRUD controller coverage for list visibility plus update/delete rejection paths.

Closes #1027
Refs #1011

## Validation
- `bun install --frozen-lockfile --ignore-scripts`
- `bun run --cwd packages/prisma db:generate`
- `bunx biome check --write apps/server/api/src/collections/workflows/services/workflows.service.ts apps/server/api/src/collections/workflows/services/workflows.service.spec.ts apps/server/api/src/collections/workflows/controllers/workflow-crud.controller.spec.ts`
- `bunx biome check --write apps/server/api/src/collections/workflows/services/workflow-template-seeder.service.ts apps/server/api/src/collections/workflows/services/workflow-template-seeder.service.spec.ts apps/server/api/src/collections/workflows/services/workflows.service.ts apps/server/api/src/collections/workflows/services/workflows.service.spec.ts apps/server/api/src/collections/workflows/controllers/workflow-crud.controller.spec.ts`
- `bun run --cwd apps/server/api test:file src/collections/workflows/services/workflow-template-seeder.service.spec.ts src/collections/workflows/services/workflows.service.spec.ts src/collections/workflows/controllers/workflow-crud.controller.spec.ts` (3 files, 32 tests)
- `git diff --check`
- `git diff --cached --check`

## Notes
- Broad workspace type-check/build/full suites are left to PR CI per local verification policy.
- Source issue #1027 has no queue label; this PR carries `codex:automation` because Codex automation selected it.