### PR TITLE
feat(studio): add one-click YouTube clip flow

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/ClipsInputForm.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/ClipsInputForm.test.tsx
@@ -1,0 +1,66 @@
+import '@testing-library/jest-dom/vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ComponentProps } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import ClipsInputForm from './ClipsInputForm';
+
+function renderForm(
+  overrides: Partial<ComponentProps<typeof ClipsInputForm>> = {},
+) {
+  const props = {
+    error: null,
+    isSubmitting: false,
+    maxClips: 10,
+    minViralityScore: 50,
+    onAnalyze: vi.fn(),
+    onSetMaxClips: vi.fn(),
+    onSetMinViralityScore: vi.fn(),
+    onSetYoutubeUrl: vi.fn(),
+    onStartQuick: vi.fn(),
+    quickStartHint: 'Uses saved brand avatar and voice defaults.',
+    youtubeUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+    ...overrides,
+  };
+
+  return {
+    props,
+    ...render(<ClipsInputForm {...props} />),
+  };
+}
+
+describe('ClipsInputForm', () => {
+  it('starts the one-click clip factory from the primary action', () => {
+    const { props } = renderForm();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /start clip factory/i }),
+    );
+
+    expect(props.onStartQuick).toHaveBeenCalledTimes(1);
+    expect(props.onAnalyze).not.toHaveBeenCalled();
+  });
+
+  it('keeps the highlight review path available as a secondary action', () => {
+    const { props } = renderForm();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /review highlights first/i }),
+    );
+
+    expect(props.onAnalyze).toHaveBeenCalledTimes(1);
+    expect(props.onStartQuick).not.toHaveBeenCalled();
+  });
+
+  it('shows the saved-defaults readiness hint', () => {
+    renderForm({
+      quickStartHint:
+        'No saved HeyGen defaults. Review highlights first to enter IDs manually.',
+    });
+
+    expect(
+      screen.getByText(
+        'No saved HeyGen defaults. Review highlights first to enter IDs manually.',
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/ClipsInputForm.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/ClipsInputForm.tsx
@@ -12,9 +12,11 @@ interface ClipsInputFormProps {
   maxClips: number;
   minViralityScore: number;
   onAnalyze: () => void;
+  onStartQuick: () => void;
   onSetMaxClips: (value: number) => void;
   onSetMinViralityScore: (value: number) => void;
   onSetYoutubeUrl: (value: string) => void;
+  quickStartHint: string;
   youtubeUrl: string;
 }
 
@@ -24,9 +26,11 @@ export default function ClipsInputForm({
   maxClips,
   minViralityScore,
   onAnalyze,
+  onStartQuick,
   onSetMaxClips,
   onSetMinViralityScore,
   onSetYoutubeUrl,
+  quickStartHint,
   youtubeUrl,
 }: ClipsInputFormProps) {
   return (
@@ -121,22 +125,35 @@ export default function ClipsInputForm({
           </div>
         )}
 
-        {/* Submit */}
-        <Button
-          variant={ButtonVariant.UNSTYLED}
-          onClick={onAnalyze}
-          isDisabled={isSubmitting || !youtubeUrl}
-          isLoading={isSubmitting}
-          className="flex w-full items-center justify-center gap-2 rounded-lg bg-primary px-4 py-3 text-sm font-medium text-white transition-colors hover:bg-primary disabled:cursor-not-allowed disabled:opacity-50"
-          icon={
-            isSubmitting ? (
-              <Spinner size={ComponentSize.SM} className="text-white" />
-            ) : (
-              <HiOutlineMagnifyingGlass className="size-4" />
-            )
-          }
-          label={isSubmitting ? 'Analyzing…' : 'Analyze Video'}
-        />
+        <div className="space-y-3">
+          <Button
+            variant={ButtonVariant.UNSTYLED}
+            onClick={onStartQuick}
+            isDisabled={isSubmitting || !youtubeUrl}
+            isLoading={isSubmitting}
+            className="flex w-full items-center justify-center gap-2 rounded-lg bg-primary px-4 py-3 text-sm font-medium text-white transition-colors hover:bg-primary disabled:cursor-not-allowed disabled:opacity-50"
+            icon={
+              isSubmitting ? (
+                <Spinner size={ComponentSize.SM} className="text-white" />
+              ) : (
+                <HiOutlineSparkles className="size-4" />
+              )
+            }
+            label={isSubmitting ? 'Starting…' : 'Start Clip Factory'}
+          />
+
+          <div className="flex flex-col items-center gap-2 sm:flex-row sm:justify-between">
+            <p className="text-xs text-zinc-500">{quickStartHint}</p>
+            <Button
+              variant={ButtonVariant.LINK}
+              onClick={onAnalyze}
+              isDisabled={isSubmitting || !youtubeUrl}
+              className="text-xs text-zinc-500 hover:text-zinc-300"
+              icon={<HiOutlineMagnifyingGlass className="size-3.5" />}
+              label="Review highlights first"
+            />
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/ClipsProgressView.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/ClipsProgressView.tsx
@@ -21,6 +21,11 @@ export default function ClipsProgressView({
   project,
   selectedCount,
 }: ClipsProgressViewProps) {
+  const pendingDescription =
+    selectedCount > 0
+      ? `Generating ${selectedCount} clips...`
+      : 'Processing YouTube video and generating clips...';
+
   return (
     <div className="mx-auto max-w-6xl px-6 py-10">
       <div className="mb-8">
@@ -35,7 +40,7 @@ export default function ClipsProgressView({
             ? `Done -- ${project.clips.length} clips generated`
             : project.status === 'failed'
               ? 'Pipeline failed. Check logs for details.'
-              : `Generating ${selectedCount} clips...`}
+              : pendingDescription}
         </p>
 
         {project.status !== 'completed' && project.status !== 'failed' && (
@@ -66,7 +71,7 @@ export default function ClipsProgressView({
           <div className="flex flex-col items-center justify-center rounded-xl bg-secondary py-20 shadow-border">
             <Spinner size={ComponentSize.LG} className="mb-4 text-primary" />
             <p className="text-sm text-zinc-500">
-              Generating avatar clips for selected highlights…
+              Processing YouTube video and generating avatar clips…
             </p>
           </div>
         )

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/page.tsx
@@ -43,6 +43,7 @@ export default function StudioClipsPage() {
     error,
     handleAnalyze,
     handleGenerate,
+    handleStartFromYoutube,
     identityDefaults,
     isSubmitting,
     maxClips,
@@ -72,7 +73,7 @@ export default function StudioClipsPage() {
     return (
       <ClipsProgressView
         project={project}
-        selectedCount={selectedCount}
+        selectedCount={project.estimatedClips ?? selectedCount}
         clipsService={clipsService}
         onReset={resetToInput}
       />
@@ -281,6 +282,14 @@ export default function StudioClipsPage() {
       error={error}
       isSubmitting={isSubmitting}
       onAnalyze={handleAnalyze}
+      onStartQuick={handleStartFromYoutube}
+      quickStartHint={
+        identityDefaults.isComplete
+          ? identityDefaults.source === 'brand'
+            ? 'Uses saved brand avatar and voice defaults.'
+            : 'Uses saved organization voice default.'
+          : 'No saved HeyGen defaults. Review highlights first to enter IDs manually.'
+      }
     />
   );
 }

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/services/clips-api.service.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/services/clips-api.service.test.tsx
@@ -1,5 +1,80 @@
 import { assertSourceHasExport } from '@shared/pages/sourceContractTestUtils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@services/core/environment.service', () => ({
+  EnvironmentService: {
+    apiEndpoint: 'https://api.test/v1',
+  },
+}));
+
+import { ClipsApiService } from './clips-api.service';
 
 assertSourceHasExport(
   'app/(protected)/[orgSlug]/[brandSlug]/studio/clips/services/clips-api.service.ts',
 );
+
+describe('ClipsApiService', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          batchJobId: 'clip-factory-job-1',
+          estimatedClips: 4,
+          projectId: 'clip-project-1',
+          status: 'processing',
+        }),
+        { status: 202 },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('starts the one-click YouTube clip factory path', async () => {
+    const getToken = vi.fn().mockResolvedValue('token-1');
+    const service = new ClipsApiService(getToken);
+
+    await expect(
+      service.createFromYoutube({
+        avatarId: 'avatar-1',
+        avatarProvider: 'heygen',
+        language: 'en',
+        maxClips: 4,
+        minViralityScore: 60,
+        voiceId: 'voice-1',
+        youtubeUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+      }),
+    ).resolves.toEqual({
+      batchJobId: 'clip-factory-job-1',
+      estimatedClips: 4,
+      projectId: 'clip-project-1',
+      status: 'processing',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.test/v1/clip-projects/from-youtube',
+      expect.objectContaining({
+        body: JSON.stringify({
+          avatarId: 'avatar-1',
+          avatarProvider: 'heygen',
+          language: 'en',
+          maxClips: 4,
+          minViralityScore: 60,
+          voiceId: 'voice-1',
+          youtubeUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+        }),
+        headers: {
+          Authorization: 'Bearer token-1',
+          'Content-Type': 'application/json',
+        },
+        method: 'POST',
+      }),
+    );
+  });
+});

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/services/clips-api.service.ts
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/services/clips-api.service.ts
@@ -31,6 +31,23 @@ interface GenerateClipsPayload {
   avatarProvider: string;
 }
 
+interface CreateFromYoutubePayload {
+  avatarId: string;
+  avatarProvider: string;
+  language: string;
+  maxClips: number;
+  minViralityScore: number;
+  voiceId: string;
+  youtubeUrl: string;
+}
+
+interface CreateFromYoutubeResponse {
+  batchJobId: string;
+  estimatedClips: number;
+  projectId: string;
+  status: string;
+}
+
 interface ProjectResponse {
   status?: string;
 }
@@ -194,6 +211,18 @@ export class ClipsApiService {
   ): Promise<void> {
     await this.fetchJson(
       `${this.apiEndpoint}/clip-projects/${projectId}/generate`,
+      {
+        body: JSON.stringify(payload),
+        method: 'POST',
+      },
+    );
+  }
+
+  async createFromYoutube(
+    payload: CreateFromYoutubePayload,
+  ): Promise<CreateFromYoutubeResponse> {
+    return this.fetchJson<CreateFromYoutubeResponse>(
+      `${this.apiEndpoint}/clip-projects/from-youtube`,
       {
         body: JSON.stringify(payload),
         method: 'POST',

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/useStudioClipsPage.ts
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/useStudioClipsPage.ts
@@ -195,6 +195,74 @@ export function useStudioClipsPage() {
     }
   }, [youtubeUrl, maxClips, minViralityScore, clipsService]);
 
+  // ─── Step 1: One-click YouTube clip factory ───────────────────
+  const handleStartFromYoutube = useCallback(async () => {
+    if (!youtubeUrl) {
+      setError('YouTube URL is required.');
+      return;
+    }
+
+    const quickAvatarId = avatarId || identityDefaults.avatarId;
+    const quickVoiceId = voiceId || identityDefaults.voiceId;
+
+    if (!quickAvatarId || !quickVoiceId) {
+      setError(
+        'Saved HeyGen avatar and voice defaults are required for one-click generation. Review highlights first to enter IDs manually.',
+      );
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+    clipCompletionReportedRef.current = null;
+    captureAnalyticsEvent(ANALYTICS_EVENTS.GENERATION_STARTED, {
+      generationType: GenerationType.CLIP,
+    });
+
+    try {
+      const data = await clipsService.createFromYoutube({
+        avatarId: quickAvatarId,
+        avatarProvider,
+        language: 'en',
+        maxClips,
+        minViralityScore,
+        voiceId: quickVoiceId,
+        youtubeUrl,
+      });
+
+      setAvatarId(quickAvatarId);
+      setVoiceId(quickVoiceId);
+      setProject({
+        clips: [],
+        estimatedClips: data.estimatedClips,
+        highlights: [],
+        projectId: data.projectId,
+        status: data.status ?? 'processing',
+      });
+      setSelectedIds(new Set());
+      setEditedHighlights([]);
+      setStep('progress');
+    } catch (err: unknown) {
+      captureAnalyticsEvent(ANALYTICS_EVENTS.GENERATION_COMPLETED, {
+        generationType: GenerationType.CLIP,
+        outcome: 'failure',
+      });
+      setError(err instanceof Error ? err.message : 'Something went wrong');
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [
+    youtubeUrl,
+    avatarId,
+    voiceId,
+    identityDefaults.avatarId,
+    identityDefaults.voiceId,
+    avatarProvider,
+    maxClips,
+    minViralityScore,
+    clipsService,
+  ]);
+
   // ─── Poll for analysis completion ─────────────────────────────
   useEffect(() => {
     if (step !== 'review' || !project?.projectId) return;
@@ -458,6 +526,7 @@ export function useStudioClipsPage() {
     error,
     handleAnalyze,
     handleGenerate,
+    handleStartFromYoutube,
     identityDefaults,
     isSubmitting,
     maxClips,

--- a/packages/props/studio/clips.props.ts
+++ b/packages/props/studio/clips.props.ts
@@ -59,6 +59,7 @@ export interface ProjectState {
   status: string;
   highlights: IHighlight[];
   clips: ClipResult[];
+  estimatedClips?: number;
 }
 
 // ─── Component Props ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add a primary Studio Clips quick-start action that posts YouTube URLs directly to `POST /clip-projects/from-youtube` using saved HeyGen avatar/voice defaults.
- Keep the analyze/review flow available as the secondary advanced path for manual highlight and ID review.
- Show progress copy for direct clip-factory jobs before clip rows exist, including an estimated clip count when returned by the API.

Closes #231
Refs #230

## Validation
- `bunx biome check --write apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/ClipsInputForm.tsx apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/ClipsInputForm.test.tsx apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/ClipsProgressView.tsx apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/page.tsx apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/services/clips-api.service.test.tsx apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/services/clips-api.service.ts apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/useStudioClipsPage.ts packages/props/studio/clips.props.ts`
- `git diff --check`
- Commit hook: staged `biome check --write`, `bun scripts/run-secretlint.ts --no-glob`, `bash scripts/lint-no-raw-html.sh`, `bash scripts/lint-no-bespoke-card.sh`

## CI Handoff
- Focused Vitest command was attempted but local execution could not start because this worktree is missing the local `vitest` package/bin needed by `apps/app/vitest.config.mts`; PR CI should run the app test job with installed dependencies.
- Broad `bun type-check` / full design-system checks were not run locally per automation policy against heavy local suites.