### PR TITLE
fix(services): route BrandInterviewService through shared instance cache

### DIFF
--- a/packages/services/social/brand-interview.service.test.ts
+++ b/packages/services/social/brand-interview.service.test.ts
@@ -1,0 +1,45 @@
+import {
+  clearAllServiceInstances,
+  HTTPBaseService,
+} from '@services/core/interceptor.service';
+import { BrandInterviewService } from '@services/social/brand-interview.service';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@services/core/environment.service', () => ({
+  EnvironmentService: {
+    apiEndpoint: 'https://api.genfeed.ai/v1',
+  },
+}));
+
+describe('BrandInterviewService', () => {
+  beforeEach(() => {
+    HTTPBaseService.clearAllInstances();
+    vi.clearAllMocks();
+  });
+
+  it('returns the same cached instance for a repeated token', () => {
+    const first = BrandInterviewService.getInstance('token-a');
+    const second = BrandInterviewService.getInstance('token-a');
+
+    expect(first).toBeInstanceOf(BrandInterviewService);
+    expect(second).toBe(first);
+  });
+
+  it('returns a distinct instance per token', () => {
+    const a = BrandInterviewService.getInstance('token-a');
+    const b = BrandInterviewService.getInstance('token-b');
+
+    expect(a).not.toBe(b);
+  });
+
+  it('participates in the shared cache cleared on sign-out', () => {
+    // clearAllServiceInstances() runs on logout and must wipe this service's
+    // token-bound instance so stale tokens cannot leak across sessions.
+    const before = BrandInterviewService.getInstance('token-a');
+
+    clearAllServiceInstances();
+
+    const after = BrandInterviewService.getInstance('token-a');
+    expect(after).not.toBe(before);
+  });
+});

--- a/packages/services/social/brand-interview.service.ts
+++ b/packages/services/social/brand-interview.service.ts
@@ -7,14 +7,8 @@ import type {
 } from '@genfeedai/interfaces';
 import { EnvironmentService } from '@services/core/environment.service';
 import { HTTPBaseService } from '@services/core/interceptor.service';
-import {
-  buildInstanceKey,
-  ServiceInstanceManager,
-} from '@services/core/service-instance-manager';
 
 export type { IActiveBrandInterview };
-
-const serviceInstances = new ServiceInstanceManager<BrandInterviewService>();
 
 export interface StartInterviewOptions {
   signal?: AbortSignal;
@@ -26,23 +20,10 @@ export class BrandInterviewService extends HTTPBaseService {
   }
 
   public static getInstance(token: string): BrandInterviewService {
-    const instanceKey = buildInstanceKey([token]);
-    const cached = serviceInstances.get<BrandInterviewService>(
+    return HTTPBaseService.getBaseServiceInstance(
       BrandInterviewService,
-      instanceKey,
-    );
-
-    if (
-      cached &&
-      Object.getPrototypeOf(cached) === BrandInterviewService.prototype
-    ) {
-      return cached;
-    }
-
-    const instance = new BrandInterviewService(token);
-    serviceInstances.set(BrandInterviewService, instanceKey, instance);
-
-    return instance;
+      token,
+    ) as BrandInterviewService;
   }
 
   public async startInterview(


### PR DESCRIPTION
## Problem

**P1 instance-cache leak** introduced by `8bd295b9c` (*feat(brands): brand context interview*).

`BrandInterviewService` rolled its own module-level `ServiceInstanceManager` + `getInstance(token)` cache instead of the shared `HTTPBaseService.getBaseServiceInstance(...)` factory used by every sibling service added in the same window (`AdminFleetService`, `AdminWarmupAccountsService`, `AdminPlatformSettingsService`, `AdminSystemEmailsService`).

The shared factory's cache (`httpServiceInstances` in `packages/services/core/interceptor.service.ts`) is wiped on sign-out by `clearAllServiceInstances()` (called from `useBrandProviderState.ts`). The private cache was **never cleared**, so stale token-bound `BrandInterviewService` instances leaked across logout.

## Fix

- Delete the custom `ServiceInstanceManager`/`buildInstanceKey` usage and the module-level `serviceInstances`.
- `getInstance(token)` now delegates to `HTTPBaseService.getBaseServiceInstance(BrandInterviewService, token)`, matching the siblings.
- Call sites (`use-brand-interview.ts`, `settings/interview/content.tsx`) keep the **identical** `getInstance(token)` signature — no call-site changes required.

## Tests

Added `packages/services/social/brand-interview.service.test.ts` (focused spec):
- same cached instance per repeated token
- distinct instance per token
- **participates in the shared cache cleared on sign-out** (the regression guard)

```
Test Files  1 passed (1)
     Tests  3 passed (3)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)