### PR TITLE
fix(docker): publish MCP port 3014 in self-hosted compose

### DIFF
--- a/docker/docker-compose.selfhosted.yml
+++ b/docker/docker-compose.selfhosted.yml
@@ -27,9 +27,11 @@ services:
       - .env
     ports:
       # Host side overridable; container side is FIXED — the entrypoint always
-      # starts the app on 3000 and the API on 3010 regardless of these vars.
+      # starts the app on 3000, the API on 3010, and MCP on 3014 regardless of
+      # these vars (see docker/selfhosted-entrypoint.sh).
       - "${SELFHOSTED_APP_PORT:-3000}:3000"  # Web UI
       - "${SELFHOSTED_API_PORT:-3010}:3010"  # API
+      - "${SELFHOSTED_MCP_PORT:-3014}:3014"  # MCP
     volumes:
       - genfeed_data:/data
     healthcheck:


### PR DESCRIPTION
## Problem

P0 docs bug from #867 (d072d178f). The self-host docs advertise `http://localhost:3014` for MCP:

- `apps/docs/content/guides/self-host-quickstart.mdx:57,72`
- `apps/docs/content/core/installation.mdx:171`
- `docs/self-hosting.md:17`

But `docker/docker-compose.selfhosted.yml` only published `3000` and `3010` — so following the quickstart hit a dead port from the host.

## Root cause (not what it first looks like)

MCP is **not** phantom in self-host. It genuinely runs in the container:

- `docker/selfhosted-entrypoint.sh:99` — `PORT=${MCP_PORT} node apps/server/dist/apps/mcp/main.js &` starts MCP on 3014
- `docker/Dockerfile.selfhosted:196,254` — builds `@genfeedai/mcp` and `EXPOSE 3000 3010 3014`, with an explicit comment that the entrypoint starts it
- `docker/docker-compose.staging.yml:114` — MCP serves a real `/v1/health` on 3014

`EXPOSE` only *documents* a port; it does not *publish* it to the host. The compose file just never mapped 3014.

So the correct fix is to **publish the port**, making the docs accurate — not to delete a real, intended surface.

## Change

Map `3014:3014` in the self-hosted compose, host-overridable via `SELFHOSTED_MCP_PORT` to match the existing `SELFHOSTED_APP_PORT` / `SELFHOSTED_API_PORT` pattern.

```diff
       - "${SELFHOSTED_APP_PORT:-3000}:3000"  # Web UI
       - "${SELFHOSTED_API_PORT:-3010}:3010"  # API
+      - "${SELFHOSTED_MCP_PORT:-3014}:3014"  # MCP
```

No doc edits required — all four references become correct once the port is published.

## Verification

- Code-path traced: entrypoint starts MCP on 3014 → Dockerfile EXPOSEs 3014 → healthcheck target exists on 3014. The single missing link was the host port publish.
- Full compose boot is validated by the release E2E workflow (which builds/pulls the `ghcr.io/genfeedai/genfeed.ai` image and runs `docker-compose.selfhosted.yml`) in CI, not locally.