### PR TITLE
fix(mobile): don't alert on dismissed Google sign-in popup

### DIFF
--- a/apps/mobile/app/app/(public)/login.tsx
+++ b/apps/mobile/app/app/(public)/login.tsx
@@ -71,14 +71,26 @@ export default function Login() {
     try {
       setIsGoogleLoading(true);
       const result = await promptGoogleAsync();
-      const auth = result.type === 'success' ? result.authentication : null;
+
+      // Anything other than a completed flow is not a failure: 'cancel' and
+      // 'dismiss' mean the user closed the OAuth popup, and 'opened'/'locked'
+      // are non-terminal states. Only a genuine 'error' warrants an alert.
+      if (result.type !== 'success') {
+        if (result.type === 'error') {
+          Alert.alert(
+            'Google sign in failed',
+            result.error?.message || 'An error occurred',
+          );
+        }
+        return;
+      }
+
+      const auth = result.authentication;
       // Prefer the canonical OIDC field; fall back to the raw params entry.
       const idToken =
-        result.type === 'success'
-          ? (auth?.idToken ??
-            (result.params?.id_token as string | undefined) ??
-            null)
-          : null;
+        auth?.idToken ??
+        (result.params?.id_token as string | undefined) ??
+        null;
 
       if (!idToken) {
         Alert.alert(
@@ -89,8 +101,7 @@ export default function Login() {
       }
 
       // Forward the nonce so the server can verify it against the token claim.
-      const nonce =
-        result.type === 'success' ? (googleRequest?.nonce ?? null) : null;
+      const nonce = googleRequest?.nonce ?? null;
 
       await signInWithGoogleIdToken({
         accessToken: auth?.accessToken ?? null,


### PR DESCRIPTION
## Problem

P2 UX bug from #943 (67467c8da). In `apps/mobile/app/app/(public)/login.tsx`, after `promptGoogleAsync()` any result other than `success` fell through to the missing-ID-token branch and fired an `Alert.alert('Google sign in failed', …)`. So a user who simply **dismissed the Google OAuth popup** got a spurious error alert.

## Root cause

`promptGoogleAsync()` (expo-auth-session `AuthSessionResult`, verified against installed **v57.0.2**) returns:

- `type: 'cancel'` — user closed the browser / OAuth popup
- `type: 'dismiss'` — dismissed manually
- `type: 'opened' | 'locked'` — non-terminal states
- `type: 'error'` — genuine failure
- `type: 'success'` — completed

The old code only special-cased `'success'`; every other type produced `idToken === null` → failure alert.

## Fix

Return **silently** for every non-`success` result, keeping the failure alert only for a genuine `'error'` result (now surfacing `result.error?.message`) or a successful flow that returns no ID token. As a bonus the success-branch narrowing simplifies (`result.authentication` / `result.params` / `googleRequest.nonce` no longer need the inline `type === 'success'` guards).

## Apple sign-in

The task flagged checking the Apple path for the same pattern — this file has **no Apple sign-in** (only Google + email/password), so there was nothing to fix there.

## Verification

- `biome check` — clean
- Pre-commit hooks (secretlint, biome, raw-HTML, bespoke-card) — pass
- Type-check deferred to PR CI (worktree has no `node_modules`; the change is type-sound via standard union narrowing)

Fixes #943.