### PR TITLE
refactor(services): extract shared cleanBody helper on BaseService

### DIFF
--- a/packages/services/core/base.service.ts
+++ b/packages/services/core/base.service.ts
@@ -129,6 +129,34 @@ export abstract class BaseService<
   }
 
   /**
+   * Strip a request payload of empty values before sending it to the API.
+   *
+   * Drops keys whose value is `undefined`, `null`, or the literal string
+   * `'undefined'` (the last leaks in from query-string coercion). Pass
+   * `{ excludeId: true }` for POST requests, which must never carry an `id`
+   * — the serializer would otherwise echo it back into the create payload.
+   */
+  protected static cleanBody<TBody>(
+    body: TBody,
+    options: { excludeId?: boolean } = {},
+  ): Record<string, unknown> {
+    const cleanedBody: Record<string, unknown> = {};
+
+    for (const key in body) {
+      if (options.excludeId && key === 'id') {
+        continue;
+      }
+
+      const value = body[key];
+      if (value !== undefined && value !== null && value !== 'undefined') {
+        cleanedBody[key] = value;
+      }
+    }
+
+    return cleanedBody;
+  }
+
+  /**
    * Clear all singleton instances (useful for testing)
    */
   static clearAllInstances(): void {
@@ -295,28 +323,9 @@ export abstract class BaseService<
   public post(...args: unknown[]): Promise<T> {
     const body = args[args.length - 1] as TCreate;
 
-    // Remove id field completely (shouldn't be in POST requests)
-    // The serializer automatically includes id if present, so we must remove it entirely
-    // Use hasOwnProperty to check for id even if it's undefined
-    const cleanedBody: Record<string, unknown> = {};
-
-    for (const key in body) {
-      // Skip id field entirely for POST requests
-      if (key === 'id') {
-        continue;
-      }
-
-      const value = body[key];
-      // Only include defined values (exclude undefined, null, and string "undefined")
-      if (value !== undefined && value !== null && value !== 'undefined') {
-        cleanedBody[key] = value;
-      }
-    }
-
-    // Explicitly ensure id is not present (defensive check)
-    if ('id' in cleanedBody) {
-      delete cleanedBody.id;
-    }
+    // Remove id field completely (shouldn't be in POST requests) — the
+    // serializer automatically includes id if present, so it must not be here.
+    const cleanedBody = BaseService.cleanBody(body, { excludeId: true });
 
     const url =
       args.length > 1 && typeof args[0] === 'string' ? `/${args[0]}` : '';
@@ -347,16 +356,8 @@ export abstract class BaseService<
    * ```
    */
   public patch(id: string, body: TUpdate): Promise<T> {
-    // Clean body similar to POST - remove undefined/null values
-    const cleanedBody: Record<string, unknown> = {};
-
-    for (const key in body) {
-      const value = body[key];
-      // Only include defined values (exclude undefined, null, and string "undefined")
-      if (value !== undefined && value !== null && value !== 'undefined') {
-        cleanedBody[key] = value;
-      }
-    }
+    // Clean body similar to POST, but keep id (it's the patch target).
+    const cleanedBody = BaseService.cleanBody(body);
 
     return this.executeWithErrorHandling(
       `PATCH ${this.baseURL}/${id}`,

--- a/packages/services/social/brands.service.ts
+++ b/packages/services/social/brands.service.ts
@@ -439,13 +439,7 @@ export class BrandsService extends BaseService<Brand> {
     id: string,
     body: IBrandRelocationPatchBody,
   ): Promise<IBrandRelocationResult> {
-    const cleanedBody: Record<string, unknown> = {};
-    for (const key in body) {
-      const value = body[key as keyof IBrandRelocationPatchBody];
-      if (value !== undefined && value !== null && value !== 'undefined') {
-        cleanedBody[key] = value;
-      }
-    }
+    const cleanedBody = BaseService.cleanBody(body);
 
     return await this.instance
       .patch<JsonApiResponseDocument>(`/${id}`, cleanedBody)


### PR DESCRIPTION
## What

Collapses three hand-rolled copies of the request-body value-cleaning loop into one shared helper.

The loop `for (key in body) { if (value !== undefined && value !== null && value !== 'undefined') ... }` was duplicated across:

- `BaseService.post` — `packages/services/core/base.service.ts`
- `BaseService.patch` — same file
- `BrandsService.relocateBrand` — `packages/services/social/brands.service.ts` (introduced in bbceb3839, the third copy that prompted this)

Now a single `protected static cleanBody<TBody>(body, { excludeId? })` on `BaseService` backs all three. `post()` passes `{ excludeId: true }` — the helper skips `id` inside the loop, so the old defensive `delete cleanedBody.id` after the loop is now redundant and removed.

## Why

P2 DRY cleanup. A grep of `packages/services` confirms these were the only three copies (no fourth).

## Behavior

Behavior-preserving — the predicate and the id-exclusion semantics are unchanged.

## Verification

- `bunx vitest run core/base.service.test.ts social/brands.service.test.ts core/brand-commands.service.test.ts` → **90 passed**
- Full `@genfeedai/services` suite: 824 passed; the 6 failing suites are pre-existing (`Cannot find package 'ts-jsonapi'` in `packages/helpers`), reproduced identically with the change stashed — unrelated to this diff.
- `tsc --noEmit` on the package: no errors in the changed files (the two reported errors are pre-existing missing-dep errors in `packages/helpers` and `packages/types`).
- biome + secretlint pre-commit hooks green.