### PR TITLE
fix(evaluations): org-scope content lookups, refund failed post evals, scope pattern deletes

### DIFF
--- a/apps/server/api/src/collections/content-intelligence/controllers/creators.controller.spec.ts
+++ b/apps/server/api/src/collections/content-intelligence/controllers/creators.controller.spec.ts
@@ -283,6 +283,7 @@ describe('CreatorsController', () => {
 
       expect(mockPatternStoreService.deleteByCreator).toHaveBeenCalledWith(
         '507f1f77bcf86cd799439015',
+        '507f1f77bcf86cd799439012',
       );
       expect(mockContentIntelligenceService.remove).toHaveBeenCalledWith(
         '507f1f77bcf86cd799439015',

--- a/apps/server/api/src/collections/content-intelligence/controllers/creators.controller.ts
+++ b/apps/server/api/src/collections/content-intelligence/controllers/creators.controller.ts
@@ -300,8 +300,11 @@ export class CreatorsController {
       ErrorResponse.notFound('CreatorAnalysis', id);
     }
 
-    // Delete associated patterns
-    await this.patternStoreService.deleteByCreator(id);
+    // Delete associated patterns (scoped to the caller's organization)
+    await this.patternStoreService.deleteByCreator(
+      id,
+      publicMetadata.organization,
+    );
 
     // Soft delete creator
     const deleted = await this.contentIntelligenceService.remove(id);

--- a/apps/server/api/src/collections/content-intelligence/services/pattern-store.service.spec.ts
+++ b/apps/server/api/src/collections/content-intelligence/services/pattern-store.service.spec.ts
@@ -1,0 +1,123 @@
+import {
+  type CreatePatternDto,
+  PatternStoreService,
+} from '@api/collections/content-intelligence/services/pattern-store.service';
+import {
+  ContentIntelligencePlatform,
+  ContentPatternType,
+} from '@genfeedai/enums';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+function createMocks() {
+  const contentPattern = {
+    findMany: vi.fn(),
+    updateMany: vi.fn(),
+  };
+
+  return {
+    logger: {
+      error: vi.fn(),
+      log: vi.fn(),
+      warn: vi.fn(),
+    },
+    prisma: { contentPattern },
+  };
+}
+
+describe('PatternStoreService organization scoping', () => {
+  let service: PatternStoreService;
+  let mocks: ReturnType<typeof createMocks>;
+
+  const organizationId = 'org-123';
+  const creatorId = 'creator-1';
+
+  beforeEach(() => {
+    mocks = createMocks();
+    service = new PatternStoreService(
+      mocks.prisma as never,
+      mocks.logger as never,
+    );
+  });
+
+  describe('findByCreator', () => {
+    it('should scope the lookup to the organization and creator', async () => {
+      mocks.prisma.contentPattern.findMany.mockResolvedValue([]);
+
+      await service.findByCreator(creatorId, organizationId);
+
+      expect(mocks.prisma.contentPattern.findMany).toHaveBeenCalledWith({
+        where: { isDeleted: false, organizationId, sourceCreatorId: creatorId },
+      });
+    });
+
+    it('should not match a foreign organization', async () => {
+      // A creator that belongs to another org yields no rows because the
+      // organization filter is part of the where clause.
+      mocks.prisma.contentPattern.findMany.mockResolvedValue([]);
+
+      const result = await service.findByCreator(creatorId, 'other-org');
+
+      expect(result).toEqual([]);
+      expect(mocks.prisma.contentPattern.findMany).toHaveBeenCalledWith({
+        where: {
+          isDeleted: false,
+          organizationId: 'other-org',
+          sourceCreatorId: creatorId,
+        },
+      });
+    });
+  });
+
+  describe('deleteByCreator', () => {
+    it('should scope the soft-delete to the organization and creator', async () => {
+      mocks.prisma.contentPattern.updateMany.mockResolvedValue({ count: 3 });
+
+      const result = await service.deleteByCreator(creatorId, organizationId);
+
+      expect(mocks.prisma.contentPattern.updateMany).toHaveBeenCalledWith({
+        where: { isDeleted: false, organizationId, sourceCreatorId: creatorId },
+        data: { isDeleted: true },
+      });
+      expect(result).toEqual({ count: 3 });
+    });
+  });
+
+  describe('storeBulkPatterns', () => {
+    it('should persist each pattern via storePattern', async () => {
+      const storePattern = vi
+        .spyOn(service, 'storePattern')
+        .mockImplementation(async (dto) => ({ id: dto.rawExample }) as never);
+
+      const patterns = [
+        buildPattern('a'),
+        buildPattern('b'),
+        buildPattern('c'),
+      ];
+
+      const result = await service.storeBulkPatterns(patterns);
+
+      expect(storePattern).toHaveBeenCalledTimes(3);
+      expect(result).toEqual([{ id: 'a' }, { id: 'b' }, { id: 'c' }]);
+    });
+  });
+
+  function buildPattern(rawExample: string): CreatePatternDto {
+    return {
+      extractedFormula: 'formula',
+      organizationId,
+      patternType: ContentPatternType.HOOK,
+      placeholders: [],
+      platform: ContentIntelligencePlatform.INSTAGRAM,
+      rawExample,
+      sourceMetrics: {
+        comments: 0,
+        engagementRate: 0,
+        likes: 0,
+        shares: 0,
+        views: 0,
+        viralScore: 0,
+      },
+      tags: [],
+    };
+  }
+});

--- a/apps/server/api/src/collections/content-intelligence/services/pattern-store.service.ts
+++ b/apps/server/api/src/collections/content-intelligence/services/pattern-store.service.ts
@@ -57,15 +57,10 @@ export class PatternStoreService extends BaseService<
     } as CreatePatternDto);
   }
 
-  async storeBulkPatterns(
+  storeBulkPatterns(
     patterns: CreatePatternDto[],
   ): Promise<ContentPatternDocument[]> {
-    const results: ContentPatternDocument[] = [];
-    for (const pattern of patterns) {
-      const result = await this.storePattern(pattern);
-      results.push(result);
-    }
-    return results;
+    return Promise.all(patterns.map((pattern) => this.storePattern(pattern)));
   }
 
   async findByOrganization(
@@ -116,9 +111,12 @@ export class PatternStoreService extends BaseService<
     }) as Promise<ContentPatternDocument[]>;
   }
 
-  findByCreator(creatorId: string): Promise<ContentPatternDocument[]> {
+  findByCreator(
+    creatorId: string,
+    organizationId: string,
+  ): Promise<ContentPatternDocument[]> {
     return this.delegate.findMany({
-      where: { isDeleted: false, sourceCreatorId: creatorId },
+      where: { isDeleted: false, organizationId, sourceCreatorId: creatorId },
     }) as Promise<ContentPatternDocument[]>;
   }
 
@@ -138,9 +136,12 @@ export class PatternStoreService extends BaseService<
     });
   }
 
-  async deleteByCreator(creatorId: string): Promise<{ count: number }> {
+  async deleteByCreator(
+    creatorId: string,
+    organizationId: string,
+  ): Promise<{ count: number }> {
     const result = (await this.delegate.updateMany({
-      where: { isDeleted: false, sourceCreatorId: creatorId },
+      where: { isDeleted: false, organizationId, sourceCreatorId: creatorId },
       data: { isDeleted: true },
     })) as { count: number };
     return { count: result.count };

--- a/apps/server/api/src/collections/evaluations/services/evaluations.service.spec.ts
+++ b/apps/server/api/src/collections/evaluations/services/evaluations.service.spec.ts
@@ -18,6 +18,7 @@ function createMocks() {
       checkOrganizationCreditsAvailable: vi.fn(),
       deductCreditsFromOrganization: vi.fn(),
       getOrganizationCreditsBalance: vi.fn(),
+      refundOrganizationCredits: vi.fn(),
     },
     evaluationsOperationsService: {},
     logger: {
@@ -26,6 +27,9 @@ function createMocks() {
       warn: vi.fn(),
     },
     prisma,
+    videosService: {
+      findOne: vi.fn(),
+    },
     websocketService: {
       emit: vi.fn(),
     },
@@ -47,7 +51,46 @@ describe('EvaluationsService review and comparison workflow', () => {
       mocks.evaluationsOperationsService as never,
       mocks.creditsUtilsService as never,
       mocks.websocketService as never,
+      undefined,
+      mocks.videosService as never,
     );
+  });
+
+  describe('evaluateVideo organization scoping', () => {
+    it('should scope the video lookup to the caller organization and 404 on a foreign video', async () => {
+      mocks.videosService.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.evaluateVideo(
+          'video-1',
+          'pre_publication' as never,
+          organizationId,
+          reviewerId,
+          'brand-1',
+        ),
+      ).rejects.toBeInstanceOf(NotFoundException);
+
+      expect(mocks.videosService.findOne).toHaveBeenCalledWith(
+        { _id: 'video-1', isDeleted: false, organizationId },
+        expect.any(Array),
+      );
+    });
+  });
+
+  describe('syncPostPublicationPerformance organization scoping', () => {
+    it('should throw not found when the evaluation is outside the organization', async () => {
+      mocks.prisma.evaluation.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.syncPostPublicationPerformance('eval-1', organizationId, {
+          engagement: 42,
+        }),
+      ).rejects.toBeInstanceOf(NotFoundException);
+
+      expect(mocks.prisma.evaluation.findFirst).toHaveBeenCalledWith({
+        where: { id: 'eval-1', isDeleted: false, organizationId },
+      });
+    });
   });
 
   describe('recordReviewerFeedback', () => {

--- a/apps/server/api/src/collections/evaluations/services/evaluations.service.ts
+++ b/apps/server/api/src/collections/evaluations/services/evaluations.service.ts
@@ -15,7 +15,6 @@ import { WebSocketPaths } from '@api/helpers/utils/websocket/websocket.util';
 import { NotificationsPublisherService } from '@api/services/notifications/publisher/notifications-publisher.service';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { BaseService } from '@api/shared/services/base/base.service';
-import { findUniqueOrThrow } from '@api/shared/utils/find-or-throw/find-or-throw.util';
 import {
   ActivitySource,
   EvaluationType,
@@ -402,11 +401,10 @@ export class EvaluationsService extends BaseService<EvaluationDocument> {
 
     if (!this.videosService) throw new Error('VideosService not available');
 
-    const video = await this.videosService.findOne({ _id: videoId }, [
-      { path: 'metadata' },
-      { path: 'prompt' },
-      { path: 'brand' },
-    ]);
+    const video = await this.videosService.findOne(
+      { _id: videoId, organizationId, isDeleted: false },
+      [{ path: 'metadata' }, { path: 'prompt' }, { path: 'brand' }],
+    );
 
     if (!video) throw new NotFoundException('Video', videoId);
 
@@ -473,11 +471,10 @@ export class EvaluationsService extends BaseService<EvaluationDocument> {
 
     if (!this.imagesService) throw new Error('ImagesService not available');
 
-    const image = await this.imagesService.findOne({ _id: imageId }, [
-      { path: 'metadata' },
-      { path: 'prompt' },
-      { path: 'brand' },
-    ]);
+    const image = await this.imagesService.findOne(
+      { _id: imageId, organizationId, isDeleted: false },
+      [{ path: 'metadata' }, { path: 'prompt' }, { path: 'brand' }],
+    );
 
     if (!image) throw new NotFoundException('Image', imageId);
 
@@ -544,9 +541,10 @@ export class EvaluationsService extends BaseService<EvaluationDocument> {
 
     if (!this.articlesService) throw new Error('ArticlesService not available');
 
-    const article = await this.articlesService.findOne({ _id: articleId }, [
-      { path: 'brand' },
-    ]);
+    const article = await this.articlesService.findOne(
+      { _id: articleId, organizationId, isDeleted: false },
+      [{ path: 'brand' }],
+    );
 
     if (!article) throw new NotFoundException('Article', articleId);
     if (!article.content)
@@ -611,9 +609,10 @@ export class EvaluationsService extends BaseService<EvaluationDocument> {
 
     if (!this.postsService) throw new Error('PostsService not available');
 
-    const post = await this.postsService.findOne({ _id: postId }, [
-      { path: 'brand' },
-    ]);
+    const post = await this.postsService.findOne(
+      { _id: postId, organizationId, isDeleted: false },
+      [{ path: 'brand' }],
+    );
     if (!post) throw new NotFoundException('Post', postId);
     if (!post.description)
       throw new NotFoundException(`Post ${postId} has no content`);
@@ -658,6 +657,8 @@ export class EvaluationsService extends BaseService<EvaluationDocument> {
     userId: string,
   ): Promise<void> {
     const postId = String(post.id);
+    let billedCredits = 0;
+    let creditsSettled = false;
 
     try {
       const children = (await this.postsService?.getChildren(postId)) as
@@ -716,7 +717,6 @@ export class EvaluationsService extends BaseService<EvaluationDocument> {
         threadLength: isThread ? threadChildren.length + 1 : 1,
       };
 
-      let billedCredits = 0;
       const aiResult = (await this.evaluationsOperationsService.evaluatePost(
         threadContent,
         context,
@@ -732,6 +732,7 @@ export class EvaluationsService extends BaseService<EvaluationDocument> {
         billedCredits,
         'Content evaluation: post',
       );
+      creditsSettled = true;
 
       const existing = await this.prisma.evaluation.findUnique({
         where: { id: evaluationId },
@@ -778,6 +779,17 @@ export class EvaluationsService extends BaseService<EvaluationDocument> {
           }) as never,
         },
       });
+
+      // Credits were settled before the evaluation ultimately failed (e.g. the
+      // completion write threw after the AI charge). Return them so a failed
+      // evaluation is never billed.
+      if (creditsSettled) {
+        await this.refundEvaluationCredits(
+          organizationId,
+          billedCredits,
+          'Content evaluation failed: post',
+        );
+      }
 
       await this.websocketService.emit(
         WebSocketPaths.evaluation(evaluationId),
@@ -978,6 +990,7 @@ export class EvaluationsService extends BaseService<EvaluationDocument> {
 
   async syncPostPublicationPerformance(
     evaluationId: string,
+    organizationId: string,
     publicationData: Record<string, unknown>,
   ): Promise<EvaluationDocument> {
     this.logger.log(
@@ -985,16 +998,17 @@ export class EvaluationsService extends BaseService<EvaluationDocument> {
       this.constructorName,
     );
 
-    const evaluation = await findUniqueOrThrow(
-      this.prisma.evaluation,
-      { where: { id: evaluationId } },
-      'Evaluation',
-      evaluationId,
-    );
+    const evaluation = await this.prisma.evaluation.findFirst({
+      where: { id: evaluationId, isDeleted: false, organizationId },
+    });
+
+    if (!evaluation) {
+      throw new NotFoundException('Evaluation', evaluationId);
+    }
 
     const data = evaluation.data as EvaluationData | null;
 
-    if (data?.status !== Status.COMPLETED) {
+    if (!data || data.status !== Status.COMPLETED) {
       throw new NotFoundException(
         `Evaluation ${evaluationId} is not completed (status: ${data?.status}). Cannot sync performance metrics for incomplete evaluations.`,
       );
@@ -1191,5 +1205,33 @@ export class EvaluationsService extends BaseService<EvaluationDocument> {
           EvaluationsService.EVALUATION_MAX_OVERDRAFT_CREDITS,
       },
     );
+  }
+
+  private async refundEvaluationCredits(
+    organizationId: string,
+    amount: number,
+    description: string,
+  ): Promise<void> {
+    if (amount <= 0) return;
+
+    try {
+      const refundExpiresAt = new Date();
+      refundExpiresAt.setFullYear(refundExpiresAt.getFullYear() + 1);
+
+      await this.creditsUtilsService.refundOrganizationCredits(
+        organizationId,
+        amount,
+        'content-evaluation-refund',
+        description,
+        refundExpiresAt,
+      );
+    } catch (error: unknown) {
+      // A failed refund must not mask the original evaluation failure — log and
+      // move on so the caller still surfaces the FAILED status.
+      this.logger.error(
+        `Failed to refund evaluation credits for organization ${organizationId}`,
+        error,
+      );
+    }
   }
 }


### PR DESCRIPTION
## Summary

Hardens org scoping across the evaluations and content-intelligence surfaces flagged in a 2026-07-10 audit against HEAD `0b74eb757`. Every fix keeps the documented single-tenant exception intact (self-hosted may skip org filters) and only tightens paths where the caller already carries org context.

Multi-tenancy rule enforced: tenant-scoped Prisma queries include `{ organizationId, isDeleted: false }` (per repo `CLAUDE.md` Multi-Tenancy).

## Changes

### `evaluations.service.ts`
- **Content lookups scoped.** `evaluateVideo` / `evaluateImage` / `evaluateArticle` / `evaluatePost` re-fetched the target content with a bare `findOne({ _id })`. Now scoped to `{ _id, organizationId, isDeleted: false }`. The public HTTP path already pre-validates org in `evaluateContent`, but these are public service methods — this is defence-in-depth so they are safe by construction for any caller.
- **`syncPostPublicationPerformance` scoped.** Previously took no `organizationId` and used an unscoped `findUniqueOrThrow`. Now takes `organizationId` and resolves via an org-scoped `findFirst`, returning `NotFound` for foreign/soft-deleted evaluations. (No live callers today — closes the latent gap before it is wired.)
- **Credit refund on failed post evaluation.** `evaluatePostAsync` settled credits after the AI charge but before the completion write. If the completion write threw, the org was billed for a failed evaluation with no refund. It now tracks settlement and refunds via `refundOrganizationCredits` (1-year expiry, following the `prompts.controller` pattern) in the failure path. Refund errors are logged, never masking the original failure.

### `pattern-store.service.ts`
- `findByCreator` / `deleteByCreator` now require `organizationId` and filter on it; the `deleteByCreator` caller in `creators.controller` passes the authenticated org (the creator is already org-verified upstream — this is defence-in-depth).
- `storeBulkPatterns` now persists patterns concurrently via `Promise.all` instead of a sequential `await` loop (per-record `storePattern` semantics + cache invalidation preserved).

## Deliberately NOT changed: `elements.service.ts`

`findAllElements` returns all rows when `organizationId` is falsy. **Decision: legitimate single-tenant path, left as-is.** Element models carry a required `organizationId` and the route runs under `CombinedAuthGuard`, which always yields an org in SaaS; the falsy-org branch is the documented self-hosted single-tenant case (org filter optional). Forcing an org id would break self-hosted. The org-present branch already scopes to `organizationId = X` with no cross-tenant leak.

## Tests

Focused specs asserting wrong-org access returns `NotFound`:
- `evaluations.service.spec.ts` — `evaluateVideo` scopes the lookup + 404s a foreign video; `syncPostPublicationPerformance` 404s an out-of-org evaluation.
- `pattern-store.service.spec.ts` (new) — `findByCreator` / `deleteByCreator` include `organizationId`; `storeBulkPatterns` persists each pattern.
- `creators.controller.spec.ts` — updated `deleteByCreator` assertion to include the org arg.

`bunx vitest run` (3 files): **25 passed**. Biome + scoped type-check clean on touched files (remaining `@genfeedai/*` module-resolution errors are unbuilt-workspace artifacts local to the worktree; resolved in CI).