### PR TITLE
fix(workers): youtube status cron post.id + build-verify bundle count

### DIFF
--- a/.github/workflows/build-verify.yml
+++ b/.github/workflows/build-verify.yml
@@ -103,7 +103,7 @@ jobs:
               test -f apps/server/dist/apps/voices/main.js && echo "✅ Voices bundle" || (echo "❌ Voices bundle missing" && exit 1)
               test -f apps/server/dist/apps/videos/main.js && echo "✅ Videos bundle" || (echo "❌ Videos bundle missing" && exit 1)
               echo ""
-              echo "All 12 service bundles verified ✅"
+              echo "All 11 service bundles verified ✅"
 
               # Check bundle sizes (catch empty/broken bundles)
               for svc in api workers files mcp notifications telegram discord slack images voices videos; do
@@ -151,5 +151,5 @@ jobs:
           {
             echo "## ✅ Build Verification Passed"
             echo ""
-            echo "Docker image built + all 12 bundles verified; EE api bundle booted past module init (#574 guard)."
+            echo "Docker image built + all 11 bundles verified; EE api bundle booted past module init (#574 guard)."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/apps/server/workers/src/crons/youtube/cron.youtube-status.service.ts
+++ b/apps/server/workers/src/crons/youtube/cron.youtube-status.service.ts
@@ -105,7 +105,7 @@ export class CronYoutubeStatusService {
 
     try {
       if (!post.credential) {
-        this.logger.warn(`${url} post ${post._id} has no credential`);
+        this.logger.warn(`${url} post ${post.id} has no credential`);
         return;
       }
 
@@ -116,7 +116,7 @@ export class CronYoutubeStatusService {
         post.externalId,
       );
 
-      this.logger.log(`${url} post ${post._id} video ${post.externalId}`, {
+      this.logger.log(`${url} post ${post.id} video ${post.externalId}`, {
         privacyStatus: videoStatus.privacyStatus,
         publishAt: videoStatus.publishAt,
       });
@@ -162,7 +162,7 @@ export class CronYoutubeStatusService {
           `${url} YouTube video ${post.externalId} status synced`,
           {
             newStatus: targetStatus,
-            postId: post._id,
+            postId: post.id,
             previousStatus: post.status,
             youtubePrivacyStatus: videoStatus.privacyStatus,
           },
@@ -187,7 +187,7 @@ export class CronYoutubeStatusService {
               hoursSinceScheduled: Math.round(
                 timeSinceScheduled / (60 * 60 * 1000),
               ),
-              postId: post._id,
+              postId: post.id,
               publishAt: videoStatus.publishAt,
               scheduledDate: scheduledDate.toISOString(),
             },
@@ -204,7 +204,7 @@ export class CronYoutubeStatusService {
       ) {
         this.logger.warn(
           `${url} video ${post.externalId} not found on YouTube, marking post as deleted`,
-          { postId: post._id },
+          { postId: post.id },
         );
 
         await this.recordStatusTransition(
@@ -222,7 +222,7 @@ export class CronYoutubeStatusService {
       }
 
       this.logger.error(
-        `${url} failed to check status for post ${post._id}`,
+        `${url} failed to check status for post ${post.id}`,
         error,
       );
     }
@@ -250,7 +250,7 @@ export class CronYoutubeStatusService {
           inputValues: {
             detail,
             outcome,
-            postId: String(post._id),
+            postId: String(post.id),
             videoId: post.externalId,
           },
           label: 'YouTube Status Reconciliation',
@@ -268,7 +268,7 @@ export class CronYoutubeStatusService {
       this.logger.error('Failed to record YouTube status transition', {
         error: (error as Error)?.message,
         outcome,
-        postId: String(post._id),
+        postId: String(post.id),
       });
       return false;
     }


### PR DESCRIPTION
## Summary
Two correctness fixes surfaced by the 2026-07-10 net-diff audit (`ba866d28a..origin/master`), each adversarially verified against HEAD.

### 1. P1 — YouTube status cron wrote `undefined` into the provenance audit trail
`apps/server/workers/src/crons/youtube/cron.youtube-status.service.ts` read `post._id` at **8 sites**. `PostEntity`/`BaseEntity` only expose `id`; `BaseService.normalizeDocument` backfills `organization`/`user`/`brand` aliases but **never `_id`**, so `post._id` is `undefined` at runtime. Every YouTube status sweep serialized `String(post._id)` → the literal string `"undefined"` into the tenant-visible provenance record introduced for auditability (#1092). The sibling `cron.tiktok-status.service.ts` already uses `post.id` throughout.

Fix: replace all `post._id` → `post.id`. The underlying post-status update was unaffected (already used `post.id`); only the audit trail was corrupted.

- Introduced by `90199d59b6` (#1111).

### 2. P2 — stale bundle count in build-verify gate summary
`.github/workflows/build-verify.yml` echoed "All **12** service bundles verified" / "all **12** bundles verified", but only **11** services are checked (bundle-existence list + size-check loop) after the `clips` bundle was removed (#1222). Log/summary text only — pass/fail logic was already correct — but a wrong count in a deploy-gate summary misleads anyone debugging a missing-service incident.

Fix: both strings → "11".

- Introduced by `bf2645203` (#1222).

## Verification
- `post.id` is already used elsewhere in the same file (e.g. the actual `postsService.patch` calls), so the type is valid; heavy typecheck deferred to PR CI per repo policy.
- No browser-observable surface; pre-commit secretlint + biome passed.

## Not included (tracked separately)
- P2 org seat-limit gate (`members-list.tsx`) — compares current page vs org total; UI-only, server guard enforces the real limit. Spun off to its own session.