### PR TITLE
fix(members): compute seat limit from org-wide total, not current page

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/organization/members/members-list.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/organization/members/members-list.test.tsx
@@ -1,59 +1,185 @@
-import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import MembersList from './members-list';
-import '@testing-library/jest-dom/vitest';
+
+const mocks = vi.hoisted(() => ({
+  findAll: vi.fn(),
+  getTotalDocs: vi.fn(),
+  loggerError: vi.fn(),
+  loggerInfo: vi.fn(),
+  notificationsError: vi.fn(),
+  openModal: vi.fn(),
+  replace: vi.fn(),
+  useBrand: vi.fn(),
+  useSearchParams: vi.fn(),
+}));
 
 vi.mock('@contexts/user/brand-context/brand-context', () => ({
-  useBrand: vi.fn(() => ({
-    organizationId: 'org-123',
-    settings: { subscriptionTier: 'pro' },
-  })),
+  useBrand: () => mocks.useBrand(),
+}));
+
+vi.mock('@helpers/ui/modal/modal.helper', () => ({
+  openModal: mocks.openModal,
 }));
 
 vi.mock('@hooks/auth/use-authed-service/use-authed-service', () => ({
-  useAuthedService: vi.fn(() => vi.fn()),
+  useAuthedService: (factory: (token: string) => unknown) => async () =>
+    factory('token-1'),
 }));
 
-vi.mock('@tanstack/react-query', () => ({
-  useQuery: vi.fn(() => ({
-    data: [],
-    isLoading: false,
-    refetch: vi.fn(),
-  })),
-  useQueryClient: vi.fn(() => ({
-    setQueryData: vi.fn(),
-  })),
+// Org-wide total is exposed via PagesService (written by BaseService.findAll).
+// getTotalDocs is the value the seat-limit check must read — not the page length.
+vi.mock('@services/content/pages.service', () => ({
+  PagesService: {
+    getCurrentPage: () => 1,
+    getTotalDocs: () => mocks.getTotalDocs(),
+    getTotalPages: () => 1,
+    setCurrentPage: vi.fn(),
+    setTotalDocs: vi.fn(),
+    setTotalPages: vi.fn(),
+  },
 }));
 
-vi.mock('@providers/global-modals/global-modals.provider', () => ({
-  useConfirmModal: vi.fn(() => ({
-    openConfirm: vi.fn(),
-  })),
-  useInviteMemberModal: vi.fn(() => ({
-    openInviteMemberModal: vi.fn(),
-  })),
+vi.mock('@services/core/logger.service', () => ({
+  logger: { error: mocks.loggerError, info: mocks.loggerInfo },
+}));
+
+vi.mock('@services/core/notifications.service', () => ({
+  NotificationsService: {
+    getInstance: () => ({ error: mocks.notificationsError }),
+  },
+}));
+
+vi.mock('@services/organization/members.service', () => ({
+  MembersService: {
+    getInstance: () => ({ findAll: mocks.findAll }),
+  },
+}));
+
+vi.mock('@ui/display/table/Table', () => ({
+  default: ({
+    emptyLabel,
+    isLoading,
+    items,
+  }: {
+    emptyLabel: string;
+    isLoading?: boolean;
+    items: Array<{ id: string }>;
+  }) => {
+    if (isLoading) {
+      return <div>Loading members</div>;
+    }
+
+    if (items.length === 0) {
+      return <div>{emptyLabel}</div>;
+    }
+
+    return <div>{items.length} members</div>;
+  },
+}));
+
+vi.mock('@ui/lazy/modal/LazyModal', () => ({
+  LazyModalMember: () => null,
+}));
+
+vi.mock('@ui/navigation/pagination/auto-pagination/AutoPagination', () => ({
+  default: () => null,
 }));
 
 vi.mock('next/navigation', () => ({
-  usePathname: vi.fn(() => '/org-123/settings/organization/members'),
-  useRouter: vi.fn(() => ({
-    push: vi.fn(),
-    refresh: vi.fn(),
-    replace: vi.fn(),
-  })),
-  useSearchParams: vi.fn(() => ({
-    get: vi.fn(() => null),
-    toString: vi.fn(() => ''),
-  })),
+  usePathname: () => '/org-123/settings/organization/members',
+  useRouter: () => ({ replace: mocks.replace }),
+  useSearchParams: () => mocks.useSearchParams(),
 }));
 
-describe('MembersList', () => {
+interface RenderOptions {
+  orgTotal: number;
+  page?: string | null;
+  pageCount: number;
+  tier: string | null;
+}
+
+function renderMembers({
+  orgTotal,
+  page = null,
+  pageCount,
+  tier,
+}: RenderOptions) {
+  mocks.useBrand.mockReturnValue({
+    organizationId: 'org-123',
+    settings: { subscriptionTier: tier },
+  });
+  mocks.useSearchParams.mockReturnValue({
+    get: (key: string) => (key === 'page' ? page : null),
+    toString: () => (page ? `page=${page}` : ''),
+  });
+  mocks.getTotalDocs.mockReturnValue(orgTotal);
+
+  const pageMembers = Array.from({ length: pageCount }, (_, index) => ({
+    createdAt: '2026-01-01T00:00:00.000Z',
+    id: `member-${index}`,
+    roleLabel: 'Member',
+    userEmail: `user-${index}@example.test`,
+    userFullName: `User ${index}`,
+  }));
+  mocks.findAll.mockResolvedValue(pageMembers);
+
+  return render(<MembersList />);
+}
+
+function inviteButton(): HTMLElement {
+  return screen.getByRole('button', { name: /Invite Member/i });
+}
+
+describe('MembersList seat limit', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.getTotalDocs.mockReturnValue(0);
+    mocks.findAll.mockResolvedValue([]);
   });
 
-  it('should render without crashing', () => {
-    const { container } = render(<MembersList />);
-    expect(container.firstChild).toBeInTheDocument();
+  it('disables invite and shows upgrade copy when the org is at its seat limit', async () => {
+    // Free tier caps at 1 seat; org already has 1 member on this page.
+    renderMembers({ orgTotal: 1, pageCount: 1, tier: 'free' });
+
+    await waitFor(() => {
+      expect(inviteButton()).toBeDisabled();
+    });
+    expect(
+      screen.getByText(/Upgrade to Pro to invite more people/i),
+    ).toBeVisible();
+  });
+
+  it('enables invite and hides upgrade copy when the org is under its seat limit', async () => {
+    // Free tier, but no members yet — one seat still available.
+    renderMembers({ orgTotal: 0, pageCount: 0, tier: 'free' });
+
+    await screen.findByText('No members found');
+    expect(inviteButton()).toBeEnabled();
+    expect(screen.queryByText(/Upgrade to/i)).not.toBeInTheDocument();
+  });
+
+  it('stays at the seat limit on an out-of-range page that returns no rows', async () => {
+    // Regression: page 2 returns an empty slice, but the org-wide total (1)
+    // already meets the free-tier cap. Must not re-enable invite from the empty
+    // page length.
+    renderMembers({ orgTotal: 1, page: '2', pageCount: 0, tier: 'free' });
+
+    await waitFor(() => {
+      expect(inviteButton()).toBeDisabled();
+    });
+    expect(
+      screen.getByText(/Upgrade to Pro to invite more people/i),
+    ).toBeVisible();
+  });
+
+  it('never blocks invite for an unlimited tier regardless of member count', async () => {
+    // Pro tier has unlimited seats; a full page and a large total stay enabled.
+    renderMembers({ orgTotal: 100, pageCount: 15, tier: 'pro' });
+
+    await screen.findByText('15 members');
+    expect(inviteButton()).toBeEnabled();
+    expect(screen.queryByText(/Upgrade to/i)).not.toBeInTheDocument();
   });
 });

--- a/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/organization/members/members-list.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/organization/members/members-list.tsx
@@ -13,6 +13,7 @@ import { openModal } from '@helpers/ui/modal/modal.helper';
 import { useAuthedService } from '@hooks/auth/use-authed-service/use-authed-service';
 import type { Member } from '@models/organization/member.model';
 import type { TableColumn } from '@props/ui/display/table.props';
+import { PagesService } from '@services/content/pages.service';
 import { logger } from '@services/core/logger.service';
 import { NotificationsService } from '@services/core/notifications.service';
 import { MembersService } from '@services/organization/members.service';
@@ -48,6 +49,7 @@ function MembersListContent() {
   );
 
   const [members, setMembers] = useState<Member[] | null>(null);
+  const [totalMembers, setTotalMembers] = useState<number>(0);
 
   const columns: TableColumn<Member>[] = [
     {
@@ -90,11 +92,17 @@ function MembersListContent() {
 
       const data = await service.findAll(query);
       setMembers(data);
+      // Seat-limit checks must use the org-wide total, not just this page of
+      // results. BaseService.findAll writes the paginated total into
+      // PagesService (same value AutoPagination shows). Fall back to the
+      // current page length if the total isn't populated for any reason.
+      setTotalMembers(Math.max(PagesService.getTotalDocs(), data.length));
       logger.info('GET /members success', data);
     } catch (error) {
       logger.error('GET /members failed', error);
       notificationsService.error('Failed to load members');
       setMembers([]);
+      setTotalMembers(0);
     }
   }, [currentPage, getMembersService, notificationsService, organizationId]);
 
@@ -104,7 +112,7 @@ function MembersListContent() {
 
   const seatLimit = getSeatLimitForTier(settings?.subscriptionTier);
   const isAtSeatLimit =
-    seatLimit !== null && members !== null && members.length >= seatLimit;
+    seatLimit !== null && members !== null && totalMembers >= seatLimit;
   const memberLimitDescription = isAtSeatLimit
     ? `Current plan includes ${seatLimit} ${formatSeatLabel(seatLimit)}. Upgrade to ${formatTierLabel(
         getUpgradeTierForLimit('seats', settings?.subscriptionTier),


### PR DESCRIPTION
## Problem

`isAtSeatLimit` in [members-list.tsx](apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/organization/members/members-list.tsx) compared `members.length` — a single **paginated page** of results (capped at `ITEMS_PER_PAGE = 15` via the `limit`/`page` query params) — against the tier seat limit. `members` is never the org-wide total.

Introduced by fb7152acd "Enforce plan tier limits (#1443)".

### Impact (UI-only, bounded)

- The server guard `member-credits.guard.ts` independently re-checks the full un-paginated `activeMembersCount`, so there is **no real invite bypass**.
- Per `packages/pricing/src/tier-entitlements.ts`, the only finite `seatLimit` today is `FREE_SEAT_LIMIT = 1` (FREE/BYOK); every paid tier is unlimited.
- Reachable failure: navigating to an out-of-range/empty page (e.g. `?page=2` when the org total already meets the limit but that page returns 0 rows) flipped `isAtSeatLimit` to `false`, wrongly **enabling the Invite button and hiding the upgrade copy**. It also becomes materially wrong if any finite seat limit ever exceeds 15.

## Fix

Read the org-wide total from `PagesService.getTotalDocs()` — the value `BaseService.findAll` writes and the adjacent `<AutoPagination showTotal>` already consumes — into component state, and compare **that** against `getSeatLimitForTier`. The total is written synchronously inside `findAll` before the data resolves, and `isAtSeatLimit` stays gated on `members !== null`, so it's populated on first render. Falls back to `Math.max(total, page length)` for safety.

The `member-credits.guard` server check remains the real enforcement; this is UI correctness only.

## Tests

Added focused seat-limit tests to [members-list.test.tsx](apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/organization/members/members-list.test.tsx):
- at-limit (FREE, total 1) → invite disabled + upgrade copy
- under-limit (FREE, total 0) → invite enabled, no copy
- **regression**: out-of-range page 2 returning 0 rows with org total 1 → stays disabled
- unlimited tier (Pro, total 100, full page) → stays enabled

All 4 pass locally (`bun run test --filter=@genfeedai/app -- members-list`). Broader validation via PR CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)