### PR TITLE
perf(prisma): index real hot-path filters for prompts, context_entries, votes

### DIFF
--- a/packages/prisma/prisma/migrations/20260710120000_add_missing_fk_scoped_indexes/migration.sql
+++ b/packages/prisma/prisma/migrations/20260710120000_add_missing_fk_scoped_indexes/migration.sql
@@ -1,0 +1,37 @@
+-- Add the missing hot-path indexes for three tenant tables that were doing
+-- sequential scans (audit docs/audits/01-dry-slop-audit.md, org-index gap).
+--
+-- The audit framed this as an "organizationId index gap", but a per-model query
+-- audit shows these three are NOT read by organizationId — their hot filters are
+-- FK-leading. Indexing the real filter is the actual fix; a dead organizationId
+-- index would only add write amplification:
+--   * prompts        — list scoped by owning user: WHERE userId, isDeleted
+--                      ORDER BY createdAt DESC (prompts.controller findAll).
+--   * context_entries — read per context base: WHERE contextBaseId, isDeleted
+--                      (contexts.service getStats / findSimilarEntries).
+--   * votes          — toggled per (entity, user): WHERE entityId, userId,
+--                      isDeleted (agent-tool-executor toggle + votes remove).
+--
+-- Built CONCURRENTLY: all three are continuously written (every generation,
+-- context add, and vote), so a plain CREATE INDEX would take an ACCESS EXCLUSIVE
+-- lock for the whole build and stall live writes. CONCURRENTLY keeps reads/writes
+-- running.
+--
+-- CONCURRENTLY must run OUTSIDE a transaction block. Prisma runs a migration's
+-- statements without a wrapping transaction ONLY when the file contains just
+-- CONCURRENTLY index builds — so this file carries ONLY bare CONCURRENTLY builds,
+-- no DML / DO $$ blocks, matching the precedent
+-- 20260703120100_add_post_analytics_daily_unique. See prisma/prisma#14456.
+--
+-- `IF NOT EXISTS` makes each build a no-op where the index already exists. If a
+-- build fails it leaves an INVALID index of the same name — DROP it and re-deploy;
+-- do not blindly re-run.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "prompts_user_deleted_created_at_idx"
+  ON "prompts" ("userId", "isDeleted", "createdAt" DESC);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "context_entries_context_base_deleted_idx"
+  ON "context_entries" ("contextBaseId", "isDeleted");
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "votes_entity_user_deleted_idx"
+  ON "votes" ("entityId", "userId", "isDeleted");

--- a/packages/prisma/prisma/schema.prisma
+++ b/packages/prisma/prisma/schema.prisma
@@ -1624,6 +1624,10 @@ model Prompt {
   ingredients Ingredient[] @relation("ingredient_prompt")
   metadata    Metadata[]
 
+  // Prompt list is scoped by owning user, not organization: the controller
+  // filters `{ userId, scope, isDeleted }` and orders by `createdAt desc`
+  // (prompts.controller findAll). No org-leading read path exists.
+  @@index([userId, isDeleted, createdAt(sort: Desc)], map: "prompts_user_deleted_created_at_idx")
   @@map("prompts")
 }
 
@@ -4324,6 +4328,11 @@ model ContextEntry {
   createdAt      DateTime     @default(now())
   updatedAt      DateTime     @updatedAt
 
+  // Entries are read per context base, not per organization: the hot paths
+  // filter `{ contextBaseId, isDeleted }` (contexts.service getStats /
+  // findSimilarEntries / removeEntry). organizationId is only an ownership
+  // guard on point mutations.
+  @@index([contextBaseId, isDeleted], map: "context_entries_context_base_deleted_idx")
   @@map("context_entries")
 }
 
@@ -4434,6 +4443,11 @@ model Vote {
   createdAt      DateTime      @default(now())
   updatedAt      DateTime      @updatedAt
 
+  // Votes are read/toggled by `{ entityId, userId, isDeleted }` (votes toggle
+  // in agent-tool-executor + votes.controller remove). entityId leads so the
+  // same index also serves per-entity vote counts on cache miss. Never queried
+  // by organizationId.
+  @@index([entityId, userId, isDeleted], map: "votes_entity_user_deleted_idx")
   @@map("votes")
 }
 


### PR DESCRIPTION
## Summary

The DRY/slop audit (`docs/audits/01-dry-slop-audit.md`) flagged an "organizationId index gap" across 12 tenant models. I re-measured against the actual code (grep of every `where:` per model — repo rule: *code wins over the audit body*) and the org-index framing does **not** hold for most of the list. Only **3** tables were genuinely missing an index for their real hot filter — and **none of them lead with `organizationId`**.

### Indexes added (all built `CONCURRENTLY`)

| Table | Index | Hot query |
|---|---|---|
| `prompts` | `[userId, isDeleted, createdAt DESC]` | list is **user-scoped**: `WHERE userId, isDeleted ORDER BY createdAt DESC` (`prompts.controller` findAll) |
| `context_entries` | `[contextBaseId, isDeleted]` | read **per context base**: `WHERE contextBaseId, isDeleted` (`contexts.service` getStats / findSimilarEntries) |
| `votes` | `[entityId, userId, isDeleted]` | **toggle** path: `WHERE entityId, userId, isDeleted` (agent-tool-executor + `votes.controller`); `entityId` leads so it also serves per-entity counts on cache miss |

### Why the other 9 got no index (deliberate)

Adding an `organizationId` index to these would be pure write amplification with zero read benefit:

- **Already covered by `@unique` org** (singleton-per-org, one row each): `AdOptimizationConfig`, `CreditBalance`, `OrganizationSetting`, `TaskCounter` — `@unique` *is* an index containing `organizationId`.
- **Already indexed on their true FK**: `CampaignTarget` (→ `campaignId`, existing `@@index`), `Watchlist` (→ `brandId`, existing `@@index([brandId, isDeleted, createdAt DESC])`).
- **Global / admin-only, never org-filtered**: `Announcement` (`getAll` reads `WHERE isDeleted` with no org filter — explicit "global/admin data" comment).
- **Write-only or PK-guarded, no list scan**: `ContentScore` (create-only), `RepurposingJob` (create + `findOrThrow` by `id`).

This matches the audit's own guidance: *"Don't blanket-add… index the proven org-queried models."*

## Migration safety

`20260710120000_add_missing_fk_scoped_indexes` contains **only** bare `CREATE INDEX CONCURRENTLY … IF NOT EXISTS` statements, no DML / `DO $$` blocks — per `packages/prisma/CLAUDE.md` (#1212), since `CONCURRENTLY` cannot run inside Prisma's implicit transaction. All three tables are continuously written (every generation / context add / vote), so a plain `CREATE INDEX` would take an `ACCESS EXCLUSIVE` lock and stall live writes. Index names carry explicit `map:` so schema and the hand-written migration stay drift-free. Follows the `20260703120100_add_post_analytics_daily_unique` precedent.

## Verification

- `prisma validate` → valid ✓
- `prisma generate` → client built ✓
- `@genfeedai/prisma` vitest → 26/26 pass ✓
- `check:model-metadata` (generate + biome) → no drift (index-only change touches no fields/enums) ✓
- Schema `@@index` names/columns match the migration SQL exactly ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)