### PR TITLE
chore(api): collapse duplicate branch in getBatchItemId

### DIFF
--- a/apps/server/api/src/collections/workflows/controllers/workflow-batch.controller.ts
+++ b/apps/server/api/src/collections/workflows/controllers/workflow-batch.controller.ts
@@ -43,18 +43,9 @@ export class WorkflowBatchController {
   }
 
   private getBatchItemId(item: {
-    _id?: string | { toString(): string };
     id?: string | { toString(): string };
     ingredientId: string | { toString(): string };
   }): string {
-    if (typeof item.id === 'string') {
-      return item.id;
-    }
-
-    if (item.id && typeof item.id.toString === 'function') {
-      return item.id.toString();
-    }
-
     if (typeof item.id === 'string') {
       return item.id;
     }


### PR DESCRIPTION
## What

Dead-code cleanup in `workflow-batch.controller.ts` left over from the Mongo-to-Postgres cleanup (5c72b89c1, #1114).

`getBatchItemId` checked `item.id` with the **same two branches twice in a row** — the mechanical cleanup replaced what was an `_id` fallback pair with an identical `id` pair, so the second pair was unreachable dead code. The `_id` field in the inline param type was also never read.

## Change

- Collapse the duplicated `typeof id === 'string'` / `id.toString()` branch pair to a single pair.
- Drop the unused `_id` field from the inline param type.

Pure behavior-preserving refactor — no runtime change.

## Verification

- Static: removed branches were provably unreachable (identical condition already handled above); `_id` never read.
- Focused spec (`workflow-batch.controller.spec`) could not run locally in this fresh worktree (missing built `@genfeedai/prisma/testing` export); relying on PR CI to run the full suite as the gate.