### PR TITLE
fix(auth): first-time signup handle + auto-trust local dev origins

### DIFF
--- a/apps/server/api/src/auth/better-auth/better-auth.config.spec.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.config.spec.ts
@@ -7,6 +7,7 @@ import {
   resolveCookieDomain,
   resolveExperimentalJoins,
   resolveSocialProviderConfig,
+  resolveTrustedOrigins,
 } from './better-auth.config';
 import { BETTER_AUTH_BASE_PATH } from './better-auth.constants';
 
@@ -25,6 +26,33 @@ describe('Better Auth config', () => {
         'https://genfeed.ai, https://app.genfeed.ai, https://console.genfeed.ai',
       ),
     ).toContain('https://console.genfeed.ai');
+  });
+
+  describe('resolveTrustedOrigins', () => {
+    it('auto-trusts localhost AND local.genfeed.ai for local dev (no env needed)', () => {
+      const origins = resolveTrustedOrigins(undefined, 'development');
+      expect(origins).toContain('http://localhost:3000');
+      expect(origins).toContain('http://local.genfeed.ai:3000');
+    });
+
+    it('merges configured origins with the local-dev defaults and de-dupes', () => {
+      const origins = resolveTrustedOrigins(
+        'https://app.genfeed.ai, http://localhost:3000',
+        'development',
+      );
+      expect(origins).toContain('https://app.genfeed.ai');
+      expect(origins.filter((o) => o === 'http://localhost:3000')).toHaveLength(
+        1,
+      );
+    });
+
+    it('never auto-trusts localhost in production or staging', () => {
+      for (const env of ['production', 'staging']) {
+        const origins = resolveTrustedOrigins('https://app.genfeed.ai', env);
+        expect(origins).toEqual(['https://app.genfeed.ai']);
+        expect(origins).not.toContain('http://localhost:3000');
+      }
+    });
   });
 
   describe('parseCommaSeparated', () => {

--- a/apps/server/api/src/auth/better-auth/better-auth.config.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.config.ts
@@ -38,6 +38,41 @@ export function parseTrustedOrigins(value: string | undefined): string[] {
 }
 
 /**
+ * Frontends local dev serves from. Both `localhost` and `local.genfeed.ai`
+ * (which resolves to 127.0.0.1 via /etc/hosts) are auto-trusted so a fresh
+ * clone works on either hostname — app (3000), website (3002), API (3010) —
+ * without anyone having to set `BETTER_AUTH_TRUSTED_ORIGINS` by hand.
+ */
+const LOCAL_DEV_TRUSTED_ORIGINS = [
+  'http://localhost:3000',
+  'http://local.genfeed.ai:3000',
+  'http://localhost:3002',
+  'http://local.genfeed.ai:3002',
+  'http://localhost:3010',
+  'http://local.genfeed.ai:3010',
+] as const;
+
+/**
+ * Resolve Better Auth's trusted origins. Always honours whatever
+ * `BETTER_AUTH_TRUSTED_ORIGINS` lists; outside production/staging it also merges
+ * the standard {@link LOCAL_DEV_TRUSTED_ORIGINS} so local dev needs zero env
+ * config and never hits a spurious `INVALID_ORIGIN` when accessed via either
+ * `localhost` or `local.genfeed.ai`. Real deployments (production/staging) get
+ * exactly the configured list — localhost is never auto-trusted there.
+ */
+export function resolveTrustedOrigins(
+  value: string | undefined,
+  nodeEnv: string | undefined,
+): string[] {
+  const configured = parseTrustedOrigins(value);
+  const isDeployedEnv = nodeEnv === 'production' || nodeEnv === 'staging';
+  if (isDeployedEnv) {
+    return configured;
+  }
+  return Array.from(new Set([...configured, ...LOCAL_DEV_TRUSTED_ORIGINS]));
+}
+
+/**
  * Resolve the optional cross-subdomain cookie domain (e.g. `.genfeed.ai`).
  * Returns `undefined` when unset so single-host / Community deployments keep
  * the default host-scoped session cookie.

--- a/apps/server/api/src/auth/better-auth/better-auth.factory.spec.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.factory.spec.ts
@@ -465,4 +465,16 @@ describe('createBetterAuthInstance source', () => {
     expect(source).toContain('enabled: true');
     expect(source).toContain('rateLimit');
   });
+
+  it('declares `handle` as a known user field so first-time sign-ups persist it', () => {
+    // The `databaseHooks.user.create.before` hook injects a generated `handle`,
+    // but Better Auth strips fields it does not know about before the adapter
+    // write. Without this `additionalFields` declaration the `handle` value is
+    // dropped and every first-time sign-up fails at `db.user.create()` with
+    // `Argument 'handle' is missing`, so no session is ever established.
+    const source = createBetterAuthInstance.toString();
+
+    expect(source).toContain('additionalFields');
+    expect(source).toMatch(/handle:\s*\{/);
+  });
 });

--- a/apps/server/api/src/auth/better-auth/better-auth.factory.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.factory.ts
@@ -546,6 +546,18 @@ export function createBetterAuthInstance(options: ICreateBetterAuthOptions) {
     user: {
       // Better Auth's `image` field maps onto the existing `User.avatar` column.
       fields: { image: 'avatar' },
+      // `handle` is a required + unique column that Better Auth does not know
+      // about, so it strips the value injected by the `create.before` hook
+      // below before the adapter write — every first-time sign-up then fails
+      // with `Argument 'handle' is missing`. Declaring it as a known
+      // (non-input) field preserves the hook-supplied value through to Prisma.
+      additionalFields: {
+        handle: {
+          input: false,
+          required: false,
+          type: 'string',
+        },
+      },
     },
     databaseHooks: {
       user: {

--- a/apps/server/api/src/auth/better-auth/better-auth.module.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.module.ts
@@ -16,12 +16,12 @@ import { PassportModule } from '@nestjs/passport';
 
 import {
   parseCommaSeparated,
-  parseTrustedOrigins,
   resolveBetterAuthBaseUrl,
   resolveBooleanFlag,
   resolveCookieDomain,
   resolveExperimentalJoins,
   resolveSocialProviderConfig,
+  resolveTrustedOrigins,
 } from './better-auth.config';
 import {
   BETTER_AUTH_INSTANCE,
@@ -175,8 +175,9 @@ import { RateLimitClientService } from './services/rate-limit-client.service';
           sendResetPassword: (params) => mailer.sendResetPassword(params),
           sendVerificationEmail: (params) =>
             mailer.sendVerificationEmail(params),
-          trustedOrigins: parseTrustedOrigins(
+          trustedOrigins: resolveTrustedOrigins(
             config.get('BETTER_AUTH_TRUSTED_ORIGINS'),
+            config.get('NODE_ENV'),
           ),
         });
       },


### PR DESCRIPTION
Two Better Auth correctness fixes for local dev + first-time signup, found while running the app locally.

## 1. First-time sign-up fails: `Argument 'handle' is missing`

Every brand-new user (magic-link/OAuth/password signup for an email with no row yet) fails at `db.user.create()` → no session. `User.handle` is `@unique` with no default, and the `create.before` hook that generates it has its value **stripped** because `handle` isn't declared as a known Better Auth user field (unlike `organization`/`member`, which declare their custom columns). Fix: declare `handle` in `user.additionalFields`. Existing-user **sign-in** is unaffected (never calls `user.create`), which is why it looks fine day-to-day.

## 2. Local dev 403s on `localhost`: `INVALID_ORIGIN`

`trustedOrigins` came only from `BETTER_AUTH_TRUSTED_ORIGINS`, so a fresh clone accessed via `http://localhost:3000` got a 403 unless someone hand-set the env var. Add `resolveTrustedOrigins`: outside production/staging it auto-merges the standard local frontends (app :3000, website :3002, api :3010) on **both** `localhost` and `local.genfeed.ai`. Deployed envs unchanged — localhost is never auto-trusted there.

## Verification

- `better-auth.factory.spec.ts` (21/21) + `better-auth.config.spec.ts` (14/14, adds trusted-origins cases). `bun type-check` clean.
- End-to-end: new-user magic-link signup now creates the user (`handle: vincent-ef5360da`) and logs in; a magic-link request from a `localhost:3000` origin now returns `{status:true}` instead of `INVALID_ORIGIN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)