### PR TITLE
feat(api): add agent run retry endpoint and client wiring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -696,6 +696,11 @@ jobs:
           bun run scripts/emit-openapi.ts --skip-build --out=/tmp/openapi-emit-1.json
           bun run scripts/emit-openapi.ts --skip-build --out=/tmp/openapi-emit-2.json
           cmp /tmp/openapi-emit-1.json /tmp/openapi-emit-2.json
+      - name: Upload generated OpenAPI document
+        uses: actions/upload-artifact@v4
+        with:
+          name: generated-openapi
+          path: /tmp/openapi-emit-1.json
       - name: Committed spec must match generated
         run: |
           if ! cmp apps/server/api/openapi/openapi.json /tmp/openapi-emit-1.json; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -696,11 +696,6 @@ jobs:
           bun run scripts/emit-openapi.ts --skip-build --out=/tmp/openapi-emit-1.json
           bun run scripts/emit-openapi.ts --skip-build --out=/tmp/openapi-emit-2.json
           cmp /tmp/openapi-emit-1.json /tmp/openapi-emit-2.json
-      - name: Upload generated OpenAPI document
-        uses: actions/upload-artifact@v4
-        with:
-          name: generated-openapi
-          path: /tmp/openapi-emit-1.json
       - name: Committed spec must match generated
         run: |
           if ! cmp apps/server/api/openapi/openapi.json /tmp/openapi-emit-1.json; then

--- a/apps/server/api/openapi/openapi.json
+++ b/apps/server/api/openapi/openapi.json
@@ -41136,6 +41136,31 @@
         ]
       }
     },
+    "/runs/{id}/retries": {
+      "post": {
+        "operationId": "AgentRunsController.retryRun",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Run requeued"
+          }
+        },
+        "summary": "Retry a failed or cancelled agent run",
+        "tags": [
+          "runs",
+          "Agent Runs"
+        ]
+      }
+    },
     "/runs/{runId}": {
       "get": {
         "operationId": "RunsController.findOne",

--- a/apps/server/api/src/collections/agent-runs/agent-runs.module.ts
+++ b/apps/server/api/src/collections/agent-runs/agent-runs.module.ts
@@ -6,13 +6,17 @@
 import { AgentRunsController } from '@api/collections/agent-runs/controllers/agent-runs.controller';
 import { ThreadRunsController } from '@api/collections/agent-runs/controllers/thread-runs.controller';
 import { AgentRunsService } from '@api/collections/agent-runs/services/agent-runs.service';
+import { QueuesModule } from '@api/queues/core/queues.module';
 import { AgentThreadingModule } from '@api/services/agent-threading/agent-threading.module';
 import { forwardRef, Module } from '@nestjs/common';
 
 @Module({
   controllers: [AgentRunsController, ThreadRunsController],
   exports: [AgentRunsService],
-  imports: [forwardRef(() => AgentThreadingModule)],
+  imports: [
+    forwardRef(() => AgentThreadingModule),
+    forwardRef(() => QueuesModule),
+  ],
   providers: [AgentRunsService],
 })
 export class AgentRunsModule {}

--- a/apps/server/api/src/collections/agent-runs/controllers/agent-runs.controller.spec.ts
+++ b/apps/server/api/src/collections/agent-runs/controllers/agent-runs.controller.spec.ts
@@ -50,6 +50,7 @@ describe('AgentRunsController', () => {
     patch: vi.fn(),
     prepareRetry: vi.fn(),
     remove: vi.fn(),
+    rollbackRetry: vi.fn(),
   };
 
   const mockQueueService = {
@@ -438,6 +439,10 @@ describe('AgentRunsController', () => {
         userId: 'user_run_owner',
       },
       previousStatus: 'FAILED',
+      rollback: {
+        claimedAt: new Date('2026-07-10T00:00:00.000Z'),
+        state: { error: 'original failure', status: 'FAILED' },
+      },
       run: { id: 'run1', retryCount: 1, status: 'PENDING' },
     };
 
@@ -470,16 +475,32 @@ describe('AgentRunsController', () => {
       expect(mockQueueService.queueRun).not.toHaveBeenCalled();
     });
 
-    it('should revert the run status when enqueueing fails', async () => {
+    it('should restore the prior run state when enqueueing fails', async () => {
       mockServiceMethods.prepareRetry.mockResolvedValue(preparation);
       mockQueueService.queueRun.mockRejectedValue(new Error('redis down'));
+      mockServiceMethods.rollbackRetry.mockResolvedValue(true);
 
       await expect(
         controller.retryRun(mockRequest, 'run1', mockUser),
       ).rejects.toThrow('redis down');
-      expect(mockServiceMethods.patch).toHaveBeenCalledWith('run1', {
-        status: 'FAILED',
-      });
+      expect(mockServiceMethods.rollbackRetry).toHaveBeenCalledWith(
+        'run1',
+        '507f1f77bcf86cd799439012',
+        preparation.rollback,
+        '507f1f77bcf86cd799439013',
+      );
+    });
+
+    it('should preserve the enqueue error when rollback also fails', async () => {
+      mockServiceMethods.prepareRetry.mockResolvedValue(preparation);
+      mockQueueService.queueRun.mockRejectedValue(new Error('redis down'));
+      mockServiceMethods.rollbackRetry.mockRejectedValue(
+        new Error('database unavailable'),
+      );
+
+      await expect(
+        controller.retryRun(mockRequest, 'run1', mockUser),
+      ).rejects.toThrow('redis down');
     });
 
     it('should append a run.retried thread event when the run has a thread', async () => {

--- a/apps/server/api/src/collections/agent-runs/controllers/agent-runs.controller.spec.ts
+++ b/apps/server/api/src/collections/agent-runs/controllers/agent-runs.controller.spec.ts
@@ -16,7 +16,10 @@ import type { CreateAgentRunDto } from '@api/collections/agent-runs/dto/create-a
 import type { AgentRunDocument } from '@api/collections/agent-runs/schemas/agent-run.schema';
 import { AgentRunsService } from '@api/collections/agent-runs/services/agent-runs.service';
 import { NotFoundException } from '@api/helpers/exceptions/http/not-found.exception';
+import { AgentRunQueueService } from '@api/queues/agent-run/agent-run-queue.service';
+import { AgentThreadEngineService } from '@api/services/agent-threading/services/agent-thread-engine.service';
 import { LoggerService } from '@libs/logger/logger.service';
+import { ServiceUnavailableException } from '@nestjs/common';
 import { Test, type TestingModule } from '@nestjs/testing';
 import type { Request } from 'express';
 
@@ -45,7 +48,16 @@ describe('AgentRunsController', () => {
     getActiveRuns: vi.fn(),
     getStats: vi.fn(),
     patch: vi.fn(),
+    prepareRetry: vi.fn(),
     remove: vi.fn(),
+  };
+
+  const mockQueueService = {
+    queueRun: vi.fn(),
+  };
+
+  const mockThreadEngineService = {
+    appendEvent: vi.fn(),
   };
 
   beforeEach(async () => {
@@ -53,6 +65,11 @@ describe('AgentRunsController', () => {
       controllers: [AgentRunsController],
       providers: [
         { provide: AgentRunsService, useValue: mockServiceMethods },
+        { provide: AgentRunQueueService, useValue: mockQueueService },
+        {
+          provide: AgentThreadEngineService,
+          useValue: mockThreadEngineService,
+        },
         {
           provide: LoggerService,
           useValue: {
@@ -356,6 +373,130 @@ describe('AgentRunsController', () => {
       await expect(
         controller.cancelRun(mockRequest, 'nonexistent', mockUser),
       ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('retryRun', () => {
+    const preparation = {
+      jobData: {
+        organizationId: '507f1f77bcf86cd799439012',
+        runId: 'run1',
+        userId: 'user_run_owner',
+      },
+      previousStatus: 'FAILED',
+      run: { id: 'run1', retryCount: 1, status: 'PENDING' },
+    };
+
+    it('should reset the run, requeue it, and scope by auth metadata', async () => {
+      mockServiceMethods.prepareRetry.mockResolvedValue(preparation);
+      mockQueueService.queueRun.mockResolvedValue('agent-run-run1');
+
+      const result = await controller.retryRun(mockRequest, 'run1', mockUser);
+
+      expect(mockServiceMethods.prepareRetry).toHaveBeenCalledWith(
+        'run1',
+        '507f1f77bcf86cd799439012',
+        {
+          brandId: '507f1f77bcf86cd799439013',
+          retriedBy: '507f1f77bcf86cd799439014',
+        },
+      );
+      expect(mockQueueService.queueRun).toHaveBeenCalledWith(
+        preparation.jobData,
+      );
+      expect(result).toEqual({ data: preparation.run });
+    });
+
+    it('should throw NotFoundException when run not found', async () => {
+      mockServiceMethods.prepareRetry.mockResolvedValue(null);
+
+      await expect(
+        controller.retryRun(mockRequest, 'nonexistent', mockUser),
+      ).rejects.toThrow(NotFoundException);
+      expect(mockQueueService.queueRun).not.toHaveBeenCalled();
+    });
+
+    it('should revert the run status when enqueueing fails', async () => {
+      mockServiceMethods.prepareRetry.mockResolvedValue(preparation);
+      mockQueueService.queueRun.mockRejectedValue(new Error('redis down'));
+
+      await expect(
+        controller.retryRun(mockRequest, 'run1', mockUser),
+      ).rejects.toThrow('redis down');
+      expect(mockServiceMethods.patch).toHaveBeenCalledWith('run1', {
+        status: 'FAILED',
+      });
+    });
+
+    it('should append a run.retried thread event when the run has a thread', async () => {
+      mockServiceMethods.prepareRetry.mockResolvedValue({
+        ...preparation,
+        run: { ...preparation.run, threadId: 'thread1' },
+      });
+      mockQueueService.queueRun.mockResolvedValue('agent-run-run1');
+      mockThreadEngineService.appendEvent.mockResolvedValue({});
+
+      await controller.retryRun(mockRequest, 'run1', mockUser);
+
+      expect(mockThreadEngineService.appendEvent).toHaveBeenCalledWith({
+        commandId: 'run-retried:run1:1',
+        organizationId: '507f1f77bcf86cd799439012',
+        payload: {
+          detail: 'The run was requeued for retry by the user.',
+          label: 'Run retried',
+          status: 'pending',
+        },
+        runId: 'run1',
+        threadId: 'thread1',
+        type: 'run.retried',
+        userId: '507f1f77bcf86cd799439014',
+      });
+    });
+
+    it('should not fail the retry when the thread event append fails', async () => {
+      mockServiceMethods.prepareRetry.mockResolvedValue({
+        ...preparation,
+        run: { ...preparation.run, threadId: 'thread1' },
+      });
+      mockQueueService.queueRun.mockResolvedValue('agent-run-run1');
+      mockThreadEngineService.appendEvent.mockRejectedValue(
+        new Error('thread not found'),
+      );
+
+      const result = await controller.retryRun(mockRequest, 'run1', mockUser);
+
+      expect(result).toEqual({
+        data: { ...preparation.run, threadId: 'thread1' },
+      });
+    });
+
+    it('should throw ServiceUnavailableException when the queue is not wired', async () => {
+      const module: TestingModule = await Test.createTestingModule({
+        controllers: [AgentRunsController],
+        providers: [
+          { provide: AgentRunsService, useValue: mockServiceMethods },
+          {
+            provide: LoggerService,
+            useValue: {
+              debug: vi.fn(),
+              error: vi.fn(),
+              log: vi.fn(),
+              warn: vi.fn(),
+            },
+          },
+        ],
+      })
+        .overrideGuard(BetterAuthGuard)
+        .useValue({ canActivate: () => true })
+        .compile();
+
+      const queuelessController =
+        module.get<AgentRunsController>(AgentRunsController);
+
+      await expect(
+        queuelessController.retryRun(mockRequest, 'run1', mockUser),
+      ).rejects.toThrow(ServiceUnavailableException);
+      expect(mockServiceMethods.prepareRetry).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/server/api/src/collections/agent-runs/controllers/agent-runs.controller.ts
+++ b/apps/server/api/src/collections/agent-runs/controllers/agent-runs.controller.ts
@@ -430,13 +430,29 @@ export class AgentRunsController extends BaseCRUDController<
       throw new NotFoundException('Agent run');
     }
 
-    const { jobData, previousStatus, run } = preparation;
+    const { jobData, rollback, run } = preparation;
 
     try {
       await this.agentRunQueueService.queueRun(jobData);
     } catch (error) {
-      // The run was already reset to PENDING; revert so it stays retryable.
-      await this.agentRunsService.patch(id, { status: previousStatus });
+      try {
+        const restored = await this.agentRunsService.rollbackRetry(
+          id,
+          publicMetadata.organization,
+          rollback,
+          publicMetadata.brand,
+        );
+        if (!restored) {
+          this.loggerService.warn('Agent run retry rollback was not applied', {
+            runId: id,
+          });
+        }
+      } catch (rollbackError) {
+        this.loggerService.warn('Failed to roll back agent run retry', {
+          error: (rollbackError as Error)?.message,
+          runId: id,
+        });
+      }
       throw error;
     }
 

--- a/apps/server/api/src/collections/agent-runs/controllers/agent-runs.controller.ts
+++ b/apps/server/api/src/collections/agent-runs/controllers/agent-runs.controller.ts
@@ -18,6 +18,7 @@ import {
   serializeSingle,
 } from '@api/helpers/utils/response/response.util';
 import { handleQuerySort } from '@api/helpers/utils/sort/sort.util';
+import { AgentRunQueueService } from '@api/queues/agent-run/agent-run-queue.service';
 import { AgentThreadEngineService } from '@api/services/agent-threading/services/agent-thread-engine.service';
 import { BaseCRUDController } from '@api/shared/controllers/base-crud/base-crud.controller';
 import { AgentExecutionStatus } from '@genfeedai/enums';
@@ -35,6 +36,7 @@ import {
   Post,
   Query,
   Req,
+  ServiceUnavailableException,
 } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import type { Request } from 'express';
@@ -53,6 +55,8 @@ export class AgentRunsController extends BaseCRUDController<
     public readonly loggerService: LoggerService,
     @Optional()
     private readonly agentThreadEngineService?: AgentThreadEngineService,
+    @Optional()
+    private readonly agentRunQueueService?: AgentRunQueueService,
   ) {
     super(loggerService, agentRunsService, AgentRunSerializer, 'AgentRun', [
       'organization',
@@ -393,6 +397,76 @@ export class AgentRunsController extends BaseCRUDController<
         type: 'run.cancelled',
         userId: publicMetadata.user,
       });
+    }
+
+    return serializeSingle(request, AgentRunSerializer, run);
+  }
+
+  @Post(':id/retries')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Retry a failed or cancelled agent run' })
+  @ApiResponse({ description: 'Run requeued', status: 200 })
+  async retryRun(
+    @Req() request: Request,
+    @Param('id') id: string,
+    @CurrentUser() user: User,
+  ) {
+    if (!this.agentRunQueueService) {
+      throw new ServiceUnavailableException('Agent run queue is unavailable');
+    }
+
+    const publicMetadata = getPublicMetadata(user);
+    const preparation = await this.agentRunsService.prepareRetry(
+      id,
+      publicMetadata.organization,
+      {
+        brandId: publicMetadata.brand,
+        retriedBy: publicMetadata.user,
+      },
+    );
+
+    if (!preparation) {
+      throw new NotFoundException('Agent run');
+    }
+
+    const { jobData, previousStatus, run } = preparation;
+
+    try {
+      await this.agentRunQueueService.queueRun(jobData);
+    } catch (error) {
+      // The run was already reset to PENDING; revert so it stays retryable.
+      await this.agentRunsService.patch(id, { status: previousStatus });
+      throw error;
+    }
+
+    const threadId =
+      run.threadId?.toString() ??
+      (run.thread as unknown as { id?: string })?.id?.toString() ??
+      run.thread?.toString();
+
+    if (threadId) {
+      try {
+        await this.agentThreadEngineService?.appendEvent({
+          commandId: `run-retried:${id}:${run.retryCount ?? 0}`,
+          organizationId: publicMetadata.organization,
+          payload: {
+            detail: 'The run was requeued for retry by the user.',
+            label: 'Run retried',
+            status: 'pending',
+          },
+          runId: id,
+          threadId,
+          type: 'run.retried',
+          userId: publicMetadata.user,
+        });
+      } catch (error) {
+        // The retry already succeeded; thread provenance is best-effort.
+        this.loggerService.warn('Failed to append run.retried thread event', {
+          error: (error as Error)?.message,
+          runId: id,
+          threadId,
+        });
+      }
     }
 
     return serializeSingle(request, AgentRunSerializer, run);

--- a/apps/server/api/src/collections/agent-runs/services/agent-runs.service.spec.ts
+++ b/apps/server/api/src/collections/agent-runs/services/agent-runs.service.spec.ts
@@ -201,4 +201,151 @@ describe('AgentRunsService', () => {
       },
     });
   });
+
+  describe('prepareRetry', () => {
+    const failedRun = {
+      creditBudget: 40,
+      id: 'run-1',
+      metadata: {
+        campaignId: 'campaign-1',
+        requestedModel: 'model-from-metadata',
+        source: 'test',
+      },
+      objective: 'Do the thing',
+      retryCount: 1,
+      status: 'FAILED',
+      strategy: {
+        agentType: 'content',
+        config: { autonomyMode: 'supervised', model: 'model-from-config' },
+      },
+      strategyId: 'strategy-1',
+      threadId: 'thread-1',
+      userId: 'user-1',
+    };
+
+    it('returns null when the run is not found', async () => {
+      agentRun.findFirst.mockResolvedValue(null);
+
+      const preparation = await service.prepareRetry('missing', 'org-1', {
+        retriedBy: 'user-2',
+      });
+
+      expect(preparation).toBeNull();
+      expect(agentRun.update).not.toHaveBeenCalled();
+    });
+
+    it('scopes the lookup by organization and brand', async () => {
+      agentRun.findFirst.mockResolvedValue(null);
+
+      await service.prepareRetry('run-1', 'org-1', {
+        brandId: 'brand-1',
+        retriedBy: 'user-2',
+      });
+
+      expect(agentRun.findFirst).toHaveBeenCalledWith({
+        include: { strategy: true },
+        where: {
+          brandId: 'brand-1',
+          id: 'run-1',
+          isDeleted: false,
+          organizationId: 'org-1',
+        },
+      });
+    });
+
+    it('rejects runs that are not failed or cancelled', async () => {
+      agentRun.findFirst.mockResolvedValue({
+        ...failedRun,
+        status: 'RUNNING',
+      });
+
+      await expect(
+        service.prepareRetry('run-1', 'org-1', { retriedBy: 'user-2' }),
+      ).rejects.toThrow('Only failed or cancelled agent runs can be retried');
+      expect(agentRun.update).not.toHaveBeenCalled();
+    });
+
+    it('resets terminal state and stamps retry provenance metadata', async () => {
+      agentRun.findFirst.mockResolvedValue(failedRun);
+      agentRun.update.mockResolvedValue({ ...failedRun, status: 'PENDING' });
+
+      const preparation = await service.prepareRetry('run-1', 'org-1', {
+        retriedBy: 'user-2',
+      });
+
+      expect(preparation?.previousStatus).toBe('FAILED');
+      expect(agentRun.update).toHaveBeenCalledWith({
+        data: {
+          completedAt: null,
+          durationMs: null,
+          error: null,
+          metadata: expect.objectContaining({
+            campaignId: 'campaign-1',
+            lastRetryAt: expect.any(String),
+            retriedBy: 'user-2',
+            source: 'test',
+          }),
+          progress: 0,
+          startedAt: null,
+          status: 'PENDING',
+          summary: null,
+        },
+        where: { id: 'run-1' },
+      });
+
+      const writtenMetadata = agentRun.update.mock.calls[0]?.[0].data.metadata;
+      expect(Number.isNaN(Date.parse(writtenMetadata.lastRetryAt))).toBe(false);
+    });
+
+    it('rebuilds queue job data from the durable run and strategy records', async () => {
+      agentRun.findFirst.mockResolvedValue(failedRun);
+      agentRun.update.mockResolvedValue({ ...failedRun, status: 'PENDING' });
+
+      const preparation = await service.prepareRetry('run-1', 'org-1', {
+        retriedBy: 'user-2',
+      });
+
+      expect(preparation?.jobData).toEqual({
+        agentType: 'content',
+        autonomyMode: 'supervised',
+        campaignId: 'campaign-1',
+        creditBudget: 40,
+        model: 'model-from-metadata',
+        objective: 'Do the thing',
+        organizationId: 'org-1',
+        runId: 'run-1',
+        strategyId: 'strategy-1',
+        userId: 'user-1',
+      });
+    });
+
+    it('falls back to strategy config model and omits absent fields for cancelled runs', async () => {
+      agentRun.findFirst.mockResolvedValue({
+        id: 'run-1',
+        metadata: null,
+        status: 'CANCELLED',
+        strategy: { agentType: null, config: { model: 'model-from-config' } },
+        userId: 'user-1',
+      });
+      agentRun.update.mockResolvedValue({ id: 'run-1', status: 'PENDING' });
+
+      const preparation = await service.prepareRetry('run-1', 'org-1', {
+        retriedBy: 'user-2',
+      });
+
+      expect(preparation?.previousStatus).toBe('CANCELLED');
+      expect(preparation?.jobData).toEqual({
+        agentType: undefined,
+        autonomyMode: undefined,
+        campaignId: undefined,
+        creditBudget: undefined,
+        model: 'model-from-config',
+        objective: undefined,
+        organizationId: 'org-1',
+        runId: 'run-1',
+        strategyId: undefined,
+        userId: 'user-1',
+      });
+    });
+  });
 });

--- a/apps/server/api/src/collections/agent-runs/services/agent-runs.service.spec.ts
+++ b/apps/server/api/src/collections/agent-runs/services/agent-runs.service.spec.ts
@@ -204,7 +204,10 @@ describe('AgentRunsService', () => {
 
   describe('prepareRetry', () => {
     const failedRun = {
+      completedAt: new Date('2026-07-09T11:00:00.000Z'),
       creditBudget: 40,
+      durationMs: 60000,
+      error: 'original failure',
       id: 'run-1',
       metadata: {
         campaignId: 'campaign-1',
@@ -212,13 +215,16 @@ describe('AgentRunsService', () => {
         source: 'test',
       },
       objective: 'Do the thing',
+      progress: 70,
       retryCount: 1,
+      startedAt: new Date('2026-07-09T10:59:00.000Z'),
       status: 'FAILED',
       strategy: {
         agentType: 'content',
         config: { autonomyMode: 'supervised', model: 'model-from-config' },
       },
       strategyId: 'strategy-1',
+      summary: 'partial output',
       threadId: 'thread-1',
       userId: 'user-1',
     };
@@ -231,7 +237,7 @@ describe('AgentRunsService', () => {
       });
 
       expect(preparation).toBeNull();
-      expect(agentRun.update).not.toHaveBeenCalled();
+      expect(agentRun.updateMany).not.toHaveBeenCalled();
     });
 
     it('scopes the lookup by organization and brand', async () => {
@@ -262,19 +268,18 @@ describe('AgentRunsService', () => {
       await expect(
         service.prepareRetry('run-1', 'org-1', { retriedBy: 'user-2' }),
       ).rejects.toThrow('Only failed or cancelled agent runs can be retried');
-      expect(agentRun.update).not.toHaveBeenCalled();
+      expect(agentRun.updateMany).not.toHaveBeenCalled();
     });
 
     it('resets terminal state and stamps retry provenance metadata', async () => {
       agentRun.findFirst.mockResolvedValue(failedRun);
-      agentRun.update.mockResolvedValue({ ...failedRun, status: 'PENDING' });
 
       const preparation = await service.prepareRetry('run-1', 'org-1', {
         retriedBy: 'user-2',
       });
 
       expect(preparation?.previousStatus).toBe('FAILED');
-      expect(agentRun.update).toHaveBeenCalledWith({
+      expect(agentRun.updateMany).toHaveBeenCalledWith({
         data: {
           completedAt: null,
           durationMs: null,
@@ -289,17 +294,42 @@ describe('AgentRunsService', () => {
           startedAt: null,
           status: 'PENDING',
           summary: null,
+          updatedAt: expect.any(Date),
         },
-        where: { id: 'run-1' },
+        where: {
+          id: 'run-1',
+          isDeleted: false,
+          organizationId: 'org-1',
+          status: 'FAILED',
+        },
       });
 
-      const writtenMetadata = agentRun.update.mock.calls[0]?.[0].data.metadata;
+      const writtenMetadata =
+        agentRun.updateMany.mock.calls[0]?.[0].data.metadata;
       expect(Number.isNaN(Date.parse(writtenMetadata.lastRetryAt))).toBe(false);
+      expect(preparation?.rollback.state).toEqual({
+        completedAt: failedRun.completedAt,
+        durationMs: 60000,
+        error: 'original failure',
+        metadata: failedRun.metadata,
+        progress: 70,
+        startedAt: failedRun.startedAt,
+        status: 'FAILED',
+        summary: 'partial output',
+      });
+    });
+
+    it('rejects a concurrent retry after another request claims the run', async () => {
+      agentRun.findFirst.mockResolvedValue(failedRun);
+      agentRun.updateMany.mockResolvedValue({ count: 0 });
+
+      await expect(
+        service.prepareRetry('run-1', 'org-1', { retriedBy: 'user-2' }),
+      ).rejects.toThrow('Agent run retry is already in progress');
     });
 
     it('rebuilds queue job data from the durable run and strategy records', async () => {
       agentRun.findFirst.mockResolvedValue(failedRun);
-      agentRun.update.mockResolvedValue({ ...failedRun, status: 'PENDING' });
 
       const preparation = await service.prepareRetry('run-1', 'org-1', {
         retriedBy: 'user-2',
@@ -327,7 +357,6 @@ describe('AgentRunsService', () => {
         strategy: { agentType: null, config: { model: 'model-from-config' } },
         userId: 'user-1',
       });
-      agentRun.update.mockResolvedValue({ id: 'run-1', status: 'PENDING' });
 
       const preparation = await service.prepareRetry('run-1', 'org-1', {
         retriedBy: 'user-2',
@@ -345,6 +374,37 @@ describe('AgentRunsService', () => {
         runId: 'run-1',
         strategyId: undefined,
         userId: 'user-1',
+      });
+    });
+  });
+
+  describe('rollbackRetry', () => {
+    it('restores the prior state only for the claimed tenant-scoped retry', async () => {
+      const claimedAt = new Date('2026-07-10T00:00:00.000Z');
+      const state = {
+        error: 'original failure',
+        status: 'FAILED',
+      };
+
+      await expect(
+        service.rollbackRetry(
+          'run-1',
+          'org-1',
+          { claimedAt, state },
+          'brand-1',
+        ),
+      ).resolves.toBe(true);
+
+      expect(agentRun.updateMany).toHaveBeenCalledWith({
+        data: state,
+        where: {
+          brandId: 'brand-1',
+          id: 'run-1',
+          isDeleted: false,
+          organizationId: 'org-1',
+          status: 'PENDING',
+          updatedAt: claimedAt,
+        },
       });
     });
   });

--- a/apps/server/api/src/collections/agent-runs/services/agent-runs.service.ts
+++ b/apps/server/api/src/collections/agent-runs/services/agent-runs.service.ts
@@ -10,6 +10,7 @@ import { BaseService } from '@api/shared/services/base/base.service';
 import { AgentExecutionStatus } from '@genfeedai/enums';
 import type { PopulateOption } from '@genfeedai/interfaces';
 import type { Prisma } from '@genfeedai/prisma';
+import type { AgentRunJobData } from '@genfeedai/queue-contracts';
 import type {
   AgentRunStats,
   AgentRunStatsQueryParams,
@@ -17,7 +18,7 @@ import type {
 } from '@genfeedai/types';
 import { DEFAULT_AGENT_RUN_TIME_RANGE } from '@genfeedai/types';
 import { LoggerService } from '@libs/logger/logger.service';
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 
 type AgentRunStatsSummary = Omit<
   AgentRunStats,
@@ -37,6 +38,22 @@ type AgentRunPageOptions = {
 
 type AgentRunWriteData = Record<string, unknown>;
 type AgentRunPopulateInput = (string | PopulateOption)[] | 'none';
+
+type AgentRunRetryOptions = {
+  brandId?: string | null;
+  retriedBy: string;
+};
+
+type AgentRunRetryPreparation = {
+  jobData: AgentRunJobData;
+  previousStatus: AgentExecutionStatus;
+  run: AgentRunDocument;
+};
+
+const RETRYABLE_AGENT_RUN_STATUSES: AgentExecutionStatus[] = [
+  AgentExecutionStatus.FAILED,
+  AgentExecutionStatus.CANCELLED,
+];
 
 const DAY_IN_MS = 24 * 60 * 60 * 1000;
 const DEFAULT_AGENT_RUN_LIMIT = 50;
@@ -70,6 +87,12 @@ function requireId(
 
 function brandScope(brandId: string | null | undefined) {
   return brandId ? { brandId } : {};
+}
+
+function readJsonRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
 }
 
 function getTimeRangeDays(timeRange: AgentRunTimeRange): number {
@@ -373,6 +396,83 @@ export class AgentRunsService extends BaseService<
         status: AgentExecutionStatus.CANCELLED,
       },
     })) as AgentRunDocument | null;
+  }
+
+  /**
+   * Reset a failed or cancelled run so it can be re-enqueued, and rebuild the
+   * queue job data from the durable run/strategy records. Enqueueing is the
+   * caller's responsibility — this method only prepares state.
+   */
+  @HandleErrors('prepare agent run retry', 'agent-runs')
+  async prepareRetry(
+    id: string,
+    organizationId: string,
+    options: AgentRunRetryOptions,
+  ): Promise<AgentRunRetryPreparation | null> {
+    const run = (await this.delegate.findFirst({
+      include: { strategy: true },
+      where: {
+        id,
+        ...brandScope(options.brandId),
+        isDeleted: false,
+        organizationId,
+      },
+    })) as
+      | (AgentRunDocument & {
+          strategy?: { agentType?: string | null; config?: unknown } | null;
+        })
+      | null;
+
+    if (!run) return null;
+
+    const previousStatus = run.status as AgentExecutionStatus;
+    if (!RETRYABLE_AGENT_RUN_STATUSES.includes(previousStatus)) {
+      throw new BadRequestException(
+        `Only failed or cancelled agent runs can be retried (current status: ${previousStatus})`,
+      );
+    }
+
+    const metadata = readJsonRecord(run.metadata);
+    const strategyConfig = readJsonRecord(run.strategy?.config);
+
+    const jobData: AgentRunJobData = {
+      agentType:
+        run.strategy?.agentType ??
+        readOptionalId(strategyConfig, 'agentType') ??
+        undefined,
+      autonomyMode: readOptionalId(strategyConfig, 'autonomyMode') ?? undefined,
+      campaignId: readOptionalId(metadata, 'campaignId') ?? undefined,
+      creditBudget: run.creditBudget ?? undefined,
+      model:
+        readOptionalId(metadata, 'requestedModel') ??
+        readOptionalId(strategyConfig, 'model') ??
+        undefined,
+      objective: run.objective ?? undefined,
+      organizationId,
+      runId: run.id,
+      strategyId: run.strategyId ?? undefined,
+      userId: run.userId,
+    };
+
+    const updated = (await this.delegate.update({
+      where: { id },
+      data: {
+        completedAt: null,
+        durationMs: null,
+        error: null,
+        metadata: {
+          ...metadata,
+          lastRetryAt: new Date().toISOString(),
+          retriedBy: options.retriedBy,
+        },
+        progress: 0,
+        startedAt: null,
+        status: AgentExecutionStatus.PENDING,
+        summary: null,
+      },
+    })) as AgentRunDocument;
+
+    return { jobData, previousStatus, run: updated };
   }
 
   @HandleErrors('get active runs', 'agent-runs')

--- a/apps/server/api/src/collections/agent-runs/services/agent-runs.service.ts
+++ b/apps/server/api/src/collections/agent-runs/services/agent-runs.service.ts
@@ -9,7 +9,7 @@ import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { BaseService } from '@api/shared/services/base/base.service';
 import { AgentExecutionStatus } from '@genfeedai/enums';
 import type { PopulateOption } from '@genfeedai/interfaces';
-import type { Prisma } from '@genfeedai/prisma';
+import { Prisma } from '@genfeedai/prisma';
 import type { AgentRunJobData } from '@genfeedai/queue-contracts';
 import type {
   AgentRunStats,
@@ -18,7 +18,11 @@ import type {
 } from '@genfeedai/types';
 import { DEFAULT_AGENT_RUN_TIME_RANGE } from '@genfeedai/types';
 import { LoggerService } from '@libs/logger/logger.service';
-import { BadRequestException, Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+} from '@nestjs/common';
 
 type AgentRunStatsSummary = Omit<
   AgentRunStats,
@@ -47,7 +51,13 @@ type AgentRunRetryOptions = {
 type AgentRunRetryPreparation = {
   jobData: AgentRunJobData;
   previousStatus: AgentExecutionStatus;
+  rollback: AgentRunRetryRollback;
   run: AgentRunDocument;
+};
+
+type AgentRunRetryRollback = {
+  claimedAt: Date;
+  state: Prisma.AgentRunUpdateManyMutationInput;
 };
 
 const RETRYABLE_AGENT_RUN_STATUSES: AgentExecutionStatus[] = [
@@ -434,6 +444,7 @@ export class AgentRunsService extends BaseService<
 
     const metadata = readJsonRecord(run.metadata);
     const strategyConfig = readJsonRecord(run.strategy?.config);
+    const claimedAt = new Date();
 
     const jobData: AgentRunJobData = {
       agentType:
@@ -454,25 +465,80 @@ export class AgentRunsService extends BaseService<
       userId: run.userId,
     };
 
-    const updated = (await this.delegate.update({
-      where: { id },
-      data: {
-        completedAt: null,
-        durationMs: null,
-        error: null,
-        metadata: {
-          ...metadata,
-          lastRetryAt: new Date().toISOString(),
-          retriedBy: options.retriedBy,
-        },
-        progress: 0,
-        startedAt: null,
-        status: AgentExecutionStatus.PENDING,
-        summary: null,
+    const retryState: Prisma.AgentRunUpdateManyMutationInput = {
+      completedAt: null,
+      durationMs: null,
+      error: null,
+      metadata: {
+        ...metadata,
+        lastRetryAt: claimedAt.toISOString(),
+        retriedBy: options.retriedBy,
       },
-    })) as AgentRunDocument;
+      progress: 0,
+      startedAt: null,
+      status: AgentExecutionStatus.PENDING,
+      summary: null,
+      updatedAt: claimedAt,
+    };
+    const claim = await this.delegate.updateMany({
+      where: {
+        id,
+        ...brandScope(options.brandId),
+        isDeleted: false,
+        organizationId,
+        status: previousStatus,
+      },
+      data: retryState,
+    });
 
-    return { jobData, previousStatus, run: updated };
+    if (claim.count !== 1) {
+      throw new ConflictException('Agent run retry is already in progress');
+    }
+
+    const updated = {
+      ...run,
+      ...retryState,
+    } as AgentRunDocument;
+    const rollback: AgentRunRetryRollback = {
+      claimedAt,
+      state: {
+        completedAt: run.completedAt ?? null,
+        durationMs: run.durationMs ?? null,
+        error: run.error ?? null,
+        metadata:
+          run.metadata === null
+            ? Prisma.JsonNull
+            : (run.metadata as Prisma.InputJsonValue),
+        progress: run.progress,
+        startedAt: run.startedAt ?? null,
+        status: previousStatus,
+        summary: run.summary ?? null,
+      },
+    };
+
+    return { jobData, previousStatus, rollback, run: updated };
+  }
+
+  @HandleErrors('rollback agent run retry', 'agent-runs')
+  async rollbackRetry(
+    id: string,
+    organizationId: string,
+    rollback: AgentRunRetryRollback,
+    brandId?: string | null,
+  ): Promise<boolean> {
+    const result = await this.delegate.updateMany({
+      data: rollback.state,
+      where: {
+        id,
+        ...brandScope(brandId),
+        isDeleted: false,
+        organizationId,
+        status: AgentExecutionStatus.PENDING,
+        updatedAt: rollback.claimedAt,
+      },
+    });
+
+    return result.count === 1;
   }
 
   @HandleErrors('get active runs', 'agent-runs')

--- a/apps/server/api/src/config/openapi-parity-baseline.json
+++ b/apps/server/api/src/config/openapi-parity-baseline.json
@@ -228,6 +228,11 @@
     },
     {
       "method": "post",
+      "operationId": "AgentRunsController.retryRun",
+      "path": "/runs/{id}/retries"
+    },
+    {
+      "method": "post",
       "operationId": "AgentStrategiesController.create",
       "path": "/agent-strategies"
     },

--- a/apps/server/api/src/services/agent-threading/types/agent-thread.types.ts
+++ b/apps/server/api/src/services/agent-threading/types/agent-thread.types.ts
@@ -15,6 +15,7 @@ export const AGENT_THREAD_EVENT_TYPES = [
   'run.cancelled',
   'run.completed',
   'run.failed',
+  'run.retried',
   'memory.flushed',
   'work.started',
   'work.updated',

--- a/packages/services/ai/agent-runs.service.ts
+++ b/packages/services/ai/agent-runs.service.ts
@@ -1,6 +1,6 @@
 /**
  * Agent Runs Service
- * Manages agent execution runs — list, create, cancel, get stats.
+ * Manages agent execution runs — list, create, cancel, retry, get stats.
  * Backend: /runs API
  */
 
@@ -136,6 +136,16 @@ class AgentRunsServiceClass {
       'POST',
       undefined,
       'Failed to cancel agent run',
+    );
+    return deserializeResource<IAgentRun>(json);
+  }
+
+  async retry(id: string): Promise<IAgentRun> {
+    const json = await this.request<JsonApiResponseDocument>(
+      `/runs/${id}/retries`,
+      'POST',
+      undefined,
+      'Failed to retry agent run',
     );
     return deserializeResource<IAgentRun>(json);
   }

--- a/packages/tools/src/registry/generated/mcp-operations.generated.ts
+++ b/packages/tools/src/registry/generated/mcp-operations.generated.ts
@@ -3,7 +3,7 @@
 // Source of truth: apps/server/api/openapi/openapi.json (Phase 1 / #1247).
 // Regenerate:      bun run --filter=@genfeedai/tools generate:mcp-tools
 //
-// 1021 MCP operation bindings for generated-tool dispatch (#1249 / #1250).
+// 1022 MCP operation bindings for generated-tool dispatch (#1249 / #1250).
 
 import type { IGeneratedMcpOperationBinding } from '../openapi/build-generated-mcp-tools.js';
 
@@ -673,6 +673,19 @@ export const GENERATED_MCP_OPERATIONS: IGeneratedMcpOperationBinding[] = [
     ],
     "queryParams": [],
     "toolName": "agent_runs__remove"
+  },
+  {
+    "bodyFields": [],
+    "bodyRequired": false,
+    "bodyStyle": "none",
+    "method": "post",
+    "operationId": "AgentRunsController.retryRun",
+    "path": "/runs/{id}/retries",
+    "pathParams": [
+      "id"
+    ],
+    "queryParams": [],
+    "toolName": "agent_runs__retry_run"
   },
   {
     "bodyFields": [],

--- a/packages/tools/src/registry/generated/mcp-tools.generated.ts
+++ b/packages/tools/src/registry/generated/mcp-tools.generated.ts
@@ -3,7 +3,7 @@
 // Source of truth: apps/server/api/openapi/openapi.json (Phase 1 / #1247).
 // Regenerate:      bun run --filter=@genfeedai/tools generate:mcp-tools
 //
-// 1021 MCP tools, one per non-internal OpenAPI operation (#1248).
+// 1022 MCP tools, one per non-internal OpenAPI operation (#1248).
 // Execution metadata lives in mcp-operations.generated.ts (#1249 / #1250).
 
 import type { CanonicalToolDefinition } from '../../interfaces/tool-definition.interface.js';
@@ -1572,6 +1572,32 @@ export const GENERATED_MCP_TOOLS: CanonicalToolDefinition[] = [
     "creditCost": 0,
     "description": "remove (DELETE /runs/{id})",
     "name": "agent_runs__remove",
+    "parameters": {
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "type": "object"
+    },
+    "requiredRole": "user",
+    "surfaces": {
+      "agent": false,
+      "cliAgentVisible": false,
+      "mcp": true
+    },
+    "tags": [
+      "agent_runs"
+    ]
+  },
+  {
+    "category": "other",
+    "creditCost": 0,
+    "description": "Retry a failed or cancelled agent run (POST /runs/{id}/retries)",
+    "name": "agent_runs__retry_run",
     "parameters": {
       "properties": {
         "id": {


### PR DESCRIPTION
## Summary

Completes the agent run management API surface from #1014. A code audit showed list/inspect/cancel/stats/batch + pagination were already shipped in `apps/server/api/src/collections/agent-runs/` (creation flows through the base CRUD controller and orchestrator/cron/campaign paths); the remaining gap was **retry** — no service method, endpoint, or client wiring existed.

- **`AgentRunsService.prepareRetry`** — org/brand-scoped lookup; only `FAILED`/`CANCELLED` runs are retryable (others get a 400). Resets terminal state (status → `PENDING`, clears error/timing/progress/summary), stamps `retriedBy`/`lastRetryAt` provenance into run metadata, and rebuilds `AgentRunJobData` from durable records: strategy `agentType`/config (`autonomyMode`, `model`), run metadata (`requestedModel`, `campaignId`), and run columns (`objective`, `creditBudget`, `strategyId`, `userId`).
- **`POST /runs/:id/retries`** — mirrors the `:id/cancellations` pattern. Re-enqueues via `AgentRunQueueService.queueRun` (deterministic job IDs make concurrent retries idempotent). If enqueueing fails, the run status is reverted so it stays retryable. Appends a best-effort `run.retried` thread event (idempotent per retryCount) that never fails the request.
- **Module** — `AgentRunsModule` imports `QueuesModule` via `forwardRef` (same pattern as `AgentCampaignsModule`).
- **Event types** — `run.retried` added to `AGENT_THREAD_EVENT_TYPES`; timeline/snapshot consumers degrade gracefully on unmapped types by design.
- **Client** — `AgentRunsService.retry(id)` in `packages/services/ai`, mirroring `cancel(id)`.

## Verification

- `agent-runs.service.spec.ts` — 14 passed (6 new: scoping, status guard, state reset + provenance, job-data reconstruction incl. fallbacks)
- `agent-runs.controller.spec.ts` — 28 passed (6 new: happy path, 404, enqueue-failure revert, thread event, best-effort event failure, queue-unavailable 503)
- `bunx turbo run type-check --filter=@genfeedai/api` and `--filter=@genfeedai/services` — green
- `bunx turbo run lint --filter=@genfeedai/api --filter=@genfeedai/services` — green
- `bun run check:di-value-imports` — no violations (new `AgentRunQueueService` constructor dep is a value import)

Closes #1014

🤖 Generated with [Claude Code](https://claude.com/claude-code)