### PR TITLE
Route scheduled publishes through post-publish queue

### DIFF
--- a/apps/server/api/src/collections/post-groups/post-groups.module.ts
+++ b/apps/server/api/src/collections/post-groups/post-groups.module.ts
@@ -1,10 +1,12 @@
 import { PostGroupsController } from '@api/collections/post-groups/controllers/post-groups.controller';
 import { PostGroupsService } from '@api/collections/post-groups/services/post-groups.service';
-import { Module } from '@nestjs/common';
+import { QueuesModule } from '@api/queues/core/queues.module';
+import { forwardRef, Module } from '@nestjs/common';
 
 @Module({
   controllers: [PostGroupsController],
   exports: [PostGroupsService],
+  imports: [forwardRef(() => QueuesModule)],
   providers: [PostGroupsService],
 })
 export class PostGroupsModule {}

--- a/apps/server/api/src/collections/post-groups/services/post-groups.service.spec.ts
+++ b/apps/server/api/src/collections/post-groups/services/post-groups.service.spec.ts
@@ -1,4 +1,5 @@
 import { PostGroupsService } from '@api/collections/post-groups/services/post-groups.service';
+import { PostPublishQueueService } from '@api/queues/post-publish/post-publish-queue.service';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import {
   CredentialPlatform,
@@ -60,6 +61,7 @@ type MockPostTarget = {
 
 describe('PostGroupsService', () => {
   let service: PostGroupsService;
+  let postPublishQueueService: { enqueue: ReturnType<typeof vi.fn> };
   let prisma: {
     $transaction: ReturnType<typeof vi.fn>;
     brand: { findFirst: ReturnType<typeof vi.fn> };
@@ -125,6 +127,9 @@ describe('PostGroupsService', () => {
           ),
       },
     };
+    postPublishQueueService = {
+      enqueue: vi.fn().mockResolvedValue('target-1'),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -141,6 +146,10 @@ describe('PostGroupsService', () => {
             log: vi.fn(),
             warn: vi.fn(),
           },
+        },
+        {
+          provide: PostPublishQueueService,
+          useValue: postPublishQueueService,
         },
       ],
     }).compile();
@@ -261,6 +270,45 @@ describe('PostGroupsService', () => {
 
     expect(prisma.postGroup.create).not.toHaveBeenCalled();
     expect(prisma.post.create).not.toHaveBeenCalled();
+  });
+
+  it('queues publish-now targets after scheduler state is committed', async () => {
+    prisma.postGroup.findFirst.mockResolvedValue(
+      makeGroup({ id: 'group-1', status: ReleaseStatus.DRAFT }),
+    );
+    prisma.post.findMany.mockResolvedValue([
+      makeTarget({
+        groupId: 'group-1',
+        id: 'target-1',
+        targetExecutionState: TargetExecutionState.SCHEDULED,
+      }),
+    ]);
+    prisma.postGroup.update.mockImplementation(({ data }) =>
+      Promise.resolve(
+        makeGroup({
+          id: 'group-1',
+          status: data.status ?? ReleaseStatus.SCHEDULED,
+          statusTransitions: data.statusTransitions ?? [],
+        }),
+      ),
+    );
+
+    const result = await service.publishNow('org-1', 'user-1', 'group-1');
+
+    expect(prisma.post.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          targetExecutionState: TargetExecutionState.SCHEDULED,
+        }),
+      }),
+    );
+    expect(postPublishQueueService.enqueue).toHaveBeenCalledWith({
+      organizationId: 'org-1',
+      postId: 'target-1',
+      source: 'publish_now',
+      userId: 'user-1',
+    });
+    expect(result.targets?.[0]?.id).toBe('target-1');
   });
 
   it('pauses eligible targets and rolls the group up to paused', async () => {

--- a/apps/server/api/src/collections/post-groups/services/post-groups.service.spec.ts
+++ b/apps/server/api/src/collections/post-groups/services/post-groups.service.spec.ts
@@ -1,5 +1,4 @@
 import { PostGroupsService } from '@api/collections/post-groups/services/post-groups.service';
-import { PostPublishQueueService } from '@api/queues/post-publish/post-publish-queue.service';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import {
   CredentialPlatform,
@@ -7,6 +6,7 @@ import {
   TargetExecutionState,
   TargetValidationState,
 } from '@genfeedai/enums';
+import { PostPublishQueueService } from '@genfeedai/server';
 import { LoggerService } from '@libs/logger/logger.service';
 import { BadRequestException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';

--- a/apps/server/api/src/collections/post-groups/services/post-groups.service.ts
+++ b/apps/server/api/src/collections/post-groups/services/post-groups.service.ts
@@ -1,5 +1,4 @@
 import { NotFoundException } from '@api/helpers/exceptions/http/not-found.exception';
-import { PostPublishQueueService } from '@api/queues/post-publish/post-publish-queue.service';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import {
   type ChannelTargetValidationResult,
@@ -34,6 +33,7 @@ import type {
   IScheduleStatusTransition,
 } from '@genfeedai/interfaces';
 import { Prisma } from '@genfeedai/prisma';
+import { PostPublishQueueService } from '@genfeedai/server';
 import { LoggerService } from '@libs/logger/logger.service';
 import { BadRequestException, Injectable } from '@nestjs/common';
 import type { ZodError } from 'zod';
@@ -1076,7 +1076,12 @@ export class PostGroupsService {
   }
 
   private toValidationMedia(
-    media: readonly ReleaseMediaReferenceInput[] | undefined,
+    media:
+      | readonly {
+          assetId: string;
+          kind?: string | null;
+        }[]
+      | undefined,
   ): ChannelValidationMedia | undefined {
     if (!media?.length) {
       return undefined;
@@ -1090,7 +1095,7 @@ export class PostGroupsService {
   }
 
   private isValidationMediaKind(
-    kind: ReleaseMediaReferenceInput['kind'],
+    kind: string | null | undefined,
   ): kind is ChannelValidationMedia[number]['kind'] {
     return (
       kind === 'carousel' ||

--- a/apps/server/api/src/collections/post-groups/services/post-groups.service.ts
+++ b/apps/server/api/src/collections/post-groups/services/post-groups.service.ts
@@ -1,4 +1,5 @@
 import { NotFoundException } from '@api/helpers/exceptions/http/not-found.exception';
+import { PostPublishQueueService } from '@api/queues/post-publish/post-publish-queue.service';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import {
   type ChannelTargetValidationResult,
@@ -116,6 +117,7 @@ export class PostGroupsService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly logger: LoggerService,
+    private readonly postPublishQueueService: PostPublishQueueService,
   ) {}
 
   async create(
@@ -492,13 +494,15 @@ export class PostGroupsService {
     userId: string,
     groupId: string,
   ): Promise<IReleaseGroup> {
-    return this.prisma.$transaction(async (tx) => {
+    const release = await this.prisma.$transaction(async (tx) => {
       const group = await this.getGroupOrThrow(tx, organizationId, groupId);
       const targets = await this.getTargets(tx, organizationId, group.id);
 
       for (const target of targets) {
         const validation = validateChannelTargetSettings({
+          caption: group.baseContent,
           credentialId: target.credentialId,
+          media: this.toValidationMedia(this.asMedia(group.media)),
           platform: target.platform,
           publishMode: 'publish_now',
           settings: this.asRecord(target.targetSettings),
@@ -531,6 +535,30 @@ export class PostGroupsService {
 
       return this.recalculateAndHydrate(tx, organizationId, group.id, userId);
     });
+
+    await this.enqueueReleaseTargets(release, userId);
+    return release;
+  }
+
+  private async enqueueReleaseTargets(
+    release: IReleaseGroup,
+    userId: string,
+  ): Promise<void> {
+    const targets = release.targets ?? [];
+    await Promise.all(
+      targets
+        .filter(
+          (target) => target.executionState === TargetExecutionState.SCHEDULED,
+        )
+        .map((target) =>
+          this.postPublishQueueService.enqueue({
+            organizationId: release.organizationId,
+            postId: target.id,
+            source: 'publish_now',
+            userId,
+          }),
+        ),
+    );
   }
 
   private async transitionGroupTargets(

--- a/apps/server/api/src/queues/core/queues.module.ts
+++ b/apps/server/api/src/queues/core/queues.module.ts
@@ -11,7 +11,6 @@ import { AgentRunQueueService } from '@api/queues/agent-run/agent-run-queue.serv
 import { CampaignQueueService } from '@api/queues/campaign/campaign-queue.service';
 import { QueueService } from '@api/queues/core/queue.service';
 import { HeygenPollQueueService } from '@api/queues/heygen-poll/heygen-poll-queue.service';
-import { PostPublishQueueService } from '@api/queues/post-publish/post-publish-queue.service';
 import { ReplyBotQueueService } from '@api/queues/reply-bot/reply-bot-queue.service';
 import { WorkspaceTaskQueueService } from '@api/services/task-orchestration/workspace-task-queue.service';
 import {
@@ -38,8 +37,10 @@ import {
   TELEGRAM_DISTRIBUTE_QUEUE,
   WORKSPACE_TASK_QUEUE,
 } from '@genfeedai/queue-contracts';
+import { PostPublishQueueService, SERVER_TOKENS } from '@genfeedai/server';
 import { ConfigModule } from '@libs/config/config.module';
 import { ConfigService } from '@libs/config/config.service';
+import { LoggerService } from '@libs/logger/logger.service';
 import {
   buildBullMQConnection,
   parseRedisConnectionForWorkload,
@@ -278,6 +279,10 @@ import { Module } from '@nestjs/common';
     WorkspaceTaskQueueService,
     HeygenPollQueueService,
     PostPublishQueueService,
+    {
+      provide: SERVER_TOKENS.logger,
+      useExisting: LoggerService,
+    },
   ],
 })
 export class QueuesModule {}

--- a/apps/server/api/src/queues/core/queues.module.ts
+++ b/apps/server/api/src/queues/core/queues.module.ts
@@ -11,6 +11,7 @@ import { AgentRunQueueService } from '@api/queues/agent-run/agent-run-queue.serv
 import { CampaignQueueService } from '@api/queues/campaign/campaign-queue.service';
 import { QueueService } from '@api/queues/core/queue.service';
 import { HeygenPollQueueService } from '@api/queues/heygen-poll/heygen-poll-queue.service';
+import { PostPublishQueueService } from '@api/queues/post-publish/post-publish-queue.service';
 import { ReplyBotQueueService } from '@api/queues/reply-bot/reply-bot-queue.service';
 import { WorkspaceTaskQueueService } from '@api/services/task-orchestration/workspace-task-queue.service';
 import {
@@ -32,6 +33,7 @@ import {
   HEYGEN_POLL_QUEUE,
   LIFECYCLE_EMAIL_QUEUE,
   PATTERN_EXTRACTION_QUEUE,
+  POST_PUBLISH_QUEUE,
   REPLY_BOT_POLLING_QUEUE,
   TELEGRAM_DISTRIBUTE_QUEUE,
   WORKSPACE_TASK_QUEUE,
@@ -50,6 +52,7 @@ import { Module } from '@nestjs/common';
   exports: [
     AgentRunQueueService,
     HeygenPollQueueService,
+    PostPublishQueueService,
     QueueService,
     ReplyBotQueueService,
     CampaignQueueService,
@@ -223,6 +226,14 @@ import { Module } from '@nestjs/common';
       },
       {
         defaultJobOptions: {
+          attempts: 1,
+          removeOnComplete: 100,
+          removeOnFail: 50,
+        },
+        name: POST_PUBLISH_QUEUE,
+      },
+      {
+        defaultJobOptions: {
           attempts: 2,
           backoff: { delay: 5000, type: 'exponential' },
           removeOnComplete: 100,
@@ -266,6 +277,7 @@ import { Module } from '@nestjs/common';
     AgentRunQueueService,
     WorkspaceTaskQueueService,
     HeygenPollQueueService,
+    PostPublishQueueService,
   ],
 })
 export class QueuesModule {}

--- a/apps/server/api/src/queues/post-publish/post-publish-queue.service.spec.ts
+++ b/apps/server/api/src/queues/post-publish/post-publish-queue.service.spec.ts
@@ -1,0 +1,101 @@
+import { PostPublishQueueService } from '@api/queues/post-publish/post-publish-queue.service';
+import {
+  POST_PUBLISH_JOB_NAME,
+  POST_PUBLISH_QUEUE,
+} from '@genfeedai/queue-contracts';
+import { LoggerService } from '@libs/logger/logger.service';
+import { getQueueToken } from '@nestjs/bullmq';
+import { Test } from '@nestjs/testing';
+
+const makeJob = (state: string, id = 'post-1') => ({
+  getState: vi.fn().mockResolvedValue(state),
+  id,
+  remove: vi.fn().mockResolvedValue(undefined),
+});
+
+describe('PostPublishQueueService', () => {
+  let service: PostPublishQueueService;
+  let queue: {
+    add: ReturnType<typeof vi.fn>;
+    getJob: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(async () => {
+    queue = {
+      add: vi.fn().mockResolvedValue({ id: 'post-1' }),
+      getJob: vi.fn().mockResolvedValue(null),
+    };
+
+    const module = await Test.createTestingModule({
+      providers: [
+        PostPublishQueueService,
+        {
+          provide: getQueueToken(POST_PUBLISH_QUEUE),
+          useValue: queue,
+        },
+        {
+          provide: LoggerService,
+          useValue: {
+            log: vi.fn(),
+            warn: vi.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(PostPublishQueueService);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('queues one publish job with the post id as BullMQ jobId', async () => {
+    await service.enqueue({
+      organizationId: 'org-1',
+      postId: 'post-1',
+      source: 'scheduled_sweep',
+    });
+
+    expect(queue.add).toHaveBeenCalledWith(
+      POST_PUBLISH_JOB_NAME,
+      expect.objectContaining({
+        organizationId: 'org-1',
+        postId: 'post-1',
+        source: 'scheduled_sweep',
+      }),
+      expect.objectContaining({
+        attempts: 1,
+        jobId: 'post-1',
+      }),
+    );
+  });
+
+  it('does not enqueue a duplicate active job', async () => {
+    queue.getJob.mockResolvedValue(makeJob('active'));
+
+    const jobId = await service.enqueue({
+      organizationId: 'org-1',
+      postId: 'post-1',
+      source: 'publish_now',
+      userId: 'user-1',
+    });
+
+    expect(jobId).toBe('post-1');
+    expect(queue.add).not.toHaveBeenCalled();
+  });
+
+  it('removes completed jobs so a later sweep can retry through durable state', async () => {
+    const completed = makeJob('completed');
+    queue.getJob.mockResolvedValue(completed);
+
+    await service.enqueue({
+      organizationId: 'org-1',
+      postId: 'post-1',
+      source: 'scheduled_sweep',
+    });
+
+    expect(completed.remove).toHaveBeenCalled();
+    expect(queue.add).toHaveBeenCalled();
+  });
+});

--- a/apps/server/api/src/queues/post-publish/post-publish-queue.service.spec.ts
+++ b/apps/server/api/src/queues/post-publish/post-publish-queue.service.spec.ts
@@ -1,9 +1,8 @@
-import { PostPublishQueueService } from '@api/queues/post-publish/post-publish-queue.service';
 import {
   POST_PUBLISH_JOB_NAME,
   POST_PUBLISH_QUEUE,
 } from '@genfeedai/queue-contracts';
-import { LoggerService } from '@libs/logger/logger.service';
+import { PostPublishQueueService, SERVER_TOKENS } from '@genfeedai/server';
 import { getQueueToken } from '@nestjs/bullmq';
 import { Test } from '@nestjs/testing';
 
@@ -34,7 +33,7 @@ describe('PostPublishQueueService', () => {
           useValue: queue,
         },
         {
-          provide: LoggerService,
+          provide: SERVER_TOKENS.logger,
           useValue: {
             log: vi.fn(),
             warn: vi.fn(),

--- a/apps/server/api/src/queues/post-publish/post-publish-queue.service.ts
+++ b/apps/server/api/src/queues/post-publish/post-publish-queue.service.ts
@@ -1,0 +1,67 @@
+import {
+  POST_PUBLISH_JOB_NAME,
+  POST_PUBLISH_QUEUE,
+  type PostPublishJobData,
+} from '@genfeedai/queue-contracts';
+import { LoggerService } from '@libs/logger/logger.service';
+import { InjectQueue } from '@nestjs/bullmq';
+import { Injectable, Optional } from '@nestjs/common';
+import type { Queue } from 'bullmq';
+
+@Injectable()
+export class PostPublishQueueService {
+  private readonly logContext = 'PostPublishQueueService';
+
+  constructor(
+    @InjectQueue(POST_PUBLISH_QUEUE)
+    @Optional()
+    private readonly queue: Queue<PostPublishJobData> | undefined,
+    private readonly logger: LoggerService,
+  ) {}
+
+  async enqueue(data: Omit<PostPublishJobData, 'enqueuedAt'>): Promise<string> {
+    const payload: PostPublishJobData = {
+      ...data,
+      enqueuedAt: new Date().toISOString(),
+    };
+    const jobId = data.postId;
+    if (!this.queue) {
+      this.logger.warn(`${this.logContext} queue unavailable`, {
+        jobId,
+        postId: data.postId,
+      });
+      return jobId;
+    }
+
+    const existingJob = await this.queue.getJob(jobId);
+
+    if (existingJob) {
+      const state = await existingJob.getState();
+      if (state === 'active' || state === 'waiting' || state === 'delayed') {
+        this.logger.warn(`${this.logContext} post already queued`, {
+          jobId,
+          postId: data.postId,
+          state,
+        });
+        return jobId;
+      }
+      await existingJob.remove();
+    }
+
+    const job = await this.queue.add(POST_PUBLISH_JOB_NAME, payload, {
+      attempts: 1,
+      jobId,
+      removeOnComplete: 100,
+      removeOnFail: 50,
+    });
+
+    this.logger.log(`${this.logContext} queued post publish`, {
+      jobId: job.id,
+      organizationId: data.organizationId,
+      postId: data.postId,
+      source: data.source,
+    });
+
+    return job.id ?? jobId;
+  }
+}

--- a/apps/server/server/package.json
+++ b/apps/server/server/package.json
@@ -4,7 +4,10 @@
     "@genfeedai/helpers": "workspace:*",
     "@genfeedai/interfaces": "workspace:*",
     "@genfeedai/prisma": "workspace:*",
-    "@genfeedai/queue-contracts": "workspace:*"
+    "@genfeedai/queue-contracts": "workspace:*",
+    "@nestjs/bullmq": "11.0.4",
+    "@nestjs/common": "11.1.28",
+    "bullmq": "5.79.3"
   },
   "description": "Server-tier services shared by Genfeed API and workers",
   "devDependencies": {

--- a/apps/server/server/src/index.ts
+++ b/apps/server/server/src/index.ts
@@ -19,6 +19,7 @@ export type {
   ServerModelDimensions,
   ServerModelRecord,
 } from './collections/models/model-record.types';
+export { PostPublishQueueService } from './queues/post-publish/post-publish-queue.service';
 export {
   SERVER_TOKENS,
   type ServerBrandMemorySync,

--- a/apps/server/server/src/queues/post-publish/post-publish-queue.service.ts
+++ b/apps/server/server/src/queues/post-publish/post-publish-queue.service.ts
@@ -3,9 +3,9 @@ import {
   POST_PUBLISH_QUEUE,
   type PostPublishJobData,
 } from '@genfeedai/queue-contracts';
-import { LoggerService } from '@libs/logger/logger.service';
 import { InjectQueue } from '@nestjs/bullmq';
-import { Injectable, Optional } from '@nestjs/common';
+import { Inject, Injectable, Optional } from '@nestjs/common';
+import { SERVER_TOKENS, type ServerLogger } from '@server/server.dependencies';
 import type { Queue } from 'bullmq';
 
 @Injectable()
@@ -16,7 +16,8 @@ export class PostPublishQueueService {
     @InjectQueue(POST_PUBLISH_QUEUE)
     @Optional()
     private readonly queue: Queue<PostPublishJobData> | undefined,
-    private readonly logger: LoggerService,
+    @Inject(SERVER_TOKENS.logger)
+    private readonly logger: ServerLogger,
   ) {}
 
   async enqueue(data: Omit<PostPublishJobData, 'enqueuedAt'>): Promise<string> {

--- a/apps/server/workers/package.json
+++ b/apps/server/workers/package.json
@@ -10,7 +10,9 @@
     "@genfeedai/queue-contracts": "workspace:*",
     "@genfeedai/server": "workspace:*",
     "@genfeedai/workflows": "workspace:*",
-    "@nestjs/event-emitter": "3.1.0"
+    "@nestjs/bullmq": "11.0.4",
+    "@nestjs/event-emitter": "3.1.0",
+    "bullmq": "5.79.3"
   },
   "description": "Genfeed Workers Service (Cron Jobs)",
   "devDependencies": {

--- a/apps/server/workers/src/crons/posts/cron.posts.module.ts
+++ b/apps/server/workers/src/crons/posts/cron.posts.module.ts
@@ -8,6 +8,7 @@ import { QuotaModule } from '@api/services/quota/quota.module';
 import { WebhookClientModule } from '@api/services/webhook-client/webhook-client.module';
 import { forwardRef, Module } from '@nestjs/common';
 import { CronPostsService } from '@workers/crons/posts/cron.posts.service';
+import { WorkersQueuesModule } from '@workers/queues/queues.module';
 
 @Module({
   imports: [
@@ -18,6 +19,7 @@ import { CronPostsService } from '@workers/crons/posts/cron.posts.service';
     forwardRef(() => WebhookClientModule),
     PublishersModule,
     QuotaModule,
+    forwardRef(() => WorkersQueuesModule),
   ],
   exports: [CronPostsService],
   providers: [CronPostsService, SystemWorkflowProvenanceService],

--- a/apps/server/workers/src/crons/posts/cron.posts.service.spec.ts
+++ b/apps/server/workers/src/crons/posts/cron.posts.service.spec.ts
@@ -3,11 +3,11 @@ import { CredentialsService } from '@api/collections/credentials/services/creden
 import { OrganizationsService } from '@api/collections/organizations/services/organizations.service';
 import { PostsService } from '@api/collections/posts/services/posts.service';
 import { SystemWorkflowProvenanceService } from '@api/collections/workflows/services/system-workflow-provenance.service';
-import { PostPublishQueueService } from '@api/queues/post-publish/post-publish-queue.service';
 import { PublisherFactoryService } from '@api/services/integrations/publishers/publisher-factory.service';
 import { QuotaService } from '@api/services/quota/quota.service';
 import { PublishEventWebhookService } from '@api/services/webhook-client/webhook-client.module';
 import { CredentialPlatform, PostStatus } from '@genfeedai/enums';
+import { PostPublishQueueService } from '@genfeedai/server';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Test, TestingModule } from '@nestjs/testing';
 import { CronPostsService } from '@workers/crons/posts/cron.posts.service';

--- a/apps/server/workers/src/crons/posts/cron.posts.service.spec.ts
+++ b/apps/server/workers/src/crons/posts/cron.posts.service.spec.ts
@@ -3,6 +3,7 @@ import { CredentialsService } from '@api/collections/credentials/services/creden
 import { OrganizationsService } from '@api/collections/organizations/services/organizations.service';
 import { PostsService } from '@api/collections/posts/services/posts.service';
 import { SystemWorkflowProvenanceService } from '@api/collections/workflows/services/system-workflow-provenance.service';
+import { PostPublishQueueService } from '@api/queues/post-publish/post-publish-queue.service';
 import { PublisherFactoryService } from '@api/services/integrations/publishers/publisher-factory.service';
 import { QuotaService } from '@api/services/quota/quota.service';
 import { PublishEventWebhookService } from '@api/services/webhook-client/webhook-client.module';
@@ -17,6 +18,7 @@ describe('CronPostsService', () => {
   let credentialsService: { findOne: ReturnType<typeof vi.fn> };
   let postsService: vi.Mocked<PostsService>;
   let publisherFactory: { getPublisher: ReturnType<typeof vi.fn> };
+  let postPublishQueueService: { enqueue: ReturnType<typeof vi.fn> };
   let publishEventWebhookService: {
     emitLegacyPostFailed: ReturnType<typeof vi.fn>;
     emitLegacyPostPublished: ReturnType<typeof vi.fn>;
@@ -33,6 +35,9 @@ describe('CronPostsService', () => {
     };
     publisherFactory = {
       getPublisher: vi.fn(),
+    };
+    postPublishQueueService = {
+      enqueue: vi.fn().mockResolvedValue('post-1'),
     };
     publishEventWebhookService = {
       emitLegacyPostFailed: vi.fn().mockResolvedValue(undefined),
@@ -109,6 +114,10 @@ describe('CronPostsService', () => {
           provide: PublishEventWebhookService,
           useValue: publishEventWebhookService,
         },
+        {
+          provide: PostPublishQueueService,
+          useValue: postPublishQueueService,
+        },
       ],
     }).compile();
 
@@ -132,9 +141,38 @@ describe('CronPostsService', () => {
     expect(loggerService.log).toHaveBeenCalledWith(
       expect.stringContaining('no posts to process'),
     );
+    expect(postPublishQueueService.enqueue).not.toHaveBeenCalled();
   });
 
-  it('emits publish webhooks after a scheduled post publishes', async () => {
+  it('publishScheduledPosts queues due posts instead of publishing inline', async () => {
+    const post = {
+      brand: 'brand-1',
+      children: [],
+      credential: 'cred-1',
+      id: 'post-1',
+      ingredients: [],
+      organization: 'org-1',
+      platform: CredentialPlatform.TWITTER,
+      scheduledDate: new Date('2026-07-07T09:55:00.000Z'),
+      status: PostStatus.SCHEDULED,
+      user: 'user-1',
+    };
+    postsService.findAll.mockResolvedValueOnce({
+      docs: [post],
+      total: 1,
+    } as never);
+
+    await service.publishScheduledPosts();
+
+    expect(postPublishQueueService.enqueue).toHaveBeenCalledWith({
+      organizationId: 'org-1',
+      postId: 'post-1',
+      source: 'scheduled_sweep',
+    });
+    expect(publisherFactory.getPublisher).not.toHaveBeenCalled();
+  });
+
+  it('emits publish webhooks after a queued scheduled post publishes', async () => {
     const post = {
       brand: 'brand-1',
       children: [],
@@ -172,7 +210,12 @@ describe('CronPostsService', () => {
       supportsThreads: false,
     });
 
-    await service.publishScheduledPosts();
+    await service.processQueuedPost({
+      enqueuedAt: '2026-07-07T09:55:00.000Z',
+      organizationId: 'org-1',
+      postId: 'post-1',
+      source: 'scheduled_sweep',
+    });
 
     expect(
       publishEventWebhookService.emitLegacyPostPublished,
@@ -185,6 +228,23 @@ describe('CronPostsService', () => {
         url: 'https://x.com/example/status/tweet-1',
       }),
     );
+  });
+
+  it('skips queued publish jobs that are no longer eligible', async () => {
+    postsService.findAll.mockResolvedValueOnce({
+      docs: [],
+      total: 0,
+    } as never);
+
+    const result = await service.processQueuedPost({
+      enqueuedAt: '2026-07-07T09:55:00.000Z',
+      organizationId: 'org-1',
+      postId: 'post-1',
+      source: 'scheduled_sweep',
+    });
+
+    expect(result).toEqual({ reason: 'not_eligible', skipped: true });
+    expect(publisherFactory.getPublisher).not.toHaveBeenCalled();
   });
 
   it('emits failure webhooks only after retries are exhausted', async () => {
@@ -226,7 +286,12 @@ describe('CronPostsService', () => {
       supportsThreads: false,
     });
 
-    await service.publishScheduledPosts();
+    await service.processQueuedPost({
+      enqueuedAt: '2026-07-07T09:55:00.000Z',
+      organizationId: 'org-1',
+      postId: 'post-1',
+      source: 'scheduled_sweep',
+    });
 
     expect(
       publishEventWebhookService.emitLegacyPostFailed,

--- a/apps/server/workers/src/crons/posts/cron.posts.service.ts
+++ b/apps/server/workers/src/crons/posts/cron.posts.service.ts
@@ -10,6 +10,7 @@ import {
   SystemWorkflowProvenanceService,
 } from '@api/collections/workflows/services/system-workflow-provenance.service';
 import { customLabels } from '@api/helpers/utils/pagination/pagination.util';
+import { PostPublishQueueService } from '@api/queues/post-publish/post-publish-queue.service';
 import type {
   PublishContext,
   PublishResult,
@@ -27,6 +28,7 @@ import {
   PostStatus,
   WorkflowExecutionTrigger,
 } from '@genfeedai/enums';
+import type { PostPublishJobData } from '@genfeedai/queue-contracts';
 import { LoggerService } from '@libs/logger/logger.service';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
 import { Injectable } from '@nestjs/common';
@@ -46,6 +48,11 @@ type QuotaCheckResult = {
   dailyLimit: number;
 };
 
+type QueuedPostPublishSkip = {
+  reason: 'not_eligible';
+  skipped: true;
+};
+
 @Injectable()
 export class CronPostsService {
   private readonly constructorName: string = String(this.constructor.name);
@@ -62,6 +69,7 @@ export class CronPostsService {
     private readonly publisherFactory: PublisherFactoryService,
     private readonly systemWorkflowProvenanceService: SystemWorkflowProvenanceService,
     private readonly publishEventWebhookService: PublishEventWebhookService,
+    private readonly postPublishQueueService: PostPublishQueueService,
   ) {}
 
   /**
@@ -72,121 +80,180 @@ export class CronPostsService {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
 
     try {
-      const now = new Date();
+      const posts = await this.findDueScheduledPosts();
 
-      const options = {
-        customLabels,
-        limit: 50,
-        page: 1,
-      };
-
-      // Calculate backoff threshold - posts attempted within this time are skipped
-      const backoffThreshold = new Date(
-        now.getTime() - this.RETRY_BACKOFF_SECONDS * 1000,
-      );
-
-      // Find all scheduled parent posts that are due.
-      const posts = await this.postsService.findAll(
-        {
-          include: {
-            children: {
-              include: {
-                credential: true,
-                ingredients: true,
-              },
-              where: {
-                status: PostStatus.SCHEDULED,
-              },
-            },
-            ingredients: true,
-          },
-          where: {
-            // Backoff: skip posts that were attempted recently (within RETRY_BACKOFF_SECONDS)
-            // This prevents rapid retries and double-posting from overlapping cron runs
-            OR: [
-              { scheduledDate: { lte: now } },
-              { nextScheduledDate: { lte: now } },
-            ],
-            AND: [
-              {
-                OR: [
-                  { lastAttemptAt: null },
-                  { lastAttemptAt: { lte: backoffThreshold } },
-                ],
-              },
-            ],
-            isDeleted: false,
-            parent: null, // Only parent posts (not thread children)
-            status: { in: [PostStatus.SCHEDULED, PostStatus.PROCESSING] },
-          },
-        },
-        options,
-      );
-
-      this.logger.log(`${url} found ${posts.docs?.length || 0} posts`, {
-        total: posts.total || 0,
-        totalDocs: posts.docs?.length || 0,
+      this.logger.log(`${url} found ${posts.length} posts`, {
+        total: posts.length,
+        totalDocs: posts.length,
       });
 
-      if (posts.docs.length === 0) {
+      if (posts.length === 0) {
         this.logger.log(`${url} no posts to process`);
         return;
       }
 
-      // Process posts
-      await this.processPostGroup(posts.docs as unknown as PostEntity[]);
+      await this.enqueuePostPublishJobs(posts);
     } catch (error: unknown) {
       this.logger.error(`${url} error`, { error });
     }
   }
 
-  /**
-   * Process a group of posts with parallel execution
-   * Uses concurrency limit to avoid overwhelming external APIs
-   */
-  private async processPostGroup(posts: PostEntity[]) {
+  async processQueuedPost(
+    data: PostPublishJobData,
+  ): Promise<PublishResult | QueuedPostPublishSkip> {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
-    const CONCURRENCY_LIMIT = 5;
+    const post = await this.findQueuedPostForPublish(data);
 
-    // Process in batches for controlled concurrency
-    for (let i = 0; i < posts.length; i += CONCURRENCY_LIMIT) {
-      const batch = posts.slice(i, i + CONCURRENCY_LIMIT);
+    if (!post) {
+      this.logger.log(`${url} skipped stale post publish job`, {
+        organizationId: data.organizationId,
+        postId: data.postId,
+        source: data.source,
+      });
+      return { reason: 'not_eligible', skipped: true };
+    }
 
-      const batchPromises = batch.map(async (post) => {
-        try {
-          const result = await this.publishSinglePost(post);
+    return this.publishPostWithSideEffects(post);
+  }
 
-          if (result.success) {
-            // Log successful publication
-            await this.activitiesService.create(
-              new ActivityEntity({
-                brand: post.brand,
-                entityId: post.id,
-                entityModel: ActivityEntityModel.POST,
-                key: ActivityKey.POST_PUBLISHED,
-                organization: post.organization,
-                source: ActivitySource.POST,
-                user: post.user,
-                value: `Published to ${result.platform}: ${result.url}`,
-              }),
-            );
+  private async enqueuePostPublishJobs(posts: PostEntity[]): Promise<void> {
+    const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
 
-            // Handle repeat scheduling if enabled
-            if (post.isRepeat && post.repeatFrequency) {
-              await this.scheduleNextRepeat(post, url);
-            }
-          }
-        } catch (error: unknown) {
-          this.logger.error(`${url} failed to process post`, {
-            error: (error as Error)?.message,
+    await Promise.all(
+      posts.map(async (post) => {
+        const organizationId = this.readPostString(post, [
+          'organization',
+          'organizationId',
+        ]);
+        if (!organizationId) {
+          this.logger.warn(`${url} missing organization for post publish job`, {
             postId: post.id,
           });
+          return;
         }
-      });
 
-      // Wait for batch to complete before processing next batch
-      await Promise.all(batchPromises);
+        await this.postPublishQueueService.enqueue({
+          organizationId,
+          postId: post.id.toString(),
+          source: 'scheduled_sweep',
+        });
+      }),
+    );
+  }
+
+  private async publishPostWithSideEffects(
+    post: PostEntity,
+  ): Promise<PublishResult> {
+    const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
+    const result = await this.publishSinglePost(post);
+
+    if (result.success) {
+      await this.activitiesService.create(
+        new ActivityEntity({
+          brand: post.brand,
+          entityId: post.id,
+          entityModel: ActivityEntityModel.POST,
+          key: ActivityKey.POST_PUBLISHED,
+          organization: post.organization,
+          source: ActivitySource.POST,
+          user: post.user,
+          value: `Published to ${result.platform}: ${result.url}`,
+        }),
+      );
+
+      if (post.isRepeat && post.repeatFrequency) {
+        await this.scheduleNextRepeat(post, url);
+      }
     }
+
+    return result;
+  }
+
+  private async findQueuedPostForPublish(
+    data: PostPublishJobData,
+  ): Promise<PostEntity | null> {
+    const posts = await this.findDueScheduledPosts({
+      limit: 1,
+      organizationId: data.organizationId,
+      postId: data.postId,
+    });
+
+    return posts[0] ?? null;
+  }
+
+  private async findDueScheduledPosts(
+    filter: { limit?: number; organizationId?: string; postId?: string } = {},
+  ): Promise<PostEntity[]> {
+    const now = new Date();
+    const backoffThreshold = new Date(
+      now.getTime() - this.RETRY_BACKOFF_SECONDS * 1000,
+    );
+
+    const posts = await this.postsService.findAll(
+      {
+        include: {
+          children: {
+            include: {
+              credential: true,
+              ingredients: true,
+            },
+            where: {
+              status: PostStatus.SCHEDULED,
+            },
+          },
+          ingredients: true,
+        },
+        where: {
+          ...(filter.postId ? { id: filter.postId } : {}),
+          ...(filter.organizationId
+            ? { organizationId: filter.organizationId }
+            : {}),
+          AND: [
+            {
+              OR: [
+                { lastAttemptAt: null },
+                { lastAttemptAt: { lte: backoffThreshold } },
+              ],
+            },
+          ],
+          OR: [
+            { scheduledDate: { lte: now } },
+            { nextScheduledDate: { lte: now } },
+          ],
+          isDeleted: false,
+          parentId: null,
+          status: { in: [PostStatus.SCHEDULED, PostStatus.PROCESSING] },
+        },
+      },
+      {
+        customLabels,
+        limit: filter.limit ?? 50,
+        page: 1,
+      },
+    );
+
+    return posts.docs as unknown as PostEntity[];
+  }
+
+  private readPostString(
+    post: PostEntity,
+    keys: readonly string[],
+  ): string | undefined {
+    const record = post as unknown as Record<string, unknown>;
+    for (const key of keys) {
+      const value = record[key];
+      if (typeof value === 'string' && value.length > 0) {
+        return value;
+      }
+      if (value && typeof value === 'object' && 'id' in value) {
+        const id = (value as { id?: unknown }).id;
+        if (typeof id === 'string' && id.length > 0) {
+          return id;
+        }
+      }
+    }
+
+    return undefined;
   }
 
   /**

--- a/apps/server/workers/src/crons/posts/cron.posts.service.ts
+++ b/apps/server/workers/src/crons/posts/cron.posts.service.ts
@@ -10,7 +10,6 @@ import {
   SystemWorkflowProvenanceService,
 } from '@api/collections/workflows/services/system-workflow-provenance.service';
 import { customLabels } from '@api/helpers/utils/pagination/pagination.util';
-import { PostPublishQueueService } from '@api/queues/post-publish/post-publish-queue.service';
 import type {
   PublishContext,
   PublishResult,
@@ -29,6 +28,7 @@ import {
   WorkflowExecutionTrigger,
 } from '@genfeedai/enums';
 import type { PostPublishJobData } from '@genfeedai/queue-contracts';
+import { PostPublishQueueService } from '@genfeedai/server';
 import { LoggerService } from '@libs/logger/logger.service';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
 import { Injectable } from '@nestjs/common';

--- a/apps/server/workers/src/processors/api/queues/post-publish/post-publish.processor.spec.ts
+++ b/apps/server/workers/src/processors/api/queues/post-publish/post-publish.processor.spec.ts
@@ -1,0 +1,57 @@
+import type { PostPublishJobData } from '@genfeedai/queue-contracts';
+import { LoggerService } from '@libs/logger/logger.service';
+import { Test } from '@nestjs/testing';
+import { CronPostsService } from '@workers/crons/posts/cron.posts.service';
+import { PostPublishProcessor } from '@workers/processors/api/queues/post-publish/post-publish.processor';
+import type { Job } from 'bullmq';
+
+describe('PostPublishProcessor', () => {
+  let processor: PostPublishProcessor;
+  let cronPostsService: {
+    processQueuedPost: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(async () => {
+    cronPostsService = {
+      processQueuedPost: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const module = await Test.createTestingModule({
+      providers: [
+        PostPublishProcessor,
+        {
+          provide: LoggerService,
+          useValue: {
+            log: vi.fn(),
+          },
+        },
+        {
+          provide: CronPostsService,
+          useValue: cronPostsService,
+        },
+      ],
+    }).compile();
+
+    processor = module.get(PostPublishProcessor);
+  });
+
+  it('delegates queued jobs to CronPostsService', async () => {
+    const data: PostPublishJobData = {
+      enqueuedAt: '2026-07-09T17:26:45.000Z',
+      organizationId: 'org-1',
+      postId: 'post-1',
+      source: 'scheduled_sweep',
+    };
+    const job = {
+      data,
+      id: 'post-1',
+      updateProgress: vi.fn().mockResolvedValue(undefined),
+    } as unknown as Job<PostPublishJobData>;
+
+    await processor.process(job);
+
+    expect(cronPostsService.processQueuedPost).toHaveBeenCalledWith(data);
+    expect(job.updateProgress).toHaveBeenCalledWith(10);
+    expect(job.updateProgress).toHaveBeenCalledWith(100);
+  });
+});

--- a/apps/server/workers/src/processors/api/queues/post-publish/post-publish.processor.ts
+++ b/apps/server/workers/src/processors/api/queues/post-publish/post-publish.processor.ts
@@ -1,0 +1,35 @@
+import {
+  POST_PUBLISH_QUEUE,
+  type PostPublishJobData,
+} from '@genfeedai/queue-contracts';
+import { LoggerService } from '@libs/logger/logger.service';
+import { Processor, WorkerHost } from '@nestjs/bullmq';
+import { Injectable } from '@nestjs/common';
+import { CronPostsService } from '@workers/crons/posts/cron.posts.service';
+import type { Job } from 'bullmq';
+
+@Injectable()
+@Processor(POST_PUBLISH_QUEUE, { concurrency: 5 })
+export class PostPublishProcessor extends WorkerHost {
+  private readonly logContext = 'PostPublishProcessor';
+
+  constructor(
+    private readonly logger: LoggerService,
+    private readonly cronPostsService: CronPostsService,
+  ) {
+    super();
+  }
+
+  async process(job: Job<PostPublishJobData>): Promise<void> {
+    this.logger.log(`${this.logContext} processing`, {
+      jobId: job.id,
+      organizationId: job.data.organizationId,
+      postId: job.data.postId,
+      source: job.data.source,
+    });
+
+    await job.updateProgress(10);
+    await this.cronPostsService.processQueuedPost(job.data);
+    await job.updateProgress(100);
+  }
+}

--- a/apps/server/workers/src/processors/processors.module.ts
+++ b/apps/server/workers/src/processors/processors.module.ts
@@ -75,6 +75,7 @@ import { AnalyticsSocialJobService } from '@server/analytics/services/analytics-
 import { AnalyticsTwitterJobService } from '@server/analytics/services/analytics-twitter-job.service';
 import { AnalyticsYouTubeJobService } from '@server/analytics/services/analytics-youtube-job.service';
 import { SERVER_TOKENS } from '@server/server.dependencies';
+import { CronPostsModule } from '@workers/crons/posts/cron.posts.module';
 // --- collections/ processors ---
 import { ArticleGenerationProcessor } from '@workers/processors/api/collections/articles/processors/article-generation.processor';
 import { BatchWorkflowProcessor } from '@workers/processors/api/collections/workflows/services/batch-workflow.processor';
@@ -100,6 +101,7 @@ import { EmailDigestProcessor } from '@workers/processors/api/queues/email-diges
 import { HeygenPollProcessor } from '@workers/processors/api/queues/heygen-poll/heygen-poll.processor';
 import { LifecycleEmailProcessor } from '@workers/processors/api/queues/lifecycle-email/lifecycle-email.processor';
 import { PatternExtractionProcessor } from '@workers/processors/api/queues/pattern-extraction/pattern-extraction.processor';
+import { PostPublishProcessor } from '@workers/processors/api/queues/post-publish/post-publish.processor';
 import { ReplyBotPollingProcessor } from '@workers/processors/api/queues/reply-bot/reply-bot-polling.processor';
 import { TelegramDistributeProcessor } from '@workers/processors/api/queues/telegram-distribute/telegram-distribute.processor';
 // --- services/ processors ---
@@ -119,6 +121,7 @@ import { WorkersQueuesModule } from '@workers/queues/queues.module';
     LoggerModule,
     HttpModule,
     WorkersQueuesModule,
+    forwardRef(() => CronPostsModule),
 
     // Config
     forwardRef(() => ConfigModule),
@@ -223,7 +226,7 @@ import { WorkersQueuesModule } from '@workers/queues/queues.module';
       useExisting: YoutubeService,
     },
 
-    // --- queues/ processors (22) ---
+    // --- queues/ processors (23) ---
     AdBulkUploadProcessor,
     AdOptimizationProcessor,
     AdSyncGoogleProcessor,
@@ -244,6 +247,7 @@ import { WorkersQueuesModule } from '@workers/queues/queues.module';
     HeygenPollProcessor,
     LifecycleEmailProcessor,
     PatternExtractionProcessor,
+    PostPublishProcessor,
     ReplyBotPollingProcessor,
     TelegramDistributeProcessor,
 

--- a/apps/server/workers/src/queues/queues.module.ts
+++ b/apps/server/workers/src/queues/queues.module.ts
@@ -8,7 +8,6 @@
 
 import { QueueService } from '@api/queues/core/queue.service';
 import { HeygenPollQueueService } from '@api/queues/heygen-poll/heygen-poll-queue.service';
-import { PostPublishQueueService } from '@api/queues/post-publish/post-publish-queue.service';
 import { WorkspaceTaskQueueService } from '@api/services/task-orchestration/workspace-task-queue.service';
 import {
   AD_BULK_UPLOAD_QUEUE,
@@ -47,7 +46,9 @@ import {
   WORKFLOW_EXECUTION_QUEUE,
   WORKSPACE_TASK_QUEUE,
 } from '@genfeedai/queue-contracts';
+import { PostPublishQueueService, SERVER_TOKENS } from '@genfeedai/server';
 import { LoggerModule } from '@libs/logger/logger.module';
+import { LoggerService } from '@libs/logger/logger.service';
 import {
   buildBullMQConnection,
   parseRedisConnectionForWorkload,
@@ -405,6 +406,10 @@ import { ConfigService } from '@workers/config/config.service';
     WorkspaceTaskQueueService,
     HeygenPollQueueService,
     PostPublishQueueService,
+    {
+      provide: SERVER_TOKENS.logger,
+      useExisting: LoggerService,
+    },
   ],
 })
 export class WorkersQueuesModule {}

--- a/apps/server/workers/src/queues/queues.module.ts
+++ b/apps/server/workers/src/queues/queues.module.ts
@@ -8,6 +8,7 @@
 
 import { QueueService } from '@api/queues/core/queue.service';
 import { HeygenPollQueueService } from '@api/queues/heygen-poll/heygen-poll-queue.service';
+import { PostPublishQueueService } from '@api/queues/post-publish/post-publish-queue.service';
 import { WorkspaceTaskQueueService } from '@api/services/task-orchestration/workspace-task-queue.service';
 import {
   AD_BULK_UPLOAD_QUEUE,
@@ -38,6 +39,7 @@ import {
   LIFECYCLE_EMAIL_QUEUE,
   ORCHESTRATOR_RUN_QUEUE,
   PATTERN_EXTRACTION_QUEUE,
+  POST_PUBLISH_QUEUE,
   REPLY_BOT_POLLING_QUEUE,
   TELEGRAM_DISTRIBUTE_QUEUE,
   TRIGGER_EVALUATION_QUEUE,
@@ -57,7 +59,12 @@ import { ConfigModule } from '@workers/config/config.module';
 import { ConfigService } from '@workers/config/config.service';
 
 @Module({
-  exports: [QueueService, WorkspaceTaskQueueService, HeygenPollQueueService],
+  exports: [
+    QueueService,
+    WorkspaceTaskQueueService,
+    HeygenPollQueueService,
+    PostPublishQueueService,
+  ],
   imports: [
     LoggerModule,
     BullModule.forRootAsync({
@@ -198,6 +205,14 @@ import { ConfigService } from '@workers/config/config.service';
           removeOnFail: 50,
         },
         name: PATTERN_EXTRACTION_QUEUE,
+      },
+      {
+        defaultJobOptions: {
+          attempts: 1,
+          removeOnComplete: 100,
+          removeOnFail: 50,
+        },
+        name: POST_PUBLISH_QUEUE,
       },
 
       // ---------- Newly registered queues (moved from API) ----------
@@ -385,6 +400,11 @@ import { ConfigService } from '@workers/config/config.service';
       },
     ),
   ],
-  providers: [QueueService, WorkspaceTaskQueueService, HeygenPollQueueService],
+  providers: [
+    QueueService,
+    WorkspaceTaskQueueService,
+    HeygenPollQueueService,
+    PostPublishQueueService,
+  ],
 })
 export class WorkersQueuesModule {}

--- a/bun.lock
+++ b/bun.lock
@@ -515,6 +515,9 @@
         "@genfeedai/interfaces": "workspace:*",
         "@genfeedai/prisma": "workspace:*",
         "@genfeedai/queue-contracts": "workspace:*",
+        "@nestjs/bullmq": "11.0.4",
+        "@nestjs/common": "11.1.28",
+        "bullmq": "5.79.3",
       },
       "devDependencies": {
         "@nestjs/testing": "11.1.28",
@@ -576,7 +579,9 @@
         "@genfeedai/queue-contracts": "workspace:*",
         "@genfeedai/server": "workspace:*",
         "@genfeedai/workflows": "workspace:*",
+        "@nestjs/bullmq": "11.0.4",
         "@nestjs/event-emitter": "3.1.0",
+        "bullmq": "5.79.3",
       },
       "devDependencies": {
         "@nestjs/testing": "11.1.28",

--- a/packages/queue-contracts/src/job-data/index.ts
+++ b/packages/queue-contracts/src/job-data/index.ts
@@ -21,6 +21,7 @@ export * from './email-digest-job.interface';
 export * from './heygen-poll-job.interface';
 export * from './lifecycle-email-job.interface';
 export * from './pattern-extraction-job.interface';
+export * from './post-publish-job.interface';
 export * from './reply-bot-polling-job.interface';
 export * from './telegram-distribute-job.interface';
 export * from './webhook-client-job.interface';

--- a/packages/queue-contracts/src/job-data/post-publish-job.interface.ts
+++ b/packages/queue-contracts/src/job-data/post-publish-job.interface.ts
@@ -1,0 +1,16 @@
+/**
+ * Post publish queue contract.
+ *
+ * One job wakes one scheduled post target. The worker re-reads durable post
+ * state before publishing, so this payload intentionally carries identifiers
+ * only and never carries trusted execution state.
+ */
+export const POST_PUBLISH_JOB_NAME = 'publish-post';
+
+export interface PostPublishJobData {
+  enqueuedAt: string;
+  organizationId: string;
+  postId: string;
+  source: 'publish_now' | 'scheduled_sweep';
+  userId?: string;
+}

--- a/packages/queue-contracts/src/queue-names.constant.test.ts
+++ b/packages/queue-contracts/src/queue-names.constant.test.ts
@@ -15,6 +15,7 @@ import {
   DEFAULT_QUEUE,
   HEYGEN_POLL_QUEUE,
   LIFECYCLE_EMAIL_QUEUE,
+  POST_PUBLISH_QUEUE,
   REPLY_BOT_POLLING_QUEUE,
   TRIGGER_EVALUATION_QUEUE,
   WORKFLOW_EXECUTION_QUEUE,
@@ -33,6 +34,7 @@ describe('queue-names.constant', () => {
     expect(WORKSPACE_TASK_QUEUE).toBe('workspace-task');
     expect(HEYGEN_POLL_QUEUE).toBe('heygen-poll');
     expect(LIFECYCLE_EMAIL_QUEUE).toBe('lifecycle-email');
+    expect(POST_PUBLISH_QUEUE).toBe('post-publish');
     expect(CREDIT_DEDUCTION_QUEUE).toBe('credit-deduction');
     expect(CLIP_ANALYZE_QUEUE).toBe('clip-analyze');
     expect(CLIP_FACTORY_QUEUE).toBe('clip-factory');

--- a/packages/queue-contracts/src/queue-names.constant.ts
+++ b/packages/queue-contracts/src/queue-names.constant.ts
@@ -34,6 +34,7 @@ export const CONTENT_OPTIMIZATION_QUEUE = 'content-optimization';
 export const CONTENT_PIPELINE_QUEUE = 'content-pipeline';
 export const ARTICLE_GENERATION_QUEUE = 'article-generation';
 export const PATTERN_EXTRACTION_QUEUE = 'pattern-extraction';
+export const POST_PUBLISH_QUEUE = 'post-publish';
 
 // ---------- Clips ----------
 export const CLIP_ANALYZE_QUEUE = 'clip-analyze';
@@ -78,6 +79,7 @@ export const ALL_QUEUE_NAMES = [
   CONTENT_PIPELINE_QUEUE,
   ARTICLE_GENERATION_QUEUE,
   PATTERN_EXTRACTION_QUEUE,
+  POST_PUBLISH_QUEUE,
   CLIP_ANALYZE_QUEUE,
   CLIP_FACTORY_QUEUE,
   WORKFLOW_EXECUTION_QUEUE,


### PR DESCRIPTION
## Summary
- Add a shared post-publish queue contract and register the queue in API/workers.
- Route publish-now targets and scheduled sweeps into idempotent jobs keyed by post id.
- Add a worker processor that re-reads eligible post state and runs the existing publish side effects.

Closes #1532
Refs #1128

## Validation
- `bun run test:file src/queues/post-publish/post-publish-queue.service.spec.ts src/collections/post-groups/services/post-groups.service.spec.ts` from `apps/server/api`
- `bun run test src/processors/api/queues/post-publish/post-publish.processor.spec.ts` from `apps/server/workers`
- `bun run test:cron src/crons/posts/cron.posts.service.spec.ts` from `apps/server/workers`
- `bun run --cwd packages/queue-contracts test src/queue-names.constant.test.ts`
- `bunx biome check --write` on the 17 touched files
- `bunx secretlint` on the 17 touched files
- `git diff --check origin/master..HEAD`

## Not run
- Full package/workspace typecheck, builds, and broad test suites; those are intentionally left to PR CI per local verification policy.