### PR TITLE
fix(workflow-engine): correct trend-hashtag resolvedFromSource + extract shared trend helpers

### DIFF
--- a/packages/workflow-engine/src/executors/saas/hook-generator-executor.ts
+++ b/packages/workflow-engine/src/executors/saas/hook-generator-executor.ts
@@ -3,6 +3,7 @@ import {
   type ExecutorInput,
   type ExecutorOutput,
 } from '@workflow-engine/executors/base-executor';
+import { toNonEmptyString } from '@workflow-engine/executors/saas/trend-inspiration-shared';
 import type { ExecutableNode } from '@workflow-engine/types';
 
 export type HookFormula =
@@ -69,15 +70,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
-function toNonEmptyString(value: unknown): string | null {
-  if (typeof value !== 'string') {
-    return null;
-  }
-
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : null;
-}
-
 function stringifyContext(value: unknown): string | null {
   const text = toNonEmptyString(value);
   if (text) {
@@ -109,6 +101,9 @@ function stringifyContext(value: unknown): string | null {
   return null;
 }
 
+// Intentionally distinct from the trend-inspiration builder: hook hashtags are
+// lowercased and stripped of underscores (e.g. `Build_In_Public` -> `#buildinpublic`),
+// so this stays local rather than importing `buildOptionalHashtag`.
 function buildHashtag(value: string): string | null {
   const normalized = value.replace(/[^a-zA-Z0-9]/g, '').toLowerCase();
   return normalized.length > 0 ? `#${normalized}` : null;

--- a/packages/workflow-engine/src/executors/saas/trend-hashtag-inspiration-executor.ts
+++ b/packages/workflow-engine/src/executors/saas/trend-hashtag-inspiration-executor.ts
@@ -3,14 +3,17 @@ import {
   type ExecutorInput,
   type ExecutorOutput,
 } from '@workflow-engine/executors/base-executor';
+import {
+  buildHashtag,
+  normalizeHashtag,
+  type TrendInspirationPlatform,
+  toNonEmptyString,
+  uniqHashtags,
+  VALID_PLATFORMS,
+} from '@workflow-engine/executors/saas/trend-inspiration-shared';
 import type { ExecutableNode } from '@workflow-engine/types';
 
-export type TrendInspirationPlatform =
-  | 'tiktok'
-  | 'instagram'
-  | 'twitter'
-  | 'youtube'
-  | 'reddit';
+export type { TrendInspirationPlatform };
 
 export type TrendContentPreference = 'video' | 'image' | 'any';
 export type TrendContentType = 'video' | 'image' | 'carousel' | 'thread';
@@ -38,55 +41,11 @@ export type TrendHashtagInspirationResolver = (params: {
   auto: boolean;
 }) => Promise<TrendHashtagInspirationSource | null>;
 
-const VALID_PLATFORMS = new Set<TrendInspirationPlatform>([
-  'tiktok',
-  'instagram',
-  'twitter',
-  'youtube',
-  'reddit',
-]);
-
 const VALID_CONTENT_PREFERENCES = new Set<TrendContentPreference>([
   'video',
   'image',
   'any',
 ]);
-
-function toNonEmptyString(value: unknown): string | null {
-  if (typeof value !== 'string') {
-    return null;
-  }
-
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : null;
-}
-
-function normalizeHashtag(value: string): string {
-  const normalized = value.replace(/^#/, '').replace(/[^a-zA-Z0-9_]/g, '');
-  return normalized.length > 0 ? normalized : 'trend';
-}
-
-function buildHashtag(value: string): string {
-  return `#${normalizeHashtag(value)}`;
-}
-
-function uniq(values: string[]): string[] {
-  const seen = new Set<string>();
-  const result: string[] = [];
-
-  for (const value of values) {
-    const normalized = buildHashtag(value);
-    const key = normalized.toLowerCase();
-    if (seen.has(key)) {
-      continue;
-    }
-
-    seen.add(key);
-    result.push(normalized);
-  }
-
-  return result;
-}
 
 function selectContentType(
   preference: TrendContentPreference,
@@ -187,13 +146,15 @@ export class TrendHashtagInspirationExecutor extends BaseExecutor {
       toNonEmptyString(inputs.get('hashtag')) ??
       toNonEmptyString(node.config.hashtag);
 
+    const resolverResult = await this.resolver?.({
+      auto,
+      hashtag: requestedHashtag ? normalizeHashtag(requestedHashtag) : null,
+      organizationId: context.organizationId,
+      platform,
+    });
+
     const source =
-      (await this.resolver?.({
-        auto,
-        hashtag: requestedHashtag ? normalizeHashtag(requestedHashtag) : null,
-        organizationId: context.organizationId,
-        platform,
-      })) ??
+      resolverResult ??
       ({
         hashtag: requestedHashtag
           ? normalizeHashtag(requestedHashtag)
@@ -205,7 +166,7 @@ export class TrendHashtagInspirationExecutor extends BaseExecutor {
 
     const sourceHashtag = buildHashtag(source.hashtag);
     const contentType = selectContentType(contentPreference, source.platform);
-    const hashtags = uniq([
+    const hashtags = uniqHashtags([
       source.hashtag,
       ...source.relatedHashtags,
       source.platform,
@@ -231,7 +192,7 @@ export class TrendHashtagInspirationExecutor extends BaseExecutor {
       metadata: {
         auto,
         contentPreference,
-        resolvedFromSource: Boolean(this.resolver),
+        resolvedFromSource: Boolean(resolverResult),
       },
     };
   }

--- a/packages/workflow-engine/src/executors/saas/trend-inspiration-executors.spec.ts
+++ b/packages/workflow-engine/src/executors/saas/trend-inspiration-executors.spec.ts
@@ -85,6 +85,32 @@ describe('trend inspiration executors', () => {
       expect(data.contentType).toBe('thread');
       expect(data.prompt).toContain('#CreatorTips');
       expect(data.hashtags).toContain('#CreatorTips');
+      expect(result.metadata?.resolvedFromSource).toBe(false);
+    });
+
+    it('reports resolvedFromSource=false and uses the fallback when the resolver returns null', async () => {
+      const resolver = vi.fn().mockResolvedValue(null);
+
+      const result = await createTrendHashtagInspirationExecutor(
+        resolver,
+      ).execute({
+        context: ctx,
+        inputs: new Map<string, unknown>([['hashtag', '#CreatorTips']]),
+        node: {
+          config: { platform: 'tiktok' },
+          id: 'n1',
+          inputs: [],
+          label: 'Trend Hashtag Inspiration',
+          type: 'trendHashtagInspiration',
+        },
+      });
+
+      const data = result.data as TrendHashtagInspirationOutput;
+      expect(resolver).toHaveBeenCalledTimes(1);
+      // Wired resolver returned null -> synthesized fallback, not a real source.
+      expect(result.metadata?.resolvedFromSource).toBe(false);
+      expect(data.sourceHashtag).toBe('#CreatorTips');
+      expect(data.hashtagPostCount).toBeNull();
     });
 
     it('uses resolver data when available', async () => {
@@ -116,6 +142,7 @@ describe('trend inspiration executors', () => {
       expect(data.sourceHashtag).toBe('#AIWorkflow');
       expect(data.hashtagPostCount).toBe(100000);
       expect(data.hashtags).toContain('#automation');
+      expect(result.metadata?.resolvedFromSource).toBe(true);
     });
   });
 

--- a/packages/workflow-engine/src/executors/saas/trend-inspiration-shared.ts
+++ b/packages/workflow-engine/src/executors/saas/trend-inspiration-shared.ts
@@ -1,0 +1,109 @@
+// =============================================================================
+// SHARED TREND-INSPIRATION HELPERS
+// =============================================================================
+//
+// Extracted from the trend inspiration trio (trendVideoInspiration,
+// trendHashtagInspiration) which previously duplicated these helpers verbatim.
+// Mirrors the SEO trio's shared-module pattern (see seo-score-executor.ts).
+
+/** Platforms the trend inspiration executors can target. */
+export type TrendInspirationPlatform =
+  | 'tiktok'
+  | 'instagram'
+  | 'twitter'
+  | 'youtube'
+  | 'reddit';
+
+export const VALID_PLATFORMS = new Set<TrendInspirationPlatform>([
+  'tiktok',
+  'instagram',
+  'twitter',
+  'youtube',
+  'reddit',
+]);
+
+/** Returns the trimmed string, or null for non-strings and blank strings. */
+export function toNonEmptyString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/** Strips a leading `#` and any non-`[a-zA-Z0-9_]` characters. */
+function stripHashtag(value: string): string {
+  return value.replace(/^#/, '').replace(/[^a-zA-Z0-9_]/g, '');
+}
+
+/**
+ * Bare hashtag slug (no leading `#`), preserving case and underscores.
+ * Falls back to `'trend'` when the value normalizes to empty.
+ */
+export function normalizeHashtag(value: string): string {
+  const stripped = stripHashtag(value);
+  return stripped.length > 0 ? stripped : 'trend';
+}
+
+/** `#`-prefixed hashtag. Never null — an empty value becomes `#trend`. */
+export function buildHashtag(value: string): string {
+  return `#${normalizeHashtag(value)}`;
+}
+
+/**
+ * `#`-prefixed hashtag, or null when the value normalizes to empty. Use when
+ * empty inputs should be dropped rather than coerced to a `#trend` placeholder.
+ */
+export function buildOptionalHashtag(value: string): string | null {
+  const stripped = stripHashtag(value);
+  return stripped.length > 0 ? `#${stripped}` : null;
+}
+
+/**
+ * De-dupes hashtags case-insensitively via {@link buildHashtag}. Empty inputs
+ * are coerced to `#trend`, so every input yields an entry.
+ */
+export function uniqHashtags(values: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const value of values) {
+    const normalized = buildHashtag(value);
+    const key = normalized.toLowerCase();
+    if (seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+    result.push(normalized);
+  }
+
+  return result;
+}
+
+/**
+ * De-dupes hashtags case-insensitively via {@link buildOptionalHashtag},
+ * dropping any value that normalizes to empty.
+ */
+export function uniqOptionalHashtags(values: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+
+  for (const value of values) {
+    const hashtag = buildOptionalHashtag(value);
+    if (!hashtag) {
+      continue;
+    }
+
+    const key = hashtag.toLowerCase();
+    if (seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+    result.push(hashtag);
+  }
+
+  return result;
+}

--- a/packages/workflow-engine/src/executors/saas/trend-video-inspiration-executor.ts
+++ b/packages/workflow-engine/src/executors/saas/trend-video-inspiration-executor.ts
@@ -3,8 +3,13 @@ import {
   type ExecutorInput,
   type ExecutorOutput,
 } from '@workflow-engine/executors/base-executor';
+import {
+  type TrendInspirationPlatform,
+  toNonEmptyString,
+  uniqOptionalHashtags,
+  VALID_PLATFORMS,
+} from '@workflow-engine/executors/saas/trend-inspiration-shared';
 import type { ExecutableNode } from '@workflow-engine/types';
-import type { TrendInspirationPlatform } from './trend-hashtag-inspiration-executor';
 
 export type TrendInspirationStyle =
   | 'match_closely'
@@ -55,55 +60,11 @@ export type TrendVideoInspirationResolver = (params: {
   minViralScore: number;
 }) => Promise<TrendVideoInspirationSource | null>;
 
-const VALID_PLATFORMS = new Set<TrendInspirationPlatform>([
-  'tiktok',
-  'instagram',
-  'twitter',
-  'youtube',
-  'reddit',
-]);
-
 const VALID_INSPIRATION_STYLES = new Set<TrendInspirationStyle>([
   'match_closely',
   'inspired_by',
   'remix_concept',
 ]);
-
-function toNonEmptyString(value: unknown): string | null {
-  if (typeof value !== 'string') {
-    return null;
-  }
-
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : null;
-}
-
-function buildHashtag(value: string): string | null {
-  const normalized = value.replace(/^#/, '').replace(/[^a-zA-Z0-9_]/g, '');
-  return normalized.length > 0 ? `#${normalized}` : null;
-}
-
-function uniqHashtags(values: string[]): string[] {
-  const seen = new Set<string>();
-  const result: string[] = [];
-
-  for (const value of values) {
-    const hashtag = buildHashtag(value);
-    if (!hashtag) {
-      continue;
-    }
-
-    const key = hashtag.toLowerCase();
-    if (seen.has(key)) {
-      continue;
-    }
-
-    seen.add(key);
-    result.push(hashtag);
-  }
-
-  return result;
-}
 
 function aspectRatioForPlatform(
   platform: TrendInspirationPlatform,
@@ -236,7 +197,7 @@ export class TrendVideoInspirationExecutor extends BaseExecutor {
         trendId,
       })) ?? null;
 
-    const hashtags = uniqHashtags([
+    const hashtags = uniqOptionalHashtags([
       ...(source?.hashtags ?? []),
       platform,
       inspirationStyle,


### PR DESCRIPTION
## Summary

Two related fixes in `packages/workflow-engine/src/executors/saas/`, both introduced by #1473 (046e32f03).

### 1. P2 bug — `resolvedFromSource` false positive (trendHashtagInspiration)

`trend-hashtag-inspiration-executor.ts` reported `resolvedFromSource: Boolean(this.resolver)` — **true whenever a resolver is *wired***, even when the resolver returned `null` and the executor fell back to a synthesized source. The siblings do it right: `trendVideo`/`trendSound` report `Boolean(source)` on the actual result.

Fix: capture `const resolverResult = await this.resolver?.(...)`, use `resolverResult ?? fallback` for the source and `Boolean(resolverResult)` for the metadata. Now the flag reflects whether real resolver data was used, not merely whether a resolver was configured.

### 2. P1 DRY — extract `trend-inspiration-shared.ts`

The trend trio duplicated `toNonEmptyString`, `buildHashtag`/`normalizeHashtag`, `uniq`/`uniqHashtags`, and the `VALID_PLATFORMS` set verbatim across `trendVideo` + `trendHashtag`, with a third near-duplicate `buildHashtag` in `hook-generator-executor.ts`. Mirrors the SEO trio's shared-module pattern (`seo-score-executor.ts`).

New `trend-inspiration-shared.ts` exports the shared helpers + `TrendInspirationPlatform` type. **Both hashtag-dedup semantics are preserved** so this is behavior-preserving:
- `uniqHashtags` — empty inputs coerced to `#trend` (hashtag executor semantics)
- `uniqOptionalHashtags` — empty inputs dropped (video executor semantics)

`hook-generator` imports the shared `toNonEmptyString`; its `buildHashtag` **stays local** because it intentionally lowercases and strips underscores (`Build_In_Public` → `#buildinpublic`) — different behavior from the trend builder, so consolidating it would change output. Documented inline.

## Testing

- Extended `trend-inspiration-executors.spec.ts` to assert `resolvedFromSource` for the hashtag executor across all three paths (no resolver → false, wired resolver returns null → false + fallback used, resolver returns data → true). Previously only the sound executor asserted this field.
- `bunx vitest run src/executors/saas/trend-inspiration-executors.spec.ts` → **11 passed**
- `bunx turbo run type-check --filter=@genfeedai/workflow-engine` → **pass**
- `bunx biome check` on the 5 files → clean