### PR TITLE
fix(pricing): rebuild clean artifacts

### DIFF
--- a/packages/pricing/package.json
+++ b/packages/pricing/package.json
@@ -36,7 +36,7 @@
   },
   "type": "module",
   "scripts": {
-    "build": "tsc --build",
+    "build": "bun run clean && tsc --build",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "dev": "tsc --watch",
     "type-check": "tsc --noEmit"


### PR DESCRIPTION
## Summary
- clean `@genfeedai/pricing` build outputs and incremental metadata before its project build
- prevent restored/stale `tsconfig.tsbuildinfo` from leaving an unusable `dist/index.d.ts`

## Evidence
Trunk OpenAPI job `29072359622` failed while building `@genfeedai/config` with `TS2306` against `packages/pricing/dist/index.d.ts`; the preceding pricing build had skipped emission using restored incremental state.

## Verification
- `bunx biome check packages/pricing/package.json`
- `git diff --check`
- broad build verification delegated to PR CI