### PR TITLE
fix(api): preserve autoRequeueWinners on partial trend preference updates

### DIFF
--- a/apps/server/api/src/collections/trends/services/trend-preferences.service.spec.ts
+++ b/apps/server/api/src/collections/trends/services/trend-preferences.service.spec.ts
@@ -288,9 +288,15 @@ describe('TrendPreferencesService', () => {
       expect(createArg.data.config).not.toHaveProperty('autoRequeueWinners');
     });
 
-    it('should preserve an existing autoRequeueWinners when a partial update omits it', async () => {
+    it('should preserve every omitted field on a partial update', async () => {
       prisma.trendPreferences.findFirst.mockResolvedValue({
-        config: { autoRequeueWinners: true, keywords: ['old'] },
+        config: {
+          autoRequeueWinners: true,
+          categories: ['technology'],
+          hashtags: ['#ai'],
+          keywords: ['old'],
+          platforms: ['twitter'],
+        },
         id: 'pref-1',
       });
       prisma.trendPreferences.update.mockResolvedValue({});
@@ -299,8 +305,40 @@ describe('TrendPreferencesService', () => {
       await service.savePreferences(organizationId, { keywords: ['ai'] });
 
       const updateArg = prisma.trendPreferences.update.mock.calls[0][0];
-      expect(updateArg.data.config.autoRequeueWinners).toBe(true);
-      expect(updateArg.data.config.keywords).toEqual(['ai']);
+      expect(updateArg.data.config).toEqual({
+        autoRequeueWinners: true,
+        categories: ['technology'],
+        hashtags: ['#ai'],
+        keywords: ['ai'],
+        platforms: ['twitter'],
+      });
+    });
+
+    it('should preserve stored arrays when only the opt-in flag changes', async () => {
+      prisma.trendPreferences.findFirst.mockResolvedValue({
+        config: {
+          autoRequeueWinners: false,
+          categories: ['technology'],
+          hashtags: ['#ai'],
+          keywords: ['agents'],
+          platforms: ['twitter'],
+        },
+        id: 'pref-1',
+      });
+      prisma.trendPreferences.update.mockResolvedValue({});
+
+      await service.savePreferences(organizationId, {
+        autoRequeueWinners: true,
+      });
+
+      const updateArg = prisma.trendPreferences.update.mock.calls[0][0];
+      expect(updateArg.data.config).toEqual({
+        autoRequeueWinners: true,
+        categories: ['technology'],
+        hashtags: ['#ai'],
+        keywords: ['agents'],
+        platforms: ['twitter'],
+      });
     });
   });
 

--- a/apps/server/api/src/collections/trends/services/trend-preferences.service.spec.ts
+++ b/apps/server/api/src/collections/trends/services/trend-preferences.service.spec.ts
@@ -287,6 +287,21 @@ describe('TrendPreferencesService', () => {
       const createArg = prisma.trendPreferences.create.mock.calls[0][0];
       expect(createArg.data.config).not.toHaveProperty('autoRequeueWinners');
     });
+
+    it('should preserve an existing autoRequeueWinners when a partial update omits it', async () => {
+      prisma.trendPreferences.findFirst.mockResolvedValue({
+        config: { autoRequeueWinners: true, keywords: ['old'] },
+        id: 'pref-1',
+      });
+      prisma.trendPreferences.update.mockResolvedValue({});
+
+      // Common edit flow: keywords/categories/platforms change, opt-in flag untouched.
+      await service.savePreferences(organizationId, { keywords: ['ai'] });
+
+      const updateArg = prisma.trendPreferences.update.mock.calls[0][0];
+      expect(updateArg.data.config.autoRequeueWinners).toBe(true);
+      expect(updateArg.data.config.keywords).toEqual(['ai']);
+    });
   });
 
   describe('mergeWinnerSignals', () => {

--- a/apps/server/api/src/collections/trends/services/trend-preferences.service.ts
+++ b/apps/server/api/src/collections/trends/services/trend-preferences.service.ts
@@ -49,33 +49,36 @@ export class TrendPreferencesService {
   ): Promise<TrendPreferencesDocument> {
     try {
       const brandId = preferences.brandId ?? null;
-      const normalizedPreferences: Record<string, unknown> = {
-        categories: preferences.categories ?? [],
-        hashtags: preferences.hashtags ?? [],
-        keywords: preferences.keywords ?? [],
-        platforms: preferences.platforms ?? [],
-      };
-
       const existing = await this.prisma.trendPreferences.findFirst({
         where: { brandId, isDeleted: false, organizationId },
       });
+      const storedConfig = this.readObjectRecord(existing?.config);
+      const normalizedPreferences: Record<string, unknown> = {
+        ...(storedConfig ?? {}),
+        categories:
+          preferences.categories ??
+          this.readStringArray(storedConfig?.categories),
+        hashtags:
+          preferences.hashtags ?? this.readStringArray(storedConfig?.hashtags),
+        keywords:
+          preferences.keywords ?? this.readStringArray(storedConfig?.keywords),
+        platforms:
+          preferences.platforms ??
+          this.readStringArray(storedConfig?.platforms),
+      };
 
       if (preferences.autoRequeueWinners !== undefined) {
         normalizedPreferences.autoRequeueWinners =
           preferences.autoRequeueWinners;
-      } else if (existing) {
+      } else if (storedConfig?.autoRequeueWinners !== undefined) {
         // `config` is a Json column and Prisma REPLACES Json values on update
-        // (it does not merge), so a partial update that omits the opt-in flag
-        // would silently wipe a previously saved `autoRequeueWinners: true`.
-        // Carry the stored value forward when one exists; leave it absent for a
-        // never-configured record so the config shape stays clean (#1112).
-        const storedConfig = this.readObjectRecord(existing.config);
-        if (storedConfig?.autoRequeueWinners !== undefined) {
-          normalizedPreferences.autoRequeueWinners = this.readBoolean(
-            storedConfig.autoRequeueWinners,
-            false,
-          );
-        }
+        // (it does not merge), so preserve omitted fields from the stored
+        // document. Leave the opt-in flag absent for a never-configured record
+        // so the config shape stays clean (#1112).
+        normalizedPreferences.autoRequeueWinners = this.readBoolean(
+          storedConfig.autoRequeueWinners,
+          false,
+        );
       }
 
       const updateData = {

--- a/apps/server/api/src/collections/trends/services/trend-preferences.service.ts
+++ b/apps/server/api/src/collections/trends/services/trend-preferences.service.ts
@@ -55,20 +55,33 @@ export class TrendPreferencesService {
         keywords: preferences.keywords ?? [],
         platforms: preferences.platforms ?? [],
       };
-      // Only persist the opt-in flag when the caller supplied it, so callers that
-      // never touch it (the common case) leave the stored config shape untouched.
-      if (preferences.autoRequeueWinners !== undefined) {
-        normalizedPreferences.autoRequeueWinners =
-          preferences.autoRequeueWinners;
-      }
-      const updateData = {
-        config: normalizedPreferences,
-        updatedAt: new Date(),
-      };
 
       const existing = await this.prisma.trendPreferences.findFirst({
         where: { brandId, isDeleted: false, organizationId },
       });
+
+      if (preferences.autoRequeueWinners !== undefined) {
+        normalizedPreferences.autoRequeueWinners =
+          preferences.autoRequeueWinners;
+      } else if (existing) {
+        // `config` is a Json column and Prisma REPLACES Json values on update
+        // (it does not merge), so a partial update that omits the opt-in flag
+        // would silently wipe a previously saved `autoRequeueWinners: true`.
+        // Carry the stored value forward when one exists; leave it absent for a
+        // never-configured record so the config shape stays clean (#1112).
+        const storedConfig = this.readObjectRecord(existing.config);
+        if (storedConfig?.autoRequeueWinners !== undefined) {
+          normalizedPreferences.autoRequeueWinners = this.readBoolean(
+            storedConfig.autoRequeueWinners,
+            false,
+          );
+        }
+      }
+
+      const updateData = {
+        config: normalizedPreferences,
+        updatedAt: new Date(),
+      };
 
       if (existing) {
         const updated = await this.prisma.trendPreferences.update({

--- a/apps/server/api/src/collections/trends/services/trend-reference-corpus.service.ts
+++ b/apps/server/api/src/collections/trends/services/trend-reference-corpus.service.ts
@@ -650,25 +650,34 @@ export class TrendReferenceCorpusService {
       },
     });
 
-    const remixCounts = await this.getRemixCounts(
-      docs.map((doc) => doc.id),
-      organizationId,
-      brandId,
-    );
-
+    // `isPromptReadyReference` does not consult remix counts, so build records
+    // with an empty map for the filter/slice pass and defer the remix-count
+    // query until after selection. Only the final `selectedReferences` are
+    // consumed downstream, so the raw `ANY(...)` array should carry just those
+    // ids rather than the full `limit * 4` over-fetched page (#1112 P2).
+    const emptyRemixCounts = new Map<string, number>();
     const promptReadyReferences = docs
       .map((doc) =>
         this.toReferenceRecord(
           doc.id,
           doc.data as unknown as ReferenceRecordData,
           doc.createdAt,
-          remixCounts,
+          emptyRemixCounts,
         ),
       )
       .filter((reference) =>
         this.isPromptReadyReference(reference, contentIntent),
       );
     const selectedReferences = promptReadyReferences.slice(0, limit);
+
+    const remixCounts = await this.getRemixCounts(
+      selectedReferences.map((reference) => reference.id),
+      organizationId,
+      brandId,
+    );
+    for (const reference of selectedReferences) {
+      reference.remixCount = remixCounts.get(reference.id) ?? 0;
+    }
 
     const packs = requestedTypes
       .map((type) =>


### PR DESCRIPTION
## Problem

`TrendPreferences.config` is a Json column ([schema.prisma:3842](packages/prisma/prisma/schema.prisma)) and **Prisma replaces Json values on update — it does not merge**. `TrendPreferencesService.savePreferences` only copied `autoRequeueWinners` into the config when the caller supplied it, then did `update({ data: { config } })`.

So any partial update through `PUT /preferences` — the common keywords/categories/platforms edit flow, where [trends.controller.ts:599-609](apps/server/api/src/collections/trends/controllers/trends.controller.ts) passes `autoRequeueWinners: dto.autoRequeueWinners` = `undefined` — silently wiped a previously saved `autoRequeueWinners: true`. The next read fell back to `false`.

`mergeWinnerSignals` already dodged this by manually re-injecting `existing?.autoRequeueWinners`; the controller path did not.

## Fix (P1)

In `savePreferences`, when the caller omits `autoRequeueWinners` and an existing record already holds one, carry the stored value forward (read from the raw `config`, the flag's only source of truth) before the update. Create still omits the flag so a never-configured record keeps a clean config shape.

New spec asserts a partial update preserves an existing `true` (the create path was already covered).

## Also (P2 optimization, same collection)

`getPromptReferencePacks` ([trend-reference-corpus.service.ts](apps/server/api/src/collections/trends/services/trend-reference-corpus.service.ts)) ran `getRemixCounts` over the full `limit * 4` over-fetched doc set **before** `isPromptReadyReference` filtering + `.slice(0, limit)`. The filter never consults remix counts, so the query is now deferred until after selection — the raw `ANY(...)` array carries only the consumed ids.

## Verification

Focused specs green:

```
Test Files  2 passed (2)
     Tests  34 passed (34)
```
(`trend-preferences.service.spec.ts`, `trend-reference-corpus.service.spec.ts`)

Refs #1112