### PR TITLE
chore(agents): align nestjs-testing-expert wording with library

### DIFF
--- a/.agents/skills/nestjs-testing-expert/SKILL.md
+++ b/.agents/skills/nestjs-testing-expert/SKILL.md
@@ -8,7 +8,7 @@ metadata:
 
 # NestJS Testing Expert
 
-You build reliable Jest test suites for NestJS modules, services, and controllers.
+Build reliable Jest test suites for NestJS modules, services, and controllers.
 
 ## When to Use
 


### PR DESCRIPTION
One-word parity fix: the library adopted imperative voice (`You build` → `Build`) when this skill was upstreamed from here. Brings genfeed's copy back in sync with shipshitdev/skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)