### PR TITLE
feat(workflows): surface safe system workflow duplication

### DIFF
--- a/apps/app/src/features/workflows/pages/library/WorkflowCardDropdown.test.tsx
+++ b/apps/app/src/features/workflows/pages/library/WorkflowCardDropdown.test.tsx
@@ -1,0 +1,20 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import WorkflowCardDropdown from './WorkflowCardDropdown';
+
+describe('WorkflowCardDropdown', () => {
+  it('keeps duplicate available while hiding delete for canonical system workflows', () => {
+    render(
+      <WorkflowCardDropdown
+        canDelete={false}
+        onDelete={vi.fn()}
+        onDuplicate={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Workflow actions' }));
+
+    expect(screen.getByRole('button', { name: 'Duplicate' })).toBeDefined();
+    expect(screen.queryByRole('button', { name: 'Delete' })).toBeNull();
+  });
+});

--- a/apps/app/src/features/workflows/pages/library/WorkflowCardDropdown.tsx
+++ b/apps/app/src/features/workflows/pages/library/WorkflowCardDropdown.tsx
@@ -10,11 +10,13 @@ import {
 } from 'react-icons/hi2';
 
 type WorkflowCardDropdownProps = {
+  canDelete?: boolean;
   onDuplicate: () => void;
   onDelete: () => void;
 };
 
 export default function WorkflowCardDropdown({
+  canDelete = true,
   onDuplicate,
   onDelete,
 }: WorkflowCardDropdownProps) {
@@ -38,6 +40,7 @@ export default function WorkflowCardDropdown({
   return (
     <div ref={dropdownRef} className="relative">
       <Button
+        aria-label="Workflow actions"
         type="button"
         variant={ButtonVariant.UNSTYLED}
         onClick={(e) => {
@@ -66,20 +69,22 @@ export default function WorkflowCardDropdown({
             <HiOutlineDocumentDuplicate className="size-4" />
             Duplicate
           </Button>
-          <Button
-            type="button"
-            variant={ButtonVariant.UNSTYLED}
-            onClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              onDelete();
-              setIsOpen(false);
-            }}
-            className="flex w-full items-center gap-2 px-3 py-2 text-sm text-red-400 transition-colors hover:bg-muted"
-          >
-            <HiOutlineTrash className="size-4" />
-            Delete
-          </Button>
+          {canDelete ? (
+            <Button
+              type="button"
+              variant={ButtonVariant.UNSTYLED}
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                onDelete();
+                setIsOpen(false);
+              }}
+              className="flex w-full items-center gap-2 px-3 py-2 text-sm text-red-400 transition-colors hover:bg-muted"
+            >
+              <HiOutlineTrash className="size-4" />
+              Delete
+            </Button>
+          ) : null}
         </div>
       )}
     </div>

--- a/apps/app/src/features/workflows/pages/library/WorkflowLibraryPage.tsx
+++ b/apps/app/src/features/workflows/pages/library/WorkflowLibraryPage.tsx
@@ -15,6 +15,7 @@ import {
   HiOutlinePlus,
 } from 'react-icons/hi2';
 import { ClientFormattedDate } from '@/components/ui/client-formatted-date';
+import { isCanonicalSystemWorkflow } from '@/features/workflows/services/workflow-api';
 import { getLifecycleBadgeClass } from '@/features/workflows/utils/status-helpers';
 import EmptyWorkflowState from './EmptyWorkflowState';
 import { useWorkflowLibraryPage } from './useWorkflowLibraryPage';
@@ -177,79 +178,92 @@ export default function WorkflowLibraryPage() {
           </Button>
 
           {/* Workflow cards */}
-          {filteredWorkflows.map((workflow) => (
-            <Link key={workflow._id} href={href(`/workflows/${workflow._id}`)}>
-              <Card
-                className="h-full hover:-translate-y-0.5"
-                label={workflow.name}
-                description={
-                  workflow.description ??
-                  'Reusable automation workflow for content operations.'
-                }
-                headerAction={
-                  <div className="flex items-center gap-2">
-                    {isCapable && isConnected && workflow.cloudSync ? (
-                      <span className="flex items-center gap-1 rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs text-emerald-400">
-                        <Cloud className="size-3" />
-                        synced
+          {filteredWorkflows.map((workflow) => {
+            const isSystemWorkflow = isCanonicalSystemWorkflow(workflow);
+
+            return (
+              <Link
+                key={workflow._id}
+                href={href(`/workflows/${workflow._id}`)}
+              >
+                <Card
+                  className="h-full hover:-translate-y-0.5"
+                  label={workflow.name}
+                  description={
+                    workflow.description ??
+                    'Reusable automation workflow for content operations.'
+                  }
+                  headerAction={
+                    <div className="flex items-center gap-2">
+                      {isSystemWorkflow ? (
+                        <span className="rounded-full bg-sky-500/10 px-2 py-0.5 text-xs text-sky-300">
+                          System
+                        </span>
+                      ) : null}
+                      {isCapable && isConnected && workflow.cloudSync ? (
+                        <span className="flex items-center gap-1 rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs text-emerald-400">
+                          <Cloud className="size-3" />
+                          synced
+                        </span>
+                      ) : isCapable && isConnected && !workflow.cloudSync ? (
+                        <span className="flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+                          <CloudUpload className="size-3" />
+                          local
+                        </span>
+                      ) : null}
+                      <span
+                        className={`rounded-full px-2 py-0.5 text-xs ${getLifecycleBadgeClass(
+                          workflow.lifecycle,
+                        )}`}
+                      >
+                        {workflow.lifecycle}
                       </span>
-                    ) : isCapable && isConnected && !workflow.cloudSync ? (
-                      <span className="flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
-                        <CloudUpload className="size-3" />
-                        local
-                      </span>
-                    ) : null}
-                    <span
-                      className={`rounded-full px-2 py-0.5 text-xs ${getLifecycleBadgeClass(
-                        workflow.lifecycle,
-                      )}`}
-                    >
-                      {workflow.lifecycle}
-                    </span>
-                    {workflow.schedule ? (
-                      <span role="none" onClick={(e) => e.preventDefault()}>
-                        <Switch
-                          checked={workflow.isScheduleEnabled ?? false}
-                          aria-label={`${workflow.isScheduleEnabled ? 'Disable' : 'Enable'} schedule for ${workflow.name}`}
-                          onCheckedChange={(checked) =>
-                            handleToggleSchedule(workflow._id, checked)
-                          }
+                      {!isSystemWorkflow && workflow.schedule ? (
+                        <span role="none" onClick={(e) => e.preventDefault()}>
+                          <Switch
+                            checked={workflow.isScheduleEnabled ?? false}
+                            aria-label={`${workflow.isScheduleEnabled ? 'Disable' : 'Enable'} schedule for ${workflow.name}`}
+                            onCheckedChange={(checked) =>
+                              handleToggleSchedule(workflow._id, checked)
+                            }
+                          />
+                        </span>
+                      ) : null}
+                      <WorkflowCardDropdown
+                        canDelete={!isSystemWorkflow}
+                        onDuplicate={() => handleDuplicate(workflow._id)}
+                        onDelete={() => handleDelete(workflow._id)}
+                      />
+                    </div>
+                  }
+                  bodyClassName="h-full justify-between"
+                >
+                  <div className="space-y-3">
+                    <WorkflowCardPreview
+                      name={workflow.name}
+                      thumbnail={workflow.thumbnail}
+                    />
+                    <div className="flex items-center justify-between text-xs text-foreground/50">
+                      <span>
+                        Updated{' '}
+                        <ClientFormattedDate
+                          format="relative"
+                          value={workflow.updatedAt}
                         />
                       </span>
-                    ) : null}
-                    <WorkflowCardDropdown
-                      onDuplicate={() => handleDuplicate(workflow._id)}
-                      onDelete={() => handleDelete(workflow._id)}
-                    />
+                      <span>
+                        Created{' '}
+                        <ClientFormattedDate
+                          format="date"
+                          value={workflow.createdAt}
+                        />
+                      </span>
+                    </div>
                   </div>
-                }
-                bodyClassName="h-full justify-between"
-              >
-                <div className="space-y-3">
-                  <WorkflowCardPreview
-                    name={workflow.name}
-                    thumbnail={workflow.thumbnail}
-                  />
-                  <div className="flex items-center justify-between text-xs text-foreground/50">
-                    <span>
-                      Updated{' '}
-                      <ClientFormattedDate
-                        format="relative"
-                        value={workflow.updatedAt}
-                      />
-                    </span>
-                    <span>
-                      Created{' '}
-                      <ClientFormattedDate
-                        format="date"
-                        value={workflow.createdAt}
-                      />
-                    </span>
-                  </div>
-                </div>
-              </Card>
-            </Link>
-          ))}
+                </Card>
+              </Link>
+            );
+          })}
         </div>
       )}
     </Container>

--- a/apps/app/src/features/workflows/pages/library/useWorkflowLibraryPage.test.ts
+++ b/apps/app/src/features/workflows/pages/library/useWorkflowLibraryPage.test.ts
@@ -153,4 +153,90 @@ describe('useWorkflowLibraryPage — handleToggleSchedule', () => {
 
     expect(mocks.serviceSetSchedule).not.toHaveBeenCalled();
   });
+
+  it('does not toggle schedules on canonical system workflows', async () => {
+    mocks.serviceList.mockResolvedValueOnce([
+      makeWorkflow({
+        _id: 'system-wf',
+        isScheduleEnabled: true,
+        metadata: {
+          systemWorkflow: {
+            immutable: true,
+            kind: 'system-workflow',
+            owner: 'genfeed',
+          },
+        },
+        name: 'Daily Trends Digest',
+        schedule: '0 7 * * *',
+        timezone: 'UTC',
+      }),
+    ]);
+
+    const { result } = renderHook(() => useWorkflowLibraryPage());
+    await waitFor(() => expect(result.current.workflows).toHaveLength(1));
+
+    await act(async () => {
+      await result.current.handleToggleSchedule('system-wf', false);
+    });
+
+    expect(mocks.serviceSetSchedule).not.toHaveBeenCalled();
+    expect(result.current.workflows[0]?.isScheduleEnabled).toBe(true);
+  });
+});
+
+describe('useWorkflowLibraryPage — workflow duplication and deletion', () => {
+  beforeEach(() => {
+    mocks.serviceList.mockResolvedValue([
+      makeWorkflow({
+        _id: 'wf-1',
+        name: 'Editable Workflow',
+      }),
+    ]);
+    mocks.serviceDuplicate.mockResolvedValue({ _id: 'wf-copy' });
+    mocks.serviceRemove.mockResolvedValue(undefined);
+    mocks.getService.mockResolvedValue({
+      list: mocks.serviceList,
+      duplicate: mocks.serviceDuplicate,
+      remove: mocks.serviceRemove,
+      setSchedule: mocks.serviceSetSchedule,
+    });
+  });
+
+  it('routes to the editable duplicated workflow returned by the API', async () => {
+    const { result } = renderHook(() => useWorkflowLibraryPage());
+    await waitFor(() => expect(result.current.workflows).toHaveLength(1));
+
+    await act(async () => {
+      await result.current.handleDuplicate('wf-1');
+    });
+
+    expect(mocks.serviceDuplicate).toHaveBeenCalledWith('wf-1');
+    expect(mocks.push).toHaveBeenCalledWith('/org/brand/workflows/wf-copy');
+  });
+
+  it('does not delete canonical system workflows from the library', async () => {
+    mocks.serviceList.mockResolvedValueOnce([
+      makeWorkflow({
+        _id: 'system-wf',
+        metadata: {
+          systemWorkflow: {
+            immutable: true,
+            kind: 'system-workflow',
+            owner: 'genfeed',
+          },
+        },
+        name: 'Daily Trends Digest',
+      }),
+    ]);
+
+    const { result } = renderHook(() => useWorkflowLibraryPage());
+    await waitFor(() => expect(result.current.workflows).toHaveLength(1));
+
+    await act(async () => {
+      await result.current.handleDelete('system-wf');
+    });
+
+    expect(mocks.serviceRemove).not.toHaveBeenCalled();
+    expect(result.current.workflows).toHaveLength(1);
+  });
 });

--- a/apps/app/src/features/workflows/pages/library/useWorkflowLibraryPage.ts
+++ b/apps/app/src/features/workflows/pages/library/useWorkflowLibraryPage.ts
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   createWorkflowApiService,
+  isCanonicalSystemWorkflow,
   type WorkflowSummary,
 } from '@/features/workflows/services/workflow-api';
 import { useCloudSession } from '@/hooks/useCloudSession';
@@ -94,6 +95,11 @@ export function useWorkflowLibraryPage() {
 
   const handleDelete = useCallback(
     async (id: string) => {
+      const workflow = workflows.find((w) => w._id === id);
+      if (workflow && isCanonicalSystemWorkflow(workflow)) {
+        return;
+      }
+
       try {
         const service = await getService();
         await service.remove(id);
@@ -105,13 +111,13 @@ export function useWorkflowLibraryPage() {
         });
       }
     },
-    [getService],
+    [getService, workflows],
   );
 
   const handleToggleSchedule = useCallback(
     async (id: string, enabled: boolean) => {
       const previous = workflows.find((w) => w._id === id);
-      if (!previous?.schedule) return;
+      if (!previous?.schedule || isCanonicalSystemWorkflow(previous)) return;
 
       // Optimistic update
       setWorkflows((prev) =>

--- a/apps/app/src/features/workflows/services/workflow-api.test.ts
+++ b/apps/app/src/features/workflows/services/workflow-api.test.ts
@@ -70,7 +70,11 @@ vi.mock('@services/social/brands.service', () => ({
   },
 }));
 
-import { createWorkflowApiService, WorkflowApiService } from './workflow-api';
+import {
+  createWorkflowApiService,
+  isCanonicalSystemWorkflow,
+  WorkflowApiService,
+} from './workflow-api';
 
 function workflow(overrides: Record<string, unknown> = {}) {
   return {
@@ -105,6 +109,13 @@ describe('WorkflowApiService', () => {
             id: 'workflow-1',
             label: 'Launch calendar',
             lifecycle: 'draft',
+            metadata: {
+              systemWorkflow: {
+                immutable: true,
+                kind: 'system-workflow',
+                owner: 'genfeed',
+              },
+            },
             nodeCount: 3,
             updatedAt: '2026-01-02T00:00:00.000Z',
           },
@@ -115,12 +126,44 @@ describe('WorkflowApiService', () => {
     await expect(service().list({ lifecycle: 'draft' })).resolves.toEqual([
       expect.objectContaining({
         _id: 'workflow-1',
+        metadata: {
+          systemWorkflow: {
+            immutable: true,
+            kind: 'system-workflow',
+            owner: 'genfeed',
+          },
+        },
         name: 'Launch calendar',
       }),
     ]);
     expect(mocks.get).toHaveBeenCalledWith('', {
       params: { lifecycle: 'draft' },
     });
+  });
+
+  it('detects canonical immutable system workflow summaries', () => {
+    expect(
+      isCanonicalSystemWorkflow({
+        metadata: {
+          systemWorkflow: {
+            immutable: true,
+            kind: 'system-workflow',
+            owner: 'genfeed',
+          },
+        },
+      }),
+    ).toBe(true);
+
+    expect(
+      isCanonicalSystemWorkflow({
+        metadata: {
+          duplicatedFromSystemWorkflow: {
+            canonicalId: 'daily-trends-digest',
+            sourceWorkflowId: 'system-workflow-1',
+          },
+        },
+      }),
+    ).toBe(false);
   });
 
   it('creates workflows with backend label payloads and normalizes defaults', async () => {

--- a/apps/app/src/features/workflows/services/workflow-api.ts
+++ b/apps/app/src/features/workflows/services/workflow-api.ts
@@ -46,8 +46,14 @@ export interface CloudWorkflowData {
   isScheduleEnabled?: boolean;
   createdBy?: string;
   createdAt: string;
+  metadata?: WorkflowMetadata;
   updatedAt: string;
 }
+
+export type WorkflowMetadata = Record<string, unknown> & {
+  duplicatedFromSystemWorkflow?: Record<string, unknown>;
+  systemWorkflow?: Record<string, unknown>;
+};
 
 /** Lightweight workflow summary for list views */
 export interface WorkflowSummary {
@@ -66,9 +72,23 @@ export interface WorkflowSummary {
     remoteId: string;
     syncDirection: 'push' | 'pull';
   } | null;
+  metadata?: WorkflowMetadata;
   schedule?: string;
   timezone?: string;
   isScheduleEnabled?: boolean;
+}
+
+export function isCanonicalSystemWorkflow(
+  workflow: Pick<WorkflowSummary, 'metadata'>,
+): boolean {
+  const systemWorkflow = workflow.metadata?.systemWorkflow;
+
+  return (
+    Boolean(systemWorkflow) &&
+    systemWorkflow?.kind === 'system-workflow' &&
+    systemWorkflow?.owner === 'genfeed' &&
+    systemWorkflow?.immutable === true
+  );
 }
 
 /** Payload for PATCH /workflows/:id (schedule fields) */


### PR DESCRIPTION
## Summary
- Carry workflow metadata through the app workflow summary contract and detect canonical immutable system workflows.
- Keep canonical system workflow cards duplicable while hiding schedule toggles and delete actions that the API rejects.
- Route duplicated workflows to the editable copy and cover system-workflow action guards with focused tests.

## Validation
- `bunx biome check --write apps/app/src/features/workflows/services/workflow-api.ts apps/app/src/features/workflows/services/workflow-api.test.ts apps/app/src/features/workflows/pages/library/useWorkflowLibraryPage.ts apps/app/src/features/workflows/pages/library/useWorkflowLibraryPage.test.ts apps/app/src/features/workflows/pages/library/WorkflowLibraryPage.tsx apps/app/src/features/workflows/pages/library/WorkflowCardDropdown.tsx apps/app/src/features/workflows/pages/library/WorkflowCardDropdown.test.tsx`
- `bun run --cwd apps/app test src/features/workflows/services/workflow-api.test.ts src/features/workflows/pages/library/useWorkflowLibraryPage.test.ts src/features/workflows/pages/library/WorkflowCardDropdown.test.tsx`
- `bun run --cwd packages/prisma db:generate`
- `bun run --cwd apps/server/api test:file src/collections/workflows/services/workflows.service.spec.ts src/collections/workflows/controllers/workflow-crud.controller.spec.ts`
- `git diff --check`
- `bunx secretlint <staged workflow files>`
- pre-commit lint-staged: Secretlint, Biome, raw HTML guard, bespoke-card guard

## Notes
- The first API spec attempt failed before tests because the generated Prisma client was missing after scripts-disabled install; `bun run --cwd packages/prisma db:generate` fixed the local prerequisite and the same focused specs then passed.
- Broad app/workspace type-check and build are left to PR CI per local verification policy.

Closes #1028
Refs #1011