### PR TITLE
feat(agent): show active runs in workspace

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/~/agent/AgentWorkspacePageShell.spec.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/agent/AgentWorkspacePageShell.spec.tsx
@@ -105,10 +105,22 @@ describe('AgentWorkspacePageShell', () => {
         onboardingMode: true,
         onOAuthConnect: handleOAuthConnectMock,
         onOnboardingCompleted: completeOnboardingFlowMock,
+        showRunSummary: true,
         showThreadSidebar: false,
         threadId: 'thread-123',
       }),
     );
+  });
+
+  it('routes run thread handoffs to the org agent workspace', () => {
+    render(<AgentWorkspacePageShell />);
+
+    const props = agentFullPageSpy.mock.calls[0]?.[0] as {
+      onOpenRunThread: (threadId: string) => void;
+    };
+    props.onOpenRunThread('run-thread-123');
+
+    expect(pushMock).toHaveBeenCalledWith('/test-org/~/agent/run-thread-123');
   });
 
   it('routes billing actions to Credits in OSS mode', () => {

--- a/apps/app/app/(protected)/[orgSlug]/~/agent/AgentWorkspacePageShell.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/agent/AgentWorkspacePageShell.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { AgentFullPage } from '@genfeedai/agent';
+import { APP_ROUTES } from '@genfeedai/constants';
 import { useAuthIdentity } from '@genfeedai/hooks/auth/use-auth-identity/use-auth-identity';
 import { resolveAuthToken } from '@helpers/auth/auth.helper';
 import { useOrgUrl } from '@hooks/navigation/use-org-url';
@@ -52,7 +53,11 @@ export function AgentWorkspacePageShell({
         authReady={isLoaded}
         onboardingMode={isOnboarding}
         onCreateFollowUpTasks={handleCreateFollowUpTasks}
+        onOpenRunThread={(runThreadId) => {
+          push(orgHref(`${APP_ROUTES.AGENT.ROOT}/${runThreadId}`));
+        }}
         showThreadSidebar={false}
+        showRunSummary
         threadId={threadId}
         onNavigateToBilling={() => {
           push(

--- a/packages/agent/src/components/AgentFullPage.tsx
+++ b/packages/agent/src/components/AgentFullPage.tsx
@@ -4,6 +4,7 @@ import { AgentFullPageMobileDrawers } from '@genfeedai/agent/components/AgentFul
 import { AgentFullPageOnboardingChrome } from '@genfeedai/agent/components/AgentFullPageOnboardingChrome';
 import { AgentOutputsPanel } from '@genfeedai/agent/components/AgentOutputsPanel';
 import { AgentSidebarContent } from '@genfeedai/agent/components/AgentSidebarContent';
+import { AgentWorkspaceRunSummary } from '@genfeedai/agent/components/AgentWorkspaceRunSummary';
 import { useAgentFullPage } from '@genfeedai/agent/components/useAgentFullPage';
 import type { AgentApiService } from '@genfeedai/agent/services/agent-api.service';
 import type { MemberRole } from '@genfeedai/enums';
@@ -18,10 +19,12 @@ interface AgentFullPageProps {
   authReady?: boolean;
   threadId?: string;
   showThreadSidebar?: boolean;
+  showRunSummary?: boolean;
   onboardingMode?: boolean;
   onOnboardingCompleted?: () => void | Promise<void>;
   onCreateFollowUpTasks?: (taskId: string) => Promise<{ createdCount: number }>;
   onOAuthConnect?: (platform: string) => void;
+  onOpenRunThread?: (threadId: string) => void;
   onSelectCreditPack?: (pack: {
     label: string;
     price: string;
@@ -36,10 +39,12 @@ export function AgentFullPage({
   authReady = true,
   threadId,
   showThreadSidebar = true,
+  showRunSummary = false,
   onboardingMode = false,
   onOnboardingCompleted,
   onCreateFollowUpTasks,
   onOAuthConnect,
+  onOpenRunThread,
   onSelectCreditPack,
   userRole,
 }: AgentFullPageProps): ReactElement {
@@ -92,6 +97,14 @@ export function AgentFullPage({
           onOpenThreads={() => setMobileThreadsOpen(true)}
           onOpenOutputs={() => setMobileOutputsOpen(true)}
         />
+
+        {showRunSummary ? (
+          <AgentWorkspaceRunSummary
+            apiService={apiService}
+            authReady={authReady}
+            onOpenThread={onOpenRunThread}
+          />
+        ) : null}
 
         <div className="flex min-h-0 flex-1">
           <div className="flex min-w-0 flex-1 flex-col overflow-hidden">

--- a/packages/agent/src/components/AgentWorkspaceRunSummary.spec.tsx
+++ b/packages/agent/src/components/AgentWorkspaceRunSummary.spec.tsx
@@ -1,0 +1,130 @@
+import type { AgentRunSummary } from '@genfeedai/agent/models/agent-chat.model';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { Effect } from 'effect';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AgentWorkspaceRunSummary } from './AgentWorkspaceRunSummary';
+
+vi.mock('@helpers/formatting/cn/cn.util', () => ({
+  cn: (...classes: Array<string | false | null | undefined>) =>
+    classes.filter(Boolean).join(' '),
+}));
+
+vi.mock('@ui/primitives/button', () => ({
+  Button: ({
+    ariaLabel,
+    children,
+    disabled,
+    isDisabled,
+    isLoading,
+    onClick,
+  }: {
+    ariaLabel?: string;
+    children?: ReactNode;
+    disabled?: boolean;
+    isDisabled?: boolean;
+    isLoading?: boolean;
+    onClick?: () => void;
+  }) => (
+    <button
+      aria-label={ariaLabel}
+      disabled={disabled || isDisabled || isLoading}
+      type="button"
+      onClick={onClick}
+    >
+      {isLoading ? 'Loading' : children}
+    </button>
+  ),
+}));
+
+function createRun(overrides: Partial<AgentRunSummary> = {}): AgentRunSummary {
+  return {
+    id: 'run-1',
+    label: 'Long content run',
+    startedAt: '2026-07-09T03:00:00.000Z',
+    status: 'RUNNING',
+    thread: 'thread-1',
+    ...overrides,
+  };
+}
+
+function createApiService(overrides: Record<string, unknown> = {}) {
+  return {
+    cancelRunEffect: vi.fn((runId: string) =>
+      Effect.succeed(createRun({ id: runId, status: 'CANCELLED' })),
+    ),
+    getActiveRunsEffect: vi.fn(() => Effect.succeed([])),
+    ...overrides,
+  };
+}
+
+describe('AgentWorkspaceRunSummary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the empty active-run state', async () => {
+    const apiService = createApiService();
+
+    render(<AgentWorkspaceRunSummary apiService={apiService as never} />);
+
+    await screen.findByText('No active runs');
+
+    expect(screen.getByText(/New agent work will appear/)).toBeInTheDocument();
+    expect(apiService.getActiveRunsEffect).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens and cancels an active run with a thread handoff', async () => {
+    const onOpenThread = vi.fn();
+    const apiService = createApiService({
+      getActiveRunsEffect: vi.fn(() => Effect.succeed([createRun()])),
+    });
+
+    render(
+      <AgentWorkspaceRunSummary
+        apiService={apiService as never}
+        onOpenThread={onOpenThread}
+      />,
+    );
+
+    await screen.findByText('Long content run');
+
+    fireEvent.click(screen.getByLabelText('Open Long content run thread'));
+    expect(onOpenThread).toHaveBeenCalledWith('thread-1');
+
+    fireEvent.click(screen.getByLabelText('Cancel Long content run'));
+
+    await waitFor(() => {
+      expect(apiService.cancelRunEffect).toHaveBeenCalledWith('run-1');
+    });
+    await screen.findByText('Cancelled');
+  });
+
+  it('shows a load error and retries active-run fetches', async () => {
+    const apiService = createApiService({
+      getActiveRunsEffect: vi
+        .fn()
+        .mockReturnValueOnce(Effect.fail(new Error('Failed to load runs')))
+        .mockReturnValueOnce(
+          Effect.succeed([
+            createRun({
+              id: 'run-2',
+              label: 'Queued import',
+              startedAt: undefined,
+              status: 'PENDING',
+              thread: undefined,
+            }),
+          ]),
+        ),
+    });
+
+    render(<AgentWorkspaceRunSummary apiService={apiService as never} />);
+
+    await screen.findByText('Failed to load runs');
+
+    fireEvent.click(screen.getByText('Retry'));
+
+    await screen.findByText('Queued import');
+    expect(apiService.getActiveRunsEffect).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/agent/src/components/AgentWorkspaceRunSummary.tsx
+++ b/packages/agent/src/components/AgentWorkspaceRunSummary.tsx
@@ -1,0 +1,290 @@
+import type { AgentRunSummary } from '@genfeedai/agent/models/agent-chat.model';
+import type { AgentApiService } from '@genfeedai/agent/services/agent-api.service';
+import { runAgentApiEffect } from '@genfeedai/agent/services/agent-base-api.service';
+import { ButtonSize, ButtonVariant } from '@genfeedai/enums';
+import { cn } from '@helpers/formatting/cn/cn.util';
+import { Button } from '@ui/primitives/button';
+import type { ReactElement } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  HiOutlineArrowPath,
+  HiOutlineBolt,
+  HiOutlineNoSymbol,
+  HiOutlinePlayCircle,
+} from 'react-icons/hi2';
+
+interface AgentWorkspaceRunSummaryProps {
+  apiService: AgentApiService;
+  authReady?: boolean;
+  onOpenThread?: (threadId: string) => void;
+}
+
+function formatRunStatus(status: string): string {
+  return status
+    .toLowerCase()
+    .split(/[_\s-]+/)
+    .filter(Boolean)
+    .map((part) => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
+    .join(' ');
+}
+
+function getRunStatusClassName(status: string): string {
+  switch (status.toUpperCase()) {
+    case 'RUNNING':
+      return 'bg-primary/10 text-primary';
+    case 'PENDING':
+      return 'bg-yellow-500/10 text-yellow-600 dark:text-yellow-400';
+    case 'CANCELLED':
+      return 'bg-foreground/10 text-foreground/60';
+    case 'FAILED':
+      return 'bg-destructive/10 text-destructive';
+    default:
+      return 'bg-green-500/10 text-green-600 dark:text-green-400';
+  }
+}
+
+function isRunCancellable(status: string): boolean {
+  return status === 'PENDING' || status === 'RUNNING';
+}
+
+function getRunThreadId(run: AgentRunSummary): string | null {
+  return typeof run.thread === 'string' && run.thread.length > 0
+    ? run.thread
+    : null;
+}
+
+function formatStartedAt(startedAt?: string): string {
+  if (!startedAt) {
+    return 'Queued';
+  }
+
+  const started = new Date(startedAt);
+  if (Number.isNaN(started.getTime())) {
+    return 'Started recently';
+  }
+
+  const diffMs = Date.now() - started.getTime();
+  const diffMins = Math.max(0, Math.floor(diffMs / 60_000));
+  const diffHours = Math.floor(diffMs / 3_600_000);
+
+  if (diffMins < 1) {
+    return 'Started just now';
+  }
+  if (diffMins < 60) {
+    return `Started ${diffMins}m ago`;
+  }
+  if (diffHours < 24) {
+    return `Started ${diffHours}h ago`;
+  }
+  return `Started ${started.toLocaleDateString()}`;
+}
+
+export function AgentWorkspaceRunSummary({
+  apiService,
+  authReady = true,
+  onOpenThread,
+}: AgentWorkspaceRunSummaryProps): ReactElement {
+  const [runs, setRuns] = useState<AgentRunSummary[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [cancellingRunId, setCancellingRunId] = useState<string | null>(null);
+
+  const loadRuns = useCallback(
+    async (signal?: AbortSignal) => {
+      setIsLoading(true);
+      setLoadError(null);
+
+      try {
+        const activeRuns = await runAgentApiEffect(
+          apiService.getActiveRunsEffect(signal),
+        );
+        if (!signal?.aborted) {
+          setRuns(activeRuns);
+        }
+      } catch (error) {
+        if (signal?.aborted) {
+          return;
+        }
+        setLoadError(
+          error instanceof Error
+            ? error.message
+            : 'Failed to load active runs.',
+        );
+      } finally {
+        if (!signal?.aborted) {
+          setIsLoading(false);
+        }
+      }
+    },
+    [apiService],
+  );
+
+  useEffect(() => {
+    if (!authReady) {
+      return;
+    }
+
+    const controller = new AbortController();
+    void loadRuns(controller.signal);
+
+    return () => controller.abort();
+  }, [authReady, loadRuns]);
+
+  const activeRunCount = useMemo(
+    () => runs.filter((run) => isRunCancellable(run.status)).length,
+    [runs],
+  );
+  const isRunSummaryLoading = !authReady || isLoading;
+
+  const handleCancelRun = useCallback(
+    async (runId: string) => {
+      setCancellingRunId(runId);
+      setLoadError(null);
+
+      try {
+        const cancelledRun = await runAgentApiEffect(
+          apiService.cancelRunEffect(runId),
+        );
+        setRuns((currentRuns) =>
+          currentRuns.map((run) =>
+            run.id === cancelledRun.id ? cancelledRun : run,
+          ),
+        );
+      } catch (error) {
+        setLoadError(
+          error instanceof Error
+            ? error.message
+            : 'Failed to cancel active run.',
+        );
+      } finally {
+        setCancellingRunId(null);
+      }
+    },
+    [apiService],
+  );
+
+  return (
+    <section className="border-b border-border bg-background-secondary px-4 py-3">
+      <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
+        <div className="flex items-center gap-3">
+          <div className="flex size-9 shrink-0 items-center justify-center rounded-lg border border-border bg-background">
+            <HiOutlineBolt className="size-5 text-primary" />
+          </div>
+          <div className="min-w-0">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+              Active Runs
+            </p>
+            <h2 className="truncate text-sm font-semibold text-foreground">
+              {isRunSummaryLoading
+                ? 'Checking current work'
+                : activeRunCount > 0
+                  ? `${activeRunCount} run${activeRunCount === 1 ? '' : 's'} in flight`
+                  : 'No active runs'}
+            </h2>
+          </div>
+        </div>
+
+        {loadError ? (
+          <div className="flex items-center gap-2 text-xs text-destructive">
+            <span className="line-clamp-1">{loadError}</span>
+            <Button
+              variant={ButtonVariant.OUTLINE}
+              size={ButtonSize.XS}
+              withWrapper={false}
+              onClick={() => void loadRuns()}
+            >
+              Retry
+            </Button>
+          </div>
+        ) : null}
+      </div>
+
+      {isRunSummaryLoading ? (
+        <div className="mt-3 flex items-center gap-2 text-xs text-muted-foreground">
+          <div className="size-4 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+          Loading active runs
+        </div>
+      ) : null}
+
+      {!isRunSummaryLoading && !loadError && runs.length === 0 ? (
+        <p className="mt-3 text-xs text-muted-foreground">
+          New agent work will appear here while it is queued or running.
+        </p>
+      ) : null}
+
+      {!isRunSummaryLoading && runs.length > 0 ? (
+        <div className="mt-3 grid gap-2 xl:grid-cols-2">
+          {runs.map((run) => {
+            const threadId = getRunThreadId(run);
+            const isCancelling = cancellingRunId === run.id;
+            return (
+              <div
+                key={run.id}
+                className="flex min-w-0 items-center justify-between gap-3 rounded-md border border-border bg-background px-3 py-2"
+              >
+                <div className="min-w-0">
+                  <div className="flex min-w-0 items-center gap-2">
+                    <span
+                      className={cn(
+                        'shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold',
+                        getRunStatusClassName(run.status),
+                      )}
+                    >
+                      {formatRunStatus(run.status)}
+                    </span>
+                    <p className="truncate text-xs font-medium text-foreground">
+                      {run.label}
+                    </p>
+                  </div>
+                  <p className="mt-1 text-[11px] text-muted-foreground">
+                    {formatStartedAt(run.startedAt)}
+                  </p>
+                </div>
+
+                <div className="flex shrink-0 items-center gap-2">
+                  {threadId && onOpenThread ? (
+                    <Button
+                      ariaLabel={`Open ${run.label} thread`}
+                      variant={ButtonVariant.OUTLINE}
+                      size={ButtonSize.XS}
+                      withWrapper={false}
+                      onClick={() => onOpenThread(threadId)}
+                    >
+                      <HiOutlinePlayCircle className="size-3.5" />
+                      Open
+                    </Button>
+                  ) : null}
+                  {isRunCancellable(run.status) ? (
+                    <Button
+                      ariaLabel={`Cancel ${run.label}`}
+                      variant={ButtonVariant.GHOST}
+                      size={ButtonSize.XS}
+                      withWrapper={false}
+                      isLoading={isCancelling}
+                      onClick={() => void handleCancelRun(run.id)}
+                    >
+                      <HiOutlineNoSymbol className="size-3.5" />
+                      Cancel
+                    </Button>
+                  ) : null}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      ) : null}
+
+      {!isRunSummaryLoading && runs.length > 0 ? (
+        <Button
+          variant={ButtonVariant.UNSTYLED}
+          withWrapper={false}
+          className="mt-3 inline-flex items-center gap-1.5 text-xs font-medium text-muted-foreground hover:text-foreground"
+          onClick={() => void loadRuns()}
+        >
+          <HiOutlineArrowPath className="size-3.5" />
+          Refresh runs
+        </Button>
+      ) : null}
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add an active-run summary strip to the `/agent` workspace shell
- fetch active runs through the existing agent API service
- support thread handoff and cancellable active runs from the workspace

Closes #1508
Refs #1015

## Validation
- `bunx biome check --write packages/agent/src/components/AgentWorkspaceRunSummary.tsx packages/agent/src/components/AgentWorkspaceRunSummary.spec.tsx packages/agent/src/components/AgentFullPage.tsx apps/app/app/(protected)/[orgSlug]/~/agent/AgentWorkspacePageShell.tsx apps/app/app/(protected)/[orgSlug]/~/agent/AgentWorkspacePageShell.spec.tsx`
- `TZ=UTC scripts/sh/sanitize-node-color-env.sh bun run --cwd packages/agent test src/components/AgentWorkspaceRunSummary.spec.tsx src/components/AgentFullPage.spec.tsx`
- `TZ=UTC scripts/sh/sanitize-node-color-env.sh bun run --cwd apps/app test app/(protected)/[orgSlug]/~/agent/AgentWorkspacePageShell.spec.tsx`
- `git diff --check origin/master..HEAD`
- `bunx secretlint apps/app/app/(protected)/[orgSlug]/~/agent/AgentWorkspacePageShell.spec.tsx apps/app/app/(protected)/[orgSlug]/~/agent/AgentWorkspacePageShell.tsx packages/agent/src/components/AgentFullPage.tsx packages/agent/src/components/AgentWorkspaceRunSummary.spec.tsx packages/agent/src/components/AgentWorkspaceRunSummary.tsx`

## Notes
- Broad workspace type-check/build gates are left to PR CI per local verification policy.
