### PR TITLE
fix(e2e): restore agent route and auth gates

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -290,12 +290,13 @@ jobs:
 
           if [ "${#missing[@]}" -gt 0 ]; then
             echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "::error::Authed E2E is enabled but missing required GitHub Actions secret(s): ${missing[*]}"
             {
-              echo "## Authed E2E Skipped"
+              echo "## Authed E2E Blocked"
               echo ""
               echo "Missing GitHub Actions secret(s): ${missing[*]}."
             } >> "$GITHUB_STEP_SUMMARY"
-            exit 0
+            exit 1
           fi
 
           echo "ready=true" >> "$GITHUB_OUTPUT"

--- a/playwright/e2e/tests/smoke/all-app-pages.spec.ts
+++ b/playwright/e2e/tests/smoke/all-app-pages.spec.ts
@@ -141,7 +141,7 @@ const protectedRouteBuckets: RouteBucket[] = [
     route.startsWith('/test-org/brand-1/orchestration'),
   ),
   routeBucket('protected content operations', protectedRoutes, (route) =>
-    /^\/test-org\/brand-1\/(messages|overview|posts|research|studio|tasks|workflows|workspace)(\/|$)/.test(
+    /^\/test-org\/brand-1\/(agent|messages|overview|posts|research|studio|tasks|workflows|workspace)(\/|$)/.test(
       route,
     ),
   ),


### PR DESCRIPTION
## Summary

- classify the six brand-scoped `/test-org/brand-1/agent*` aliases in the all-pages smoke sweep, restoring the deterministic nightly/release gate
- fail the enabled real-Better-Auth E2E job when required credentials are absent instead of reporting a successful no-op
- inherit the merged first-time signup repair from #1576 without duplicating its auth changes

Refs #1448 and #334.

## GitHub run evidence

- Nightly [29073314816](https://github.com/genfeedai/genfeed.ai/actions/runs/29073314816) and [28998180185](https://github.com/genfeedai/genfeed.ai/actions/runs/28998180185) failed only frontend shard 4 plus the aggregate gate. The assertion listed exactly six unbucketed brand-agent routes; API E2E, static route coverage, and frontend shards 1–3 passed.
- Production deploy [29068584464](https://github.com/genfeedai/genfeed.ai/actions/runs/29068584464) reached the same shard-4 failure and skipped Deploy, so production has not yet received the signup fix merged in #1576.
- The real-auth job in nightly [29073314816](https://github.com/genfeedai/genfeed.ai/actions/runs/29073314816) was green only because its build/test steps skipped when both required secrets were empty.

## Verification

- Branch E2E [29102380868](https://github.com/genfeedai/genfeed.ai/actions/runs/29102380868) completed successfully: route coverage, API E2E, all four frontend shards, merged report, and the aggregate E2E gate passed. The real-auth job separately failed closed with the exact missing-secret names and remained non-gating for manual dispatch as designed.
- PR CI [29102375361](https://github.com/genfeedai/genfeed.ai/actions/runs/29102375361) passed on failed-job rerun, including format, guards, lint, typecheck, tests, secret scans, and build. The first Lint attempt timed out inside shared Bun setup before reaching lint; attempt 2 passed in 2m35s.
- `actionlint .github/workflows/e2e.yml`
- `node scripts/e2e-route-coverage.mjs` — 96.0% dedicated / 100.0% effective
- route classifier red/green reproduction — baseline missed 6/6 agent routes; fixed matcher covers 6/6
- `git diff --check origin/master...HEAD`
- independent QA Reviewer verdict: approve, no blocking findings
- pre-commit staged Biome, UI control guard, and secretlint passed

The exact Playwright route-discovery assertion was not run locally because this isolated worktree had no installed `@playwright/test`; branch E2E above provides the required hosted proof per repository policy.

## External actions still required

No deploy or production data mutation was performed.

1. Add/rotate valid GitHub Actions secrets `BETTER_AUTH_SECRET` and `E2E_BETTER_AUTH_SESSION_TOKEN` for the dedicated real-Better-Auth test session. `E2E_AUTHED_ENABLED=true` is already set; scheduled E2E now fails closed until these exist.
2. If #334 retains separate verification-email delivery as acceptance, add SecureString `/genfeed/production/BETTER_AUTH_REQUIRE_EMAIL_VERIFICATION=true`; the server default is false today.
3. After merge, run the normal `Deploy ECS (production)` workflow from `master`. Do not use a branch or local deploy.
4. Execute #334's live signup → billing → credits → generation → publish walkthrough with fresh email/Google identities, Stripe, production providers, and a real social credential; attach redacted evidence to #334.
5. Clarify #334's signup wording: the current product exposes Google + email magic-link signup, not password signup. Implementing a new password-signup surface is deliberately outside this blocker repair.

Separately, self-hosted release issue #1450 is still testing a stale published `latest` image. Its source fixes are already merged; a fresh release image must be published through the approved release workflow and the release E2E rerun.
