### PR TITLE
fix(website): wire workflow feed fetch modes

### DIFF
--- a/apps/website/packages/ui/workflow-builder/nodes/RssInputNode.test.tsx
+++ b/apps/website/packages/ui/workflow-builder/nodes/RssInputNode.test.tsx
@@ -1,0 +1,117 @@
+import '@testing-library/jest-dom/vitest';
+import { WorkflowNodeStatus } from '@genfeedai/enums';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { RssInputNode, type RssInputNodeData } from './RssInputNode';
+
+const defaultData: RssInputNodeData = {
+  feedItems: null,
+  feedTitle: null,
+  feedUrl: 'https://example.com/feed.xml',
+  inputMode: 'url',
+  label: 'RSS input',
+  rawXml: '',
+  selectedItemIndex: 0,
+  status: WorkflowNodeStatus.IDLE,
+};
+
+describe('Website RssInputNode', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('fetches RSS feed items from the core endpoint', async () => {
+    const items = [
+      {
+        description: 'Post description',
+        link: 'https://example.com/post',
+        pubDate: '2026-07-09T00:00:00.000Z',
+        title: 'Post title',
+      },
+    ];
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ feedTitle: 'Example Feed', items }), {
+        status: 200,
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const onUpdate = vi.fn();
+
+    render(<RssInputNode data={defaultData} id="rss-1" onUpdate={onUpdate} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Fetch Feed' }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/v1/core/rss/fetch', {
+        body: JSON.stringify({ url: defaultData.feedUrl, xml: null }),
+        headers: { 'Content-Type': 'application/json' },
+        method: 'POST',
+      });
+      expect(onUpdate).toHaveBeenCalledWith('rss-1', {
+        feedItems: items,
+        feedTitle: 'Example Feed',
+        selectedItemIndex: 0,
+        status: WorkflowNodeStatus.COMPLETE,
+      });
+    });
+  });
+
+  it('parses raw RSS XML through the core endpoint', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ feedTitle: 'XML Feed', items: [] }), {
+        status: 200,
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const onUpdate = vi.fn();
+
+    render(
+      <RssInputNode
+        data={{
+          ...defaultData,
+          feedUrl: '',
+          inputMode: 'text',
+          rawXml: '<rss><channel /></rss>',
+        }}
+        id="rss-1"
+        onUpdate={onUpdate}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Parse Feed' }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/v1/core/rss/fetch', {
+        body: JSON.stringify({
+          url: null,
+          xml: '<rss><channel /></rss>',
+        }),
+        headers: { 'Content-Type': 'application/json' },
+        method: 'POST',
+      });
+    });
+  });
+
+  it('surfaces RSS fetch failures through node error state', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ error: 'Feed unavailable' }), {
+          status: 502,
+        }),
+      ),
+    );
+    const onUpdate = vi.fn();
+
+    render(<RssInputNode data={defaultData} id="rss-1" onUpdate={onUpdate} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Fetch Feed' }));
+
+    await waitFor(() => {
+      expect(onUpdate).toHaveBeenCalledWith('rss-1', {
+        error: 'Feed unavailable',
+        status: WorkflowNodeStatus.ERROR,
+      });
+    });
+  });
+});

--- a/apps/website/packages/ui/workflow-builder/nodes/RssInputNode.tsx
+++ b/apps/website/packages/ui/workflow-builder/nodes/RssInputNode.tsx
@@ -19,7 +19,7 @@ function formatFeedItemDate(pubDate: string): string {
 }
 
 function RssInputNodeComponent({ id, data, onUpdate }: RssInputNodeProps) {
-  const [isFetching, _setIsFetching] = useState(false);
+  const [isFetching, setIsFetching] = useState(false);
 
   const handleModeChange = useCallback(
     (mode: 'url' | 'text') => {
@@ -42,7 +42,6 @@ function RssInputNodeComponent({ id, data, onUpdate }: RssInputNodeProps) {
     [id, onUpdate],
   );
 
-  // TODO: migrate RSS fetching to NestJS backend endpoint
   const handleFetchFeed = useCallback(async () => {
     const url = data.inputMode === 'url' ? data.feedUrl : null;
     const xml = data.inputMode === 'text' ? data.rawXml : null;
@@ -51,11 +50,34 @@ function RssInputNodeComponent({ id, data, onUpdate }: RssInputNodeProps) {
       return;
     }
 
-    onUpdate(id, {
-      error:
-        'RSS feed fetching is not yet available. Please use XML mode instead.',
-      status: WorkflowNodeStatus.ERROR,
-    });
+    setIsFetching(true);
+    try {
+      const response = await fetch('/v1/core/rss/fetch', {
+        body: JSON.stringify({ url, xml }),
+        headers: { 'Content-Type': 'application/json' },
+        method: 'POST',
+      });
+
+      if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.error || 'Failed to fetch feed');
+      }
+
+      const { feedTitle, items } = await response.json();
+      onUpdate(id, {
+        feedItems: items,
+        feedTitle,
+        selectedItemIndex: 0,
+        status: WorkflowNodeStatus.COMPLETE,
+      });
+    } catch (error) {
+      onUpdate(id, {
+        error: error instanceof Error ? error.message : 'Failed to fetch',
+        status: WorkflowNodeStatus.ERROR,
+      });
+    } finally {
+      setIsFetching(false);
+    }
   }, [id, data.feedUrl, data.rawXml, data.inputMode, onUpdate]);
 
   const handlePrevItem = useCallback(() => {

--- a/apps/website/packages/ui/workflow-builder/nodes/TweetInputNode.test.tsx
+++ b/apps/website/packages/ui/workflow-builder/nodes/TweetInputNode.test.tsx
@@ -1,0 +1,78 @@
+import '@testing-library/jest-dom/vitest';
+import { WorkflowNodeStatus } from '@genfeedai/enums';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { TweetInputNode, type TweetInputNodeData } from './TweetInputNode';
+
+const defaultData: TweetInputNodeData = {
+  authorHandle: null,
+  extractedTweet: null,
+  inputMode: 'url',
+  label: 'Tweet input',
+  rawText: '',
+  status: WorkflowNodeStatus.IDLE,
+  tweetUrl: 'https://twitter.com/user/status/123',
+};
+
+describe('Website TweetInputNode', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('fetches tweet text from the core endpoint', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(
+          JSON.stringify({ authorHandle: 'genfeedai', text: 'Launch note' }),
+          { status: 200 },
+        ),
+      );
+    vi.stubGlobal('fetch', fetchMock);
+    const onUpdate = vi.fn();
+
+    render(
+      <TweetInputNode data={defaultData} id="tweet-1" onUpdate={onUpdate} />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Fetch Tweet' }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith('/v1/core/tweet/fetch', {
+        body: JSON.stringify({ url: defaultData.tweetUrl }),
+        headers: { 'Content-Type': 'application/json' },
+        method: 'POST',
+      });
+      expect(onUpdate).toHaveBeenCalledWith('tweet-1', {
+        authorHandle: 'genfeedai',
+        extractedTweet: 'Launch note',
+        status: WorkflowNodeStatus.COMPLETE,
+      });
+    });
+  });
+
+  it('surfaces tweet fetch failures through node error state', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ error: 'Tweet unavailable' }), {
+          status: 502,
+        }),
+      ),
+    );
+    const onUpdate = vi.fn();
+
+    render(
+      <TweetInputNode data={defaultData} id="tweet-1" onUpdate={onUpdate} />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Fetch Tweet' }));
+
+    await waitFor(() => {
+      expect(onUpdate).toHaveBeenCalledWith('tweet-1', {
+        error: 'Tweet unavailable',
+        status: WorkflowNodeStatus.ERROR,
+      });
+    });
+  });
+});

--- a/apps/website/packages/ui/workflow-builder/nodes/TweetInputNode.tsx
+++ b/apps/website/packages/ui/workflow-builder/nodes/TweetInputNode.tsx
@@ -14,7 +14,7 @@ import { memo, useCallback, useState } from 'react';
 export type { TweetInputNodeData, TweetInputNodeProps };
 
 function TweetInputNodeComponent({ id, data, onUpdate }: TweetInputNodeProps) {
-  const [isFetching, _setIsFetching] = useState(false);
+  const [isFetching, setIsFetching] = useState(false);
 
   const handleModeChange = useCallback(
     (mode: 'url' | 'text') => {
@@ -40,17 +40,38 @@ function TweetInputNodeComponent({ id, data, onUpdate }: TweetInputNodeProps) {
     [id, onUpdate],
   );
 
-  // TODO: migrate tweet fetching to NestJS backend endpoint
   const handleFetchTweet = useCallback(async () => {
     if (!data.tweetUrl) {
       return;
     }
 
-    onUpdate(id, {
-      error:
-        'Tweet fetching is not yet available. Please use text mode instead.',
-      status: WorkflowNodeStatus.ERROR,
-    });
+    setIsFetching(true);
+    try {
+      const response = await fetch('/v1/core/tweet/fetch', {
+        body: JSON.stringify({ url: data.tweetUrl }),
+        headers: { 'Content-Type': 'application/json' },
+        method: 'POST',
+      });
+
+      if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.error || 'Failed to fetch tweet');
+      }
+
+      const { text, authorHandle } = await response.json();
+      onUpdate(id, {
+        authorHandle,
+        extractedTweet: text,
+        status: WorkflowNodeStatus.COMPLETE,
+      });
+    } catch (error) {
+      onUpdate(id, {
+        error: error instanceof Error ? error.message : 'Failed to fetch',
+        status: WorkflowNodeStatus.ERROR,
+      });
+    } finally {
+      setIsFetching(false);
+    }
   }, [id, data.tweetUrl, onUpdate]);
 
   return (


### PR DESCRIPTION
## Summary
- Wire the website-local Tweet workflow node to POST to /v1/core/tweet/fetch instead of forcing the unavailable error state.
- Wire the website-local RSS workflow node to POST URL/XML payloads to /v1/core/rss/fetch and populate feed preview state.
- Add focused website component tests for Tweet/RSS success and error paths.

## Validation
- bun install --frozen-lockfile --ignore-scripts
- bunx biome check --write apps/website/packages/ui/workflow-builder/nodes/TweetInputNode.tsx apps/website/packages/ui/workflow-builder/nodes/RssInputNode.tsx apps/website/packages/ui/workflow-builder/nodes/TweetInputNode.test.tsx apps/website/packages/ui/workflow-builder/nodes/RssInputNode.test.tsx
- bun run --cwd apps/website test packages/ui/workflow-builder/nodes/TweetInputNode.test.tsx packages/ui/workflow-builder/nodes/RssInputNode.test.tsx
- git diff --check
- git diff --check origin/master..HEAD
- bunx secretlint apps/website/packages/ui/workflow-builder/nodes/TweetInputNode.tsx apps/website/packages/ui/workflow-builder/nodes/RssInputNode.tsx apps/website/packages/ui/workflow-builder/nodes/TweetInputNode.test.tsx apps/website/packages/ui/workflow-builder/nodes/RssInputNode.test.tsx
- pre-commit lint-staged: Secretlint, Biome, raw HTML guard, bespoke-card guard

Closes #1520
Refs #1131