### PR TITLE
refactor(workflow-ui): dedupe node/handle types, loadWorkflowById, API_BASE_URL

### DIFF
--- a/packages/types/src/nodes/handles.ts
+++ b/packages/types/src/nodes/handles.ts
@@ -22,6 +22,18 @@ export interface HandleDefinition {
   fromSchema?: boolean;
 }
 
+/**
+ * Handle definition loosened for presentation. Widens `type` from the
+ * {@link HandleType} enum to a plain string so render-only handle types (e.g.
+ * `'text[]'`) and SaaS nodes outside the canonical registry can be described,
+ * and adds the `optional` presentation alias used by SaaS node definitions.
+ * Used by BaseNode and SaaSNode; canonical node data still uses HandleDefinition.
+ */
+export interface VisualHandleDefinition extends Omit<HandleDefinition, 'type'> {
+  type: string;
+  optional?: boolean;
+}
+
 // Connection validation rules
 export const CONNECTION_RULES: Record<HandleType, HandleType[]> = {
   audio: ['audio'],

--- a/packages/types/src/nodes/registry.ts
+++ b/packages/types/src/nodes/registry.ts
@@ -3,7 +3,7 @@
 // =============================================================================
 
 import type { NodeCategory, NodeType } from './base';
-import type { HandleDefinition } from './handles';
+import type { HandleDefinition, VisualHandleDefinition } from './handles';
 import type { WorkflowNodeData } from './union';
 
 export interface NodeDefinition {
@@ -15,6 +15,20 @@ export interface NodeDefinition {
   inputs: HandleDefinition[];
   outputs: HandleDefinition[];
   defaultData: Partial<WorkflowNodeData>;
+}
+
+/**
+ * Node definition loosened for presentation. The identity fields BaseNode reads
+ * to render a node, with `category` widened to a plain string and handles as
+ * {@link VisualHandleDefinition}. Used for BaseNode's `nodeDefinition` override
+ * and for SaaS node definitions that live outside the canonical registry.
+ */
+export interface VisualNodeDefinition {
+  category: string;
+  icon: string;
+  label?: string;
+  inputs: VisualHandleDefinition[];
+  outputs: VisualHandleDefinition[];
 }
 
 // =============================================================================

--- a/packages/workflow-ui/src/nodes/BaseNode.tsx
+++ b/packages/workflow-ui/src/nodes/BaseNode.tsx
@@ -5,6 +5,8 @@ import type {
   NodeStatus,
   NodeType,
   SelectedModel,
+  VisualHandleDefinition,
+  VisualNodeDefinition,
   WorkflowNodeData,
 } from '@genfeedai/types';
 import { NODE_DEFINITIONS, NodeStatusEnum } from '@genfeedai/types';
@@ -145,13 +147,7 @@ function StatusIndicator({ status }: { status: NodeStatus }) {
 
 interface BaseNodeProps extends NodeProps {
   children?: ReactNode;
-  nodeDefinition?: {
-    category: string;
-    icon: string;
-    inputs: VisualHandleDefinition[];
-    label?: string;
-    outputs: VisualHandleDefinition[];
-  };
+  nodeDefinition?: VisualNodeDefinition;
   headerActions?: ReactNode;
   title?: string;
   titleElement?: ReactNode;
@@ -159,11 +155,6 @@ interface BaseNodeProps extends NodeProps {
   hideStatusIndicator?: boolean;
   /** Input handle IDs that should appear disabled (reduced opacity) when model doesn't support them */
   disabledInputs?: string[];
-}
-
-interface VisualHandleDefinition extends Omit<HandleDefinition, 'type'> {
-  type: string;
-  optional?: boolean;
 }
 
 // Hover delay for showing preview tooltip (ms)

--- a/packages/workflow-ui/src/nodes/saas/SaaSNode.tsx
+++ b/packages/workflow-ui/src/nodes/saas/SaaSNode.tsx
@@ -1,25 +1,9 @@
 'use client';
 
+import type { VisualNodeDefinition } from '@genfeedai/types';
 import type { NodeProps } from '@xyflow/react';
 import { memo } from 'react';
 import { BaseNode } from '../BaseNode';
-
-interface WorkflowSaaSHandleDefinition {
-  id: string;
-  label: string;
-  multiple?: boolean;
-  optional?: boolean;
-  required?: boolean;
-  type: string;
-}
-
-interface WorkflowSaaSNodeDefinition {
-  category: string;
-  icon: string;
-  inputs: WorkflowSaaSHandleDefinition[];
-  label: string;
-  outputs: WorkflowSaaSHandleDefinition[];
-}
 
 export const workflowSaaSNodeDefinitions = {
   trendHashtagInspiration: {
@@ -63,7 +47,7 @@ export const workflowSaaSNodeDefinitions = {
       { id: 'style', label: 'Style', type: 'text' },
     ],
   },
-} as const satisfies Record<string, WorkflowSaaSNodeDefinition>;
+} as const satisfies Record<string, VisualNodeDefinition>;
 
 export type WorkflowSaaSNodeType = keyof typeof workflowSaaSNodeDefinitions;
 

--- a/packages/workflow-ui/src/stores/execution/executionApi.ts
+++ b/packages/workflow-ui/src/stores/execution/executionApi.ts
@@ -21,7 +21,11 @@ import type {
  * credentialed client and its provider auth headers through `WorkflowUIConfig`.
  */
 
-const API_BASE_URL =
+/**
+ * Base URL every execution HTTP/SSE request is built on. Canonical definition
+ * for the execution store; SSE helpers import this rather than redefining it.
+ */
+export const API_BASE_URL =
   process.env.NEXT_PUBLIC_API_URL || 'http://local.genfeed.ai:3010/api';
 
 /**

--- a/packages/workflow-ui/src/stores/execution/helpers/sseSubscription.ts
+++ b/packages/workflow-ui/src/stores/execution/helpers/sseSubscription.ts
@@ -4,6 +4,7 @@ import type { StoreApi } from 'zustand';
 import { getWorkflowLogger } from '../../executionLogger';
 import { useUIStore } from '../../uiStore';
 import { useWorkflowStore } from '../../workflow/workflowStore';
+import { API_BASE_URL } from '../executionApi';
 import type {
   DebugPayload,
   ExecutionData,
@@ -13,9 +14,6 @@ import type {
 import { getOutputUpdate } from './outputHelpers';
 
 const LOG_CONTEXT = 'ExecutionStore';
-
-const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_URL || 'http://local.genfeed.ai:3010/api';
 
 /**
  * Status map for converting execution statuses to node statuses

--- a/packages/workflow-ui/src/stores/workflow/slices/persistenceSlice.ts
+++ b/packages/workflow-ui/src/stores/workflow/slices/persistenceSlice.ts
@@ -221,27 +221,24 @@ export const createPersistenceSlice: StateCreator<
 
     try {
       const workflow = await getWorkflowPersistence().getById(id, signal);
-      const nodes = hydrateWorkflowNodes(workflow.nodes);
 
-      set({
+      // Reuse loadWorkflow's hydrate → normalize → cost → propagate pipeline,
+      // then override only the id/dirty/loading state it can't know about.
+      get().loadWorkflow({
+        description: '',
         edgeStyle: workflow.edgeStyle as EdgeStyle,
-        edges: normalizeEdgeTypes(workflow.edges),
+        edges: workflow.edges,
         groups: workflow.groups ?? [],
-        isDirty: false,
-        isLoading: false,
-        nodes,
-        workflowId: workflow._id,
-        workflowName: workflow.name,
+        name: workflow.name,
+        nodes: workflow.nodes,
+        version: 1,
       });
 
-      const estimatedCost = calculateWorkflowCost(nodes);
-      useExecutionStore.getState().setEstimatedCost(estimatedCost.total);
-
-      // Propagate existing outputs to downstream nodes after load
-      propagateExistingOutputs(nodes, get().propagateOutputsDownstream);
-
-      // Propagation after load is idempotent; don't trigger save cycle
-      set({ isDirty: false });
+      set({
+        isDirty: false,
+        isLoading: false,
+        workflowId: workflow._id,
+      });
     } catch (error) {
       set({ isLoading: false });
       throw error;


### PR DESCRIPTION
## Summary

Three behavior-preserving DRY cleanups in `packages/workflow-ui`, each surfaced by a prior PR:

### 1. Duplicate node/handle definition types (P1, from #1473)
`SaaSNode.tsx` hand-rolled `WorkflowSaaSHandleDefinition`/`WorkflowSaaSNodeDefinition`, and `BaseNode.tsx` hand-rolled `VisualHandleDefinition` + an inline `nodeDefinition` shape — three near-identical types for the same concept, existing only to loosen `type` from the `HandleType` enum to `string` (needed for `'text[]'`) and to describe SaaS nodes outside the canonical registry.

Replaced with two shared types in `@genfeedai/types`, colocated with their canonical counterparts:
- `VisualHandleDefinition` (in `nodes/handles.ts`) — `HandleDefinition` with `type` widened to `string` + presentation-only `optional`.
- `VisualNodeDefinition` (in `nodes/registry.ts`) — the identity fields `BaseNode` renders, `category` widened to `string`, handles as `VisualHandleDefinition`.

Keeps the repo rule of no inline interfaces in component files.

### 2. `loadWorkflowById` re-implemented `loadWorkflow` (P2, from #1298)
It duplicated the entire hydrate → normalize → cost → propagate sequence. Now it fetches via `getWorkflowPersistence().getById`, maps the result to a `WorkflowFile`, and delegates to `loadWorkflow`, overriding only `workflowId`/`isDirty`/`isLoading`.

### 3. `API_BASE_URL` fallback defined twice (P2, from #1149)
`process.env.NEXT_PUBLIC_API_URL || 'http://local.genfeed.ai:3010/api'` lived independently in `sseSubscription.ts` and `executionApi.ts`. Now exported as the canonical definition from `executionApi.ts` (the documented execution-HTTP-config module) and imported in `sseSubscription.ts`.

## Verification
- `bun type-check` — all 12 packages green (types + workflow-ui).
- `bun run test --filter=@genfeedai/workflow-ui` — **361 tests passed** (29 files), incl. `BaseNode`, `SaaSNode`, `executionApi`, `workflowPersistence`.
- `biome check` clean; pre-commit secretlint + guards passed.

No runtime behavior change.