### PR TITLE
feat(posts): add cross-post composer shell

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/composer/cross-post-composer-page.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/composer/cross-post-composer-page.test.tsx
@@ -1,0 +1,142 @@
+import '@testing-library/jest-dom/vitest';
+import { CredentialPlatform } from '@genfeedai/enums';
+import type { ICredential } from '@genfeedai/interfaces';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import CrossPostComposerPage from './cross-post-composer-page';
+
+const useBrandMock = vi.fn();
+
+vi.mock('@contexts/user/brand-context/brand-context', () => ({
+  useBrand: () => useBrandMock(),
+}));
+
+function credential(
+  overrides: Partial<ICredential> & {
+    id: string;
+    platform: CredentialPlatform;
+  },
+): ICredential {
+  return {
+    accessTokenExpiry: undefined,
+    accountHealth: undefined,
+    brand: 'brand-1',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    description: undefined,
+    externalHandle: overrides.externalHandle ?? overrides.id,
+    externalId: overrides.externalId ?? overrides.id,
+    externalUrl: undefined,
+    id: overrides.id,
+    isConnected: overrides.isConnected ?? true,
+    label: overrides.label,
+    organization: {} as ICredential['organization'],
+    platform: overrides.platform,
+    tags: [],
+    token: '',
+    tokenExpiry: undefined,
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    user: {} as ICredential['user'],
+    ...overrides,
+  };
+}
+
+describe('CrossPostComposerPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useBrandMock.mockReturnValue({ credentials: [] });
+  });
+
+  it('renders an empty channel state without connected credentials', () => {
+    render(<CrossPostComposerPage />);
+
+    expect(
+      screen.getByText('No connected publishing channels available.'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Select at least one channel target to review scheduling readiness.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('preserves per-target caption overrides while switching targets', () => {
+    useBrandMock.mockReturnValue({
+      credentials: [
+        credential({
+          externalHandle: 'launch_x',
+          id: 'cred-x',
+          platform: CredentialPlatform.TWITTER,
+        }),
+        credential({
+          externalHandle: 'company',
+          id: 'cred-linkedin',
+          platform: CredentialPlatform.LINKEDIN,
+        }),
+      ],
+    });
+
+    render(<CrossPostComposerPage />);
+
+    fireEvent.change(screen.getByLabelText('Release title'), {
+      target: { value: 'Launch release' },
+    });
+    fireEvent.change(screen.getByLabelText('Base content'), {
+      target: { value: 'Base launch copy' },
+    });
+    fireEvent.change(screen.getByLabelText('Schedule date'), {
+      target: { value: '2026-07-15T09:30' },
+    });
+
+    fireEvent.click(screen.getByRole('checkbox', { name: /x .*launch_x/i }));
+    fireEvent.click(
+      screen.getByRole('checkbox', { name: /linkedin .*company/i }),
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /edit x .*launch_x/i }));
+    fireEvent.change(screen.getByLabelText('Target caption'), {
+      target: { value: 'X variant copy' },
+    });
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /edit linkedin .*company/i }),
+    );
+    fireEvent.change(screen.getByLabelText('Target caption'), {
+      target: { value: 'LinkedIn variant copy' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /edit x .*launch_x/i }));
+
+    expect(screen.getByLabelText('Target caption')).toHaveValue(
+      'X variant copy',
+    );
+    expect(screen.getByText('2 selected')).toBeInTheDocument();
+  });
+
+  it('shows exact target blocking reasons before submit', () => {
+    useBrandMock.mockReturnValue({
+      credentials: [
+        credential({
+          externalHandle: 'studio',
+          id: 'cred-youtube',
+          platform: CredentialPlatform.YOUTUBE,
+        }),
+      ],
+    });
+
+    render(<CrossPostComposerPage />);
+
+    fireEvent.click(
+      screen.getByRole('checkbox', { name: /youtube .*studio/i }),
+    );
+
+    expect(
+      screen.getByText('Release content is required for YouTube.'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Schedule date is required for YouTube.'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('YouTube requires at least 1 media item(s).'),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/composer/cross-post-composer-page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/composer/cross-post-composer-page.tsx
@@ -1,0 +1,690 @@
+'use client';
+
+import {
+  type ChannelCapability,
+  type ChannelSettingDefinition,
+  type ChannelValidationIssue,
+  getChannelCapability,
+  PRODUCTIZED_SCHEDULER_PLATFORMS,
+  validateChannelTargetSettings,
+} from '@api-types/contracts';
+import { useBrand } from '@contexts/user/brand-context/brand-context';
+import {
+  ButtonSize,
+  ButtonVariant,
+  type CredentialPlatform,
+} from '@genfeedai/enums';
+import type { ICredential } from '@genfeedai/interfaces';
+import Card from '@ui/card/Card';
+import { Badge } from '@ui/primitives/badge';
+import { Button } from '@ui/primitives/button';
+import { Checkbox } from '@ui/primitives/checkbox';
+import { Input } from '@ui/primitives/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@ui/primitives/select';
+import { Textarea } from '@ui/primitives/textarea';
+import { useEffect, useMemo, useState } from 'react';
+
+type ComposerDraft = {
+  baseContent: string;
+  scheduledDate: string;
+  timezone: string;
+  title: string;
+};
+
+type ComposerTarget = {
+  captionOverride: string;
+  credentialId: string;
+  credentialLabel: string;
+  firstComment: string;
+  id: string;
+  isConnected: boolean;
+  platform: CredentialPlatform;
+  platformLabel: string;
+  settings: Record<string, unknown>;
+  signature: string;
+};
+
+type TargetReview = {
+  errors: ChannelValidationIssue[];
+  target: ComposerTarget;
+  valid: boolean;
+  warnings: ChannelValidationIssue[];
+};
+
+type ChannelOption = {
+  capability: ChannelCapability;
+  credentials: ICredential[];
+};
+
+const DEFAULT_TIMEZONE = 'UTC';
+
+function getInitialTimezone(): string {
+  return Intl.DateTimeFormat().resolvedOptions().timeZone || DEFAULT_TIMEZONE;
+}
+
+function getDefaultSettings(
+  capability: ChannelCapability,
+): Record<string, unknown> {
+  return Object.fromEntries(
+    capability.settings
+      .filter((setting) => setting.defaultValue !== undefined)
+      .map((setting) => [setting.key, setting.defaultValue]),
+  );
+}
+
+function getCredentialLabel(credential: ICredential): string {
+  const capability = getChannelCapability(credential.platform);
+  const platformLabel = capability?.label ?? String(credential.platform);
+  const accountLabel =
+    credential.label || credential.externalHandle || credential.externalId;
+
+  return accountLabel ? `${platformLabel} @${accountLabel}` : platformLabel;
+}
+
+function buildTarget(
+  credential: ICredential,
+  capability: ChannelCapability,
+): ComposerTarget {
+  return {
+    captionOverride: '',
+    credentialId: credential.id,
+    credentialLabel: getCredentialLabel(credential),
+    firstComment: '',
+    id: credential.id,
+    isConnected: credential.isConnected,
+    platform: capability.platform,
+    platformLabel: capability.label,
+    settings: getDefaultSettings(capability),
+    signature: '',
+  };
+}
+
+function getChannelOptions(credentials: ICredential[]): ChannelOption[] {
+  return PRODUCTIZED_SCHEDULER_PLATFORMS.map((platform) => {
+    const capability = getChannelCapability(platform);
+
+    if (!capability) {
+      return null;
+    }
+
+    return {
+      capability,
+      credentials: credentials.filter(
+        (credential) => credential.platform === platform,
+      ),
+    };
+  }).filter((option): option is ChannelOption => option !== null);
+}
+
+function createValidationIssue(
+  code: string,
+  message: string,
+  field?: string,
+): ChannelValidationIssue {
+  return {
+    code,
+    field,
+    message,
+    severity: 'error',
+  };
+}
+
+function validateComposerTarget(
+  draft: ComposerDraft,
+  target: ComposerTarget,
+): TargetReview {
+  const caption = target.captionOverride.trim() || draft.baseContent.trim();
+  const validation = validateChannelTargetSettings({
+    caption,
+    credentialId: target.credentialId,
+    media: [],
+    platform: target.platform,
+    publishMode: 'scheduled',
+    settings: target.settings,
+  });
+  const errors = [...validation.errors];
+
+  if (!target.isConnected) {
+    errors.unshift(
+      createValidationIssue(
+        'channel_target.disconnected_credential',
+        `${target.credentialLabel} is disconnected.`,
+        'credentialId',
+      ),
+    );
+  }
+
+  if (!caption) {
+    errors.unshift(
+      createValidationIssue(
+        'release.base_content_required',
+        `Release content is required for ${target.platformLabel}.`,
+        'baseContent',
+      ),
+    );
+  }
+
+  if (!draft.scheduledDate.trim()) {
+    errors.unshift(
+      createValidationIssue(
+        'release.scheduled_date_required',
+        `Schedule date is required for ${target.platformLabel}.`,
+        'scheduledDate',
+      ),
+    );
+  }
+
+  return {
+    errors,
+    target,
+    valid: errors.length === 0,
+    warnings: validation.warnings,
+  };
+}
+
+function formatSettingValue(value: unknown): string {
+  if (Array.isArray(value)) {
+    return value.join(', ');
+  }
+
+  return value === undefined || value === null ? '' : String(value);
+}
+
+function coerceSettingValue(
+  setting: ChannelSettingDefinition,
+  value: string | boolean,
+): unknown {
+  if (setting.type === 'boolean') {
+    return value === true;
+  }
+
+  if (setting.type === 'number') {
+    return value === '' ? undefined : Number(value);
+  }
+
+  if (setting.type === 'multi_select') {
+    return String(value)
+      .split(',')
+      .map((item) => item.trim())
+      .filter(Boolean);
+  }
+
+  return String(value);
+}
+
+function TargetSettingField({
+  onChange,
+  setting,
+  value,
+}: {
+  onChange: (key: string, value: unknown) => void;
+  setting: ChannelSettingDefinition;
+  value: unknown;
+}) {
+  const label = `${setting.label}${setting.required ? ' *' : ''}`;
+
+  if (setting.type === 'boolean') {
+    return (
+      <Checkbox
+        isChecked={value === true}
+        label={label}
+        onCheckedChange={(checked) =>
+          onChange(setting.key, coerceSettingValue(setting, checked === true))
+        }
+      />
+    );
+  }
+
+  if (setting.type === 'select' && setting.options?.length) {
+    return (
+      <div className="grid gap-2 text-sm text-foreground/75">
+        <span>{label}</span>
+        <Select
+          value={formatSettingValue(value)}
+          onValueChange={(nextValue) => onChange(setting.key, nextValue)}
+        >
+          <SelectTrigger aria-label={setting.label}>
+            <SelectValue placeholder={`Choose ${setting.label}`} />
+          </SelectTrigger>
+          <SelectContent>
+            {setting.options.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    );
+  }
+
+  return (
+    <Input
+      label={label}
+      type={setting.type === 'number' ? 'number' : 'text'}
+      value={formatSettingValue(value)}
+      onChange={(event) =>
+        onChange(setting.key, coerceSettingValue(setting, event.target.value))
+      }
+      placeholder={setting.description ?? setting.label}
+    />
+  );
+}
+
+function TargetReviewList({ reviews }: { reviews: TargetReview[] }) {
+  if (reviews.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Select at least one channel target to review scheduling readiness.
+      </p>
+    );
+  }
+
+  return (
+    <div className="grid gap-3">
+      {reviews.map((review) => (
+        <div
+          key={review.target.id}
+          className="rounded-lg border border-border/70 p-4"
+        >
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <p className="truncate text-sm font-medium">
+                {review.target.credentialLabel}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                {review.target.platformLabel}
+              </p>
+            </div>
+            <Badge variant={review.valid ? 'success' : 'warning'}>
+              {review.valid ? 'Ready' : 'Blocked'}
+            </Badge>
+          </div>
+
+          {review.errors.length ? (
+            <ul className="mt-3 grid gap-2 text-sm text-destructive">
+              {review.errors.map((issue) => (
+                <li key={`${review.target.id}-${issue.code}-${issue.field}`}>
+                  {issue.message}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="mt-3 text-sm text-muted-foreground">
+              This target is ready to schedule.
+            </p>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function CrossPostComposerPage() {
+  const { credentials = [] } = useBrand();
+  const channelOptions = useMemo(
+    () => getChannelOptions(credentials),
+    [credentials],
+  );
+  const [draft, setDraft] = useState<ComposerDraft>(() => ({
+    baseContent: '',
+    scheduledDate: '',
+    timezone: getInitialTimezone(),
+    title: '',
+  }));
+  const [targetsById, setTargetsById] = useState<
+    Record<string, ComposerTarget>
+  >({});
+  const selectedTargets = useMemo(
+    () => Object.values(targetsById),
+    [targetsById],
+  );
+  const [activeTargetId, setActiveTargetId] = useState<string | null>(null);
+  const activeTarget =
+    selectedTargets.find((target) => target.id === activeTargetId) ??
+    selectedTargets[0];
+  const reviews = useMemo(
+    () =>
+      selectedTargets.map((target) => validateComposerTarget(draft, target)),
+    [draft, selectedTargets],
+  );
+  const readyCount = reviews.filter((review) => review.valid).length;
+  const blockedCount = reviews.length - readyCount;
+
+  useEffect(() => {
+    if (selectedTargets.length === 0) {
+      setActiveTargetId(null);
+      return;
+    }
+
+    if (
+      !activeTargetId ||
+      !selectedTargets.some((t) => t.id === activeTargetId)
+    ) {
+      setActiveTargetId(selectedTargets[0]?.id ?? null);
+    }
+  }, [activeTargetId, selectedTargets]);
+
+  function updateDraft(key: keyof ComposerDraft, value: string) {
+    setDraft((current) => ({ ...current, [key]: value }));
+  }
+
+  function toggleTarget(
+    credential: ICredential,
+    capability: ChannelCapability,
+    isSelected: boolean,
+  ) {
+    setTargetsById((current) => {
+      if (!isSelected) {
+        const remainingTargets = { ...current };
+        delete remainingTargets[credential.id];
+        return remainingTargets;
+      }
+
+      return {
+        ...current,
+        [credential.id]:
+          current[credential.id] ?? buildTarget(credential, capability),
+      };
+    });
+
+    if (isSelected) {
+      setActiveTargetId(credential.id);
+    }
+  }
+
+  function updateActiveTarget(
+    key: keyof Pick<
+      ComposerTarget,
+      'captionOverride' | 'firstComment' | 'signature'
+    >,
+    value: string,
+  ) {
+    if (!activeTarget) {
+      return;
+    }
+
+    setTargetsById((current) => ({
+      ...current,
+      [activeTarget.id]: {
+        ...activeTarget,
+        [key]: value,
+      },
+    }));
+  }
+
+  function updateActiveTargetSetting(key: string, value: unknown) {
+    if (!activeTarget) {
+      return;
+    }
+
+    setTargetsById((current) => ({
+      ...current,
+      [activeTarget.id]: {
+        ...activeTarget,
+        settings: {
+          ...activeTarget.settings,
+          [key]: value,
+        },
+      },
+    }));
+  }
+
+  return (
+    <section className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_380px]">
+      <div className="grid gap-6">
+        <Card bodyClassName="gap-5 p-6">
+          <div>
+            <h2 className="text-base font-semibold">Release draft</h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Compose once, then tune each selected channel.
+            </p>
+          </div>
+
+          <Input
+            label="Release title"
+            value={draft.title}
+            onChange={(event) => updateDraft('title', event.target.value)}
+            placeholder="Launch announcement"
+          />
+
+          <label
+            className="grid gap-2 text-sm text-foreground/75"
+            htmlFor="cross-post-base-content"
+          >
+            <span>Base content</span>
+            <Textarea
+              id="cross-post-base-content"
+              value={draft.baseContent}
+              onChange={(event) =>
+                updateDraft('baseContent', event.target.value)
+              }
+              placeholder="Write the shared caption or post body."
+              rows={5}
+            />
+          </label>
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <Input
+              label="Schedule date"
+              type="datetime-local"
+              value={draft.scheduledDate}
+              onChange={(event) =>
+                updateDraft('scheduledDate', event.target.value)
+              }
+            />
+            <Input
+              label="Timezone"
+              value={draft.timezone}
+              onChange={(event) => updateDraft('timezone', event.target.value)}
+              placeholder={DEFAULT_TIMEZONE}
+            />
+          </div>
+        </Card>
+
+        <Card bodyClassName="gap-5 p-6">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <h2 className="text-base font-semibold">Channel targets</h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Connected publishing channels can be selected for this release.
+              </p>
+            </div>
+            <Badge variant={selectedTargets.length ? 'info' : 'outline'}>
+              {selectedTargets.length} selected
+            </Badge>
+          </div>
+
+          <div className="grid gap-3">
+            {channelOptions.map(
+              ({ capability, credentials: channelCredentials }) => (
+                <div
+                  key={capability.platform}
+                  className="rounded-lg border border-border/70 p-4"
+                >
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <p className="text-sm font-medium">{capability.label}</p>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        {capability.description}
+                      </p>
+                    </div>
+                    <Badge
+                      variant={
+                        channelCredentials.some(
+                          (credential) => credential.isConnected,
+                        )
+                          ? 'success'
+                          : 'outline'
+                      }
+                    >
+                      {channelCredentials.some(
+                        (credential) => credential.isConnected,
+                      )
+                        ? 'Connected'
+                        : 'Disconnected'}
+                    </Badge>
+                  </div>
+
+                  {channelCredentials.length ? (
+                    <div className="mt-4 grid gap-2">
+                      {channelCredentials.map((credential) => (
+                        <Checkbox
+                          key={credential.id}
+                          isChecked={Boolean(targetsById[credential.id])}
+                          isDisabled={!credential.isConnected}
+                          label={
+                            <span className="flex min-w-0 flex-col">
+                              <span className="truncate text-sm">
+                                {getCredentialLabel(credential)}
+                              </span>
+                              <span className="text-xs text-muted-foreground">
+                                {credential.isConnected
+                                  ? 'Ready for review'
+                                  : 'Reconnect before scheduling'}
+                              </span>
+                            </span>
+                          }
+                          onCheckedChange={(checked) =>
+                            toggleTarget(
+                              credential,
+                              capability,
+                              checked === true,
+                            )
+                          }
+                        />
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="mt-4 text-sm text-muted-foreground">
+                      No connected {capability.label} credential is available.
+                    </p>
+                  )}
+                </div>
+              ),
+            )}
+          </div>
+
+          {credentials.length === 0 ? (
+            <p className="rounded-lg border border-border/70 p-4 text-sm text-muted-foreground">
+              No connected publishing channels available.
+            </p>
+          ) : null}
+        </Card>
+
+        {activeTarget ? (
+          <Card bodyClassName="gap-5 p-6">
+            <div>
+              <h2 className="text-base font-semibold">Target overrides</h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Switch targets without losing channel-specific values.
+              </p>
+            </div>
+
+            <div className="flex flex-wrap gap-2">
+              {selectedTargets.map((target) => (
+                <Button
+                  key={target.id}
+                  label={`Edit ${target.credentialLabel}`}
+                  size={ButtonSize.SM}
+                  variant={
+                    target.id === activeTarget.id
+                      ? ButtonVariant.DEFAULT
+                      : ButtonVariant.OUTLINE
+                  }
+                  onClick={() => setActiveTargetId(target.id)}
+                />
+              ))}
+            </div>
+
+            <label
+              className="grid gap-2 text-sm text-foreground/75"
+              htmlFor="cross-post-target-caption"
+            >
+              <span>Target caption</span>
+              <Textarea
+                id="cross-post-target-caption"
+                value={activeTarget.captionOverride}
+                onChange={(event) =>
+                  updateActiveTarget('captionOverride', event.target.value)
+                }
+                placeholder={
+                  draft.baseContent || 'Override caption for this target'
+                }
+                rows={4}
+              />
+            </label>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <Input
+                label="First comment or thread"
+                value={activeTarget.firstComment}
+                onChange={(event) =>
+                  updateActiveTarget('firstComment', event.target.value)
+                }
+                placeholder="Optional"
+              />
+              <Input
+                label="Signature"
+                value={activeTarget.signature}
+                onChange={(event) =>
+                  updateActiveTarget('signature', event.target.value)
+                }
+                placeholder="Optional"
+              />
+            </div>
+
+            {getChannelCapability(activeTarget.platform)?.settings.length ? (
+              <div className="grid gap-4 md:grid-cols-2">
+                {getChannelCapability(activeTarget.platform)?.settings.map(
+                  (setting) => (
+                    <TargetSettingField
+                      key={setting.key}
+                      setting={setting}
+                      value={activeTarget.settings[setting.key]}
+                      onChange={updateActiveTargetSetting}
+                    />
+                  ),
+                )}
+              </div>
+            ) : null}
+          </Card>
+        ) : null}
+      </div>
+
+      <aside className="grid content-start gap-6">
+        <Card bodyClassName="gap-5 p-6">
+          <div>
+            <h2 className="text-base font-semibold">Review</h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Resolve channel blockers before scheduling.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-3 gap-2 text-center">
+            <div className="rounded-lg border border-border/70 p-3">
+              <p className="text-lg font-semibold">{reviews.length}</p>
+              <p className="text-xs text-muted-foreground">Targets</p>
+            </div>
+            <div className="rounded-lg border border-border/70 p-3">
+              <p className="text-lg font-semibold">{readyCount}</p>
+              <p className="text-xs text-muted-foreground">Ready</p>
+            </div>
+            <div className="rounded-lg border border-border/70 p-3">
+              <p className="text-lg font-semibold">{blockedCount}</p>
+              <p className="text-xs text-muted-foreground">Blocked</p>
+            </div>
+          </div>
+
+          <TargetReviewList reviews={reviews} />
+        </Card>
+      </aside>
+    </section>
+  );
+}

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/composer/page.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/composer/page.test.tsx
@@ -1,0 +1,5 @@
+import { assertSourceHasExport } from '@shared/pages/sourceContractTestUtils';
+
+assertSourceHasExport(
+  'app/(protected)/[orgSlug]/[brandSlug]/posts/composer/page.tsx',
+);

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/composer/page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/composer/page.tsx
@@ -1,0 +1,8 @@
+import { createPageMetadata } from '@helpers/media/metadata/page-metadata.helper';
+import CrossPostComposerPage from './cross-post-composer-page';
+
+export const generateMetadata = createPageMetadata('Cross-Post Composer');
+
+export default function PostsComposerPage() {
+  return <CrossPostComposerPage />;
+}

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/posts-layout-content.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/posts-layout-content.test.tsx
@@ -55,6 +55,10 @@ describe('PostsLayoutContent', () => {
       'href',
       '/acme-org/acme-creator/posts/published?platform=youtube',
     );
+    expect(screen.getByRole('link', { name: /new release/i })).toHaveAttribute(
+      'href',
+      '/acme-org/acme-creator/posts/composer',
+    );
     expect(screen.getByRole('link', { name: /scheduled/i })).toHaveAttribute(
       'data-state',
       'active',

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/posts-layout-content.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/posts-layout-content.tsx
@@ -4,7 +4,7 @@ import {
   PostsLayoutContext,
   type RefreshFunction,
 } from '@contexts/posts/posts-layout-context';
-import { PostStatus } from '@genfeedai/enums';
+import { ButtonSize, ButtonVariant, PostStatus } from '@genfeedai/enums';
 import {
   getPublisherPostsHref,
   getPublisherPostsStatusFromPathname,
@@ -12,6 +12,9 @@ import {
 import { useOrgUrl } from '@hooks/navigation/use-org-url';
 import ButtonRefresh from '@ui/buttons/refresh/button-refresh/ButtonRefresh';
 import Container from '@ui/layout/container/Container';
+import { Button } from '@ui/primitives/button';
+import { Plus } from 'lucide-react';
+import Link from 'next/link';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import type { ReactNode } from 'react';
 import { Suspense, useCallback, useMemo, useReducer } from 'react';
@@ -21,6 +24,7 @@ import { HiOutlineNewspaper } from 'react-icons/hi2';
 const KNOWN_SUB_ROUTES = [
   'analytics',
   'calendar',
+  'composer',
   'newsletters',
   'published',
   'remix',
@@ -249,6 +253,17 @@ function PostsLayoutContentContent({ children }: { children: ReactNode }) {
             {filtersNode}
             {exportNode}
             {scheduleActionsNode}
+            <Button
+              asChild
+              size={ButtonSize.SM}
+              variant={ButtonVariant.DEFAULT}
+              withWrapper={false}
+            >
+              <Link href={href('/posts/composer')}>
+                <Plus className="size-4" />
+                New release
+              </Link>
+            </Button>
             <ButtonRefresh
               onClick={handleRefresh}
               isRefreshing={isRefreshing}


### PR DESCRIPTION
## Summary
- add a brand-scoped `/posts/composer` cross-post composer shell
- let users draft shared release content, select connected channel targets, edit per-target overrides/settings, and review exact validation blockers from the shared channel capability contract
- add a persistent `New release` link in the Posts toolbar and keep `/posts/composer` inside the Posts layout chrome

Closes #1511
Refs #1126

## Validation
- `bunx biome check --write apps/app/app/'(protected)'/'[orgSlug]'/'[brandSlug]'/posts/posts-layout-content.tsx apps/app/app/'(protected)'/'[orgSlug]'/'[brandSlug]'/posts/posts-layout-content.test.tsx apps/app/app/'(protected)'/'[orgSlug]'/'[brandSlug]'/posts/composer/page.tsx apps/app/app/'(protected)'/'[orgSlug]'/'[brandSlug]'/posts/composer/page.test.tsx apps/app/app/'(protected)'/'[orgSlug]'/'[brandSlug]'/posts/composer/cross-post-composer-page.tsx apps/app/app/'(protected)'/'[orgSlug]'/'[brandSlug]'/posts/composer/cross-post-composer-page.test.tsx`
- `bun run --cwd apps/app test app/'(protected)'/'[orgSlug]'/'[brandSlug]'/posts/composer/cross-post-composer-page.test.tsx app/'(protected)'/'[orgSlug]'/'[brandSlug]'/posts/composer/page.test.tsx app/'(protected)'/'[orgSlug]'/'[brandSlug]'/posts/posts-layout-content.test.tsx`
- `git diff --check`
- `git diff --cached --check`
- `bunx secretlint <touched files>`
- pre-commit lint-staged: Secretlint, Biome, raw HTML guard, bespoke-card guard

## Notes
- Full app/workspace type-check, build, and broad suites are left to PR CI per local verification policy.
- This shell intentionally does not execute schedule/publish mutations; that remains in #1127/#1128.
