### PR TITLE
fix(clips): hide unsupported avatar providers

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/page.tsx
@@ -19,19 +19,6 @@ const PROVIDER_OPTIONS: ProviderOption[] = [
     label: 'HeyGen',
     value: 'heygen',
   },
-  { description: 'Coming Soon', disabled: true, label: 'D-ID', value: 'did' },
-  {
-    description: 'Coming Soon',
-    disabled: true,
-    label: 'Tavus',
-    value: 'tavus',
-  },
-  {
-    description: 'Self-hosted, free',
-    disabled: true,
-    label: 'MuseTalk',
-    value: 'musetalk',
-  },
 ];
 
 export default function StudioClipsPage() {

--- a/apps/server/api/openapi/openapi.json
+++ b/apps/server/api/openapi/openapi.json
@@ -1923,10 +1923,7 @@
             "default": "heygen",
             "description": "Avatar video provider to use",
             "enum": [
-              "heygen",
-              "did",
-              "tavus",
-              "musetalk"
+              "heygen"
             ],
             "type": "string"
           },
@@ -6078,10 +6075,7 @@
             "default": "heygen",
             "description": "Avatar video provider to use",
             "enum": [
-              "heygen",
-              "did",
-              "tavus",
-              "musetalk"
+              "heygen"
             ],
             "type": "string"
           },

--- a/apps/server/api/src/collections/clip-projects/clip-projects.controller.spec.ts
+++ b/apps/server/api/src/collections/clip-projects/clip-projects.controller.spec.ts
@@ -1,7 +1,10 @@
 import { ClipProjectsController } from '@api/collections/clip-projects/clip-projects.controller';
 import type { ClipProjectsService } from '@api/collections/clip-projects/clip-projects.service';
 import { CreateClipProjectFromYoutubeDto } from '@api/collections/clip-projects/dto/create-clip-project-from-youtube.dto';
-import type { GenerateClipsDto } from '@api/collections/clip-projects/dto/generate-clips.dto';
+import {
+  type GenerateClipHighlightDto,
+  GenerateClipsDto,
+} from '@api/collections/clip-projects/dto/generate-clips.dto';
 import type { ClipProjectDocument } from '@api/collections/clip-projects/schemas/clip-project.schema';
 import type { ClipGenerationService } from '@api/collections/clip-projects/services/clip-generation.service';
 import type { HighlightRewriteService } from '@api/collections/clip-projects/services/highlight-rewrite.service';
@@ -217,6 +220,73 @@ describe('ClipProjectsController', () => {
       );
 
       expect(messages).toContain('Must be a valid YouTube URL');
+    });
+
+    it.each([
+      'did',
+      'tavus',
+      'musetalk',
+    ] as const)('should reject unsupported avatar provider %s', (avatarProvider) => {
+      const dto = plainToInstance(CreateClipProjectFromYoutubeDto, {
+        avatarId: 'avatar-1',
+        avatarProvider,
+        voiceId: 'voice-1',
+        youtubeUrl: 'https://youtu.be/dQw4w9WgXcQ',
+      });
+
+      const errors = validateSync(dto);
+      const messages = errors.flatMap((error) =>
+        Object.values(error.constraints ?? {}),
+      );
+
+      expect(messages).toContain(
+        'avatarProvider must be one of the following values: heygen',
+      );
+    });
+  });
+
+  describe('GenerateClipsDto validation', () => {
+    const editedHighlights: GenerateClipHighlightDto[] = [
+      {
+        id: 'highlight-1',
+        summary: 'Edited summary',
+        title: 'Edited title',
+      },
+    ];
+
+    it('should accept the production-ready HeyGen avatar provider', () => {
+      const dto = plainToInstance(GenerateClipsDto, {
+        avatarId: 'avatar-1',
+        avatarProvider: 'heygen',
+        editedHighlights,
+        selectedHighlightIds: ['highlight-1'],
+        voiceId: 'voice-1',
+      });
+
+      expect(validateSync(dto)).toEqual([]);
+    });
+
+    it.each([
+      'did',
+      'tavus',
+      'musetalk',
+    ] as const)('should reject unsupported avatar provider %s', (avatarProvider) => {
+      const dto = plainToInstance(GenerateClipsDto, {
+        avatarId: 'avatar-1',
+        avatarProvider,
+        editedHighlights,
+        selectedHighlightIds: ['highlight-1'],
+        voiceId: 'voice-1',
+      });
+
+      const errors = validateSync(dto);
+      const messages = errors.flatMap((error) =>
+        Object.values(error.constraints ?? {}),
+      );
+
+      expect(messages).toContain(
+        'avatarProvider must be one of the following values: heygen',
+      );
     });
   });
 

--- a/apps/server/api/src/collections/clip-projects/dto/create-clip-project-from-youtube.dto.ts
+++ b/apps/server/api/src/collections/clip-projects/dto/create-clip-project-from-youtube.dto.ts
@@ -1,3 +1,7 @@
+import {
+  SUPPORTED_AVATAR_VIDEO_PROVIDER_NAMES,
+  type SupportedAvatarVideoProviderName,
+} from '@genfeedai/queue-contracts';
 import { ApiProperty } from '@nestjs/swagger';
 import {
   IsIn,
@@ -15,8 +19,6 @@ import {
  */
 const YOUTUBE_URL_REGEX =
   /^https?:\/\/(www\.)?(youtube\.com\/(watch\?v=|embed\/|shorts\/)|youtu\.be\/)/;
-
-const AVATAR_PROVIDERS = ['heygen', 'did', 'tavus', 'musetalk'] as const;
 
 export class CreateClipProjectFromYoutubeDto {
   @IsUrl()
@@ -45,14 +47,14 @@ export class CreateClipProjectFromYoutubeDto {
   readonly voiceId!: string;
 
   @IsOptional()
-  @IsIn(AVATAR_PROVIDERS)
+  @IsIn(SUPPORTED_AVATAR_VIDEO_PROVIDER_NAMES)
   @ApiProperty({
     default: 'heygen',
     description: 'Avatar video provider to use',
-    enum: AVATAR_PROVIDERS,
+    enum: SUPPORTED_AVATAR_VIDEO_PROVIDER_NAMES,
     required: false,
   })
-  readonly avatarProvider?: (typeof AVATAR_PROVIDERS)[number];
+  readonly avatarProvider?: SupportedAvatarVideoProviderName;
 
   @IsOptional()
   @IsNumber()

--- a/apps/server/api/src/collections/clip-projects/dto/generate-clips.dto.ts
+++ b/apps/server/api/src/collections/clip-projects/dto/generate-clips.dto.ts
@@ -1,3 +1,7 @@
+import {
+  SUPPORTED_AVATAR_VIDEO_PROVIDER_NAMES,
+  type SupportedAvatarVideoProviderName,
+} from '@genfeedai/queue-contracts';
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import {
@@ -8,8 +12,6 @@ import {
   IsString,
   ValidateNested,
 } from 'class-validator';
-
-const AVATAR_PROVIDERS = ['heygen', 'did', 'tavus', 'musetalk'] as const;
 
 export class GenerateClipHighlightDto {
   @IsString()
@@ -72,12 +74,12 @@ export class GenerateClipsDto {
   readonly voiceId!: string;
 
   @IsOptional()
-  @IsIn(AVATAR_PROVIDERS)
+  @IsIn(SUPPORTED_AVATAR_VIDEO_PROVIDER_NAMES)
   @ApiProperty({
     default: 'heygen',
     description: 'Avatar video provider to use',
-    enum: AVATAR_PROVIDERS,
+    enum: SUPPORTED_AVATAR_VIDEO_PROVIDER_NAMES,
     required: false,
   })
-  readonly avatarProvider?: (typeof AVATAR_PROVIDERS)[number];
+  readonly avatarProvider?: SupportedAvatarVideoProviderName;
 }

--- a/apps/server/api/src/collections/clip-projects/services/clip-generation.service.ts
+++ b/apps/server/api/src/collections/clip-projects/services/clip-generation.service.ts
@@ -3,7 +3,7 @@ import type { CreateClipResultDto } from '@api/collections/clip-results/dto/crea
 import { type ClipResultDocument } from '@api/collections/clip-results/schemas/clip-result.schema';
 import { AvatarVideoService } from '@api/services/avatar-video/avatar-video.service';
 import type { ClipResultMode } from '@genfeedai/interfaces';
-import { AvatarVideoProviderName } from '@genfeedai/queue-contracts';
+import type { SupportedAvatarVideoProviderName } from '@genfeedai/queue-contracts';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
 import { generateClipSrt, type TranscriptSegment } from './clip-srt.util';
@@ -46,7 +46,7 @@ export interface ClipGenerationInput {
   // Avatar-mode inputs (required only when mode === 'avatar').
   avatarId?: string;
   voiceId?: string;
-  provider?: AvatarVideoProviderName;
+  provider?: SupportedAvatarVideoProviderName;
   transcriptText?: string;
 
   // Raw-cut-mode inputs (required only when mode === 'raw-cut').

--- a/apps/server/api/src/queues/clip-factory/clip-factory-queue.service.spec.ts
+++ b/apps/server/api/src/queues/clip-factory/clip-factory-queue.service.spec.ts
@@ -5,6 +5,7 @@ import {
 } from '@genfeedai/queue-contracts';
 import { LoggerService } from '@libs/logger/logger.service';
 import { getQueueToken } from '@nestjs/bullmq';
+import { BadRequestException } from '@nestjs/common';
 import { Test, type TestingModule } from '@nestjs/testing';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -138,7 +139,6 @@ describe('ClipFactoryQueueService', () => {
     it('should pass all job data fields through to queue', async () => {
       const jobData = makeJobData({
         avatarId: 'custom-avatar',
-        avatarProvider: 'heygen' as never,
         voiceId: 'custom-voice',
       });
 
@@ -152,6 +152,20 @@ describe('ClipFactoryQueueService', () => {
         }),
         expect.any(Object),
       );
+    });
+
+    it.each([
+      'did',
+      'tavus',
+      'musetalk',
+    ] as const)('should reject unsupported avatar provider %s before queueing', async (avatarProvider) => {
+      await expect(
+        service.enqueue(
+          makeJobData({ avatarProvider: avatarProvider as never }),
+        ),
+      ).rejects.toBeInstanceOf(BadRequestException);
+
+      expect(queue.add).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/server/api/src/queues/clip-factory/clip-factory-queue.service.ts
+++ b/apps/server/api/src/queues/clip-factory/clip-factory-queue.service.ts
@@ -2,10 +2,12 @@ import {
   CLIP_FACTORY_JOB_NAME,
   CLIP_FACTORY_QUEUE,
   ClipFactoryJobData,
+  isSupportedAvatarVideoProviderName,
+  SUPPORTED_AVATAR_VIDEO_PROVIDER_NAMES,
 } from '@genfeedai/queue-contracts';
 import { LoggerService } from '@libs/logger/logger.service';
 import { InjectQueue } from '@nestjs/bullmq';
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import type { Queue } from 'bullmq';
 
 @Injectable()
@@ -18,6 +20,14 @@ export class ClipFactoryQueueService {
   ) {}
 
   async enqueue(data: ClipFactoryJobData): Promise<string> {
+    if (!isSupportedAvatarVideoProviderName(data.avatarProvider)) {
+      throw new BadRequestException(
+        `Avatar video provider "${data.avatarProvider}" is not available. Supported providers: ${SUPPORTED_AVATAR_VIDEO_PROVIDER_NAMES.join(
+          ', ',
+        )}.`,
+      );
+    }
+
     const job = await this.clipFactoryQueue.add(CLIP_FACTORY_JOB_NAME, data, {
       jobId: `clip-factory-${data.projectId}`,
     });

--- a/apps/server/api/src/services/avatar-video/avatar-video.service.spec.ts
+++ b/apps/server/api/src/services/avatar-video/avatar-video.service.spec.ts
@@ -6,10 +6,13 @@ import { MusetalkAvatarProvider } from '@api/services/avatar-video/providers/mus
 import { TavusAvatarProvider } from '@api/services/avatar-video/providers/tavus-avatar.provider';
 import type { AvatarVideoProviderName } from '@genfeedai/queue-contracts';
 import { LoggerService } from '@libs/logger/logger.service';
+import { BadRequestException } from '@nestjs/common';
 import { Test, type TestingModule } from '@nestjs/testing';
 
 const makeProvider = (): vi.Mocked<AvatarVideoProvider> => ({
-  generate: vi.fn(),
+  generateVideo: vi.fn(),
+  getStatus: vi.fn(),
+  providerName: 'heygen',
 });
 
 describe('AvatarVideoService', () => {
@@ -59,26 +62,28 @@ describe('AvatarVideoService', () => {
       expect(service.getProvider('heygen')).toBe(heygenProvider);
     });
 
-    it('should return did provider when name is did', () => {
-      expect(service.getProvider('did')).toBe(didProvider);
-    });
-
-    it('should return tavus provider when name is tavus', () => {
-      expect(service.getProvider('tavus')).toBe(tavusProvider);
-    });
-
-    it('should return musetalk provider when name is musetalk', () => {
-      expect(service.getProvider('musetalk')).toBe(musetalkProvider);
-    });
-
     it('should default to heygen when no name supplied', () => {
       expect(service.getProvider()).toBe(heygenProvider);
     });
 
-    it('should fallback to heygen for unknown provider name and log a warning', () => {
-      const result = service.getProvider('unknown' as AvatarVideoProviderName);
+    it.each([
+      'did',
+      'tavus',
+      'musetalk',
+    ] as const)('should reject unavailable provider %s', (providerName) => {
+      expect(() => service.getProvider(providerName)).toThrow(
+        BadRequestException,
+      );
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(providerName),
+      );
+    });
 
-      expect(result).toBe(heygenProvider);
+    it('should reject unknown provider names instead of falling back silently', () => {
+      expect(() =>
+        service.getProvider('unknown' as AvatarVideoProviderName),
+      ).toThrow(BadRequestException);
+
       expect(logger.warn).toHaveBeenCalledWith(
         expect.stringContaining('unknown'),
       );
@@ -91,13 +96,9 @@ describe('AvatarVideoService', () => {
   });
 
   describe('getSupportedProviders', () => {
-    it('should return all four provider names', () => {
+    it('should return only production-ready provider names', () => {
       const providers = service.getSupportedProviders();
-      expect(providers).toHaveLength(4);
-      expect(providers).toContain('heygen');
-      expect(providers).toContain('did');
-      expect(providers).toContain('tavus');
-      expect(providers).toContain('musetalk');
+      expect(providers).toEqual(['heygen']);
     });
 
     it('should return an array of strings', () => {

--- a/apps/server/api/src/services/avatar-video/avatar-video.service.ts
+++ b/apps/server/api/src/services/avatar-video/avatar-video.service.ts
@@ -3,9 +3,14 @@ import { DidAvatarProvider } from '@api/services/avatar-video/providers/did-avat
 import { HeygenAvatarProvider } from '@api/services/avatar-video/providers/heygen-avatar.provider';
 import { MusetalkAvatarProvider } from '@api/services/avatar-video/providers/musetalk-avatar.provider';
 import { TavusAvatarProvider } from '@api/services/avatar-video/providers/tavus-avatar.provider';
-import type { AvatarVideoProviderName } from '@genfeedai/queue-contracts';
+import {
+  type AvatarVideoProviderName,
+  isSupportedAvatarVideoProviderName,
+  SUPPORTED_AVATAR_VIDEO_PROVIDER_NAMES,
+  type SupportedAvatarVideoProviderName,
+} from '@genfeedai/queue-contracts';
 import { LoggerService } from '@libs/logger/logger.service';
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 
 /**
  * Factory / router for avatar video generation providers.
@@ -36,6 +41,17 @@ export class AvatarVideoService {
   }
 
   getProvider(name: AvatarVideoProviderName = 'heygen'): AvatarVideoProvider {
+    if (!isSupportedAvatarVideoProviderName(name)) {
+      this.logger.warn(
+        `AvatarVideoService unavailable provider "${name}" requested`,
+      );
+      throw new BadRequestException(
+        `Avatar video provider "${name}" is not available. Supported providers: ${SUPPORTED_AVATAR_VIDEO_PROVIDER_NAMES.join(
+          ', ',
+        )}.`,
+      );
+    }
+
     const provider = this.providers[name];
 
     if (!provider) {
@@ -48,7 +64,7 @@ export class AvatarVideoService {
     return provider;
   }
 
-  getSupportedProviders(): AvatarVideoProviderName[] {
-    return Object.keys(this.providers) as AvatarVideoProviderName[];
+  getSupportedProviders(): SupportedAvatarVideoProviderName[] {
+    return [...SUPPORTED_AVATAR_VIDEO_PROVIDER_NAMES];
   }
 }

--- a/packages/props/studio/clips.props.ts
+++ b/packages/props/studio/clips.props.ts
@@ -6,7 +6,7 @@ import type {
 
 // ─── Shared Types ─────────────────────────────────────────────────
 
-export type AvatarProvider = 'heygen' | 'did' | 'tavus' | 'musetalk';
+export type AvatarProvider = 'heygen';
 
 export type ClipStatus = ClipResultStatus;
 

--- a/packages/queue-contracts/src/job-data/clip-factory-job.interface.ts
+++ b/packages/queue-contracts/src/job-data/clip-factory-job.interface.ts
@@ -4,7 +4,28 @@
  * Isolated queue so the clip-factory workload can be moved to a dedicated
  * worker instance without code changes.
  */
-export type AvatarVideoProviderName = 'heygen' | 'did' | 'tavus' | 'musetalk';
+export const AVATAR_VIDEO_PROVIDER_NAMES = [
+  'heygen',
+  'did',
+  'tavus',
+  'musetalk',
+] as const;
+
+export type AvatarVideoProviderName =
+  (typeof AVATAR_VIDEO_PROVIDER_NAMES)[number];
+
+export const SUPPORTED_AVATAR_VIDEO_PROVIDER_NAMES = ['heygen'] as const;
+
+export type SupportedAvatarVideoProviderName =
+  (typeof SUPPORTED_AVATAR_VIDEO_PROVIDER_NAMES)[number];
+
+export function isSupportedAvatarVideoProviderName(
+  value: string,
+): value is SupportedAvatarVideoProviderName {
+  return SUPPORTED_AVATAR_VIDEO_PROVIDER_NAMES.some(
+    (provider) => provider === value,
+  );
+}
 
 export const CLIP_FACTORY_JOB_NAME = 'clip-factory-run';
 
@@ -16,7 +37,7 @@ export interface ClipFactoryJobData {
   youtubeUrl: string;
   avatarId: string;
   voiceId: string;
-  avatarProvider: AvatarVideoProviderName;
+  avatarProvider: SupportedAvatarVideoProviderName;
   maxClips: number;
   minViralityScore: number;
   language: string;

--- a/packages/queue-contracts/src/queue-names.constant.test.ts
+++ b/packages/queue-contracts/src/queue-names.constant.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import {
+  AVATAR_VIDEO_PROVIDER_NAMES,
+  isSupportedAvatarVideoProviderName,
+  SUPPORTED_AVATAR_VIDEO_PROVIDER_NAMES,
+} from './job-data/clip-factory-job.interface';
+import {
   AGENT_RUN_QUEUE,
   ALL_QUEUE_NAMES,
   ANALYTICS_SOCIAL_QUEUE,
@@ -45,5 +50,25 @@ describe('queue-names.constant', () => {
       expect(typeof name).toBe('string');
       expect(name.length).toBeGreaterThan(0);
     }
+  });
+});
+
+describe('clip avatar provider contracts', () => {
+  it('keeps future provider names known while only advertising implemented providers', () => {
+    expect(AVATAR_VIDEO_PROVIDER_NAMES).toEqual([
+      'heygen',
+      'did',
+      'tavus',
+      'musetalk',
+    ]);
+    expect(SUPPORTED_AVATAR_VIDEO_PROVIDER_NAMES).toEqual(['heygen']);
+  });
+
+  it('recognizes only production-ready avatar providers as supported', () => {
+    expect(isSupportedAvatarVideoProviderName('heygen')).toBe(true);
+    expect(isSupportedAvatarVideoProviderName('did')).toBe(false);
+    expect(isSupportedAvatarVideoProviderName('tavus')).toBe(false);
+    expect(isSupportedAvatarVideoProviderName('musetalk')).toBe(false);
+    expect(isSupportedAvatarVideoProviderName('unknown')).toBe(false);
   });
 });

--- a/packages/tools/src/registry/generated/mcp-tools.generated.ts
+++ b/packages/tools/src/registry/generated/mcp-tools.generated.ts
@@ -10305,10 +10305,7 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
           "default": "heygen",
           "description": "Avatar video provider to use",
           "enum": [
-            "heygen",
-            "did",
-            "tavus",
-            "musetalk"
+            "heygen"
           ],
           "type": "string"
         },
@@ -10489,10 +10486,7 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
           "default": "heygen",
           "description": "Avatar video provider to use",
           "enum": [
-            "heygen",
-            "did",
-            "tavus",
-            "musetalk"
+            "heygen"
           ],
           "type": "string"
         },

--- a/packages/tools/src/registry/source/mcp-only/clips.tools.ts
+++ b/packages/tools/src/registry/source/mcp-only/clips.tools.ts
@@ -73,7 +73,7 @@ export const MCP_CLIP_TOOLS: SourceTool[] = [
         avatarProvider: {
           default: 'heygen',
           description: 'Avatar video provider to use',
-          enum: ['heygen', 'did', 'tavus', 'musetalk'],
+          enum: ['heygen'],
           type: 'string',
         },
         language: {
@@ -164,7 +164,7 @@ export const MCP_CLIP_TOOLS: SourceTool[] = [
         avatarProvider: {
           default: 'heygen',
           description: 'Avatar video provider to use (avatar mode)',
-          enum: ['heygen', 'did', 'tavus', 'musetalk'],
+          enum: ['heygen'],
           type: 'string',
         },
         editedHighlights: {


### PR DESCRIPTION
## Summary
- restrict public clip avatar-provider inputs to the production-ready HeyGen provider
- reject unsupported avatar providers before clip-factory queueing or avatar-provider routing
- remove disabled future provider choices from the clip studio selector and update OpenAPI/MCP contract snapshots

Closes #1516
Refs #230, #1234, #1238

## Validation
- bunx biome check --write <touched files>
- bun run --cwd packages/queue-contracts test src/queue-names.constant.test.ts
- bun run --cwd apps/server/api test:file src/services/avatar-video/avatar-video.service.spec.ts src/queues/clip-factory/clip-factory-queue.service.spec.ts src/collections/clip-projects/clip-projects.controller.spec.ts src/collections/clip-projects/services/clip-generation.service.spec.ts
- bun run --cwd packages/enums build && bun run --cwd packages/queue-contracts type-check
- bun run --cwd packages/tools type-check
- bun run --cwd packages/tools generate:mcp-tools:check
- bun run --cwd apps/server/api openapi:validate
- git diff --check
- touched-file Secretlint and staged pre-commit lint-staged checks

## Not run locally
- API/app/package-wide typecheck or builds; broad validation is left to PR CI per local verification policy.
- OpenAPI re-emit; this worktree lacks a compiled API bundle and emitting without `--skip-build` requires `nest build api`, so CI drift validation should verify the committed snapshot.