### PR TITLE
fix(workflows): resolve source-ingredient brand from scalar FK, org-scope the lookup

### DIFF
--- a/apps/server/api/src/collections/workflows/services/workflow-engine-executor-helper.service.spec.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-engine-executor-helper.service.spec.ts
@@ -1,0 +1,91 @@
+import type { IngredientsService } from '@api/collections/ingredients/services/ingredients.service';
+import { WorkflowEngineExecutorHelperService } from '@api/collections/workflows/services/workflow-engine-executor-helper.service';
+import type { ConfigService } from '@libs/config/config.service';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('WorkflowEngineExecutorHelperService.resolveBrandIdFromInputOrFail', () => {
+  const sourceIngredientId = 'aaaaaaaaaaaaaaaaaaaaaaaa';
+  const organizationId = 'org-1';
+
+  const findOne = vi.fn();
+  const ingredientsService = { findOne } as unknown as IngredientsService;
+  const configService = {} as unknown as ConfigService;
+
+  let service: WorkflowEngineExecutorHelperService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new WorkflowEngineExecutorHelperService(
+      configService,
+      undefined,
+      undefined,
+      ingredientsService,
+    );
+  });
+
+  it('returns the configured brandId without touching the ingredient store', async () => {
+    const brandId = await service.resolveBrandIdFromInputOrFail(
+      'brand-from-config',
+      { id: sourceIngredientId },
+      'lipSync',
+      organizationId,
+    );
+
+    expect(brandId).toBe('brand-from-config');
+    expect(findOne).not.toHaveBeenCalled();
+  });
+
+  it('resolves the brandId from the source ingredient scalar FK', async () => {
+    findOne.mockResolvedValue({
+      brandId: 'brand-from-ingredient',
+      id: sourceIngredientId,
+    });
+
+    const brandId = await service.resolveBrandIdFromInputOrFail(
+      undefined,
+      { id: sourceIngredientId },
+      'reframe',
+      organizationId,
+    );
+
+    expect(brandId).toBe('brand-from-ingredient');
+    expect(findOne).toHaveBeenCalledWith({
+      _id: sourceIngredientId,
+      isDeleted: false,
+      organizationId,
+    });
+  });
+
+  it('throws when neither a configured brandId nor a source ingredient brand exists', async () => {
+    findOne.mockResolvedValue({ brandId: null, id: sourceIngredientId });
+
+    await expect(
+      service.resolveBrandIdFromInputOrFail(
+        undefined,
+        { id: sourceIngredientId },
+        'upscale',
+        organizationId,
+      ),
+    ).rejects.toThrow('upscale requires a brandId or source ingredient brand');
+  });
+
+  it('does not resolve a brandId from an ingredient in another organization', async () => {
+    // Org-scoped query misses the foreign-org ingredient → returns null.
+    findOne.mockResolvedValue(null);
+
+    await expect(
+      service.resolveBrandIdFromInputOrFail(
+        undefined,
+        { id: sourceIngredientId },
+        'lipSync',
+        organizationId,
+      ),
+    ).rejects.toThrow('lipSync requires a brandId or source ingredient brand');
+
+    expect(findOne).toHaveBeenCalledWith({
+      _id: sourceIngredientId,
+      isDeleted: false,
+      organizationId,
+    });
+  });
+});

--- a/apps/server/api/src/collections/workflows/services/workflow-engine-executor-helper.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-engine-executor-helper.service.ts
@@ -213,6 +213,7 @@ export class WorkflowEngineExecutorHelperService {
     configuredBrandId: string | undefined,
     source: unknown,
     nodeType: string,
+    organizationId: string,
   ): Promise<string> {
     if (configuredBrandId) {
       return configuredBrandId;
@@ -223,16 +224,13 @@ export class WorkflowEngineExecutorHelperService {
       const sourceIngredient = await this.ingredientsService.findOne({
         _id: sourceIngredientId,
         isDeleted: false,
+        organizationId,
       });
-      const sourceBrandId =
-        this.getDocumentId(
-          (sourceIngredient as unknown as { brand?: unknown })?.brand,
-        ) ??
-        (
-          sourceIngredient as unknown as { brand?: { toString(): string } }
-        )?.brand?.toString();
 
-      if (sourceBrandId) {
+      // Read the scalar FK (`brandId`) — the Mongo-era `brand` alias is
+      // undefined on Prisma rows. See .agents/memory/rules/prisma_legacy_alias_fields.md.
+      const sourceBrandId = sourceIngredient?.brandId;
+      if (typeof sourceBrandId === 'string' && sourceBrandId.length > 0) {
         return sourceBrandId;
       }
     }

--- a/apps/server/api/src/collections/workflows/services/workflow-media-generation-executor-registrar.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-media-generation-executor-registrar.service.ts
@@ -121,6 +121,7 @@ export class WorkflowMediaGenerationExecutorRegistrarService {
             this.helper.readConfigString(node?.config, 'brandId'),
             mediaUrl,
             'lipSync',
+            context.organizationId,
           );
           const pendingOutput = await this.helper.createAndLinkProcessingOutput(
             {
@@ -340,6 +341,7 @@ export class WorkflowMediaGenerationExecutorRegistrarService {
       this.helper.readConfigString(params.node.config, 'brandId'),
       params.mediaUrl,
       params.nodeType,
+      params.context.organizationId,
     );
     const pendingOutput = await this.helper.createAndLinkProcessingOutput({
       output: {


### PR DESCRIPTION
## Summary

P1 bug introduced by #1418 in `resolveBrandIdFromInputOrFail` (`workflow-engine-executor-helper.service.ts`). Media-generation nodes that infer brand from an upstream ingredient (`lipSync`, `reframe`, `upscale`) could **never** resolve a brand and always threw `"<nodeType> requires a brandId or source ingredient brand"`.

## Root cause

When `configuredBrandId` was absent, the helper fetched the source ingredient and read `sourceIngredient.brand`. `IngredientsService.findOne` is an override that returns the **raw** `prisma.ingredient.findFirst` row — no `include`, no `normalizeDocument` — so the Mongo-era `brand` alias is always `undefined` at runtime. The fallback branch was therefore dead.

Secondary defect: the lookup had **no `organizationId` scoping**, so a workflow node input could reference another org's ingredient.

## Fix

- Read the scalar FK **`brandId`** instead of the `brand` alias (per `.agents/memory/rules/prisma_legacy_alias_fields.md` / `docs/identity-resolution.md`).
- Thread `organizationId` through the helper and **scope the query** to the caller's org.
- Update both callers (`lipSync` resolver + `runReplicateMediaTransform`) to pass `context.organizationId`.

## Tests

New focused spec `workflow-engine-executor-helper.service.spec.ts` covering:
- brandId from config (no store hit)
- brandId resolved from source ingredient's `brandId`
- missing both → throws
- cross-org ingredient id → not resolved (org-scoped query misses)

`bun run test --filter=@genfeedai/api -- workflow-engine-executor-helper.service.spec.ts` → 4 passed.

Full validation via PR CI.