### PR TITLE
fix(extension): point login/signup links at studio app, not marketing site

### DIFF
--- a/apps/extensions/browser/app/src/components/pages/LoginPage.tsx
+++ b/apps/extensions/browser/app/src/components/pages/LoginPage.tsx
@@ -6,8 +6,8 @@ import { EnvironmentService } from '~services/environment.service';
 
 export default function LoginPage() {
   const logoUrl = useThemeLogo();
-  const signInUrl = `${EnvironmentService.websiteDomain}/login`;
-  const signUpUrl = `${EnvironmentService.websiteDomain}/sign-up?source=browser-extension`;
+  const signInUrl = `${EnvironmentService.appDomain}/login`;
+  const signUpUrl = `${EnvironmentService.appDomain}/sign-up?source=browser-extension`;
 
   const handleSignIn = () => {
     chrome.tabs

--- a/apps/extensions/browser/app/src/services/environment.service.ts
+++ b/apps/extensions/browser/app/src/services/environment.service.ts
@@ -27,11 +27,21 @@ export const websiteDomain = isDevelopment
   ? 'https://local.genfeed.ai'
   : 'https://genfeed.ai';
 
+/**
+ * Studio app (apps/app) URL — serves the auth routes (`/login`, `/sign-up`).
+ * The marketing site (`websiteDomain`) does NOT host these routes, so auth
+ * links must target this domain instead.
+ */
+export const appDomain =
+  process.env.PLASMO_PUBLIC_APP_ENDPOINT ||
+  (isDevelopment ? 'http://local.genfeed.ai:3000' : 'https://app.genfeed.ai');
+
 export const cookieDomain = isDevelopment ? 'local.genfeed.ai' : 'genfeed.ai';
 
 /** @deprecated Use individual exports instead */
 export const EnvironmentService = {
   apiEndpoint,
+  appDomain,
   assetsEndpoint,
   cookieDomain,
   ingredientsEndpoint,

--- a/apps/extensions/browser/app/tests/components/pages/LoginPage.test.tsx
+++ b/apps/extensions/browser/app/tests/components/pages/LoginPage.test.tsx
@@ -25,7 +25,7 @@ describe('LoginPage', () => {
       screen.getByRole('link', { name: 'Create a free account' }),
     ).toHaveAttribute(
       'href',
-      'https://genfeed.ai/sign-up?source=browser-extension',
+      'https://app.genfeed.ai/sign-up?source=browser-extension',
     );
   });
 });


### PR DESCRIPTION
## Problem

P1 follow-up to #1525. The browser extension's `LoginPage` built both auth links from `EnvironmentService.websiteDomain`:

```ts
const signInUrl = `${EnvironmentService.websiteDomain}/login`;
const signUpUrl = `${EnvironmentService.websiteDomain}/sign-up?source=browser-extension`;
```

`websiteDomain` resolves to the **marketing site** (`https://genfeed.ai`), which hosts **neither** `/login` nor `/sign-up` — those routes live in the **studio app** (`apps/app`, `app.genfeed.ai`). So the "Create a free account" link **404'd**, and "Sign in" pointed at a non-existent marketing route too.

The same #1525 commit already used the correct pattern in `ButtonRequestAccess`, targeting `EnvironmentService.apps.app` → `${app}/sign-up`.

## Fix

- Add an `appDomain` field to the extension's `environment.service.ts` resolving to the studio app:
  - prod → `https://app.genfeed.ai`
  - dev → `http://local.genfeed.ai:3000` (matches `apps/app/.env.example` `NEXT_PUBLIC_APPS_APP_ENDPOINT`)
  - overridable via `PLASMO_PUBLIC_APP_ENDPOINT`
- Repoint **both** `signInUrl` and `signUpUrl` at `appDomain`.
- Update `LoginPage.test.tsx` to assert the studio-app URL (the old test locked in the broken marketing-site URL).

Verified `apps/app` serves both `/login` and `/sign-up` under `app/(public)/`.

## Notes

- The raw `<a>` for the signup link is kept — it's an external navigation link and is **not** blocked by `lint-no-raw-html.sh` (which only covers `<button>`/`<input>`/etc.).
- Out of scope: `IdeaDraftPage.tsx:222` hardcodes `https://app.genfeed.ai/posts` (a `/posts` link, dev-broken but not an auth route) — left as-is.

## Verification

- Pre-commit hooks green (secretlint, raw-html lint, biome).
- URL-resolution logic verified across prod/test/dev/override.
- The extension's vitest suite is currently **unrunnable in a git worktree** (`plasmo` dep isn't hoisted here → `Tsconfig not found` for `tests/setup.ts` on *every* extension test, including untouched ones). The updated `LoginPage.test.tsx` will run in CI from the main checkout.
