### PR TITLE
fix(clips): populate result mode, guard negative startTime, dedup handoff fetch

### DIFF
--- a/apps/server/api/src/collections/clip-projects/clip-projects.controller.ts
+++ b/apps/server/api/src/collections/clip-projects/clip-projects.controller.ts
@@ -463,10 +463,14 @@ export class ClipProjectsController {
     @Param('clipResultId') clipResultId: string,
   ): Promise<ClipEditorHandoffResponse> {
     const publicMetadata = getPublicMetadata(user);
-    await this.resolveOwnedProject(projectId, publicMetadata.organization);
+    const ownedProject = await this.resolveOwnedProject(
+      projectId,
+      publicMetadata.organization,
+    );
     await this.clipProjectsService.reconcileTerminalState(
       projectId,
       publicMetadata.organization,
+      ownedProject,
     );
 
     const clipResult = await this.resolveReadyClipResult({
@@ -548,10 +552,14 @@ export class ClipProjectsController {
     @Param('clipResultId') clipResultId: string,
   ): Promise<ClipPublishHandoffResponse> {
     const publicMetadata = getPublicMetadata(user);
-    await this.resolveOwnedProject(projectId, publicMetadata.organization);
+    const ownedProject = await this.resolveOwnedProject(
+      projectId,
+      publicMetadata.organization,
+    );
     await this.clipProjectsService.reconcileTerminalState(
       projectId,
       publicMetadata.organization,
+      ownedProject,
     );
 
     const clipResult = await this.resolveReadyClipResult({

--- a/apps/server/api/src/collections/clip-projects/clip-projects.service.ts
+++ b/apps/server/api/src/collections/clip-projects/clip-projects.service.ts
@@ -90,19 +90,23 @@ export class ClipProjectsService extends BaseService<
   async reconcileTerminalState(
     projectId: string,
     organizationId?: string,
+    preloadedProject?: ClipProjectDocument,
   ): Promise<ClipProjectDocument | null> {
-    const project = await this.findOne({
-      _id: projectId,
-      isDeleted: false,
-      ...(organizationId ? { organization: organizationId } : {}),
-    });
+    // Callers that already resolved+authorized the project (e.g. the handoff
+    // endpoints) pass it through to avoid a second identical fetch.
+    const project =
+      preloadedProject ??
+      (await this.findOne({
+        _id: projectId,
+        isDeleted: false,
+        ...(organizationId ? { organization: organizationId } : {}),
+      }));
 
     if (!project) {
       return null;
     }
 
-    const canonicalProjectId =
-      this.readString(project.id) ?? this.readString(project.id) ?? projectId;
+    const canonicalProjectId = this.readString(project.id) ?? projectId;
     const results = await this.clipResultsService.findByProject(
       canonicalProjectId,
       organizationId,

--- a/apps/server/api/src/collections/clip-projects/services/clip-generation.service.spec.ts
+++ b/apps/server/api/src/collections/clip-projects/services/clip-generation.service.spec.ts
@@ -130,6 +130,19 @@ describe('ClipGenerationService', () => {
     expect(result.clipResultIds).toEqual(['cr-1', 'cr-2']);
   });
 
+  it('persists mode "avatar" on every clip-result it creates', async () => {
+    await service.generateClips(
+      makeInput({
+        highlights: [makeHighlight(), makeHighlight({ title: 'Second' })],
+      }),
+    );
+
+    expect(clipResultsService.create).toHaveBeenCalledTimes(2);
+    for (const call of clipResultsService.create.mock.calls) {
+      expect(call[0]).toEqual(expect.objectContaining({ mode: 'avatar' }));
+    }
+  });
+
   it('should dispatch avatar generation via the correct provider', async () => {
     const input = makeInput({ provider: 'heygen' });
 
@@ -273,6 +286,35 @@ describe('ClipGenerationService', () => {
       status: 'failed',
     });
   });
+
+  // Guards the shared runGenerationLoop skeleton: the extracting-status patch is
+  // issued per highlight before dispatch, regardless of the dispatch outcome.
+  it('marks every clip extracting even when a dispatch fails', async () => {
+    provider.generateVideo
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValueOnce({
+        jobId: 'job-ok',
+        providerName: 'heygen',
+        status: 'processing',
+      });
+
+    clipResultsService.create
+      .mockResolvedValueOnce({ id: 'cr-1' })
+      .mockResolvedValueOnce({ id: 'cr-2' });
+
+    await service.generateClips(
+      makeInput({
+        highlights: [makeHighlight(), makeHighlight({ title: 'Two' })],
+      }),
+    );
+
+    expect(clipResultsService.patch).toHaveBeenCalledWith('cr-1', {
+      status: 'extracting',
+    });
+    expect(clipResultsService.patch).toHaveBeenCalledWith('cr-2', {
+      status: 'extracting',
+    });
+  });
 });
 
 describe('ClipGenerationService (raw-cut mode)', () => {
@@ -316,6 +358,19 @@ describe('ClipGenerationService (raw-cut mode)', () => {
 
   // Highlight [15, 45] with a segment [20, 25] → offset to [5, 10] of the cut.
   const EXPECTED_SRT = '1\n00:00:05,000 --> 00:00:10,000\nInside window';
+
+  it('persists mode "raw-cut" on every clip-result it creates', async () => {
+    await service.generateClips(
+      makeRawCutInput({
+        highlights: [makeHighlight(), makeHighlight({ title: 'Second' })],
+      }),
+    );
+
+    expect(clipResultsService.create).toHaveBeenCalledTimes(2);
+    for (const call of clipResultsService.create.mock.calls) {
+      expect(call[0]).toEqual(expect.objectContaining({ mode: 'raw-cut' }));
+    }
+  });
 
   it('creates one clip-result and dispatches one cut per selected highlight', async () => {
     clipResultsService.create

--- a/apps/server/api/src/collections/clip-projects/services/clip-generation.service.ts
+++ b/apps/server/api/src/collections/clip-projects/services/clip-generation.service.ts
@@ -63,6 +63,36 @@ export interface ClipGenerationResult {
   queuedClipCount: number;
 }
 
+/**
+ * Outcome of dispatching a single highlight. `jobId` is recorded on the batch
+ * result; `patch` is applied to the clip-result after a successful dispatch
+ * (mode-specific provider metadata, plus caption SRT for raw-cut).
+ */
+interface ClipDispatchOutcome {
+  jobId: string;
+  patch: Record<string, unknown>;
+}
+
+/**
+ * Configuration for the shared per-highlight generation loop. The only
+ * per-mode variation is the {@link ClipDispatchOutcome} produced by `dispatch`
+ * and the provider name recorded when a dispatch fails.
+ */
+interface GenerationLoopConfig {
+  highlights: ClipHighlight[];
+  mode: ClipGenerationMode;
+  orgId: string;
+  projectId: string;
+  userId: string;
+  /** Provider name persisted on a clip-result when its dispatch throws. */
+  failureProviderName: string;
+  dispatch: (context: {
+    highlight: ClipHighlight;
+    clipResultId: string;
+    index: number;
+  }) => Promise<ClipDispatchOutcome>;
+}
+
 @Injectable()
 export class ClipGenerationService {
   private readonly logContext = 'ClipGenerationService';
@@ -120,29 +150,8 @@ export class ClipGenerationService {
 
     const avatarProvider = this.avatarVideoService.getProvider(provider);
 
-    const clipResultIds: string[] = [];
-    const providerJobIds: string[] = [];
-    let queuedClipCount = 0;
-
-    for (let i = 0; i < highlights.length; i++) {
-      const highlight = highlights[i];
-
-      // 1. Persist the ClipResult in pending state
-      const clipResultId = await this.createPendingClipResult(
-        highlight,
-        i,
-        orgId,
-        projectId,
-        userId,
-      );
-      clipResultIds.push(clipResultId);
-
-      // 2. Fire avatar video generation via the selected provider
-      try {
-        await this.clipResultsService.patch(clipResultId, {
-          status: 'extracting',
-        });
-
+    return this.runGenerationLoop({
+      dispatch: async ({ clipResultId, highlight }) => {
         const scriptText = this.buildAvatarScript(highlight);
 
         const result = await avatarProvider.generateVideo({
@@ -158,41 +167,21 @@ export class ClipGenerationService {
           throw new Error(result.error || 'Provider returned failed status');
         }
 
-        await this.clipResultsService.patch(clipResultId, {
-          providerJobId: result.jobId,
-          providerName: result.providerName,
-        });
-
-        providerJobIds.push(result.jobId);
-        queuedClipCount += 1;
-
-        this.logger.log(
-          `${this.logContext} provider job fired for clip ${i + 1}/${highlights.length}`,
-          { clipResultId, jobId: result.jobId, provider },
-        );
-      } catch (error: unknown) {
-        this.logger.error(
-          `${this.logContext} generation failed for clip ${i + 1}`,
-          error,
-        );
-
-        await this.clipResultsService.patch(clipResultId, {
-          providerName: provider,
-          status: 'failed',
-        });
-
-        providerJobIds.push('');
-      }
-    }
-
-    this.logger.log(`${this.logContext} generation batch complete`, {
-      clipResultIds,
+        return {
+          jobId: result.jobId,
+          patch: {
+            providerJobId: result.jobId,
+            providerName: result.providerName,
+          },
+        };
+      },
+      failureProviderName: provider,
+      highlights,
+      mode: 'avatar',
+      orgId,
       projectId,
-      queuedClipCount,
-      successfulJobs: providerJobIds.filter(Boolean).length,
+      userId,
     });
-
-    return { clipResultIds, providerJobIds, queuedClipCount };
   }
 
   /**
@@ -222,29 +211,8 @@ export class ClipGenerationService {
       { orgId, projectId },
     );
 
-    const clipResultIds: string[] = [];
-    const providerJobIds: string[] = [];
-    let queuedClipCount = 0;
-
-    for (let i = 0; i < highlights.length; i++) {
-      const highlight = highlights[i];
-
-      // 1. Persist the ClipResult in pending state
-      const clipResultId = await this.createPendingClipResult(
-        highlight,
-        i,
-        orgId,
-        projectId,
-        userId,
-      );
-      clipResultIds.push(clipResultId);
-
-      // 2. Dispatch the deterministic cut + caption for this highlight
-      try {
-        await this.clipResultsService.patch(clipResultId, {
-          status: 'extracting',
-        });
-
+    return this.runGenerationLoop({
+      dispatch: async ({ clipResultId, highlight }) => {
         const captionSrt = generateClipSrt(
           transcriptSegments,
           highlight.start_time,
@@ -264,27 +232,91 @@ export class ClipGenerationService {
           userId,
         });
 
+        return {
+          jobId: dispatch.jobId,
+          patch: {
+            captionSrt,
+            providerJobId: dispatch.jobId,
+            providerName: dispatch.providerName,
+          },
+        };
+      },
+      failureProviderName: RAW_CUT_PROVIDER_NAME,
+      highlights,
+      mode: 'raw-cut',
+      orgId,
+      projectId,
+      userId,
+    });
+  }
+
+  /**
+   * Shared per-highlight generation loop. Owns the invariant skeleton both
+   * modes share — persist a pending clip-result, mark it extracting, dispatch,
+   * persist the success metadata, and isolate a per-highlight failure so the
+   * batch continues. The only per-mode variation is {@link GenerationLoopConfig.dispatch}
+   * and the provider name recorded on a failed dispatch.
+   */
+  private async runGenerationLoop(
+    config: GenerationLoopConfig,
+  ): Promise<ClipGenerationResult> {
+    const {
+      dispatch,
+      failureProviderName,
+      highlights,
+      mode,
+      orgId,
+      projectId,
+      userId,
+    } = config;
+
+    const clipResultIds: string[] = [];
+    const providerJobIds: string[] = [];
+    let queuedClipCount = 0;
+
+    for (let i = 0; i < highlights.length; i++) {
+      const highlight = highlights[i];
+
+      // 1. Persist the ClipResult in pending state
+      const clipResultId = await this.createPendingClipResult(
+        highlight,
+        i,
+        orgId,
+        projectId,
+        userId,
+        mode,
+      );
+      clipResultIds.push(clipResultId);
+
+      // 2. Dispatch generation for this highlight via the mode-specific path
+      try {
         await this.clipResultsService.patch(clipResultId, {
-          captionSrt,
-          providerJobId: dispatch.jobId,
-          providerName: dispatch.providerName,
+          status: 'extracting',
         });
 
-        providerJobIds.push(dispatch.jobId);
+        const { jobId, patch } = await dispatch({
+          clipResultId,
+          highlight,
+          index: i,
+        });
+
+        await this.clipResultsService.patch(clipResultId, patch);
+
+        providerJobIds.push(jobId);
         queuedClipCount += 1;
 
         this.logger.log(
-          `${this.logContext} raw-cut job dispatched for clip ${i + 1}/${highlights.length}`,
-          { clipResultId, jobId: dispatch.jobId },
+          `${this.logContext} ${mode} job dispatched for clip ${i + 1}/${highlights.length}`,
+          { clipResultId, jobId },
         );
       } catch (error: unknown) {
         this.logger.error(
-          `${this.logContext} raw-cut generation failed for clip ${i + 1}`,
+          `${this.logContext} ${mode} generation failed for clip ${i + 1}`,
           error,
         );
 
         await this.clipResultsService.patch(clipResultId, {
-          providerName: RAW_CUT_PROVIDER_NAME,
+          providerName: failureProviderName,
           status: 'failed',
         });
 
@@ -292,7 +324,7 @@ export class ClipGenerationService {
       }
     }
 
-    this.logger.log(`${this.logContext} raw-cut generation batch complete`, {
+    this.logger.log(`${this.logContext} ${mode} generation batch complete`, {
       clipResultIds,
       projectId,
       queuedClipCount,
@@ -304,7 +336,9 @@ export class ClipGenerationService {
 
   /**
    * Persist a ClipResult for a highlight in `pending` state and return its id.
-   * Shared by both generation modes so the created record shape stays identical.
+   * Shared by both generation modes so the created record shape stays identical;
+   * `mode` is threaded through so the durable clip-result column reflects the
+   * generation path instead of always persisting the `avatar` default.
    */
   private async createPendingClipResult(
     highlight: ClipHighlight,
@@ -312,6 +346,7 @@ export class ClipGenerationService {
     orgId: string,
     projectId: string,
     userId: string,
+    mode: ClipGenerationMode,
   ): Promise<string> {
     const clipResult: ClipResultDocument = await this.clipResultsService.create(
       {
@@ -319,6 +354,7 @@ export class ClipGenerationService {
         duration: highlight.end_time - highlight.start_time,
         endTime: highlight.end_time,
         index,
+        mode,
         organization: orgId,
         project: projectId,
         startTime: highlight.start_time,

--- a/apps/server/api/src/collections/clip-projects/services/raw-cut-clip.service.spec.ts
+++ b/apps/server/api/src/collections/clip-projects/services/raw-cut-clip.service.spec.ts
@@ -142,4 +142,12 @@ describe('RawCutClipService', () => {
 
     expect(fileQueueService.processVideo).not.toHaveBeenCalled();
   });
+
+  it('rejects a negative startTime before dispatching a trim job', async () => {
+    await expect(
+      service.dispatchClip(makeInput({ endTime: 10, startTime: -5 })),
+    ).rejects.toThrow(BadRequestException);
+
+    expect(fileQueueService.processVideo).not.toHaveBeenCalled();
+  });
 });

--- a/apps/server/api/src/collections/clip-projects/services/raw-cut-clip.service.ts
+++ b/apps/server/api/src/collections/clip-projects/services/raw-cut-clip.service.ts
@@ -71,6 +71,12 @@ export class RawCutClipService {
       );
     }
 
+    if (startTime < 0) {
+      throw new BadRequestException(
+        'Raw-cut clip requires startTime to be zero or greater.',
+      );
+    }
+
     if (endTime <= startTime) {
       throw new BadRequestException(
         'Raw-cut clip requires endTime to be greater than startTime.',


### PR DESCRIPTION
## Summary

Bundles five verified fixes in the clips surface (`apps/server/api/src/collections/clip-projects/`).

| # | Sev | Fix |
|---|-----|-----|
| 1 | P1 bug | **clip-result `mode` never populated.** #1313 added `mode` (DTO → serializer → durable column) but the only production creator — `createPendingClipResult`, shared by both generation paths — never passed it, so **every raw-cut clip persisted as `avatar`**. `mode` is now threaded through the helper into the create DTO. |
| 2 | P2 bug | **raw-cut accepted negative `startTime`.** `dispatchClip` validated `endTime <= startTime` but not `startTime >= 0`; a negative window reached ffmpeg via `processVideo`. Added the guard (#1382 only covered zero-length windows). |
| 3 | P2 perf | **handoff endpoints double-fetched.** Editor/publish handoff called `resolveOwnedProject` (fetch discarded) then `reconcileTerminalState` (re-fetched the same project). `reconcileTerminalState` now accepts an optional preloaded project, so each handoff fetches once. `findOne`'s null→404 path is unchanged. |
| 4 | P2 dry | **~100-line near-duplicate loops.** Extracted a shared `runGenerationLoop(config)` owning the loop/try-catch/logging/accumulation; the avatar and raw-cut paths now differ only in their `dispatch` outcome and failure provider name. |
| 5 | P3 dead | Collapsed the duplicated `readString(project.id) ?? readString(project.id)` in `reconcileTerminalState`. |

## Tests

- **#1** — `mode: 'avatar'` / `mode: 'raw-cut'` asserted on every `clipResultsService.create` call, per path.
- **#2** — new `rejects a negative startTime` spec (asserts `BadRequestException`, no `processVideo` dispatch).
- **#4** — behavior-preservation: extracted loop still marks every clip `extracting` in a partial-failure batch; the existing avatar + raw-cut suites (success/failure isolation, jobId ordering, `queuedClipCount`) remain the primary guard.

The #4 refactor is behavior-preserving: every asserted `patch` call, `providerJobIds` ordering, and `queuedClipCount` are unchanged; only non-asserted log strings became mode-generic.

> **Note:** this worktree was not `bun install`-provisioned, so the focused specs were **not run locally** — they run in CI on this PR.