### PR TITLE
fix(trends): split paid creative seed corpus

### DIFF
--- a/apps/server/api/src/collections/trends/data/prelaunch-reference-corpus.seed.spec.ts
+++ b/apps/server/api/src/collections/trends/data/prelaunch-reference-corpus.seed.spec.ts
@@ -1,14 +1,18 @@
 import { buildPrelaunchReferenceCorpusSeeds } from '@api/collections/trends/data/prelaunch-reference-corpus.seed';
 
 describe('prelaunch reference corpus seed', () => {
-  it('classifies every source preview as a public platform reference', () => {
+  it('classifies organic source previews as public platform references', () => {
     const seeds = buildPrelaunchReferenceCorpusSeeds(
       new Date('2026-06-09T00:00:00.000Z'),
     );
+    const organicSeeds = seeds.filter(
+      (seed) => seed.metadata.launchCorpusSlice === 'organic-reference',
+    );
 
     expect(seeds).toHaveLength(70);
+    expect(organicSeeds).toHaveLength(63);
     expect(
-      seeds.every(
+      organicSeeds.every(
         (seed) =>
           seed.metadata.sourceClassification.sourceKind ===
             'public_platform_reference' &&
@@ -17,8 +21,8 @@ describe('prelaunch reference corpus seed', () => {
       ),
     ).toBe(true);
 
-    const sourceItems = seeds.flatMap((seed) => seed.sourcePreview);
-    expect(sourceItems).toHaveLength(140);
+    const sourceItems = organicSeeds.flatMap((seed) => seed.sourcePreview);
+    expect(sourceItems).toHaveLength(126);
     expect(
       sourceItems.every(
         (item) =>
@@ -32,15 +36,64 @@ describe('prelaunch reference corpus seed', () => {
           typeof item.sourceClassification.sourceTopic === 'string',
       ),
     ).toBe(true);
+    expect(
+      organicSeeds.find((seed) => seed.platform === 'tiktok')?.metadata
+        .sourceClassification.freshnessWindowDays,
+    ).toBe(2);
+    expect(
+      organicSeeds.find((seed) => seed.platform === 'pinterest')?.metadata
+        .sourceClassification.freshnessWindowDays,
+    ).toBe(30);
   });
 
-  it('keeps LinkedIn in the same public-reference path as other platforms', () => {
+  it('keeps paid creative corpus references out of organic classification', () => {
     const seeds = buildPrelaunchReferenceCorpusSeeds(
       new Date('2026-06-09T00:00:00.000Z'),
     );
-    const linkedInSeeds = seeds.filter((seed) => seed.platform === 'linkedin');
+    const paidCreativeSeeds = seeds.filter(
+      (seed) => seed.metadata.launchCorpusSlice === 'paid-creative-reference',
+    );
 
-    expect(linkedInSeeds).toHaveLength(10);
+    expect(paidCreativeSeeds).toHaveLength(7);
+    expect(
+      paidCreativeSeeds.every(
+        (seed) =>
+          seed.metadata.sourceClassification.sourceKind ===
+            'paid_creative_reference' &&
+          seed.metadata.sourceClassification.intendedUse ===
+            'paid_creative_analysis' &&
+          seed.metadata.sourceClassification.freshnessWindowDays === 14 &&
+          seed.metadata.sourceClassification.paidCreative?.provider ===
+            'manual_paid_reference',
+      ),
+    ).toBe(true);
+
+    const sourceItems = paidCreativeSeeds.flatMap((seed) => seed.sourcePreview);
+    expect(sourceItems).toHaveLength(14);
+    expect(
+      sourceItems.every(
+        (item) =>
+          item.sourceClassification?.sourceKind === 'paid_creative_reference' &&
+          item.sourceClassification.intendedUse === 'paid_creative_analysis' &&
+          item.sourceClassification.platform === item.platform &&
+          item.sourceClassification.paidCreative?.provider ===
+            'manual_paid_reference' &&
+          typeof item.sourceClassification.sourceAuthor === 'string',
+      ),
+    ).toBe(true);
+  });
+
+  it('keeps organic LinkedIn seeds in the public-reference path', () => {
+    const seeds = buildPrelaunchReferenceCorpusSeeds(
+      new Date('2026-06-09T00:00:00.000Z'),
+    );
+    const linkedInSeeds = seeds.filter(
+      (seed) =>
+        seed.platform === 'linkedin' &&
+        seed.metadata.launchCorpusSlice === 'organic-reference',
+    );
+
+    expect(linkedInSeeds).toHaveLength(9);
     expect(
       linkedInSeeds.every((seed) =>
         seed.sourcePreview.every(

--- a/apps/server/api/src/collections/trends/data/prelaunch-reference-corpus.seed.ts
+++ b/apps/server/api/src/collections/trends/data/prelaunch-reference-corpus.seed.ts
@@ -2,7 +2,10 @@ import type {
   TrendSourceClassification,
   TrendSourceItem,
 } from '@api/collections/trends/interfaces/trend.interfaces';
-import { buildPublicPlatformReferenceClassification } from '@api/collections/trends/utils/trend-source-classification.util';
+import {
+  buildPublicPlatformReferenceClassification,
+  normalizeTrendSourceClassification,
+} from '@api/collections/trends/utils/trend-source-classification.util';
 
 export interface PrelaunchReferenceCorpusSeed {
   growthRate: number;
@@ -118,6 +121,8 @@ const THEMES: CorpusTheme[] = [
   },
 ];
 
+const PAID_CREATIVE_THEME_KEY = 'paid-creative-breakdowns';
+
 const PLATFORMS: CorpusPlatform[] = [
   {
     accountPrefix: 'tiktok',
@@ -199,17 +204,23 @@ export function buildPrelaunchReferenceCorpusSeeds(
       const publishedAt = new Date(
         capturedAt.getTime() - (themeIndex + platformIndex + 1) * 86_400_000,
       ).toISOString();
-      const sourceClassification = buildPublicPlatformReferenceClassification({
+      const confidence = themeIndex < 4 ? 'medium' : 'low';
+      const sourceClassification = buildPrelaunchSourceClassification({
         capturedAt,
-        confidence: themeIndex < 4 ? 'medium' : 'low',
+        confidence,
         freshnessWindowDays: platform.freshnessWindowDays,
         platform: platform.key,
+        platformContentType: platform.contentType,
         sourceLabel: platform.label,
         sourceTimestamp: capturedAt,
+        theme,
         sourceTopic: theme.title,
       });
       const primaryAuthor = `${platform.accountPrefix}-${theme.key}`;
       const secondaryAuthor = `${platform.accountPrefix}-reference-${themeIndex + 1}`;
+      const launchCorpusSlice = isPaidCreativeTheme(theme)
+        ? 'paid-creative-reference'
+        : 'organic-reference';
 
       return {
         growthRate: 35 + themeIndex * 3 + platformIndex,
@@ -218,7 +229,7 @@ export function buildPrelaunchReferenceCorpusSeeds(
         metadata: {
           angle: theme.angle,
           hashtags: [`#${theme.hashtag}`, `#${theme.key.replace(/-/g, '')}`],
-          launchCorpusSlice: 'organic-reference',
+          launchCorpusSlice,
           sourceClassification,
         },
         platform: platform.key,
@@ -235,14 +246,16 @@ export function buildPrelaunchReferenceCorpusSeeds(
             },
             platform: platform.key,
             publishedAt,
-            sourceClassification: buildPublicPlatformReferenceClassification({
+            sourceClassification: buildPrelaunchSourceClassification({
               capturedAt,
-              confidence: themeIndex < 4 ? 'medium' : 'low',
+              confidence,
               freshnessWindowDays: platform.freshnessWindowDays,
               platform: platform.key,
+              platformContentType: platform.contentType,
               sourceAuthor: primaryAuthor,
               sourceLabel: platform.label,
               sourceTimestamp: publishedAt,
+              theme,
               sourceTopic: theme.title,
             }),
             sourceUrl: platform.sourcePath(theme),
@@ -261,14 +274,16 @@ export function buildPrelaunchReferenceCorpusSeeds(
             },
             platform: platform.key,
             publishedAt,
-            sourceClassification: buildPublicPlatformReferenceClassification({
+            sourceClassification: buildPrelaunchSourceClassification({
               capturedAt,
-              confidence: themeIndex < 4 ? 'medium' : 'low',
+              confidence,
               freshnessWindowDays: platform.freshnessWindowDays,
               platform: platform.key,
+              platformContentType: platform.contentType,
               sourceAuthor: secondaryAuthor,
               sourceLabel: platform.label,
               sourceTimestamp: publishedAt,
+              theme,
               sourceTopic: theme.title,
             }),
             sourceUrl: platform.sourcePathAlt(theme),
@@ -281,4 +296,66 @@ export function buildPrelaunchReferenceCorpusSeeds(
       };
     }),
   );
+}
+
+function buildPrelaunchSourceClassification(input: {
+  capturedAt: Date;
+  confidence: TrendSourceClassification['confidence'];
+  freshnessWindowDays: number;
+  platform: string;
+  platformContentType: TrendSourceItem['contentType'];
+  sourceAuthor?: string;
+  sourceLabel: string;
+  sourceTimestamp: Date | string;
+  sourceTopic: string;
+  theme: CorpusTheme;
+}): TrendSourceClassification {
+  if (!isPaidCreativeTheme(input.theme)) {
+    return buildPublicPlatformReferenceClassification({
+      capturedAt: input.capturedAt,
+      confidence: input.confidence,
+      freshnessWindowDays: input.freshnessWindowDays,
+      platform: input.platform,
+      sourceAuthor: input.sourceAuthor,
+      sourceLabel: input.sourceLabel,
+      sourceTimestamp: input.sourceTimestamp,
+      sourceTopic: input.sourceTopic,
+    });
+  }
+
+  const normalized = normalizeTrendSourceClassification({
+    capturedAt: input.capturedAt,
+    confidence: input.confidence,
+    intendedUse: 'paid_creative_analysis',
+    platform: input.platform,
+    sourceAuthor: input.sourceAuthor,
+    sourceKind: 'paid_creative_reference',
+    sourceLabel: input.sourceLabel,
+    sourceTimestamp: input.sourceTimestamp,
+    sourceTopic: input.sourceTopic,
+    value: {
+      paidCreative: {
+        collectedAt: input.capturedAt.toISOString(),
+        creativeType: toPaidCreativeType(input.platformContentType),
+        hook: input.theme.angle,
+        provider: 'manual_paid_reference',
+      },
+    },
+  });
+
+  if (!normalized) {
+    throw new Error('Failed to build paid creative source classification');
+  }
+
+  return normalized;
+}
+
+function isPaidCreativeTheme(theme: CorpusTheme): boolean {
+  return theme.key === PAID_CREATIVE_THEME_KEY;
+}
+
+function toPaidCreativeType(
+  contentType: TrendSourceItem['contentType'],
+): NonNullable<TrendSourceClassification['paidCreative']>['creativeType'] {
+  return contentType === 'tweet' ? 'text' : contentType;
 }


### PR DESCRIPTION
## Summary
- classify the paid creative prelaunch corpus theme as `paid_creative_reference` / `paid_creative_analysis`
- keep the remaining prelaunch seed records in the organic public-reference path with their platform freshness windows preserved
- add focused seed coverage for the organic/paid split, plus the existing reference-corpus service coverage for paid exclusion from default reads

Closes #1528
Refs #35

## Validation
- `bun install --frozen-lockfile --ignore-scripts`
- `bun run --cwd packages/prisma db:generate`
- `bun run --cwd apps/server/api test:file src/collections/trends/data/prelaunch-reference-corpus.seed.spec.ts src/collections/trends/services/trend-reference-corpus.service.spec.ts` (2 files, 21 tests)
- `bunx biome check --write apps/server/api/src/collections/trends/data/prelaunch-reference-corpus.seed.ts apps/server/api/src/collections/trends/data/prelaunch-reference-corpus.seed.spec.ts`
- `bunx secretlint apps/server/api/src/collections/trends/data/prelaunch-reference-corpus.seed.ts apps/server/api/src/collections/trends/data/prelaunch-reference-corpus.seed.spec.ts`
- `git diff --check`
- `git diff --cached --check`
- `git diff --check origin/master..HEAD`
- pre-commit lint-staged Secretlint/Biome guards

## Notes
- Full workspace type-check, full build, and broad test suites are left to PR CI per repo local verification policy.
