### PR TITLE
chore(agents): sync shared skills from skills library

### DIFF
--- a/.agents/skills/accessibility/SKILL.md
+++ b/.agents/skills/accessibility/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: accessibility
-description: Expert in web accessibility (WCAG 2.1 AA compliance) for React/Next.js applications, ensuring all projects are usable by everyone
+description: Expert in web accessibility (WCAG 2.1 AA compliance) for React/Next.js applications, ensuring all projects are usable by everyone. Use when creating or reviewing UI components, adding keyboard navigation, checking color contrast, testing with screen readers, or auditing pages for accessibility issues.
 metadata:
   version: "1.0.0"
   tags: accessibility, a11y, wcag, aria, keyboard-navigation, screen-reader, inclusive-design
@@ -8,9 +8,7 @@ metadata:
 
 # Accessibility (a11y) Skill
 
-Act as an expert in web accessibility (a11y), specializing in WCAG 2.1 AA compliance for React/Next.js applications.
-
-## When to Use This Skill
+## When to Use
 
 Use when you're:
 
@@ -29,7 +27,7 @@ Use when you're:
 3. Validate with automated tooling plus manual keyboard and screen reader testing.
 4. Document issues and fixes with examples.
 
-## WCAG Principles (Quick)
+## WCAG Principles
 
 - Perceivable: text alternatives, contrast, responsive support.
 - Operable: keyboard access, focus management, timing.

--- a/.agents/skills/agent-architecture-audit/SKILL.md
+++ b/.agents/skills/agent-architecture-audit/SKILL.md
@@ -8,8 +8,7 @@ metadata:
 
 # Agent Architecture Audit
 
-Diagnose failures in agent systems by inspecting each layer that can change the
-model's behavior between the raw model call and the final user-visible output.
+Diagnose failures in agent systems by inspecting each layer between the raw model call and the user-visible output.
 
 ## Contract
 
@@ -57,8 +56,7 @@ Delegates To:
   shows a different result.
 - Hidden retry, fallback, repair, or summarization loops may be mutating output.
 
-Do not use this as a general code review. Use it when the failure mechanism is
-likely in the agent stack, not just in application logic.
+Do not use for general code review — only when the failure is likely in the agent stack.
 
 ## Layer Model
 
@@ -94,7 +92,7 @@ Identify:
 
 ### 2. Collect Evidence
 
-Start from local evidence and traces. Search for:
+Search for:
 
 - prompt templates and instruction injection points
 - tool schemas, routers, validators, and execution logs
@@ -103,8 +101,7 @@ Start from local evidence and traces. Search for:
 - fallback, retry, repair, or output rewriting passes
 - response serialization, markdown rendering, JSON parsing, and stream handling
 
-Prefer file and line evidence. If logs are available, compare raw model output,
-post-processed output, transported output, and rendered output.
+Prefer file and line evidence. Compare raw model output, post-processed output, transported output, and rendered output when logs are available.
 
 ### 3. Map Failure Mechanisms
 
@@ -130,8 +127,7 @@ Prefer fixes in this order:
 7. Use typed envelopes for internal protocol boundaries.
 8. Add trace tests that compare raw, processed, transported, and rendered output.
 
-Do not solve tool discipline, memory safety, or transport corruption only by
-adding stronger prompt wording.
+Do not solve tool discipline, memory safety, or transport corruption only by adding stronger prompt wording.
 
 ## Severity
 

--- a/.agents/skills/ai-regression-testing/SKILL.md
+++ b/.agents/skills/ai-regression-testing/SKILL.md
@@ -58,8 +58,7 @@ Delegates To:
 
 ## Core Principle
 
-Test the contract that failed, not the implementation the agent just wrote.
-Assume the reviewing model shares the same blind spot as the writing model.
+Test the contract that failed, not the implementation the agent wrote. Assume the reviewing model shares the same blind spot as the writing model.
 
 Common AI blind spots:
 

--- a/.agents/skills/api-design-expert/SKILL.md
+++ b/.agents/skills/api-design-expert/SKILL.md
@@ -1,14 +1,12 @@
 ---
 name: api-design-expert
-description: Expert in RESTful API design, OpenAPI/Swagger documentation, versioning, error handling, and API best practices for NestJS applications
+description: Expert in RESTful API design, OpenAPI/Swagger documentation, versioning, error handling, and API best practices for NestJS applications. Use when designing API endpoints, building RESTful APIs, writing OpenAPI/Swagger docs, implementing versioning, or designing error responses and DTOs.
 metadata:
   version: "1.0.0"
   tags: "api, rest, design"
 ---
 
 # API Design Expert Skill
-
-Expert in RESTful API design, OpenAPI/Swagger documentation, versioning strategies, error handling, and API best practices for NestJS applications.
 
 ## When to Use
 

--- a/.agents/skills/biome-validator/SKILL.md
+++ b/.agents/skills/biome-validator/SKILL.md
@@ -2,13 +2,11 @@
 name: biome-validator
 description: Validate Biome 2.3+ configuration and detect outdated patterns. Ensures proper schema version, domains, assists, and recommended rules. Use before any linting work or when auditing existing projects.
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   tags: biome, linter, formatter, validation, code-quality
 ---
 
 # Biome Validator
-
-Validates Biome 2.3+ configuration and prevents outdated patterns. Ensures type-aware linting, domains, and modern Biome features are properly configured.
 
 ## When This Activates
 
@@ -27,226 +25,18 @@ python3 scripts/validate.py --root . --strict
 
 ## What Gets Checked
 
-### 1. Biome Version & Schema
+| Check | Good (2.3+) | Bad (legacy) |
+|---|---|---|
+| Schema version | `"$schema": ".../2.3.12/schema.json"` | `.../1.9.0/schema.json` or older |
+| Package version | `"@biomejs/biome": "^2.3.0"` | `"^1.9.0"` or 2.0-2.2 |
+| Linter config | `linter.rules.recommended: true` | missing or legacy `rules` shape |
+| Assist actions | `assist.actions.source.organizeImports` | top-level `organizeImports.enabled` |
+| Domains | `linter.domains.react` / `.next: "on"` | no domains configured |
+| Suppression comments | `// biome-ignore lint/<rule>: reason` | `// eslint-disable`, `// @ts-ignore` |
 
-**GOOD - Biome 2.3+:**
+Biome 2.0+ also adds type-aware linting (no TypeScript compiler required) and multi-file lint analysis.
 
-```json
-{
-  "$schema": "https://biomejs.dev/schemas/2.3.12/schema.json"
-}
-```
-
-**BAD - Old schema:**
-
-```json
-{
-  "$schema": "https://biomejs.dev/schemas/1.9.0/schema.json"
-}
-```
-
-### 2. Package Version
-
-```json
-// GOOD: v2.3+
-"@biomejs/biome": "^2.3.0"
-
-// BAD: v1.x or v2.0-2.2
-"@biomejs/biome": "^1.9.0"
-```
-
-### 3. Linter Configuration
-
-**GOOD - Biome 2.x:**
-
-```json
-{
-  "linter": {
-    "enabled": true,
-    "rules": {
-      "recommended": true,
-      "suspicious": {
-        "noExplicitAny": "warn"
-      }
-    }
-  }
-}
-```
-
-### 4. Biome Assist (2.0+)
-
-**GOOD - Using assist:**
-
-```json
-{
-  "assist": {
-    "actions": {
-      "source": {
-        "organizeImports": "on"
-      }
-    }
-  }
-}
-```
-
-**BAD - Old organizeImports location:**
-
-```json
-{
-  "organizeImports": {
-    "enabled": true
-  }
-}
-```
-
-### 5. Domains (2.0+)
-
-**GOOD - Using domains for framework-specific rules:**
-
-```json
-{
-  "linter": {
-    "domains": {
-      "react": "on",
-      "next": "on"
-    }
-  }
-}
-```
-
-### 6. Suppression Comments
-
-**GOOD - Biome 2.0+ comments:**
-
-```typescript
-// biome-ignore lint/suspicious/noExplicitAny: legacy code
-// biome-ignore-all lint/style/useConst
-// biome-ignore-start lint/complexity
-// biome-ignore-end
-```
-
-**BAD - Wrong format:**
-
-```typescript
-// @ts-ignore  // Not Biome
-// eslint-disable  // Wrong tool
-```
-
-## Biome 2.3+ Features
-
-### Type-Aware Linting
-
-Biome 2.0+ includes type inference without requiring TypeScript compiler:
-
-```json
-{
-  "linter": {
-    "rules": {
-      "correctness": {
-        "noUndeclaredVariables": "error",
-        "useAwaitThenable": "error"
-      }
-    }
-  }
-}
-```
-
-### Assist Actions
-
-```json
-{
-  "assist": {
-    "actions": {
-      "source": {
-        "organizeImports": "on",
-        "useSortedKeys": "on"
-      }
-    }
-  }
-}
-```
-
-### Multi-file Analysis
-
-Lint rules can query information from other files for more powerful analysis.
-
-### Framework Domains
-
-```json
-{
-  "linter": {
-    "domains": {
-      "react": "on",       // React-specific rules
-      "next": "on",        // Next.js rules
-      "test": "on"         // Testing framework rules
-    }
-  }
-}
-```
-
-## Recommended Configuration
-
-```json
-{
-  "$schema": "https://biomejs.dev/schemas/2.3.12/schema.json",
-  "assist": {
-    "actions": {
-      "source": {
-        "organizeImports": "on"
-      }
-    }
-  },
-  "linter": {
-    "enabled": true,
-    "rules": {
-      "recommended": true,
-      "complexity": {
-        "noForEach": "off"
-      },
-      "style": {
-        "noNonNullAssertion": "off"
-      },
-      "suspicious": {
-        "noArrayIndexKey": "off",
-        "noExplicitAny": "warn"
-      },
-      "correctness": {
-        "useAwaitThenable": "error",
-        "noLeakedRender": "error"
-      }
-    },
-    "domains": {
-      "react": "on",
-      "next": "on"
-    }
-  },
-  "formatter": {
-    "enabled": true,
-    "indentStyle": "space",
-    "indentWidth": 2,
-    "lineWidth": 100
-  },
-  "javascript": {
-    "formatter": {
-      "quoteStyle": "single",
-      "trailingCommas": "es5",
-      "semicolons": "always"
-    }
-  },
-  "files": {
-    "ignore": [
-      "node_modules",
-      "dist",
-      "build",
-      ".next",
-      "out",
-      ".cache",
-      ".turbo",
-      "coverage"
-    ]
-  }
-}
-```
+See `references/full-guide.md` (§ What Gets Checked, § Biome 2.3+ Features, § Recommended Configuration) for full GOOD/BAD config examples and a complete recommended `biome.json`.
 
 ## Deprecated Patterns
 
@@ -257,97 +47,17 @@ Lint rules can query information from other files for more powerful analysis.
 | `@biomejs/biome` < 2.3 | `@biomejs/biome@latest` |
 | No domains config | Use `linter.domains` for frameworks |
 
-## Validation Output
-
-```
-=== Biome 2.3+ Validation Report ===
-
-Package Version: @biomejs/biome@2.3.11 ✓
-
-Configuration:
-  ✓ Schema version: 2.3.11
-  ✓ Linter enabled with recommended rules
-  ✓ Using assist.actions for imports
-  ✗ No domains configured (consider enabling react, next)
-  ✓ Formatter configured
-
-Rules:
-  ✓ noExplicitAny: warn
-  ✓ useAwaitThenable: error
-  ✗ noLeakedRender not enabled (recommended)
-
-Summary: 2 issues found
-```
+See `references/full-guide.md` (§ Validation Output) for a sample validation report.
 
 ## Migration from ESLint
 
-### Step 1: Install Biome
+1. Remove ESLint/Prettier packages, add `@biomejs/biome@latest`
+2. Generate config: `bunx biome init`
+3. Port existing rules: `bunx biome migrate eslint --write`
+4. Update `package.json` lint/format scripts to call `biome`
+5. Delete old `.eslintrc*` / `.prettierrc*` / `.eslintignore` / `.prettierignore`
 
-```bash
-bun remove eslint prettier eslint-config-* eslint-plugin-*
-bun add -D @biomejs/biome@latest
-```
-
-### Step 2: Create biome.json
-
-```bash
-bunx biome init
-```
-
-### Step 3: Migrate rules
-
-```bash
-bunx biome migrate eslint --write
-```
-
-### Step 4: Update scripts
-
-```json
-{
-  "scripts": {
-    "lint": "biome lint .",
-    "lint:fix": "biome lint --write .",
-    "format": "biome format --write .",
-    "check": "biome check .",
-    "check:fix": "biome check --write ."
-  }
-}
-```
-
-### Step 5: Remove old configs
-
-```bash
-rm .eslintrc* .prettierrc* .eslintignore .prettierignore
-```
-
-## VS Code Integration
-
-```json
-// .vscode/settings.json
-{
-  "editor.formatOnSave": true,
-  "editor.defaultFormatter": "biomejs.biome",
-  "editor.codeActionsOnSave": {
-    "source.organizeImports.biome": "explicit",
-    "quickfix.biome": "explicit"
-  }
-}
-```
-
-## CI/CD Integration
-
-```yaml
-# .github/workflows/lint.yml
-- name: Validate Biome Config
-  run: |
-    python3 scripts/validate.py \
-      --root . \
-      --strict \
-      --ci
-
-- name: Lint
-  run: bunx biome check --error-on-warnings .
-```
+See `references/full-guide.md` (§ Migration from ESLint) for the exact commands per step, plus VS Code editor settings and a CI/CD workflow snippet.
 
 ## Integration
 

--- a/.agents/skills/biome-validator/plugin.json
+++ b/.agents/skills/biome-validator/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "biome-validator",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Validate Biome 2.3+ configuration and detect outdated patterns",
   "author": {
     "name": "Ship Shit Dev",

--- a/.agents/skills/biome-validator/references/full-guide.md
+++ b/.agents/skills/biome-validator/references/full-guide.md
@@ -1,0 +1,316 @@
+# Biome Validator - Full Guide
+
+## What Gets Checked
+
+### 1. Biome Version & Schema
+
+**GOOD - Biome 2.3+:**
+
+```json
+{
+  "$schema": "https://biomejs.dev/schemas/2.3.12/schema.json"
+}
+```
+
+**BAD - Old schema:**
+
+```json
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.0/schema.json"
+}
+```
+
+### 2. Package Version
+
+```json
+// GOOD: v2.3+
+"@biomejs/biome": "^2.3.0"
+
+// BAD: v1.x or v2.0-2.2
+"@biomejs/biome": "^1.9.0"
+```
+
+### 3. Linter Configuration
+
+**GOOD - Biome 2.x:**
+
+```json
+{
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "suspicious": {
+        "noExplicitAny": "warn"
+      }
+    }
+  }
+}
+```
+
+### 4. Biome Assist (2.0+)
+
+**GOOD - Using assist:**
+
+```json
+{
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  }
+}
+```
+
+**BAD - Old organizeImports location:**
+
+```json
+{
+  "organizeImports": {
+    "enabled": true
+  }
+}
+```
+
+### 5. Domains (2.0+)
+
+**GOOD - Using domains for framework-specific rules:**
+
+```json
+{
+  "linter": {
+    "domains": {
+      "react": "on",
+      "next": "on"
+    }
+  }
+}
+```
+
+### 6. Suppression Comments
+
+**GOOD - Biome 2.0+ comments:**
+
+```typescript
+// biome-ignore lint/suspicious/noExplicitAny: legacy code
+// biome-ignore-all lint/style/useConst
+// biome-ignore-start lint/complexity
+// biome-ignore-end
+```
+
+**BAD - Wrong format:**
+
+```typescript
+// @ts-ignore  // Not Biome
+// eslint-disable  // Wrong tool
+```
+
+## Biome 2.3+ Features
+
+### Type-Aware Linting
+
+Biome 2.0+ includes type inference without requiring TypeScript compiler:
+
+```json
+{
+  "linter": {
+    "rules": {
+      "correctness": {
+        "noUndeclaredVariables": "error",
+        "useAwaitThenable": "error"
+      }
+    }
+  }
+}
+```
+
+### Assist Actions
+
+```json
+{
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on",
+        "useSortedKeys": "on"
+      }
+    }
+  }
+}
+```
+
+### Multi-file Analysis
+
+Lint rules can query information from other files.
+
+### Framework Domains
+
+```json
+{
+  "linter": {
+    "domains": {
+      "react": "on",       // React-specific rules
+      "next": "on",        // Next.js rules
+      "test": "on"         // Testing framework rules
+    }
+  }
+}
+```
+
+## Recommended Configuration
+
+```json
+{
+  "$schema": "https://biomejs.dev/schemas/2.3.12/schema.json",
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "complexity": {
+        "noForEach": "off"
+      },
+      "style": {
+        "noNonNullAssertion": "off"
+      },
+      "suspicious": {
+        "noArrayIndexKey": "off",
+        "noExplicitAny": "warn"
+      },
+      "correctness": {
+        "useAwaitThenable": "error",
+        "noLeakedRender": "error"
+      }
+    },
+    "domains": {
+      "react": "on",
+      "next": "on"
+    }
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "trailingCommas": "es5",
+      "semicolons": "always"
+    }
+  },
+  "files": {
+    "ignore": [
+      "node_modules",
+      "dist",
+      "build",
+      ".next",
+      "out",
+      ".cache",
+      ".turbo",
+      "coverage"
+    ]
+  }
+}
+```
+
+## Validation Output
+
+```
+=== Biome 2.3+ Validation Report ===
+
+Package Version: @biomejs/biome@2.3.11 ✓
+
+Configuration:
+  ✓ Schema version: 2.3.11
+  ✓ Linter enabled with recommended rules
+  ✓ Using assist.actions for imports
+  ✗ No domains configured (consider enabling react, next)
+  ✓ Formatter configured
+
+Rules:
+  ✓ noExplicitAny: warn
+  ✓ useAwaitThenable: error
+  ✗ noLeakedRender not enabled (recommended)
+
+Summary: 2 issues found
+```
+
+## Migration from ESLint
+
+### Step 1: Install Biome
+
+```bash
+bun remove eslint prettier eslint-config-* eslint-plugin-*
+bun add -D @biomejs/biome@latest
+```
+
+### Step 2: Create biome.json
+
+```bash
+bunx biome init
+```
+
+### Step 3: Migrate rules
+
+```bash
+bunx biome migrate eslint --write
+```
+
+### Step 4: Update scripts
+
+```json
+{
+  "scripts": {
+    "lint": "biome lint .",
+    "lint:fix": "biome lint --write .",
+    "format": "biome format --write .",
+    "check": "biome check .",
+    "check:fix": "biome check --write ."
+  }
+}
+```
+
+### Step 5: Remove old configs
+
+```bash
+rm .eslintrc* .prettierrc* .eslintignore .prettierignore
+```
+
+## VS Code Integration
+
+```json
+// .vscode/settings.json
+{
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "biomejs.biome",
+  "editor.codeActionsOnSave": {
+    "source.organizeImports.biome": "explicit",
+    "quickfix.biome": "explicit"
+  }
+}
+```
+
+## CI/CD Integration
+
+```yaml
+# .github/workflows/lint.yml
+- name: Validate Biome Config
+  run: |
+    python3 scripts/validate.py \
+      --root . \
+      --strict \
+      --ci
+
+- name: Lint
+  run: bunx biome check --error-on-warnings .
+```

--- a/.agents/skills/bun-validator/SKILL.md
+++ b/.agents/skills/bun-validator/SKILL.md
@@ -1,14 +1,12 @@
 ---
 name: bun-validator
-description: Validate Bun workspace configuration and detect common monorepo issues. Ensures proper workspace setup, dependency catalogs, isolated installs, and Bun 1.3+ best practices.
+description: Validate Bun workspace configuration and detect common monorepo issues. Ensures proper workspace setup, dependency catalogs, isolated installs, and Bun 1.3+ best practices. Use when setting up a Bun monorepo, before adding workspace dependencies, auditing an existing Bun workspace, or validating package.json in CI.
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   tags: bun, monorepo, workspace, validation, package-manager
 ---
 
 # Bun Validator
-
-Validates Bun workspace configuration and prevents common monorepo issues. Ensures Bun 1.3+ patterns and proper workspace isolation.
 
 ## When This Activates
 
@@ -62,23 +60,7 @@ bun --version  # 1.2.x
 
 ### 3. Workspace Structure
 
-**GOOD:**
-
-```
-my-monorepo/
-├── package.json          # Root with workspaces, private: true
-├── bun.lockb             # Single lockfile at root
-├── apps/
-│   ├── web/
-│   │   └── package.json  # Own dependencies
-│   └── api/
-│       └── package.json  # Own dependencies
-└── packages/
-    ├── ui/
-    │   └── package.json  # Shared package
-    └── config/
-        └── package.json  # Shared config
-```
+**GOOD:** See `references/full-guide.md` (§ Workspace Structure Example) for the full tree — root `package.json` + `bun.lockb`, each app/package owns its own `package.json`.
 
 **BAD:**
 
@@ -159,18 +141,7 @@ Packages can only access dependencies they explicitly declare.
 
 ### Dependency Catalogs
 
-Centralize version management:
-
-```json
-// Root package.json
-{
-  "catalog": {
-    "react": "^19.0.0",
-    "next": "^16.0.0",
-    "typescript": "^5.7.0"
-  }
-}
-```
+See § Dependency Catalogs (Bun 1.3+) above for the catalog syntax.
 
 ### Interactive Updates
 
@@ -236,67 +207,15 @@ bun install  # From root only
 
 ## Validation Output
 
-```
-=== Bun Workspace Validation Report ===
-
-Bun Version: 1.3.2 ✓
-
-Root package.json:
-  ✓ private: true
-  ✓ workspaces defined
-  ✗ Found dependencies in root (should be empty)
-
-Workspace Structure:
-  ✓ apps/web - valid workspace
-  ✓ apps/api - valid workspace
-  ✓ packages/ui - valid workspace
-  ✗ apps/web/bun.lockb - lockfile should only be at root
-
-Dependencies:
-  ✓ Using workspace:* protocol
-  ✗ @myorg/ui uses hardcoded version "1.0.0"
-
-Catalogs:
-  ✗ No dependency catalog found (recommended for Bun 1.3+)
-
-Summary: 3 issues found
-```
+See `references/full-guide.md` (§ Validation Output Example) for a sample report.
 
 ## Best Practices
 
-### 1. Always use workspace protocol
-
-```json
-"@myorg/shared": "workspace:*"
-```
-
-### 2. Use --cwd for workspace operations
-
-```bash
-bun add lodash --cwd apps/web  # NOT: cd apps/web && bun add
-```
-
-### 3. Single lockfile at root
-
-```bash
-# Only run bun install from root
-bun install
-```
-
-### 4. Use catalogs for shared dependencies
-
-```json
-{
-  "catalog": {
-    "typescript": "^5.7.0",
-    "vitest": "^3.0.0"
-  }
-}
-```
-
-### 5. Declare all dependencies explicitly
-
-Each workspace should list all its dependencies - don't rely on hoisting.
+- Always use the workspace protocol: `"@myorg/shared": "workspace:*"`
+- Use `--cwd` for workspace operations: `bun add lodash --cwd apps/web` (not `cd apps/web && bun add`)
+- Run `bun install` only from the root — keep a single lockfile
+- Use dependency catalogs for shared versions (see § Dependency Catalogs above)
+- Declare all dependencies explicitly per workspace — don't rely on hoisting
 
 ## CI/CD Integration
 

--- a/.agents/skills/bun-validator/plugin.json
+++ b/.agents/skills/bun-validator/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bun-validator",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Validate Bun workspace configuration and detect common monorepo issues",
   "author": {
     "name": "Ship Shit Dev",

--- a/.agents/skills/bun-validator/references/full-guide.md
+++ b/.agents/skills/bun-validator/references/full-guide.md
@@ -1,0 +1,47 @@
+# Bun Validator — Full Examples
+
+## Workspace Structure Example (GOOD)
+
+```
+my-monorepo/
+├── package.json          # Root with workspaces, private: true
+├── bun.lockb             # Single lockfile at root
+├── apps/
+│   ├── web/
+│   │   └── package.json  # Own dependencies
+│   └── api/
+│       └── package.json  # Own dependencies
+└── packages/
+    ├── ui/
+    │   └── package.json  # Shared package
+    └── config/
+        └── package.json  # Shared config
+```
+
+## Validation Output Example
+
+```
+=== Bun Workspace Validation Report ===
+
+Bun Version: 1.3.2 ✓
+
+Root package.json:
+  ✓ private: true
+  ✓ workspaces defined
+  ✗ Found dependencies in root (should be empty)
+
+Workspace Structure:
+  ✓ apps/web - valid workspace
+  ✓ apps/api - valid workspace
+  ✓ packages/ui - valid workspace
+  ✗ apps/web/bun.lockb - lockfile should only be at root
+
+Dependencies:
+  ✓ Using workspace:* protocol
+  ✗ @myorg/ui uses hardcoded version "1.0.0"
+
+Catalogs:
+  ✗ No dependency catalog found (recommended for Bun 1.3+)
+
+Summary: 3 issues found
+```

--- a/.agents/skills/component-library/SKILL.md
+++ b/.agents/skills/component-library/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: component-library
-description: Expert React/Next.js component architect specializing in creating consistent, reusable, and maintainable components for monorepo projects
+description: Expert React/Next.js component architect specializing in creating consistent, reusable, and maintainable components for monorepo projects. Use when creating or refactoring UI components, reviewing component architecture, or setting up shared component patterns in a monorepo.
 metadata:
   version: "1.0.0"
   tags: react, nextjs, components, design-system, typescript, performance, patterns
@@ -8,9 +8,7 @@ metadata:
 
 # Component Library Standards Skill
 
-Expert React/Next.js component architect specializing in creating consistent, reusable, and maintainable components.
-
-## When to Use This Skill
+## When to Use
 
 Use when you're:
 

--- a/.agents/skills/design-consistency-auditor/SKILL.md
+++ b/.agents/skills/design-consistency-auditor/SKILL.md
@@ -8,9 +8,7 @@ metadata:
 
 # Design Consistency Auditor
 
-## Purpose
-
-Audit and maintain design consistency across frontend applications. Before auditing, discover the project's frontend structure from documentation.
+Before auditing, discover the project's frontend structure from documentation.
 
 Ensures:
 

--- a/.agents/skills/design-consistency-auditor/references/full-guide.md
+++ b/.agents/skills/design-consistency-auditor/references/full-guide.md
@@ -454,7 +454,7 @@
 
 ### Avoid "AI Slop" Aesthetic (CRITICAL)
 
-**Source:** Claude 4 Best Practices - https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-4-best-practices
+**Source:** Anthropic prompt-engineering best practices (platform.claude.com/docs).
 
 AI-generated frontends tend to converge on generic, "on distribution" outputs that create what users call the "AI slop" aesthetic. This skill audits for and prevents this pattern.
 

--- a/.agents/skills/docker-expert/SKILL.md
+++ b/.agents/skills/docker-expert/SKILL.md
@@ -8,13 +8,7 @@ metadata:
 
 # Docker Expert
 
-## Overview
-
-This skill enables AI assistants to help with Docker containerization, docker-compose setups, and container orchestration for micro startup infrastructure.
-
-## When to Use This Skill
-
-This skill activates when users need:
+## When to Use
 
 - Dockerfile creation for NestJS/Next.js
 - docker-compose configuration

--- a/.agents/skills/error-handling-expert/SKILL.md
+++ b/.agents/skills/error-handling-expert/SKILL.md
@@ -1,14 +1,12 @@
 ---
 name: error-handling-expert
-description: Expert in error handling patterns, exception management, error responses, logging, and error recovery strategies for React, Next.js, and NestJS applications
+description: Expert in error handling patterns, exception management, error responses, logging, and error recovery strategies for React, Next.js, and NestJS applications. Use when implementing error handling, exception filters, error responses, error logging, or recovery strategies.
 metadata:
   version: "1.0.0"
   tags: "errors, reliability, architecture"
 ---
 
 # Error Handling Expert Skill
-
-Expert in error handling patterns, exception management, error responses, logging, and error recovery strategies for React, Next.js, and NestJS applications.
 
 ## When to Use
 

--- a/.agents/skills/git-safety/SKILL.md
+++ b/.agents/skills/git-safety/SKILL.md
@@ -16,8 +16,6 @@ disable-model-invocation: true
 
 # Git Safety Skill
 
-Comprehensive security scanning, cleaning, and prevention for git repositories.
-
 ## Contract
 
 Inputs:

--- a/.agents/skills/llm-structured-output/SKILL.md
+++ b/.agents/skills/llm-structured-output/SKILL.md
@@ -8,7 +8,7 @@ metadata:
 
 # LLM Structured Output
 
-Build structured-output flows that are predictable enough for software to trust.
+Build structured-output flows that downstream software can parse reliably.
 
 ## Use This Skill For
 

--- a/.agents/skills/mcp-builder/README.md
+++ b/.agents/skills/mcp-builder/README.md
@@ -14,6 +14,6 @@ Derived from **[anthropics/skills](https://github.com/anthropics/skills)** (Apac
 | Last synced | 2026-06-12 |
 | License | Apache-2.0 |
 
-**Local modifications:** Vendored from Anthropic's official skills repo as a standalone marketplace plugin. No behavioral changes beyond provenance metadata.
+**Local modifications:** Vendored from Anthropic's official skills repo as a standalone marketplace plugin. One behavioral change: `scripts/evaluation.py` and `references/evaluation.md` no longer pin a specific model default — the eval model now comes from the `ANTHROPIC_MODEL` env var (or `-m`), so the skill never ships a version that goes stale. On re-sync, re-apply this de-pinning if upstream still hardcodes a model ID; restructured 2026-07-10: long examples moved to references/.
 
 **Checking for upstream changes:** when upstream has moved ahead of the synced marker above, diff [`skills/mcp-builder/SKILL.md`](https://github.com/anthropics/skills/blob/main/skills/mcp-builder/SKILL.md) on `main` since commit `ef740771ac90`, port anything worth bringing home, then bump `metadata.upstream_commit` (or `metadata.upstream_version`) and `metadata.last_synced` in `SKILL.md` and this table.

--- a/.agents/skills/mcp-builder/SKILL.md
+++ b/.agents/skills/mcp-builder/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: mcp-builder
 description: >-
-  Creates high-quality MCP (Model Context Protocol) servers that enable LLMs to interact with
+  Creates MCP (Model Context Protocol) servers that enable LLMs to interact with
   external services through well-designed tools. Activates on: "build an MCP server", "create
-  MCP tools", "integrate API via MCP", "write a FastMCP server", "add MCP to Claude", or any
+  MCP tools", "integrate API via MCP", "write a FastMCP server", "add an MCP server to an agent", or any
   request to wrap an external API as LLM-callable tools in Python or Node/TypeScript.
 disable-model-invocation: true
 license: Complete terms in LICENSE.txt
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   source: https://github.com/anthropics/skills/blob/main/skills/mcp-builder/SKILL.md
   upstream_repo: anthropics/skills
   upstream_ref: main
@@ -19,45 +19,39 @@ metadata:
 ---
 # MCP Server Development Guide
 
-## Overview
-
-To create high-quality MCP (Model Context Protocol) servers that enable LLMs to effectively interact with external services, use this skill. An MCP server provides tools that allow LLMs to access external services and APIs. The quality of an MCP server is measured by how well it enables LLMs to accomplish real-world tasks using the tools provided.
-
----
-
 # Process
 
-## 🚀 High-Level Workflow
+## High-Level Workflow
 
-Creating a high-quality MCP server involves four main phases:
+Build an MCP server in four phases:
 
 ### Phase 1: Deep Research and Planning
 
 #### 1.1 Understand Agent-Centric Design Principles
 
-Before diving into implementation, understand how to design tools for AI agents by reviewing these principles:
+Before implementation, design tools around agent workflows:
 
 **Build for Workflows, Not Just API Endpoints:**
 
-- Don't simply wrap existing API endpoints - build thoughtful, high-impact workflow tools
+- Do not mirror every API endpoint by default. Group endpoints into workflow
+  tools when one user task requires multiple API calls.
 - Consolidate related operations (e.g., `schedule_event` that both checks availability and creates event)
-- Focus on tools that enable complete tasks, not just individual API calls
-- Consider what workflows agents actually need to accomplish
+- List the top user workflows and map each tool to one workflow.
 
 **Optimize for Limited Context:**
 
-- Agents have constrained context windows - make every token count
+- Return only fields needed for the task by default.
 - Return high-signal information, not exhaustive data dumps
 - Provide "concise" vs "detailed" response format options
 - Default to human-readable identifiers over technical codes (names over IDs)
-- Consider the agent's context budget as a scarce resource
+- Add pagination, field selection, or truncation for large responses.
 
 **Design Actionable Error Messages:**
 
-- Error messages should guide agents toward correct usage patterns
+- Error messages include the failed field or operation, the cause, and the next
+  valid action.
 - Suggest specific next steps: "Try using filter='active_only' to reduce results"
-- Make errors educational, not just diagnostic
-- Help agents learn proper tool usage through clear feedback
+- Never return raw provider errors without a tool-level explanation.
 
 **Follow Natural Task Subdivisions:**
 
@@ -73,9 +67,9 @@ Before diving into implementation, understand how to design tools for AI agents 
 
 #### 1.2 Study MCP Protocol Documentation
 
-**Fetch the latest MCP protocol documentation:**
+**Fetch the MCP protocol documentation:**
 
-Use WebFetch to load: `https://modelcontextprotocol.io/llms-full.txt`
+Fetch: `https://modelcontextprotocol.io/llms-full.txt`
 
 This document contains the complete MCP specification. Note: the URL may change as the spec evolves — if the fetch fails, search for the current MCP docs URL.
 
@@ -87,17 +81,20 @@ This document contains the complete MCP specification. Note: the URL may change 
 
 **For Python implementations, also load:**
 
-- **Python SDK Documentation**: Use WebFetch to load `https://py.sdk.modelcontextprotocol.io/`
+- **Python SDK Documentation**: Fetch `https://py.sdk.modelcontextprotocol.io/`
 - [🐍 Python Implementation Guide](./references/python_mcp_server.md) - Python-specific best practices and examples
 
 **For Node/TypeScript implementations, also load:**
 
-- **TypeScript SDK Documentation**: Use WebFetch to load `https://ts.sdk.modelcontextprotocol.io/`
+- **TypeScript SDK Documentation**: Fetch `https://ts.sdk.modelcontextprotocol.io/`
 - [⚡ TypeScript Implementation Guide](./references/node_mcp_server.md) - Node/TypeScript-specific best practices and examples
 
-#### 1.4 Exhaustively Study API Documentation
+#### 1.4 Study API Documentation
 
-To integrate a service, read through **ALL** available API documentation:
+To integrate a service, read the API documentation for the selected workflows.
+Scope endpoint and parameter coverage to those workflows, but read the
+cross-cutting concerns (auth, rate limits, error handling, data models) in full
+— they apply across every tool you expose:
 
 - Official API reference documentation
 - Authentication and authorization requirements
@@ -106,11 +103,11 @@ To integrate a service, read through **ALL** available API documentation:
 - Available endpoints and their parameters
 - Data models and schemas
 
-**To gather comprehensive information, use web search and the WebFetch tool as needed.**
+Search or fetch documentation only for gaps that block the selected workflow.
 
-#### 1.5 Create a Comprehensive Implementation Plan
+#### 1.5 Create an Implementation Plan
 
-Based on your research, create a detailed plan that includes:
+Create a plan with these sections:
 
 **Tool Selection:**
 
@@ -135,7 +132,8 @@ Based on your research, create a detailed plan that includes:
 **Error Handling Strategy:**
 
 - Plan graceful failure modes
-- Design clear, actionable, LLM-friendly, natural language error messages which prompt further action
+- Define each error shape with: error code, human-readable cause, retryability,
+  and next valid action.
 - Consider rate limiting and timeout scenarios
 - Handle authentication and authorization errors
 
@@ -143,7 +141,8 @@ Based on your research, create a detailed plan that includes:
 
 ### Phase 2: Implementation
 
-Now that you have a comprehensive plan, begin implementation following language-specific best practices.
+After the plan exists, implement the shared infrastructure before individual
+tools.
 
 #### 2.1 Set Up Project Structure
 
@@ -155,7 +154,7 @@ Now that you have a comprehensive plan, begin implementation following language-
 
 **For Node/TypeScript:**
 
-- Create proper project structure (see [⚡ TypeScript Guide](./references/node_mcp_server.md))
+- Create the project structure from [⚡ TypeScript Guide](./references/node_mcp_server.md)
 - Set up `package.json` and `tsconfig.json`
 - Use MCP TypeScript SDK
 - Define Zod schemas for input validation
@@ -177,16 +176,16 @@ For each tool in the plan:
 **Define Input Schema:**
 
 - Use Pydantic (Python) or Zod (TypeScript) for validation
-- Include proper constraints (min/max length, regex patterns, min/max values, ranges)
-- Provide clear, descriptive field descriptions
+- Include constraints (min/max length, regex patterns, min/max values, ranges)
+- Describe field purpose, accepted values, and defaults
 - Include diverse examples in field descriptions
 
-**Write Comprehensive Docstrings/Descriptions:**
+**Write Tool Docstrings/Descriptions:**
 
 - One-line summary of what the tool does
-- Detailed explanation of purpose and functionality
+- Purpose and functionality
 - Explicit parameter types with examples
-- Complete return type schema
+- Return type schema
 - Usage examples (when to use, when not to use)
 - Error handling documentation, which outlines how to proceed given specific errors
 
@@ -194,7 +193,7 @@ For each tool in the plan:
 
 - Use shared utilities to avoid code duplication
 - Follow async/await patterns for all I/O
-- Implement proper error handling
+- Implement the planned error shapes
 - Support multiple response formats (JSON and Markdown)
 - Respect pagination parameters
 - Check character limits and truncate appropriately
@@ -208,25 +207,7 @@ For each tool in the plan:
 
 #### 2.4 Follow Language-Specific Best Practices
 
-**At this point, load the appropriate language guide:**
-
-**For Python: Load [🐍 Python Implementation Guide](./references/python_mcp_server.md) and ensure the following:**
-
-- Using MCP Python SDK with proper tool registration
-- Pydantic v2 models with `model_config`
-- Type hints throughout
-- Async/await for all I/O operations
-- Proper imports organization
-- Module-level constants (CHARACTER_LIMIT, API_BASE_URL)
-
-**For Node/TypeScript: Load [⚡ TypeScript Implementation Guide](./references/node_mcp_server.md) and ensure the following:**
-
-- Using `server.registerTool` properly
-- Zod schemas with `.strict()`
-- TypeScript strict mode enabled
-- No `any` types - use proper types
-- Explicit Promise<T> return types
-- Build process configured (`bun run build`)
+Load the matching guide before finishing implementation — [🐍 Python Implementation Guide](./references/python_mcp_server.md) or [⚡ TypeScript Implementation Guide](./references/node_mcp_server.md) — and follow its patterns: proper SDK tool registration (`@mcp.tool` / `server.registerTool`), strict input validation (Pydantic v2 `model_config` / Zod `.strict()`), full type coverage with no `any`, async/await for all I/O, module-level constants for shared values (e.g. `CHARACTER_LIMIT`, `API_BASE_URL`), and — for TypeScript — a working `bun run build`.
 
 ---
 
@@ -236,38 +217,24 @@ After initial implementation:
 
 #### 3.1 Code Quality Review
 
-To ensure quality, review the code for:
+Review the code for:
 
 - **DRY Principle**: No duplicated code between tools
 - **Composability**: Shared logic extracted into functions
 - **Consistency**: Similar operations return similar formats
 - **Error Handling**: All external calls have error handling
 - **Type Safety**: Full type coverage (Python type hints, TypeScript types)
-- **Documentation**: Every tool has comprehensive docstrings/descriptions
+- **Documentation**: Every tool has summary, parameters, return shape, examples,
+  and error behavior
 
 #### 3.2 Test and Build
 
-**Important:** MCP servers are long-running processes that wait for requests over stdio/stdin or sse/http. Running them directly in your main process (e.g., `python server.py` or `node dist/index.js`) will cause your process to hang indefinitely.
+**Important:** MCP servers are long-running processes that wait for requests over stdio/stdin or sse/http. Running them directly in the main process (e.g., `python server.py` or `node dist/index.js`) hangs it indefinitely.
 
-**Safe ways to test the server:**
+Safe ways to test: run the server in tmux to keep it out of the main process, use a timeout (`timeout 5s python server.py`), or let the evaluation harness (Phase 4) manage the server subprocess directly for stdio transport.
 
-- Use the evaluation harness (see Phase 4) - recommended approach
-- Run the server in tmux to keep it outside your main process
-- Use a timeout when testing: `timeout 5s python server.py`
-
-**For Python:**
-
-- Verify Python syntax: `python -m py_compile your_server.py`
-- Check imports work correctly by reviewing the file
-- To manually test: Run server in tmux, then test with evaluation harness in main process
-- Or use the evaluation harness directly (it manages the server for stdio transport)
-
-**For Node/TypeScript:**
-
-- Run `bun run build` and ensure it completes without errors
-- Verify dist/index.js is created
-- To manually test: Run server in tmux, then test with evaluation harness in main process
-- Or use the evaluation harness directly (it manages the server for stdio transport)
+- **Python:** verify syntax with `python -m py_compile your_server.py` and review imports.
+- **Node/TypeScript:** run `bun run build`, confirm it completes without errors, and verify `dist/index.js` is created.
 
 #### 3.3 Use Quality Checklist
 
@@ -280,7 +247,8 @@ To verify implementation quality, load the appropriate checklist from the langua
 
 ### Phase 4: Create Evaluations
 
-After implementing your MCP server, create comprehensive evaluations to test its effectiveness.
+After implementing the MCP server, create evaluations that test whether agents
+can answer realistic questions with the tools.
 
 **Load [✅ Evaluation Guide](./references/evaluation.md) for complete evaluation guidelines.**
 
@@ -290,7 +258,7 @@ Evaluations test whether LLMs can effectively use your MCP server to answer real
 
 #### 4.2 Create 10 Evaluation Questions
 
-To create effective evaluations, follow the process outlined in the evaluation guide:
+Follow the process outlined in the evaluation guide:
 
 1. **Tool Inspection**: List available tools and understand their capabilities
 2. **Content Exploration**: Use READ-ONLY operations to explore available data
@@ -327,7 +295,7 @@ Create an XML file with this structure:
 ## Gotchas
 
 - **Running the server directly hangs the process.** MCP servers block on stdio/stdin waiting for requests indefinitely. Never run `python server.py` or `node dist/index.js` in your main process. Use `tmux` to background the server, or use the evaluation harness which manages the server subprocess.
-- **Live URL references can go stale.** The MCP protocol documentation URL (`modelcontextprotocol.io/llms-full.txt`) and the GitHub SDK README URLs may move between versions. If a WebFetch fails, search for the current URL rather than assuming the skill path is correct.
+- **Live URL references can go stale.** The MCP protocol documentation URL (`modelcontextprotocol.io/llms-full.txt`) and the GitHub SDK README URLs may move between versions. If a fetch fails, search for the current URL rather than assuming the skill path is correct.
 - **TypeScript builds must be re-run after every source change.** `dist/index.js` is the artifact the MCP runtime loads. Editing `.ts` files without running `bun run build` means the runtime is still running the old version.
 - **Tool annotations are hints, not enforced contracts.** `readOnlyHint: true` does not prevent a tool from writing data — it only signals intent to the LLM. Enforce safety in the tool implementation itself.
 
@@ -335,47 +303,13 @@ Create an XML file with this structure:
 
 # Reference Files
 
-## 📚 Documentation Library
+Load only the resources required by the implementation language and phase.
 
-Load these resources as needed during development:
+| File | Load during | Covers |
+|---|---|---|
+| `references/mcp_best_practices.md` | Phase 1.3 (load first) | naming conventions, response formats (JSON vs Markdown), pagination, character limits/truncation, security and error-handling standards |
+| `references/python_mcp_server.md` | Phase 2 (Python) | server init, Pydantic models, `@mcp.tool` registration, working examples, quality checklist |
+| `references/node_mcp_server.md` | Phase 2 (TypeScript) | project structure, Zod schemas, `server.registerTool`, working examples, quality checklist |
+| `references/evaluation.md` | Phase 4 | question-creation and answer-verification guidelines, XML format, example Q&A, running evaluations |
 
-### Core MCP Documentation (Load First)
-
-- **MCP Protocol**: Fetch from `https://modelcontextprotocol.io/llms-full.txt` - Complete MCP specification
-- [📋 MCP Best Practices](./references/mcp_best_practices.md) - Universal MCP guidelines including:
-  - Server and tool naming conventions
-  - Response format guidelines (JSON vs Markdown)
-  - Pagination best practices
-  - Character limits and truncation strategies
-  - Tool development guidelines
-  - Security and error handling standards
-
-### SDK Documentation (Load During Phase 1/2)
-
-- **Python SDK**: Fetch from `https://py.sdk.modelcontextprotocol.io/`
-- **TypeScript SDK**: Fetch from `https://ts.sdk.modelcontextprotocol.io/`
-
-### Language-Specific Implementation Guides (Load During Phase 2)
-
-- [🐍 Python Implementation Guide](./references/python_mcp_server.md) - Complete Python/FastMCP guide with:
-  - Server initialization patterns
-  - Pydantic model examples
-  - Tool registration with `@mcp.tool`
-  - Complete working examples
-  - Quality checklist
-
-- [⚡ TypeScript Implementation Guide](./references/node_mcp_server.md) - Complete TypeScript guide with:
-  - Project structure
-  - Zod schema patterns
-  - Tool registration with `server.registerTool`
-  - Complete working examples
-  - Quality checklist
-
-### Evaluation Guide (Load During Phase 4)
-
-- [✅ Evaluation Guide](./references/evaluation.md) - Complete evaluation creation guide with:
-  - Question creation guidelines
-  - Answer verification strategies
-  - XML format specifications
-  - Example questions and answers
-  - Running an evaluation with the provided scripts
+Also fetch the live protocol/SDK docs as needed: MCP protocol spec (`https://modelcontextprotocol.io/llms-full.txt`), Python SDK (`https://py.sdk.modelcontextprotocol.io/`), TypeScript SDK (`https://ts.sdk.modelcontextprotocol.io/`).

--- a/.agents/skills/mcp-builder/plugin.json
+++ b/.agents/skills/mcp-builder/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-builder",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Guide for creating high-quality MCP (Model Context Protocol) servers that enable LLMs to interact wi",
   "author": {
     "name": "Ship Shit Dev",

--- a/.agents/skills/mcp-builder/references/evaluation.md
+++ b/.agents/skills/mcp-builder/references/evaluation.md
@@ -510,7 +510,7 @@ positional arguments:
 optional arguments:
   -h, --help            Show help message
   -t, --transport       Transport type: stdio, sse, or http (default: stdio)
-  -m, --model           Claude model to use (default: claude-3-7-sonnet-20250219)
+  -m, --model           Model to use (defaults to the ANTHROPIC_MODEL env var; required if unset)
   -o, --output          Output file for report (default: print to stdout)
 
 stdio options:
@@ -624,7 +624,7 @@ If many evaluations fail:
 
 If tasks are timing out:
 
-- Use a more capable model (e.g., `claude-3-7-sonnet-20250219`)
+- Use a more capable model (set `ANTHROPIC_MODEL` or pass `-m`)
 - Check if tools are returning too much data
 - Verify pagination is working correctly
 - Consider simplifying complex questions

--- a/.agents/skills/mcp-builder/scripts/evaluation.py
+++ b/.agents/skills/mcp-builder/scripts/evaluation.py
@@ -6,6 +6,7 @@ This script evaluates MCP servers by running test questions against them using C
 import argparse
 import asyncio
 import json
+import os
 import re
 import sys
 import time
@@ -17,6 +18,10 @@ from typing import Any
 from anthropic import Anthropic
 
 from connections import create_connection
+
+# Model is not pinned to a version here — it goes stale on every release. Set the
+# ANTHROPIC_MODEL env var (or pass -m/--model) to your current model of choice.
+DEFAULT_MODEL = os.environ.get("ANTHROPIC_MODEL", "")
 
 EVALUATION_PROMPT = """You are an AI assistant with access to tools.
 
@@ -220,7 +225,7 @@ TASK_TEMPLATE = """
 async def run_evaluation(
     eval_path: Path,
     connection: Any,
-    model: str = "claude-3-7-sonnet-20250219",
+    model: str = DEFAULT_MODEL,
 ) -> str:
     """Run evaluation with MCP server tools."""
     print("🚀 Starting Evaluation")
@@ -314,14 +319,14 @@ Examples:
   # Evaluate an SSE MCP server
   python evaluation.py -t sse -u https://example.com/mcp -H "Authorization: Bearer token" eval.xml
 
-  # Evaluate an HTTP MCP server with custom model
-  python evaluation.py -t http -u https://example.com/mcp -m claude-3-5-sonnet-20241022 eval.xml
+  # Evaluate an HTTP MCP server with a specific model
+  python evaluation.py -t http -u https://example.com/mcp -m <your-model> eval.xml
         """,
     )
 
     parser.add_argument("eval_file", type=Path, help="Path to evaluation XML file")
     parser.add_argument("-t", "--transport", choices=["stdio", "sse", "http"], default="stdio", help="Transport type (default: stdio)")
-    parser.add_argument("-m", "--model", default="claude-3-7-sonnet-20250219", help="Claude model to use (default: claude-3-7-sonnet-20250219)")
+    parser.add_argument("-m", "--model", default=DEFAULT_MODEL, help="Model to use (defaults to the ANTHROPIC_MODEL env var; required if that is unset)")
 
     stdio_group = parser.add_argument_group("stdio options")
     stdio_group.add_argument("-c", "--command", help="Command to run MCP server (stdio only)")
@@ -335,6 +340,9 @@ Examples:
     parser.add_argument("-o", "--output", type=Path, help="Output file for evaluation report (default: stdout)")
 
     args = parser.parse_args()
+
+    if not args.model:
+        parser.error("no model set — pass -m/--model or set the ANTHROPIC_MODEL env var")
 
     if not args.eval_file.exists():
         print(f"Error: Evaluation file not found: {args.eval_file}")

--- a/.agents/skills/nestjs-expert/SKILL.md
+++ b/.agents/skills/nestjs-expert/SKILL.md
@@ -10,7 +10,7 @@ metadata:
 
 # NestJS Expert
 
-Production NestJS patterns for TypeScript APIs. Stack: NestJS + MongoDB/Mongoose + TypeScript strict mode.
+Stack: NestJS + MongoDB/Mongoose + TypeScript strict mode.
 
 ## Module architecture
 

--- a/.agents/skills/nestjs-queue-architect/SKILL.md
+++ b/.agents/skills/nestjs-queue-architect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nestjs-queue-architect
-description: Queue job management patterns, processors, and async workflows for video/image processing
+description: Queue job management patterns, processors, and async workflows for video/image processing. Use when building BullMQ queues, job processors, or async video/image processing workflows in NestJS.
 metadata:
   version: "1.0.0"
   technology: BullMQ 5.61.0 with NestJS 11.1.7
@@ -11,7 +11,7 @@ metadata:
 
 # NestJS Queue Architect - BullMQ Expert
 
-You are a **senior queue architect** specializing in BullMQ with NestJS. Design resilient, scalable job processing systems for media-heavy workflows.
+Design resilient, scalable BullMQ + NestJS job processing systems for media-heavy workflows.
 
 ## Technology Stack
 

--- a/.agents/skills/nestjs-queue-architect/references/full-guide.md
+++ b/.agents/skills/nestjs-queue-architect/references/full-guide.md
@@ -310,7 +310,7 @@ export interface VideoJobData {
   ingredientId: string;
   userId: string;
   organizationId: string;
-  authProviderUserId: string;
+  clerkUserId: string;
   priority?: JobPriority;
 
   params: {

--- a/.agents/skills/nextjs-validator/SKILL.md
+++ b/.agents/skills/nextjs-validator/SKILL.md
@@ -2,13 +2,13 @@
 name: nextjs-validator
 description: Validate Next.js 16 configuration and detect/prevent deprecated patterns. Ensures proxy.ts usage, Turbopack, Cache Components, and App Router best practices. Use before any Next.js work or when auditing existing projects.
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   tags: nextjs, validation, frontend, react, turbopack
 ---
 
 # Next.js Validator
 
-Validates Next.js 16 configuration and prevents deprecated patterns. AI assistants often generate Next.js 14/15 patterns - this skill enforces Next.js 16.
+Validates Next.js 16 configuration and prevents deprecated Next.js 14/15 patterns.
 
 ## When This Activates
 
@@ -190,7 +190,7 @@ AI-assisted debugging with contextual insight:
 
 ```typescript
 // Enable in development
-// Works with Claude Code and other MCP-compatible tools
+// Works with MCP-compatible agent tools
 ```
 
 ### Parallel Routes
@@ -207,107 +207,15 @@ app/
 
 ### Intercepting Routes
 
-```
-app/
-├── feed/
-│   └── page.tsx
-├── photo/
-│   └── [id]/
-│       └── page.tsx
-└── @modal/
-    └── (.)photo/
-        └── [id]/
-            └── page.tsx
-```
+See `references/full-guide.md` (§ Intercepting Routes Example) for the directory layout.
 
 ## Validation Output
 
-```
-=== Next.js 16 Validation Report ===
-
-Package Version: next@16.1.0 ✓
-
-File Structure:
-  ✓ Using app/ directory (App Router)
-  ✗ Found pages/ directory - migrate to App Router
-  ✓ Found proxy.ts
-  ✗ Found middleware.ts - migrate to proxy.ts
-
-Patterns:
-  ✓ Using Server Components
-  ✗ Found getServerSideProps in 2 files
-  ✓ Using next/navigation
-
-Config:
-  ✓ next.config.ts (TypeScript)
-  ✓ Turbopack enabled (default)
-
-Summary: 2 issues found
-  - Migrate pages/ to app/ directory
-  - Replace middleware.ts with proxy.ts
-```
+See `references/full-guide.md` (§ Validation Output Example) for a sample report.
 
 ## Migration Guide
 
-### From middleware.ts to proxy.ts
-
-**Before (v15):**
-
-```typescript
-// middleware.ts
-import { NextResponse } from 'next/server';
-
-export function middleware(request) {
-  // Edge runtime
-  return NextResponse.next();
-}
-
-export const config = {
-  matcher: ['/dashboard/:path*'],
-};
-```
-
-**After (v16):**
-
-```typescript
-// proxy.ts
-import { createProxy } from 'next/proxy';
-
-export const proxy = createProxy({
-  // Node.js runtime
-  async handle(request) {
-    // Full Node.js APIs available
-    return request;
-  },
-  matcher: ['/dashboard/:path*'],
-});
-```
-
-### From getServerSideProps to Server Components
-
-**Before:**
-
-```typescript
-// pages/dashboard.tsx
-export async function getServerSideProps() {
-  const data = await fetchData();
-  return { props: { data } };
-}
-
-export default function Dashboard({ data }) {
-  return <View data={data} />;
-}
-```
-
-**After:**
-
-```typescript
-// app/dashboard/page.tsx
-export default async function Dashboard() {
-  const data = await fetchData();
-  return <View data={data} />;
-}
-```
+See `references/full-guide.md` (§ Migration Guide) for before/after examples of migrating `middleware.ts` → `proxy.ts` and `getServerSideProps` → Server Components.
 
 ## CI/CD Integration
 
@@ -325,4 +233,4 @@ export default async function Dashboard() {
 
 - `tailwind-validator` - Validate Tailwind v4 config
 - `biome-validator` - Validate Biome 2.3+ config
-- `authProvider-validator` - Validate legacy auth provider auth setup
+- `clerk-validator` - Validate Clerk auth setup

--- a/.agents/skills/nextjs-validator/plugin.json
+++ b/.agents/skills/nextjs-validator/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nextjs-validator",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Validate Next.js 16 configuration and detect/prevent deprecated patterns",
   "author": {
     "name": "Ship Shit Dev",

--- a/.agents/skills/nextjs-validator/references/full-guide.md
+++ b/.agents/skills/nextjs-validator/references/full-guide.md
@@ -1,0 +1,105 @@
+# Next.js Validator — Full Examples
+
+## Validation Output Example
+
+```
+=== Next.js 16 Validation Report ===
+
+Package Version: next@16.1.0 ✓
+
+File Structure:
+  ✓ Using app/ directory (App Router)
+  ✗ Found pages/ directory - migrate to App Router
+  ✓ Found proxy.ts
+  ✗ Found middleware.ts - migrate to proxy.ts
+
+Patterns:
+  ✓ Using Server Components
+  ✗ Found getServerSideProps in 2 files
+  ✓ Using next/navigation
+
+Config:
+  ✓ next.config.ts (TypeScript)
+  ✓ Turbopack enabled (default)
+
+Summary: 2 issues found
+  - Migrate pages/ to app/ directory
+  - Replace middleware.ts with proxy.ts
+```
+
+## Migration Guide
+
+### From middleware.ts to proxy.ts
+
+**Before (v15):**
+
+```typescript
+// middleware.ts
+import { NextResponse } from 'next/server';
+
+export function middleware(request) {
+  // Edge runtime
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/dashboard/:path*'],
+};
+```
+
+**After (v16):**
+
+```typescript
+// proxy.ts
+import { createProxy } from 'next/proxy';
+
+export const proxy = createProxy({
+  // Node.js runtime
+  async handle(request) {
+    // Full Node.js APIs available
+    return request;
+  },
+  matcher: ['/dashboard/:path*'],
+});
+```
+
+### From getServerSideProps to Server Components
+
+**Before:**
+
+```typescript
+// pages/dashboard.tsx
+export async function getServerSideProps() {
+  const data = await fetchData();
+  return { props: { data } };
+}
+
+export default function Dashboard({ data }) {
+  return <View data={data} />;
+}
+```
+
+**After:**
+
+```typescript
+// app/dashboard/page.tsx
+export default async function Dashboard() {
+  const data = await fetchData();
+  return <View data={data} />;
+}
+```
+
+## Intercepting Routes Example
+
+```
+app/
+├── feed/
+│   └── page.tsx
+├── photo/
+│   └── [id]/
+│       └── page.tsx
+└── @modal/
+    └── (.)photo/
+        └── [id]/
+            └── page.tsx
+```

--- a/.agents/skills/open-source-checker/SKILL.md
+++ b/.agents/skills/open-source-checker/SKILL.md
@@ -1,16 +1,14 @@
 ---
 name: open-source-checker
-description: Expert in detecting private information, secrets, API keys, credentials, and sensitive data in codebases before open sourcing
+description: Expert in detecting private information, secrets, API keys, credentials, and sensitive data in codebases before open sourcing. Use when preparing to open source a repository, reviewing code for exposed secrets, or auditing a codebase for sensitive data before public release.
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   tags: "open-source, security, secrets"
 ---
 
 # Open Source Checker
 
-Expert in detecting private information, secrets, and sensitive data in codebases before open sourcing a repository.
-
-## When to Use This Skill
+## When to Use
 
 Use when you're:
 

--- a/.agents/skills/open-source-checker/plugin.json
+++ b/.agents/skills/open-source-checker/plugin.json
@@ -1,11 +1,11 @@
 {
   "name": "open-source-checker",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Expert in detecting private information, secrets, API keys, credentials, and sensitive data in codeb",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",
-    "url": "https://github.com/shipshitdev"
+    "url": "https://shipshit.dev"
   },
   "license": "MIT",
   "skills": "."

--- a/.agents/skills/open-source-checker/references/full-guide.md
+++ b/.agents/skills/open-source-checker/references/full-guide.md
@@ -26,10 +26,10 @@ API keys are the most common leaked secret. Check for:
 ### 1.2 Database Credentials
 
 - Connection strings with embedded passwords
-- MongoDB URIs: `mongodb+srv://user:password@...`
-- PostgreSQL: `postgresql://user:password@host:port/db`
-- MySQL: `mysql://user:password@host:port/db`
-- Redis: `redis://:password@host:port`
+- MongoDB URIs: `mongodb+srv://USER:PASSWORD@HOST`
+- PostgreSQL: `postgresql://USER:PASSWORD@HOST:PORT/DB`
+- MySQL: `mysql://USER:PASSWORD@HOST:PORT/DB`
+- Redis: `redis://:PASSWORD@HOST:PORT`
 
 ### 1.3 Private Keys and Certificates
 
@@ -191,17 +191,21 @@ SG\.[a-zA-Z0-9]{22}\.[a-zA-Z0-9\-_]{43}
 ### 2.3 Connection String Patterns
 
 ```regex
+# NOTE: schemes are written as `scheme[:]//` (semantically identical to
+# `scheme://`) so this file itself never contains a URI-shaped literal that
+# trips secret scanners (secretlint, gitleaks) in consuming repositories.
+
 # MongoDB
-mongodb(\+srv)?://[^:]+:[^@]+@[^/]+
+mongodb(\+srv)?[:]//[^:]+:[^@]+@[^/]+
 
 # PostgreSQL
-postgres(ql)?:\/\/[^:]+:[^@]+@[^/]+
+postgres(ql)?[:]//[^:]+:[^@]+@[^/]+
 
 # MySQL
-mysql:\/\/[^:]+:[^@]+@[^/]+
+mysql[:]//[^:]+:[^@]+@[^/]+
 
 # Redis
-redis://:[^@]+@[^/]+
+redis[:]//:[^@]+@[^/]+
 
 # Generic database URL
 DATABASE_URL.*[=:].*['\"][^'\"]+['\"]
@@ -997,7 +1001,7 @@ name: Secret Scanning
 
 on:
   push:
-    branches: [main, master, develop]
+    branches: [main, master]
   pull_request:
     branches: [main, master]
 
@@ -1303,12 +1307,12 @@ git push origin --force --all
 
 ```bash
 # .env.example (safe to commit)
-DATABASE_URL=<postgres_connection_url>
+DATABASE_URL=postgresql://USER:PASSWORD@HOST:5432/MYDB
 OPENAI_API_KEY=your_openai_key_here
 STRIPE_SECRET_KEY=your_stripe_key_here
 
 # .env (NEVER commit)
-DATABASE_URL=<production_database_url>
+DATABASE_URL=postgresql://USER:PASSWORD@prod.example.com:5432/proddb
 OPENAI_API_KEY=sk-abc123...
 STRIPE_SECRET_KEY=sk_live_abc123...
 ```

--- a/.agents/skills/package-architect/SKILL.md
+++ b/.agents/skills/package-architect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: package-architect
-description: Design and maintain TypeScript packages in a monorepo, including exports and build configuration.
+description: Design and maintain TypeScript packages in a monorepo, including exports and build configuration. Use when creating or restructuring monorepo packages, defining package.json exports, or setting up tsconfig references.
 metadata:
   version: "1.0.0"
   tags: "packages, monorepo, typescript"
@@ -8,7 +8,7 @@ metadata:
 
 # Package Architect
 
-You design reusable TypeScript packages in monorepos (Bun, pnpm, or npm workspaces).
+Design reusable TypeScript packages in monorepos (Bun, pnpm, or npm workspaces).
 
 ## When to Use
 

--- a/.agents/skills/performance-expert/SKILL.md
+++ b/.agents/skills/performance-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: performance-expert
-description: Expert in performance optimization for React, Next.js, NestJS applications covering frontend rendering, API response times, database queries, and infrastructure optimization
+description: Expert in performance optimization for React, Next.js, NestJS applications covering frontend rendering, API response times, database queries, and infrastructure optimization. Use when optimizing React components or Next.js pages, improving API response times, optimizing database queries, analyzing bundle sizes, or implementing caching.
 metadata:
   version: "1.0.0"
   tags: "performance, optimization, fullstack"
@@ -8,9 +8,7 @@ metadata:
 
 # Performance Expert Skill
 
-Expert in performance optimization for React, Next.js, NestJS applications, MongoDB, and AWS infrastructure.
-
-## When to Use This Skill
+## When to Use
 
 - Optimizing React components or Next.js pages
 - Improving API response times

--- a/.agents/skills/prd-quality-gate/SKILL.md
+++ b/.agents/skills/prd-quality-gate/SKILL.md
@@ -1,55 +1,54 @@
 ---
 name: prd-quality-gate
-description: Use when checking whether a Genfeed GitHub issue body is a complete Shipcode-format PRD before planning or implementation. Validates native GitHub metadata, required sections, title length, three feature phases, and concrete verification criteria.
+description: PRD completeness validation. Use to check that a PRD (or issue body that serves as one) contains the required sections before it is handed to a planning/execution agent, so the plan is built from a complete spec instead of hallucinated scope. Run it as a blocking gate or a warning-only lint.
+metadata:
+  version: "1.1.0"
+  tags: "prd, planning, validation, quality-gate, spec, requirements, ears"
 ---
 
 <prd_quality_gate>
-A well-formed PRD GitHub issue uses native GitHub/project fields for metadata
-and keeps the issue body focused on human-readable PRD content.
+A well-formed PRD (or the issue body that serves as one) must contain ALL of the
+following sections as markdown headings (## or ###).
 
-Do not require or add YAML frontmatter to GitHub issue bodies. GitHub renders
-issue-body frontmatter as visible noise, and the repository uses native GitHub
-issue/project metadata as the source of truth.
+Required sections:
 
-Required native metadata:
-- Issue type: Feature | Bug | Task
-- Project status: Backlog | Todo | In Progress | Human Review | Done | Deferred
-- Project priority: P0 | P1 | P2 | P3
-- Project complexity: Low | Medium | High
-- Project blast radius: Contained | Cross-package | Cross-app | Infra
-
-Required issue-body shape:
-- Starts with `# PRD: <name>`
-- Contains all required markdown sections before it is ready for implementation.
-
-Required sections, in order:
 - Executive Summary
 - Problem Statement
 - Goals
-- Non-Goals
-- User Stories
-- System Specification
 - Functional Requirements
-- Non-Functional Requirements
-- Feature Phase Breakdown
-- Success Criteria
-- Out of Scope
-- Dependencies
+- Acceptance Criteria
 - Verification Plan
-- Risks & Open Questions
 
-Additional quality rules:
-- Issue title should be 4-7 words and use imperative verb + object.
-- The `# PRD:` heading must be aligned with the issue title.
-- Feature Phase Breakdown must describe exactly three ordered phases.
-- Success Criteria and Out of Scope must each contain at least one concrete bullet.
-- User Stories must include explicit acceptance checks.
-- System Specification must cover observable behavior and boundaries, not implementation file names.
-- Verification Plan must name test files, suite names, or concrete manual QA steps.
-- No TODO, TBD, or placeholder text may remain when status is backlog.
+Acceptance Criteria must be written in EARS (Easy Approach to Requirements
+Syntax) so each bullet is machine-checkable and pass/fail without judgement.
+Every bullet under Acceptance Criteria must match one of:
 
-If any gate fails:
-- Keep the issue out of runnable workflow status through native GitHub/project fields.
-- Report the exact missing or weak sections.
-- Do not start implementation until the issue body is fixed.
+- WHEN <trigger> THE SYSTEM SHALL <response>        (event-driven)
+- WHILE <state> THE SYSTEM SHALL <response>         (state-driven)
+- WHERE <feature> THE SYSTEM SHALL <response>       (optional feature)
+- IF <condition> THEN THE SYSTEM SHALL <response>   (unwanted behavior)
+- THE SYSTEM SHALL <invariant>                      (ubiquitous)
+
+A bullet that does not match this grammar (case-insensitive regex
+`^\s*(\d+\.\s*)?(WHEN|WHILE|WHERE|IF|THE SYSTEM)\b.*\bSHALL\b`) is free-form
+prose, not a verifiable criterion.
+
+When the quality gate is ENABLED (blocking):
+
+- Missing any required section → fail immediately with an actionable message
+  listing the missing sections.
+- Any Acceptance Criteria bullet that is not EARS-shaped → fail, quoting each
+  offending bullet and the EARS pattern it should take.
+- The author must update the PRD and re-run the gate before planning proceeds.
+
+When the quality gate is DISABLED (default, warning-only):
+
+- Missing sections → log a warning.
+- Non-EARS Acceptance Criteria bullets → log a warning listing each offending
+  bullet.
+- Planning proceeds. The planner should still note the gaps in its output.
+
+Section matching is case-insensitive against ## and ### headings. Exact heading
+text must appear (e.g. "## Executive Summary" or "### Goals"). Headings nested
+inside code fences are ignored by convention (they are examples, not structure).
 </prd_quality_gate>

--- a/.agents/skills/prd-quality-gate/plugin.json
+++ b/.agents/skills/prd-quality-gate/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "prd-quality-gate",
+  "version": "1.0.0",
+  "description": "PRD completeness validation — check required sections before a spec is handed to a planning agent",
+  "author": {
+    "name": "Ship Shit Dev",
+    "email": "hello@shipshit.dev",
+    "url": "https://shipshit.dev"
+  },
+  "license": "MIT",
+  "skills": "."
+}

--- a/.agents/skills/production-audit/SKILL.md
+++ b/.agents/skills/production-audit/SKILL.md
@@ -8,8 +8,7 @@ metadata:
 
 # Production Audit
 
-Assess whether an application is safe to ship by inspecting the actual release
-surface and naming the risks that would matter in production.
+Assess whether an application is safe to ship by inspecting the release surface and naming production risks.
 
 ## Contract
 
@@ -54,8 +53,7 @@ Delegates To:
 - A risky PR merged or a dependency upgrade landed.
 - A deployed staging or preview URL needs a readiness pass.
 
-Do not use this as a formal compliance, legal, financial, medical, or security
-certification. It is engineering release triage.
+Not a compliance, legal, financial, medical, or security certification — engineering release triage only.
 
 ## Evidence Order
 
@@ -159,8 +157,7 @@ Then list:
 - `Evidence missing`: what would change confidence
 - `Next action`: one concrete fix or verification step
 
-If no blockers are found, still state the evidence boundary. A production audit
-is only as strong as the surfaces inspected.
+If no blockers are found, still state the evidence boundary.
 
 ## Anti-Patterns
 

--- a/.agents/skills/qa-reviewer/SKILL.md
+++ b/.agents/skills/qa-reviewer/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   multi-step implementations, before committing major refactors, or proactively
   after any task longer than five steps.
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   tags: "quality-assurance, verification, code-review, accuracy, completeness"
 ---
 
@@ -16,8 +16,6 @@ metadata:
 ## Purpose
 
 Structured framework for reviewing AI agent work before finalizing changes. Catches bugs, verifies accuracy, ensures completeness, validates solutions match requirements.
-
-**Why this exists:** AI agents can introduce subtle bugs, miss requirements, or make incorrect assumptions.
 
 ## When to Use
 
@@ -34,7 +32,7 @@ Structured framework for reviewing AI agent work before finalizing changes. Catc
 
 - Review original task and requirements
 - List all deliverables (files created/modified/deleted)
-- Check critical rules (CLAUDE.md — repo-level and global)
+- Check critical rules (agent instruction files — `AGENTS.md`/`CLAUDE.md`/`CODEX.md`, repo-level and global)
 
 ### 2. Requirement Verification
 

--- a/.agents/skills/qa-reviewer/plugin.json
+++ b/.agents/skills/qa-reviewer/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qa-reviewer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Systematically review AI agent work for quality, accuracy, and completeness. Catches bugs, verifies ",
   "author": {
     "name": "Ship Shit Dev",

--- a/.agents/skills/react-component-performance/SKILL.md
+++ b/.agents/skills/react-component-performance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: react-component-performance
-description: Diagnose slow React components and suggest targeted performance fixes.
+description: Diagnose slow React components and suggest targeted performance fixes. Use when profiling or improving a slow React component, or reducing re-renders, list lag, or expensive render work.
 metadata:
   version: "1.0.0"
   source: https://github.com/Dimillian/Skills/blob/main/react-component-performance/SKILL.md
@@ -14,8 +14,6 @@ metadata:
   date_added: "2026-03-25"
 ---
 # React Component Performance
-
-## Overview
 
 Identify render hotspots, isolate expensive updates, and apply targeted optimizations without changing UI behavior.
 

--- a/.agents/skills/react-hook-form/AGENTS.md
+++ b/.agents/skills/react-hook-form/AGENTS.md
@@ -65,7 +65,7 @@ Comprehensive performance optimization guide for React Hook Form applications, d
    - 7.3 [Verify shadcn Form Component Import Source](references/integ-shadcn-form-import.md) — MEDIUM (prevents silent component mismatch bugs)
    - 7.4 [Wire shadcn Select with onValueChange Instead of Spread](references/integ-shadcn-select-wiring.md) — MEDIUM (prevents 100% of silent select binding failures with Radix-based components)
 8. [Advanced Patterns](references/_sections.md#8-advanced-patterns) — **LOW**
-   - 8.1 [Create Test Wrapper with QueryClient and Auth Context](references/adv-testing-wrapper.md) — LOW (enables proper hook testing with required context providers)
+   - 8.1 [Create Test Wrapper with QueryClient and AuthProvider](references/adv-testing-wrapper.md) — LOW (enables proper hook testing with required context providers)
    - 8.2 [Disable DevTools in Production and During Performance Testing](references/adv-devtools-performance.md) — LOW (eliminates DevTools overhead during profiling)
    - 8.3 [Wrap FormProvider Children with React.memo](references/adv-formprovider-memo.md) — LOW (prevents cascade re-renders from FormProvider state updates)
 

--- a/.agents/skills/react-hook-form/SKILL.md
+++ b/.agents/skills/react-hook-form/SKILL.md
@@ -14,11 +14,9 @@ metadata:
 
 # React Hook Form Best Practices
 
-Comprehensive performance optimization guide for React Hook Form applications. Contains 41 rules across 8 categories, prioritized by impact to guide form development, automated refactoring, and code generation.
+41 rules across 8 categories for React Hook Form, prioritized by impact to guide form development, automated refactoring, and code generation.
 
 ## When to Apply
-
-Reference these guidelines when:
 
 - Writing new forms with React Hook Form
 - Configuring useForm options (mode, defaultValues, validation)
@@ -105,7 +103,7 @@ Reference these guidelines when:
 
 - `adv-formprovider-memo` - Wrap FormProvider children with React.memo
 - `adv-devtools-performance` - Disable DevTools in production and during performance testing
-- `adv-testing-wrapper` - Create test wrapper with QueryClient and auth context
+- `adv-testing-wrapper` - Create test wrapper with QueryClient and AuthProvider
 
 ## How to Use
 

--- a/.agents/skills/react-hook-form/references/adv-testing-wrapper.md
+++ b/.agents/skills/react-hook-form/references/adv-testing-wrapper.md
@@ -1,13 +1,13 @@
 ---
-title: Create Test Wrapper with QueryClient and Auth Context
+title: Create Test Wrapper with QueryClient and AuthProvider
 impact: LOW
 impactDescription: enables proper hook testing with required context providers
 tags: adv, testing, wrapper, vitest, react-testing-library
 ---
 
-## Create Test Wrapper with QueryClient and Auth Context
+## Create Test Wrapper with QueryClient and AuthProvider
 
-Hook tests require proper context providers. Create a reusable wrapper function that provides QueryClient, auth context, and any other required context for your forms.
+Hook tests require proper context providers. Create a reusable wrapper function that provides QueryClient, AuthProvider, and any other required context for your forms.
 
 **Incorrect (missing providers causes hook errors):**
 

--- a/.agents/skills/react-patterns/SKILL.md
+++ b/.agents/skills/react-patterns/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: react-patterns
-description: Modern React patterns and principles. Hooks, composition, performance, TypeScript best practices.
+description: Modern React patterns and principles. Hooks, composition, performance, TypeScript best practices. Use when writing or reviewing React components, applying hooks and composition patterns, or improving React performance and TypeScript usage.
 metadata:
   risk: safe
   date_added: '2026-02-27'
@@ -9,10 +9,6 @@ metadata:
 ---
 
 # React Patterns
-
-> Principles for building production-ready React applications.
-
----
 
 ## 1. Component Design Principles
 

--- a/.agents/skills/react-testing-library/SKILL.md
+++ b/.agents/skills/react-testing-library/SKILL.md
@@ -8,11 +8,9 @@ metadata:
 
 # React Testing Library Best Practices
 
-Comprehensive testing guide for React components using Testing Library, designed for AI agents and LLMs. Contains 43 rules across 9 categories, prioritized by impact to guide test writing and code review.
+43 rules across 9 categories for testing React components with Testing Library, prioritized by impact to guide test writing and code review.
 
 ## When to Apply
-
-Reference these guidelines when:
 
 - Writing new component tests with React Testing Library
 - Selecting queries (getByRole, getByLabelText, etc.)

--- a/.agents/skills/react-testing-library/references/setup-custom-render.md
+++ b/.agents/skills/react-testing-library/references/setup-custom-render.md
@@ -16,9 +16,9 @@ Create a custom render function that includes common providers. Export it from a
 test('displays user', () => {
   render(
     <QueryClientProvider client={queryClient}>
-      <AuthContextProvider>
+      <AuthProvider>
         <UserProfile />
-      </AuthContextProvider>
+      </AuthProvider>
     </QueryClientProvider>
   )
 })
@@ -27,9 +27,9 @@ test('displays user', () => {
 test('shows settings', () => {
   render(
     <QueryClientProvider client={queryClient}>
-      <AuthContextProvider>
+      <AuthProvider>
         <Settings />
-      </AuthContextProvider>
+      </AuthProvider>
     </QueryClientProvider>
   )
 })
@@ -41,7 +41,7 @@ test('shows settings', () => {
 // test-utils.tsx
 import { render } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { AuthContextProvider } from './auth'
+import { AuthProvider } from './auth'
 
 const createWrapper = () => {
   const queryClient = new QueryClient({
@@ -50,9 +50,9 @@ const createWrapper = () => {
 
   return ({ children }) => (
     <QueryClientProvider client={queryClient}>
-      <AuthContextProvider>
+      <AuthProvider>
         {children}
-      </AuthContextProvider>
+      </AuthProvider>
     </QueryClientProvider>
   )
 }

--- a/.agents/skills/refactor-code/SKILL.md
+++ b/.agents/skills/refactor-code/SKILL.md
@@ -8,7 +8,12 @@ metadata:
 
 # Refactor Code
 
-Systematic approach to refactoring code safely — improve readability, cohesion, and maintainability without changing behavior.
+Improve readability, cohesion, and maintainability without changing behavior.
+
+The `code` engine of the refactoring vertical (`/refactor code`). Draws on
+`typescript-refactor` for type-architecture work and `react-refactor` for component
+architecture. For mechanical AI-slop removal use `de-slop`; for a read-only structural
+review use `structural-review`.
 
 ## Triggers
 
@@ -25,22 +30,17 @@ Systematic approach to refactoring code safely — improve readability, cohesion
 
 ### 1. Lock Behavior First
 
-Test current behavior comprehensively before changing anything.
-
 - Read existing tests before editing
 - If behavior is unclear, derive it from current callers and runtime paths
 - Preserve public contracts unless explicitly asked for API changes
 
 ### 2. Study Local Patterns
 
-Find 3+ similar implementations in the codebase to follow.
-
-- Match naming, error handling, file structure, and test style
-- Reuse existing helpers before introducing new abstractions
+Find 3+ similar implementations in the codebase. Match naming, error handling, file structure, and test style. Reuse existing helpers before introducing new abstractions.
 
 ### 3. Refactor for Clarity
 
-Make small, incremental changes — one at a time. Prioritize in order:
+Small, incremental changes — one at a time. Prioritize in order:
 
 1. Better names
 2. Smaller focused functions (extract long methods into helpers)
@@ -53,7 +53,7 @@ Make small, incremental changes — one at a time. Prioritize in order:
 
 ### 4. Avoid Over-Engineering
 
-- Do not introduce patterns just because they are fashionable
+- Don't introduce patterns just because they're fashionable
 - Prefer straightforward code over clever indirection
 - Extract abstractions only when they reduce real duplication or confusion
 

--- a/.agents/skills/security-expert/SKILL.md
+++ b/.agents/skills/security-expert/SKILL.md
@@ -1,16 +1,14 @@
 ---
 name: security-expert
-description: Expert in application security, OWASP Top 10, authentication, authorization, data protection, and security best practices for React, Next.js, and NestJS applications
+description: Expert in application security, OWASP Top 10, authentication, authorization, data protection, and security best practices for React, Next.js, and NestJS applications. Use when implementing authentication or authorization, reviewing code for vulnerabilities, handling sensitive data, or implementing encryption or hashing.
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   tags: "security, owasp, application-security"
 ---
 
 # Security Expert Skill
 
-Expert in application security for React, Next.js, and NestJS applications.
-
-## When to Use This Skill
+## When to Use
 
 - Implementing authentication or authorization
 - Reviewing code for security vulnerabilities
@@ -24,7 +22,7 @@ Expert in application security for React, Next.js, and NestJS applications.
 ## Project Context Discovery
 
 1. Check `.agents/memory/` for security architecture notes and project facts
-2. Review `CLAUDE.md` (repo-level and global) for security rules and "never do" constraints
+2. Review the agent instruction files (`AGENTS.md`/`CLAUDE.md`/`CODEX.md`, repo-level and global) for security rules and "never do" constraints
 3. Identify security patterns and tools
 4. Check for `[project]-security-expert` skill
 

--- a/.agents/skills/security-expert/plugin.json
+++ b/.agents/skills/security-expert/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "security-expert",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Expert in application security, OWASP Top 10, authentication, authorization, data protection, and se",
   "author": {
     "name": "Ship Shit Dev",

--- a/.agents/skills/shadcn/SKILL.md
+++ b/.agents/skills/shadcn/SKILL.md
@@ -17,11 +17,9 @@ metadata:
 ---
 # shadcn/ui Community Best Practices
 
-Comprehensive best practices guide for shadcn/ui applications, maintained by the shadcn/ui community. Contains 58 rules across 10 categories, prioritized by impact to guide automated refactoring and code generation.
+58 rules across 10 categories for shadcn/ui, prioritized by impact to guide automated refactoring and code generation.
 
 ## When to Apply
-
-Reference these guidelines when:
 
 - Installing and configuring shadcn/ui in a project
 - Writing new shadcn/ui components or composing primitives

--- a/.agents/skills/spec-first/SKILL.md
+++ b/.agents/skills/spec-first/SKILL.md
@@ -37,7 +37,7 @@ Confirmation Required:
 
 Delegates To:
 
-- `task-prd-creator` for PRD-style issue creation.
+- `prd-task-creator` for PRD-style issue creation.
 - `executing-plans` for Stage D autonomous execution.
 
 A structured workflow for LLM-assisted coding that delays implementation until decisions are explicit.
@@ -196,7 +196,7 @@ GitHub Issue (one per feature)   # steps + verification commands (checklist body
 - Keeps project root clean
 - Durable spec/decisions stay in `.agents/memory/` (the source of truth)
 - Active todos live in GitHub Issues, where work is tracked
-- Works with task-prd-creator and executing-plans skills
+- Works with prd-task-creator and executing-plans skills
 - Persists across sessions
 
 ## Agent Readiness Checklist (IMPACT)

--- a/.agents/skills/systematic-debugging/SKILL.md
+++ b/.agents/skills/systematic-debugging/SKILL.md
@@ -21,7 +21,7 @@ Random fixes waste time and create new bugs. Quick patches mask underlying issue
 
 **NO FIXES WITHOUT ROOT CAUSE INVESTIGATION FIRST.**
 
-If Phase 1 is not complete, no fix may be proposed. Violating this process violates the spirit of debugging.
+If Phase 1 is not complete, no fix may be proposed.
 
 ## The Iron Law
 

--- a/.agents/skills/tailwind-validator/SKILL.md
+++ b/.agents/skills/tailwind-validator/SKILL.md
@@ -2,17 +2,15 @@
 name: tailwind-validator
 description: Validate Tailwind CSS v4 configuration and detect/prevent Tailwind v3 patterns. Use this skill when setting up Tailwind, auditing CSS configuration, or when you suspect outdated Tailwind patterns are being used. Ensures CSS-first configuration with @theme blocks.
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   tags: tailwind, css, validation, frontend, configuration
 ---
 
 # Tailwind 4 Validator
 
-Validates that a project uses Tailwind CSS v4 with proper CSS-first configuration. Detects and flags Tailwind v3 patterns that should be migrated.
-
 ## Purpose
 
-**CRITICAL**: Claude and other AI assistants often default to Tailwind v3 patterns. This skill ensures:
+Ensures:
 
 - Projects use Tailwind v4 CSS-first configuration
 - Old `tailwind.config.js` patterns are detected and flagged
@@ -30,206 +28,32 @@ Validates that a project uses Tailwind CSS v4 with proper CSS-first configuratio
 ## Quick Start
 
 ```bash
-# Validate current project
 python3 scripts/validate.py --root .
-
-# Validate with auto-fix suggestions
 python3 scripts/validate.py --root . --suggest-fixes
-
-# Strict mode (fail on any v3 pattern)
 python3 scripts/validate.py --root . --strict
 ```
 
 ## What Gets Checked
 
-### 1. Package Version
+| Check | Good (v4) | Bad (v3) |
+|---|---|---|
+| Package version | `"tailwindcss": "^4.0.0"` | `"^3.4.0"` |
+| CSS config | `@import "tailwindcss";` + `@theme { --color-primary: ...; }` | `@tailwind base/components/utilities;` |
+| Config files | none - config lives in CSS | `tailwind.config.{js,ts,mjs,cjs}` (deprecated in v4) |
+| PostCSS | `plugins: { '@tailwindcss/postcss': {} }` only | `tailwindcss` + `autoprefixer` as separate plugins |
+| Imports | `@import "tailwindcss/preflight"` / `.../utilities` | `@tailwind` directives |
 
-```json
-// GOOD: v4+
-"tailwindcss": "^4.0.0"
+See `references/full-guide.md` (§ What Gets Checked, § Validation Output) for full GOOD/BAD examples and a sample validation report.
 
-// BAD: v3
-"tailwindcss": "^3.4.0"
-```
+## Migration Guide (v3 to v4)
 
-### 2. CSS Configuration (v4 CSS-first)
+1. Swap packages: remove `tailwindcss`/`autoprefixer`, add `tailwindcss@latest` + `@tailwindcss/postcss`
+2. Point `postcss.config.js` at the `@tailwindcss/postcss` plugin only
+3. Convert `tailwind.config.js` theme/extend values into an `@theme { --color-*, --font-*, ... }` block in CSS
+4. Replace `@tailwind` directives with `@import "tailwindcss"`
+5. Delete `tailwind.config.{js,ts,mjs,cjs}`
 
-**GOOD - Tailwind v4:**
-
-```css
-/* app.css or globals.css */
-@import "tailwindcss";
-
-@theme {
-  --color-primary: #3b82f6;
-  --color-secondary: #64748b;
-  --font-sans: "Inter", sans-serif;
-  --breakpoint-3xl: 1920px;
-}
-```
-
-**BAD - Tailwind v3:**
-
-```css
-/* Old v3 directives */
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-```
-
-### 3. Config Files
-
-**BAD - Should not exist in v4:**
-
-- `tailwind.config.js`
-- `tailwind.config.ts`
-- `tailwind.config.mjs`
-- `tailwind.config.cjs`
-
-**Note**: These files are deprecated in v4. All configuration should be in CSS using `@theme`.
-
-### 4. PostCSS Configuration
-
-**GOOD - v4:**
-
-```js
-// postcss.config.js (minimal or not needed)
-export default {
-  plugins: {
-    '@tailwindcss/postcss': {},
-  },
-};
-```
-
-**BAD - v3:**
-
-```js
-// postcss.config.js
-module.exports = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
-};
-```
-
-### 5. Import Patterns
-
-**GOOD:**
-
-```css
-@import "tailwindcss";
-@import "tailwindcss/preflight";
-@import "tailwindcss/utilities";
-```
-
-**BAD:**
-
-```css
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-```
-
-## Validation Output
-
-```
-=== Tailwind 4 Validation Report ===
-
-Package Version: tailwindcss@4.0.14 ✓
-
-CSS Configuration:
-  ✓ Found @import "tailwindcss" in src/app/globals.css
-  ✓ Found @theme block with 12 custom properties
-  ✗ Found @tailwind directive in src/styles/legacy.css (line 3)
-
-Config Files:
-  ✗ Found tailwind.config.ts - should migrate to CSS @theme
-
-PostCSS:
-  ✓ Using @tailwindcss/postcss plugin
-
-Summary: 2 issues found
-  - Migrate tailwind.config.ts to @theme in CSS
-  - Remove @tailwind directives from src/styles/legacy.css
-```
-
-## Migration Guide
-
-### From Tailwind v3 to v4
-
-1. **Update package.json:**
-
-```bash
-bun remove tailwindcss autoprefixer
-bun add tailwindcss@latest @tailwindcss/postcss
-```
-
-1. **Update postcss.config.js:**
-
-```js
-export default {
-  plugins: {
-    '@tailwindcss/postcss': {},
-  },
-};
-```
-
-1. **Convert tailwind.config.js to CSS @theme:**
-
-**Before (v3):**
-
-```js
-// tailwind.config.js
-module.exports = {
-  theme: {
-    extend: {
-      colors: {
-        primary: '#3b82f6',
-        secondary: '#64748b',
-      },
-      fontFamily: {
-        sans: ['Inter', 'sans-serif'],
-      },
-    },
-  },
-};
-```
-
-**After (v4):**
-
-```css
-/* globals.css */
-@import "tailwindcss";
-
-@theme {
-  --color-primary: #3b82f6;
-  --color-secondary: #64748b;
-  --font-sans: "Inter", sans-serif;
-}
-```
-
-1. **Replace @tailwind directives:**
-
-**Before:**
-
-```css
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-```
-
-**After:**
-
-```css
-@import "tailwindcss";
-```
-
-1. **Delete old config files:**
-
-```bash
-rm tailwind.config.js tailwind.config.ts
-```
+See `references/full-guide.md` (§ Migration Guide, § CI/CD Integration) for the exact before/after code per step and a CI workflow snippet.
 
 ## Common v3 Patterns to Avoid
 
@@ -244,106 +68,11 @@ rm tailwind.config.js tailwind.config.ts
 | `content: ['./src/**/*.tsx']` | Not needed (auto-detected) |
 | `plugins: [require('@tailwindcss/forms')]` | `@plugin "@tailwindcss/forms"` |
 
-## v4 @theme Reference
-
-```css
-@import "tailwindcss";
-
-@theme {
-  /* Colors */
-  --color-primary: #3b82f6;
-  --color-primary-50: #eff6ff;
-  --color-primary-900: #1e3a8a;
-
-  /* Typography */
-  --font-sans: "Inter", system-ui, sans-serif;
-  --font-mono: "JetBrains Mono", monospace;
-
-  /* Spacing (extends default scale) */
-  --spacing-128: 32rem;
-
-  /* Breakpoints */
-  --breakpoint-3xl: 1920px;
-
-  /* Animations */
-  --animate-fade-in: fade-in 0.3s ease-out;
-
-  /* Shadows */
-  --shadow-glow: 0 0 20px rgba(59, 130, 246, 0.5);
-
-  /* Border radius */
-  --radius-4xl: 2rem;
-}
-
-@keyframes fade-in {
-  from { opacity: 0; }
-  to { opacity: 1; }
-}
-```
-
-## Using with shadcn/ui
-
-shadcn/ui v2+ supports Tailwind v4. After running the shadcn CLI:
-
-1. Verify `components.json` uses CSS variables
-2. Check that generated components use v4 patterns
-3. Ensure `@theme` includes shadcn color tokens:
-
-```css
-@theme {
-  --color-background: hsl(0 0% 100%);
-  --color-foreground: hsl(222.2 84% 4.9%);
-  --color-card: hsl(0 0% 100%);
-  --color-card-foreground: hsl(222.2 84% 4.9%);
-  --color-popover: hsl(0 0% 100%);
-  --color-popover-foreground: hsl(222.2 84% 4.9%);
-  --color-primary: hsl(222.2 47.4% 11.2%);
-  --color-primary-foreground: hsl(210 40% 98%);
-  --color-secondary: hsl(210 40% 96.1%);
-  --color-secondary-foreground: hsl(222.2 47.4% 11.2%);
-  --color-muted: hsl(210 40% 96.1%);
-  --color-muted-foreground: hsl(215.4 16.3% 46.9%);
-  --color-accent: hsl(210 40% 96.1%);
-  --color-accent-foreground: hsl(222.2 47.4% 11.2%);
-  --color-destructive: hsl(0 84.2% 60.2%);
-  --color-destructive-foreground: hsl(210 40% 98%);
-  --color-border: hsl(214.3 31.8% 91.4%);
-  --color-input: hsl(214.3 31.8% 91.4%);
-  --color-ring: hsl(222.2 84% 4.9%);
-  --radius-sm: 0.25rem;
-  --radius-md: 0.375rem;
-  --radius-lg: 0.5rem;
-}
-```
-
-## CI/CD Integration
-
-Add to your CI pipeline:
-
-```yaml
-# .github/workflows/lint.yml
-- name: Validate Tailwind v4
-  run: |
-    python3 scripts/validate.py \
-      --root . \
-      --strict \
-      --ci
-```
+See `references/full-guide.md` (§ v4 @theme Reference, § Using with shadcn/ui) for a full `@theme` token example and shadcn/ui token setup.
 
 ## Troubleshooting
 
-### "Found tailwind.config.js but using v4"
-
-Some tools still generate v3 configs. Delete the file and use `@theme` instead.
-
-### "@tailwind directives found"
-
-Replace with `@import "tailwindcss"`. The old directives are not supported in v4.
-
-### "autoprefixer in postcss.config"
-
-Remove autoprefixer - it's built into `@tailwindcss/postcss`.
-
-### "content array in config"
-
-v4 auto-detects content files. Remove the `content` config entirely.
+- **"Found tailwind.config.js but using v4"** - some tools still generate v3 configs. Delete the file and use `@theme` instead.
+- **"@tailwind directives found"** - replace with `@import "tailwindcss"`. The old directives are not supported in v4.
+- **"autoprefixer in postcss.config"** - remove autoprefixer; it's built into `@tailwindcss/postcss`.
+- **"content array in config"** - v4 auto-detects content files. Remove the `content` config entirely.

--- a/.agents/skills/tailwind-validator/plugin.json
+++ b/.agents/skills/tailwind-validator/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwind-validator",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Validate Tailwind CSS v4 configuration and detect/prevent Tailwind v3 patterns",
   "author": {
     "name": "Ship Shit Dev",

--- a/.agents/skills/tailwind-validator/references/full-guide.md
+++ b/.agents/skills/tailwind-validator/references/full-guide.md
@@ -1,0 +1,276 @@
+# Tailwind Validator - Full Guide
+
+## What Gets Checked
+
+### 1. Package Version
+
+```json
+// GOOD: v4+
+"tailwindcss": "^4.0.0"
+
+// BAD: v3
+"tailwindcss": "^3.4.0"
+```
+
+### 2. CSS Configuration (v4 CSS-first)
+
+**GOOD - Tailwind v4:**
+
+```css
+/* app.css or globals.css */
+@import "tailwindcss";
+
+@theme {
+  --color-primary: #3b82f6;
+  --color-secondary: #64748b;
+  --font-sans: "Inter", sans-serif;
+  --breakpoint-3xl: 1920px;
+}
+```
+
+**BAD - Tailwind v3:**
+
+```css
+/* Old v3 directives */
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+```
+
+### 3. Config Files
+
+**BAD - Should not exist in v4:**
+
+- `tailwind.config.js`
+- `tailwind.config.ts`
+- `tailwind.config.mjs`
+- `tailwind.config.cjs`
+
+**Note**: These files are deprecated in v4. All configuration should be in CSS using `@theme`.
+
+### 4. PostCSS Configuration
+
+**GOOD - v4:**
+
+```js
+// postcss.config.js (minimal or not needed)
+export default {
+  plugins: {
+    '@tailwindcss/postcss': {},
+  },
+};
+```
+
+**BAD - v3:**
+
+```js
+// postcss.config.js
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};
+```
+
+### 5. Import Patterns
+
+**GOOD:**
+
+```css
+@import "tailwindcss";
+@import "tailwindcss/preflight";
+@import "tailwindcss/utilities";
+```
+
+**BAD:**
+
+```css
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+```
+
+## Validation Output
+
+```
+=== Tailwind 4 Validation Report ===
+
+Package Version: tailwindcss@4.0.14 ✓
+
+CSS Configuration:
+  ✓ Found @import "tailwindcss" in src/app/globals.css
+  ✓ Found @theme block with 12 custom properties
+  ✗ Found @tailwind directive in src/styles/legacy.css (line 3)
+
+Config Files:
+  ✗ Found tailwind.config.ts - should migrate to CSS @theme
+
+PostCSS:
+  ✓ Using @tailwindcss/postcss plugin
+
+Summary: 2 issues found
+  - Migrate tailwind.config.ts to @theme in CSS
+  - Remove @tailwind directives from src/styles/legacy.css
+```
+
+## Migration Guide
+
+### From Tailwind v3 to v4
+
+1. **Update package.json:**
+
+```bash
+bun remove tailwindcss autoprefixer
+bun add tailwindcss@latest @tailwindcss/postcss
+```
+
+1. **Update postcss.config.js:**
+
+```js
+export default {
+  plugins: {
+    '@tailwindcss/postcss': {},
+  },
+};
+```
+
+1. **Convert tailwind.config.js to CSS @theme:**
+
+**Before (v3):**
+
+```js
+// tailwind.config.js
+module.exports = {
+  theme: {
+    extend: {
+      colors: {
+        primary: '#3b82f6',
+        secondary: '#64748b',
+      },
+      fontFamily: {
+        sans: ['Inter', 'sans-serif'],
+      },
+    },
+  },
+};
+```
+
+**After (v4):**
+
+```css
+/* globals.css */
+@import "tailwindcss";
+
+@theme {
+  --color-primary: #3b82f6;
+  --color-secondary: #64748b;
+  --font-sans: "Inter", sans-serif;
+}
+```
+
+1. **Replace @tailwind directives:**
+
+**Before:**
+
+```css
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+```
+
+**After:**
+
+```css
+@import "tailwindcss";
+```
+
+1. **Delete old config files:**
+
+```bash
+rm tailwind.config.js tailwind.config.ts
+```
+
+## v4 @theme Reference
+
+```css
+@import "tailwindcss";
+
+@theme {
+  /* Colors */
+  --color-primary: #3b82f6;
+  --color-primary-50: #eff6ff;
+  --color-primary-900: #1e3a8a;
+
+  /* Typography */
+  --font-sans: "Inter", system-ui, sans-serif;
+  --font-mono: "JetBrains Mono", monospace;
+
+  /* Spacing (extends default scale) */
+  --spacing-128: 32rem;
+
+  /* Breakpoints */
+  --breakpoint-3xl: 1920px;
+
+  /* Animations */
+  --animate-fade-in: fade-in 0.3s ease-out;
+
+  /* Shadows */
+  --shadow-glow: 0 0 20px rgba(59, 130, 246, 0.5);
+
+  /* Border radius */
+  --radius-4xl: 2rem;
+}
+
+@keyframes fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+```
+
+## Using with shadcn/ui
+
+shadcn/ui v2+ supports Tailwind v4. After running the shadcn CLI:
+
+1. Verify `components.json` uses CSS variables
+2. Check that generated components use v4 patterns
+3. Ensure `@theme` includes shadcn color tokens:
+
+```css
+@theme {
+  --color-background: hsl(0 0% 100%);
+  --color-foreground: hsl(222.2 84% 4.9%);
+  --color-card: hsl(0 0% 100%);
+  --color-card-foreground: hsl(222.2 84% 4.9%);
+  --color-popover: hsl(0 0% 100%);
+  --color-popover-foreground: hsl(222.2 84% 4.9%);
+  --color-primary: hsl(222.2 47.4% 11.2%);
+  --color-primary-foreground: hsl(210 40% 98%);
+  --color-secondary: hsl(210 40% 96.1%);
+  --color-secondary-foreground: hsl(222.2 47.4% 11.2%);
+  --color-muted: hsl(210 40% 96.1%);
+  --color-muted-foreground: hsl(215.4 16.3% 46.9%);
+  --color-accent: hsl(210 40% 96.1%);
+  --color-accent-foreground: hsl(222.2 47.4% 11.2%);
+  --color-destructive: hsl(0 84.2% 60.2%);
+  --color-destructive-foreground: hsl(210 40% 98%);
+  --color-border: hsl(214.3 31.8% 91.4%);
+  --color-input: hsl(214.3 31.8% 91.4%);
+  --color-ring: hsl(222.2 84% 4.9%);
+  --radius-sm: 0.25rem;
+  --radius-md: 0.375rem;
+  --radius-lg: 0.5rem;
+}
+```
+
+## CI/CD Integration
+
+```yaml
+# .github/workflows/lint.yml
+- name: Validate Tailwind v4
+  run: |
+    python3 scripts/validate.py \
+      --root . \
+      --strict \
+      --ci
+```

--- a/.agents/skills/tailwind/SKILL.md
+++ b/.agents/skills/tailwind/SKILL.md
@@ -18,11 +18,9 @@ metadata:
 ---
 # Community Tailwind CSS v4 Best Practices
 
-Comprehensive performance optimization guide for Tailwind CSS v4 applications. Contains 44 rules across 8 categories, prioritized by impact to guide automated refactoring and code generation.
+44 rules across 8 categories for Tailwind CSS v4, prioritized by impact to guide automated refactoring and code generation.
 
 ## When to Apply
-
-Reference these guidelines when:
 
 - Configuring Tailwind CSS v4 build tooling (Vite plugin, PostCSS, CLI)
 - Writing or migrating styles using v4's CSS-first approach

--- a/.agents/skills/testing-expert/SKILL.md
+++ b/.agents/skills/testing-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: testing-expert
-description: Expert in testing strategies for React, Next.js, and NestJS applications covering unit tests, integration tests, E2E tests, and testing best practices
+description: Expert in testing strategies for React, Next.js, and NestJS applications covering unit tests, integration tests, E2E tests, and testing best practices. Use when writing unit, integration, or E2E tests, testing React components, or testing API endpoints.
 metadata:
   version: "1.0.0"
   tags: "testing, quality, fullstack"
@@ -8,9 +8,7 @@ metadata:
 
 # Testing Expert Skill
 
-Expert in testing strategies for React, Next.js, and NestJS applications.
-
-## When to Use This Skill
+## When to Use
 
 - Writing unit tests
 - Creating integration tests

--- a/.agents/skills/typescript-expert/SKILL.md
+++ b/.agents/skills/typescript-expert/SKILL.md
@@ -10,19 +10,17 @@ metadata:
   category: framework
   risk: critical
   date_added: '2026-02-27'
-  version: "1.0.0"
+  version: "1.0.1"
   tags: "typescript, javascript, tooling"
 ---
 
 # TypeScript Expert
 
-You are an advanced TypeScript expert with deep, practical knowledge of type-level programming, performance optimization, and real-world problem solving based on current best practices.
-
 ## When invoked
 
 1. Analyze project setup comprehensively:
 
-   **Use internal tools first (Read, Grep, Glob) for better performance. Shell commands are fallbacks.**
+   **Prefer built-in file-reading and search capabilities for performance. Shell commands are fallbacks.**
 
    ```bash
    # Core versions and configuration
@@ -42,7 +40,7 @@ You are an advanced TypeScript expert with deep, practical knowledge of type-lev
 
 2. Identify the specific problem category and complexity level
 
-3. Apply the appropriate solution strategy from my expertise
+3. Apply the appropriate solution strategy from the expertise below
 
 4. Validate thoroughly:
 
@@ -60,70 +58,21 @@ You are an advanced TypeScript expert with deep, practical knowledge of type-lev
 
 ### Type-Level Programming Patterns
 
-**Branded Types for Domain Modeling**
+**Branded Types for Domain Modeling** — nominal types (`type UserId = Brand<string, 'UserId'>`) prevent accidentally mixing domain primitives that share a base type. Use for critical domain primitives, API boundaries, currency/units. See `references/typescript-cheatsheet.md` (§ Branded Types) for the full pattern. Resource: https://egghead.io/blog/using-branded-types-in-typescript
 
-```typescript
-// Create nominal types to prevent primitive obsession
-type Brand<K, T> = K & { __brand: T };
-type UserId = Brand<string, 'UserId'>;
-type OrderId = Brand<string, 'OrderId'>;
+**Advanced Conditional Types** — recursive type manipulation (e.g. `DeepReadonly<T>`) and template-literal event-source APIs. Use for library APIs, type-safe event systems, compile-time validation. Watch for type instantiation depth errors (limit recursion to 10 levels). See `references/typescript-cheatsheet.md` (§ Conditional Types, § Mapped Types, § Template Literal Types).
 
-// Prevents accidental mixing of domain primitives
-function processOrder(orderId: OrderId, userId: UserId) { }
-```
-
-- Use for: Critical domain primitives, API boundaries, currency/units
-- Resource: https://egghead.io/blog/using-branded-types-in-typescript
-
-**Advanced Conditional Types**
-
-```typescript
-// Recursive type manipulation
-type DeepReadonly<T> = T extends (...args: any[]) => any 
-  ? T 
-  : T extends object 
-    ? { readonly [K in keyof T]: DeepReadonly<T[K]> }
-    : T;
-
-// Template literal type magic
-type PropEventSource<Type> = {
-  on<Key extends string & keyof Type>
-    (eventName: `${Key}Changed`, callback: (newValue: Type[Key]) => void): void;
-};
-```
-
-- Use for: Library APIs, type-safe event systems, compile-time validation
-- Watch for: Type instantiation depth errors (limit recursion to 10 levels)
-
-**Type Inference Techniques**
-
-```typescript
-// Use 'satisfies' for constraint validation (TS 5.0+)
-const config = {
-  api: "https://api.example.com",
-  timeout: 5000
-} satisfies Record<string, string | number>;
-// Preserves literal types while ensuring constraints
-
-// Const assertions for maximum inference
-const routes = ['/home', '/about', '/contact'] as const;
-type Route = typeof routes[number]; // '/home' | '/about' | '/contact'
-```
+**Type Inference Techniques** — use `satisfies` (TS 5.0+) for constraint validation while preserving literal types; use `as const` assertions for maximum inference on literal arrays/objects. See `references/typescript-cheatsheet.md` (§ Best Practices).
 
 ### Performance Optimization Strategies
 
 **Type Checking Performance**
 
 ```bash
-# Diagnose slow type checking
 bunx tsc --extendedDiagnostics --incremental false | grep -E "Check time|Files:|Lines:|Nodes:"
-
-# Common fixes for "Type instantiation is excessively deep"
-# 1. Replace type intersections with interfaces
-# 2. Split large union types (>100 members)
-# 3. Avoid circular generic constraints
-# 4. Use type aliases to break recursion
 ```
+
+Common fixes for "Type instantiation is excessively deep": replace type intersections with interfaces, split large union types (>100 members), avoid circular generic constraints, use type aliases to break recursion.
 
 **Build Performance Patterns**
 
@@ -139,83 +88,41 @@ bunx tsc --extendedDiagnostics --incremental false | grep -E "Check time|Files:|
 **"The inferred type of X cannot be named"**
 
 - Cause: Missing type export or circular dependency
-- Fix priority:
-  1. Export the required type explicitly
-  2. Use `ReturnType<typeof function>` helper
-  3. Break circular dependencies with type-only imports
+- Fix priority: export the required type explicitly; use `ReturnType<typeof function>` helper; break circular dependencies with type-only imports
 - Resource: https://github.com/microsoft/TypeScript/issues/47663
 
-**Missing type declarations**
-
-- Quick fix with ambient declarations:
-
-```typescript
-// types/ambient.d.ts
-declare module 'some-untyped-package' {
-  const value: unknown;
-  export default value;
-  export = value; // if CJS interop is needed
-}
-```
-
-- For more details: [Declaration Files Guide](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html)
+**Missing type declarations** — add an ambient `.d.ts` module declaration for untyped packages. See `references/typescript-cheatsheet.md` (§ Module Declarations). For more detail: [Declaration Files Guide](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html)
 
 **"Excessive stack depth comparing types"**
 
 - Cause: Circular or deeply recursive types
-- Fix priority:
-  1. Limit recursion depth with conditional types
-  2. Use `interface` extends instead of type intersection
-  3. Simplify generic constraints
+- Fix priority: limit recursion depth with conditional types; use `interface` extends instead of type intersection; simplify generic constraints
 
 ```typescript
 // Bad: Infinite recursion
 type InfiniteArray<T> = T | InfiniteArray<T>[];
 
 // Good: Limited recursion
-type NestedArray<T, D extends number = 5> = 
+type NestedArray<T, D extends number = 5> =
   D extends 0 ? T : T | NestedArray<T, [-1, 0, 1, 2, 3, 4][D]>[];
 ```
 
-**Module Resolution Mysteries**
+**Module Resolution Mysteries** — "Cannot find module" despite the file existing:
 
-- "Cannot find module" despite file existing:
-  1. Check `moduleResolution` matches your bundler
-  2. Verify `baseUrl` and `paths` alignment
-  3. For monorepos: Ensure workspace protocol (workspace:*)
-  4. Try clearing cache: `rm -rf node_modules/.cache .tsbuildinfo`
+1. Check `moduleResolution` matches your bundler
+2. Verify `baseUrl` and `paths` alignment
+3. For monorepos: Ensure workspace protocol (`workspace:*`)
+4. Try clearing cache: `rm -rf node_modules/.cache .tsbuildinfo`
 
-**Path Mapping at Runtime**
+**Path Mapping at Runtime** — TypeScript paths only work at compile time, not runtime:
 
-- TypeScript paths only work at compile time, not runtime
-- Node.js runtime solutions:
-  - ts-node: Use `ts-node -r tsconfig-paths/register`
-  - Node ESM: Use loader alternatives or avoid TS paths at runtime
-  - Production: Pre-compile with resolved paths
+- ts-node: use `ts-node -r tsconfig-paths/register`
+- Node ESM: use loader alternatives or avoid TS paths at runtime
+- Production: pre-compile with resolved paths
 
 ### Migration Expertise
 
-**JavaScript to TypeScript Migration**
-
-```bash
-# Incremental migration strategy
-# 1. Enable allowJs and checkJs (merge into existing tsconfig.json):
-# Add to existing tsconfig.json:
-# {
-#   "compilerOptions": {
-#     "allowJs": true,
-#     "checkJs": true
-#   }
-# }
-
-# 2. Rename files gradually (.js → .ts)
-# 3. Add types file by file using AI assistance
-# 4. Enable strict mode features one by one
-
-# Automated helpers (if installed/needed)
-command -v ts-migrate >/dev/null 2>&1 && bunx ts-migrate migrate . --sources 'src/**/*.js'
-command -v typesync >/dev/null 2>&1 && bunx typesync  # Install missing @types packages
-```
+**JavaScript to TypeScript Migration** — incremental strategy: enable `allowJs`/`checkJs` in the existing tsconfig, rename files gradually (`.js` → `.ts`), add types file by file, enable strict mode features one by one. See `references/full-guide.md` (§ Migration Playbook) for the full command sequence and optional automated helpers (`ts-migrate`, `typesync`).
 
 **Tool Migration Decisions**
 
@@ -234,118 +141,33 @@ command -v typesync >/dev/null 2>&1 && bunx typesync  # Install missing @types p
 - Choose **Nx** if: Complex dependencies, need visualization, plugins required
 - Performance: Nx often performs better on large monorepos (>50 packages)
 
-**TypeScript Monorepo Configuration**
-
-```json
-// Root tsconfig.json
-{
-  "references": [
-    { "path": "./packages/core" },
-    { "path": "./packages/ui" },
-    { "path": "./apps/web" }
-  ],
-  "compilerOptions": {
-    "composite": true,
-    "declaration": true,
-    "declarationMap": true
-  }
-}
-```
+**TypeScript Monorepo Configuration** — root tsconfig `references` array plus `composite`/`declaration`/`declarationMap` per package. See `references/full-guide.md` (§ Monorepo TypeScript Configuration) for the full config.
 
 ## Modern Tooling Expertise
 
 ### Biome vs ESLint
 
-**Use Biome when:**
+**Use Biome when:** speed is critical, want a single tool for lint + format, TypeScript-first project, okay with 64 TS rules vs 100+ in typescript-eslint.
 
-- Speed is critical (often faster than traditional setups)
-- Want single tool for lint + format
-- TypeScript-first project
-- Okay with 64 TS rules vs 100+ in typescript-eslint
-
-**Stay with ESLint when:**
-
-- Need specific rules/plugins
-- Have complex custom rules
-- Working with Vue/Angular (limited Biome support)
-- Need type-aware linting (Biome doesn't have this yet)
+**Stay with ESLint when:** need specific rules/plugins, have complex custom rules, working with Vue/Angular (limited Biome support), need type-aware linting (Biome doesn't have this yet).
 
 ### Type Testing Strategies
 
-**Vitest Type Testing (Recommended)**
+**Vitest Type Testing (Recommended)** — write `.test-d.ts` files using `expectTypeOf` to assert on prop/return types at compile time. See `references/full-guide.md` (§ Vitest Type Testing) for a full example.
 
-```typescript
-// in avatar.test-d.ts
-import { expectTypeOf } from 'vitest'
-import type { Avatar } from './avatar'
-
-test('Avatar props are correctly typed', () => {
-  expectTypeOf<Avatar>().toHaveProperty('size')
-  expectTypeOf<Avatar['size']>().toEqualTypeOf<'sm' | 'md' | 'lg'>()
-})
-```
-
-**When to Test Types:**
-
-- Publishing libraries
-- Complex generic functions
-- Type-level utilities
-- API contracts
+**When to Test Types:** publishing libraries, complex generic functions, type-level utilities, API contracts.
 
 ## Debugging Mastery
 
-### CLI Debugging Tools
+**CLI Debugging Tools** — trace module resolution (`tsc --traceResolution`), profile type-check performance (`tsc --generateTrace`), debug files directly with `tsx`/`ts-node --inspect-brk`. See `references/full-guide.md` (§ CLI Debugging Tools) for the full command set.
 
-```bash
-# Debug TypeScript files directly (if tools installed)
-command -v tsx >/dev/null 2>&1 && bunx tsx --inspect src/file.ts
-command -v ts-node >/dev/null 2>&1 && bunx ts-node --inspect-brk src/file.ts
-
-# Trace module resolution issues
-bunx tsc --traceResolution > resolution.log 2>&1
-grep "Module resolution" resolution.log
-
-# Debug type checking performance (use --incremental false for clean trace)
-bunx tsc --generateTrace trace --incremental false
-# Analyze trace (if installed)
-command -v @typescript/analyze-trace >/dev/null 2>&1 && bunx @typescript/analyze-trace trace
-
-# Memory usage analysis
-node --max-old-space-size=8192 node_modules/typescript/lib/tsc.js
-```
-
-### Custom Error Classes
-
-```typescript
-// Proper error class with stack preservation
-class DomainError extends Error {
-  constructor(
-    message: string,
-    public code: string,
-    public statusCode: number
-  ) {
-    super(message);
-    this.name = 'DomainError';
-    Error.captureStackTrace(this, this.constructor);
-  }
-}
-```
+**Custom Error Classes** — extend `Error`, set `this.name`, and call `Error.captureStackTrace` to preserve the stack. See `references/full-guide.md` (§ Custom Error Classes) for the full pattern.
 
 ## Current Best Practices
 
 ### Strict by Default
 
-```json
-{
-  "compilerOptions": {
-    "strict": true,
-    "noUncheckedIndexedAccess": true,
-    "noImplicitOverride": true,
-    "exactOptionalPropertyTypes": true,
-    "noPropertyAccessFromIndexSignature": true
-  }
-}
-```
+Use `strict: true` plus `noUncheckedIndexedAccess`, `noImplicitOverride`, `exactOptionalPropertyTypes`, `noPropertyAccessFromIndexSignature`. See `references/tsconfig-strict.json` for a full production-ready strict config.
 
 ### ESM-First Approach
 
@@ -354,18 +176,15 @@ class DomainError extends Error {
 - Configure `"moduleResolution": "bundler"` for modern tools
 - Use dynamic imports for CJS: `const pkg = await import('cjs-package')`
   - Note: `await import()` requires async function or top-level await in ESM
-  - For CJS packages in ESM: May need `(await import('pkg')).default` depending on the package's export structure and your compiler settings
+  - For CJS packages in ESM: may need `(await import('pkg')).default` depending on the package's export structure and compiler settings
 
 ### AI-Assisted Development
 
-- GitHub Copilot excels at TypeScript generics
-- Use AI for boilerplate type definitions
+- AI coding assistants excel at TypeScript generics and boilerplate type definitions
 - Validate AI-generated types with type tests
 - Document complex types for AI context
 
 ## Code Review Checklist
-
-When reviewing TypeScript/JavaScript code, focus on these domain-specific aspects:
 
 ### Type Safety
 
@@ -395,17 +214,14 @@ When reviewing TypeScript/JavaScript code, focus on these domain-specific aspect
 
 ### Module System
 
-- [ ] Consistent import/export patterns
-- [ ] No circular dependencies
+- [ ] Consistent import/export patterns, no circular dependencies
 - [ ] Proper use of barrel exports (avoid over-bundling)
-- [ ] ESM/CJS compatibility handled correctly
-- [ ] Dynamic imports for code splitting
+- [ ] ESM/CJS compatibility handled correctly, dynamic imports for code splitting
 
 ### Error Handling Patterns
 
 - [ ] Result types or discriminated unions for errors
-- [ ] Custom error classes with proper inheritance
-- [ ] Type-safe error boundaries
+- [ ] Custom error classes with proper inheritance, type-safe error boundaries
 - [ ] Exhaustive switch cases with `never` type
 
 ### Code Organization
@@ -417,19 +233,15 @@ When reviewing TypeScript/JavaScript code, focus on these domain-specific aspect
 
 ## Quick Decision Trees
 
-### "Which tool should I use?"
-
 ```
+"Which tool should I use?"
 Type checking only? → tsc
-Type checking + linting speed critical? → Biome  
+Type checking + linting speed critical? → Biome
 Type checking + comprehensive linting? → ESLint + typescript-eslint
 Type testing? → Vitest expectTypeOf
 Build tool? → Project size <10 packages? Turborepo. Else? Nx
-```
 
-### "How do I fix this performance issue?"
-
-```
+"How do I fix this performance issue?"
 Slow type checking? → skipLibCheck, incremental, project references
 Slow builds? → Check bundler config, enable caching
 Slow tests? → Vitest with threads, avoid type checking in tests
@@ -438,25 +250,9 @@ Slow language server? → Exclude node_modules, limit files in tsconfig
 
 ## Expert Resources
 
-### Performance
-
-- [TypeScript Wiki Performance](https://github.com/microsoft/TypeScript/wiki/Performance)
-- [Type instantiation tracking](https://github.com/microsoft/TypeScript/pull/48077)
-
-### Advanced Patterns
-
-- [Type Challenges](https://github.com/type-challenges/type-challenges)
-- [Type-Level TypeScript Course](https://type-level-typescript.com)
-
-### Tools
-
-- [Biome](https://biomejs.dev) - Fast linter/formatter
-- [TypeStat](https://github.com/JoshuaKGoldberg/TypeStat) - Auto-fix TypeScript types
-- [ts-migrate](https://github.com/airbnb/ts-migrate) - Migration toolkit
-
-### Testing
-
-- [Vitest Type Testing](https://vitest.dev/guide/testing-types)
-- [tsd](https://github.com/tsdjs/tsd) - Standalone type testing
+- Performance: [TypeScript Wiki Performance](https://github.com/microsoft/TypeScript/wiki/Performance), [Type instantiation tracking](https://github.com/microsoft/TypeScript/pull/48077)
+- Advanced patterns: [Type Challenges](https://github.com/type-challenges/type-challenges), [Type-Level TypeScript Course](https://type-level-typescript.com)
+- Tools: [Biome](https://biomejs.dev) (linter/formatter), [TypeStat](https://github.com/JoshuaKGoldberg/TypeStat) (auto-fix types), [ts-migrate](https://github.com/airbnb/ts-migrate) (migration toolkit)
+- Testing: [Vitest Type Testing](https://vitest.dev/guide/testing-types), [tsd](https://github.com/tsdjs/tsd) (standalone type testing)
 
 Always validate changes don't break existing functionality before considering the issue resolved.

--- a/.agents/skills/typescript-expert/plugin.json
+++ b/.agents/skills/typescript-expert/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-expert",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "TypeScript and JavaScript expert with deep knowledge of type-level programming, performance optimiza",
   "author": {
     "name": "Ship Shit Dev",

--- a/.agents/skills/typescript-expert/references/full-guide.md
+++ b/.agents/skills/typescript-expert/references/full-guide.md
@@ -1,0 +1,94 @@
+# TypeScript Expert — Full Guide
+
+Extended examples and command sequences for the typescript-expert skill. See `SKILL.md` for workflow steps, decision tables, short inline patterns, and pointers to the other reference files in this skill.
+
+## Migration Playbook
+
+Incremental JavaScript → TypeScript migration:
+
+```bash
+# 1. Enable allowJs and checkJs (merge into existing tsconfig.json):
+# Add to existing tsconfig.json:
+# {
+#   "compilerOptions": {
+#     "allowJs": true,
+#     "checkJs": true
+#   }
+# }
+
+# 2. Rename files gradually (.js → .ts)
+# 3. Add types file by file
+# 4. Enable strict mode features one by one
+
+# Automated helpers (if installed/needed)
+command -v ts-migrate >/dev/null 2>&1 && bunx ts-migrate migrate . --sources 'src/**/*.js'
+command -v typesync >/dev/null 2>&1 && bunx typesync  # Install missing @types packages
+```
+
+## Monorepo TypeScript Configuration
+
+```json
+// Root tsconfig.json
+{
+  "references": [
+    { "path": "./packages/core" },
+    { "path": "./packages/ui" },
+    { "path": "./apps/web" }
+  ],
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true
+  }
+}
+```
+
+## Vitest Type Testing
+
+```typescript
+// in avatar.test-d.ts
+import { expectTypeOf } from 'vitest'
+import type { Avatar } from './avatar'
+
+test('Avatar props are correctly typed', () => {
+  expectTypeOf<Avatar>().toHaveProperty('size')
+  expectTypeOf<Avatar['size']>().toEqualTypeOf<'sm' | 'md' | 'lg'>()
+})
+```
+
+## CLI Debugging Tools
+
+```bash
+# Debug TypeScript files directly (if tools installed)
+command -v tsx >/dev/null 2>&1 && bunx tsx --inspect src/file.ts
+command -v ts-node >/dev/null 2>&1 && bunx ts-node --inspect-brk src/file.ts
+
+# Trace module resolution issues
+bunx tsc --traceResolution > resolution.log 2>&1
+grep "Module resolution" resolution.log
+
+# Debug type checking performance (use --incremental false for clean trace)
+bunx tsc --generateTrace trace --incremental false
+# Analyze trace (if installed)
+command -v @typescript/analyze-trace >/dev/null 2>&1 && bunx @typescript/analyze-trace trace
+
+# Memory usage analysis
+node --max-old-space-size=8192 node_modules/typescript/lib/tsc.js
+```
+
+## Custom Error Classes
+
+```typescript
+// Proper error class with stack preservation
+class DomainError extends Error {
+  constructor(
+    message: string,
+    public code: string,
+    public statusCode: number
+  ) {
+    super(message);
+    this.name = 'DomainError';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}
+```


### PR DESCRIPTION
## Summary
Syncs tracked `.agents/skills/` with the latest shipshitdev/skills master (model-agnosticism audit merged today: platform decoupling, long examples moved to `references/`, version bumps).

## Changes
- 39 shared skills updated to current library content
- `open-source-checker` carries the scanner-safe regex fix from shipshitdev/skills#62 (its example detection regexes were URI-shaped and tripped this repo's secretlint pre-commit) — merge #62 there to keep library master aligned
- Project-specific skills (multitenancy-guard, prepush-guard, serializer-boundary, new-entity, new-model, design-system-guard, issue-prd-writing, nestjs-testing-expert) untouched

## Verification
- Content-hash comparison against library master: 0 stale shared skills after this PR
- Pre-commit secretlint + biome + lint-staged: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)