### PR TITLE
fix(ui): address frontend audit findings

### DIFF
--- a/apps/app/app/(onboarding)/onboarding/(wizard)/brand/brand-account-type-selector.tsx
+++ b/apps/app/app/(onboarding)/onboarding/(wizard)/brand/brand-account-type-selector.tsx
@@ -46,7 +46,7 @@ export default function BrandAccountTypeSelector({
             variant={ButtonVariant.UNSTYLED}
             withWrapper={false}
             onClick={() => onSelect(category)}
-            className={`group rounded-none p-4 border text-center transition-all ${
+            className={`group rounded-none p-4 border text-center transition-colors ${
               accountType === category
                 ? 'border-white/30 bg-white/[0.08]'
                 : 'border-white/[0.08] bg-white/[0.02] hover:border-white/20 hover:bg-white/[0.04]'

--- a/apps/app/app/(onboarding)/onboarding/(wizard)/proactive/proactive-hero-card.tsx
+++ b/apps/app/app/(onboarding)/onboarding/(wizard)/proactive/proactive-hero-card.tsx
@@ -50,7 +50,7 @@ export default function ProactiveHeroCard({
           </div>
           <div className="mt-3 h-2 overflow-hidden rounded-full bg-white/10">
             <div
-              className="h-full rounded-full bg-white transition-all duration-500"
+              className="h-full rounded-full bg-primary transition-[width] duration-500"
               style={{ width: `${Math.max(workspace.prepPercent, 8)}%` }}
             />
           </div>

--- a/apps/app/app/(onboarding)/onboarding/(wizard)/success/success-content.tsx
+++ b/apps/app/app/(onboarding)/onboarding/(wizard)/success/success-content.tsx
@@ -205,7 +205,7 @@ export default function SuccessContent() {
                 variant={ButtonVariant.UNSTYLED}
                 withWrapper={false}
                 onClick={() => toggleType(id)}
-                className={`inline-flex items-center gap-2 px-4 py-2 border text-sm transition-all ${
+                className={`inline-flex items-center gap-2 px-4 py-2 border text-sm transition-colors ${
                   isSelected
                     ? 'ring-1 ring-border-strong bg-hover text-white border-transparent'
                     : 'border-white/[0.08] bg-white/[0.02] text-white/50 hover:border-white/20'

--- a/apps/app/app/(onboarding)/onboarding/components/onboarding-progress.tsx
+++ b/apps/app/app/(onboarding)/onboarding/components/onboarding-progress.tsx
@@ -34,7 +34,7 @@ export default function OnboardingProgress({
             <div key={label} className="flex items-center gap-2">
               {/* Step indicator */}
               <div
-                className={`w-6 h-6 rounded-full flex items-center justify-center text-[10px] font-bold transition-all duration-300 ${
+                className={`w-6 h-6 rounded-full flex items-center justify-center text-[10px] font-bold transition-colors duration-300 ${
                   isCompleted
                     ? 'bg-white text-black'
                     : isCurrent

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/trend-turnover/TrendFlowChart.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/trend-turnover/TrendFlowChart.tsx
@@ -73,18 +73,18 @@ export default function TrendFlowChart({
         </defs>
         <CartesianGrid
           strokeDasharray="3 3"
-          stroke="rgba(255,255,255,0.05)"
+          stroke="hsl(var(--border))"
           vertical={false}
         />
         <XAxis
           dataKey="date"
-          tick={{ fill: 'rgba(255,255,255,0.4)', fontSize: 11 }}
+          tick={{ fill: 'hsl(var(--muted-foreground))', fontSize: 11 }}
           tickLine={false}
           axisLine={false}
           tickFormatter={(v: string) => v.slice(5)} // MM-DD
         />
         <YAxis
-          tick={{ fill: 'rgba(255,255,255,0.4)', fontSize: 11 }}
+          tick={{ fill: 'hsl(var(--muted-foreground))', fontSize: 11 }}
           tickLine={false}
           axisLine={false}
           width={32}
@@ -92,11 +92,14 @@ export default function TrendFlowChart({
         <Tooltip
           contentStyle={{
             background: 'hsl(var(--card))',
-            border: '1px solid rgba(255,255,255,0.08)',
+            border: '1px solid hsl(var(--border))',
             borderRadius: 0,
             fontSize: 12,
           }}
-          labelStyle={{ color: 'rgba(255,255,255,0.6)', marginBottom: 4 }}
+          labelStyle={{
+            color: 'hsl(var(--muted-foreground))',
+            marginBottom: 4,
+          }}
         />
         <Area
           type="monotone"

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/trend-turnover/analytics-trend-turnover.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/trend-turnover/analytics-trend-turnover.tsx
@@ -257,7 +257,7 @@ export default function AnalyticsTrendTurnover() {
                 </div>
                 <div className="h-1.5 w-full bg-tertiary overflow-hidden">
                   <div
-                    className="h-full bg-primary transition-all duration-500"
+                    className="h-full bg-primary transition-[width] duration-500"
                     style={{ width: `${item.turnoverRate}%` }}
                   />
                 </div>

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/editor/editor-projects-page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/editor/editor-projects-page.tsx
@@ -199,7 +199,7 @@ export default function EditorProjectsPage() {
               <Link key={project.id} href={href(`/editor/${project.id}`)}>
                 <Card
                   variant={CardVariant.DEFAULT}
-                  className="group cursor-pointer p-6 transition-all hover:ring-1 hover:ring-primary/30"
+                  className="group cursor-pointer p-6 transition-shadow hover:ring-1 hover:ring-primary/30"
                 >
                   <div className="mb-3 flex items-start justify-between">
                     <div className="min-w-0 flex-1">

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/[agentId]/AgentRunRow.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/[agentId]/AgentRunRow.tsx
@@ -47,7 +47,7 @@ export default function AgentRunRow({
   return (
     <>
       <TableRow
-        className="cursor-pointer border-b border-white/5 transition-all duration-200 hover:bg-white/[0.02]"
+        className="cursor-pointer border-b border-border transition-colors duration-200 hover:bg-accent/30"
         onClick={() => onToggle(run.id)}
       >
         <TableCell className="px-2 py-4 align-middle">

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/runs/AgentRunCard.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/runs/AgentRunCard.test.tsx
@@ -77,7 +77,7 @@ describe('AgentRunCard', () => {
     expect(screen.getByText('x2')).toBeVisible();
     expect(screen.getByText('generateImage')).toBeVisible();
     expect(screen.getByText('1m 5s')).toBeVisible();
-    expect(document.querySelector('.bg-blue-500')).toHaveStyle({
+    expect(document.querySelector('.bg-info')).toHaveStyle({
       width: '35%',
     });
 

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/runs/AgentRunCard.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/runs/AgentRunCard.tsx
@@ -144,7 +144,7 @@ export default function AgentRunCard({ run, onCancel }: AgentRunCardProps) {
       {isActive && (
         <div className="h-1 w-full overflow-hidden bg-muted">
           <div
-            className="h-full bg-blue-500 transition-all duration-500"
+            className="h-full bg-info transition-[width] duration-500"
             style={{ width: `${run.progress}%` }}
           />
         </div>

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/review/components/ReviewItemCard.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/review/components/ReviewItemCard.test.tsx
@@ -71,7 +71,7 @@ describe('ReviewItemCard', () => {
       <ReviewItemCard
         isActive={false}
         isSelected={false}
-        item={{ ...baseItem, status: BatchItemStatus.PENDING }}
+        item={baseItem}
         onSelect={vi.fn()}
         onToggleSelect={vi.fn()}
       />,

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/review/components/ReviewItemCard.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/review/components/ReviewItemCard.test.tsx
@@ -65,4 +65,21 @@ describe('ReviewItemCard', () => {
     expect(screen.getByText('5,400 views')).toBeInTheDocument();
     expect(screen.getByText('7.4% engagement')).toBeInTheDocument();
   });
+
+  it('keeps the selection control touch-safe on compact viewports', () => {
+    render(
+      <ReviewItemCard
+        isActive={false}
+        isSelected={false}
+        item={{ ...baseItem, status: BatchItemStatus.PENDING }}
+        onSelect={vi.fn()}
+        onToggleSelect={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Select item' })).toHaveClass(
+      'size-11',
+      'sm:size-7',
+    );
+  });
 });

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/review/components/ReviewItemCard.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/review/components/ReviewItemCard.tsx
@@ -61,10 +61,10 @@ export default function ReviewItemCard({
   return (
     <div
       className={cn(
-        'group rounded-xl border bg-neutral-950/70 p-3 transition-all',
+        'group rounded-xl border bg-card p-3 transition-[background-color,border-color,box-shadow]',
         isActive
-          ? 'border-primary/50 bg-primary/[0.06] shadow-[0_0_0_1px_rgba(255,255,255,0.04)]'
-          : 'border-white/10 hover:border-white/20',
+          ? 'border-primary/50 bg-primary/[0.06] shadow-border-strong'
+          : 'border-border hover:border-border-strong',
         isSelected ? 'ring-1 ring-primary/30' : '',
       )}
     >
@@ -73,7 +73,7 @@ export default function ReviewItemCard({
           variant={ButtonVariant.UNSTYLED}
           withWrapper={false}
           onClick={onSelect}
-          className="relative size-20 shrink-0 overflow-hidden rounded-lg bg-neutral-900"
+          className="relative size-20 shrink-0 overflow-hidden rounded-lg bg-background-secondary"
         >
           {item.mediaUrl ? (
             <Image
@@ -84,7 +84,7 @@ export default function ReviewItemCard({
               sizes="80px"
             />
           ) : (
-            <div className="flex h-full items-center justify-center text-neutral-600">
+            <div className="flex h-full items-center justify-center text-muted-foreground">
               <HiPhoto className="size-6" />
             </div>
           )}
@@ -129,10 +129,10 @@ export default function ReviewItemCard({
                 onClick={() => onToggleSelect(item.id)}
                 ariaLabel={isSelected ? 'Deselect item' : 'Select item'}
                 className={cn(
-                  'flex size-6 items-center justify-center rounded border transition-all',
+                  'flex size-11 items-center justify-center rounded border transition-colors sm:size-7',
                   isSelected
-                    ? 'border-primary bg-primary text-white'
-                    : 'border-white/15 bg-card text-foreground/50 hover:border-white/25 hover:text-foreground/75',
+                    ? 'border-primary bg-primary text-primary-foreground'
+                    : 'border-border bg-card text-foreground/50 hover:border-border-strong hover:text-foreground/75',
                 )}
               >
                 {isSelected && <HiCheck className="size-3" />}

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/settings/BrandDetailLatestArticles.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/settings/BrandDetailLatestArticles.tsx
@@ -17,7 +17,7 @@ export default function BrandDetailLatestArticles({
         <h2 className="text-lg font-semibold">Latest Articles</h2>
         <Button
           asChild
-          className="inline-flex items-center justify-center gap-2 whitespace-nowrap text-xs font-medium transition-all duration-300 bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80 h-8 px-3"
+          className="inline-flex h-8 items-center justify-center gap-2 whitespace-nowrap bg-secondary px-3 text-xs font-medium text-secondary-foreground shadow-sm transition-colors duration-300 hover:bg-secondary/80"
           variant={ButtonVariant.UNSTYLED}
           withWrapper={false}
         >
@@ -57,7 +57,7 @@ export default function BrandDetailLatestArticles({
 
                 <Button
                   asChild
-                  className="inline-flex items-center justify-center gap-2 whitespace-nowrap text-xs font-medium transition-all duration-300 bg-primary text-primary-foreground shadow hover:bg-primary/90 h-8 px-3"
+                  className="inline-flex h-8 items-center justify-center gap-2 whitespace-nowrap bg-primary px-3 text-xs font-medium text-primary-foreground shadow transition-colors duration-300 hover:bg-primary/90"
                   variant={ButtonVariant.UNSTYLED}
                   withWrapper={false}
                 >
@@ -75,7 +75,7 @@ export default function BrandDetailLatestArticles({
       ) : (
         <Button
           asChild
-          className="inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium transition-all duration-300 bg-primary text-primary-foreground shadow hover:bg-primary/90 h-9 px-4 py-2"
+          className="inline-flex h-11 items-center justify-center gap-2 whitespace-nowrap bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow transition-colors duration-300 hover:bg-primary/90 sm:h-9"
           variant={ButtonVariant.UNSTYLED}
           withWrapper={false}
         >

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/settings/BrandDetailLatestImages.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/settings/BrandDetailLatestImages.tsx
@@ -17,7 +17,7 @@ export default function BrandDetailLatestImages({
         <h2 className="text-lg font-semibold">Latest Images</h2>
         <Button
           asChild
-          className="inline-flex items-center justify-center gap-2 whitespace-nowrap text-xs font-medium transition-all duration-300 bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80 h-8 px-3"
+          className="inline-flex h-8 items-center justify-center gap-2 whitespace-nowrap bg-secondary px-3 text-xs font-medium text-secondary-foreground shadow-sm transition-colors duration-300 hover:bg-secondary/80"
           variant={ButtonVariant.UNSTYLED}
           withWrapper={false}
         >
@@ -41,7 +41,7 @@ export default function BrandDetailLatestImages({
       ) : (
         <Button
           asChild
-          className="inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium transition-all duration-300 bg-primary text-primary-foreground shadow hover:bg-primary/90 h-9 px-4 py-2"
+          className="inline-flex h-11 items-center justify-center gap-2 whitespace-nowrap bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow transition-colors duration-300 hover:bg-primary/90 sm:h-9"
           variant={ButtonVariant.UNSTYLED}
           withWrapper={false}
         >

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/settings/BrandDetailLatestVideos.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/settings/BrandDetailLatestVideos.tsx
@@ -17,7 +17,7 @@ export default function BrandDetailLatestVideos({
         <h2 className="text-lg font-semibold">Latest Videos</h2>
         <Button
           asChild
-          className="inline-flex items-center justify-center gap-2 whitespace-nowrap text-xs font-medium transition-all duration-300 bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80 h-8 px-3"
+          className="inline-flex h-8 items-center justify-center gap-2 whitespace-nowrap bg-secondary px-3 text-xs font-medium text-secondary-foreground shadow-sm transition-colors duration-300 hover:bg-secondary/80"
           variant={ButtonVariant.UNSTYLED}
           withWrapper={false}
         >
@@ -41,7 +41,7 @@ export default function BrandDetailLatestVideos({
       ) : (
         <Button
           asChild
-          className="inline-flex items-center justify-center gap-2 whitespace-nowrap text-sm font-medium transition-all duration-300 bg-primary text-primary-foreground shadow hover:bg-primary/90 h-9 px-4 py-2"
+          className="inline-flex h-11 items-center justify-center gap-2 whitespace-nowrap bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow transition-colors duration-300 hover:bg-primary/90 sm:h-9"
           variant={ButtonVariant.UNSTYLED}
           withWrapper={false}
         >

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/settings/interview/content.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/settings/interview/content.tsx
@@ -174,7 +174,7 @@ export default function BrandSettingsInterviewPage() {
             <div className="flex items-center gap-3">
               <div className="h-2 flex-1 rounded-full bg-white/[0.06] overflow-hidden">
                 <div
-                  className="h-full rounded-full bg-primary transition-all duration-500"
+                  className="h-full rounded-full bg-primary transition-[width] duration-500"
                   style={{ width: `${idleScore}%` }}
                 />
               </div>
@@ -259,7 +259,7 @@ export default function BrandSettingsInterviewPage() {
             </div>
             <div className="h-1.5 rounded-full bg-white/[0.06] overflow-hidden">
               <div
-                className="h-full rounded-full bg-primary transition-all duration-500"
+                className="h-full rounded-full bg-primary transition-[width] duration-500"
                 style={{ width: `${progress.percentComplete}%` }}
               />
             </div>

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/[type]/[id]/StudioEditDetailVersionHistory.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/[type]/[id]/StudioEditDetailVersionHistory.tsx
@@ -76,7 +76,7 @@ export default function StudioEditDetailVersionHistory({
             onClick={() => onResultClick(result.id)}
             className="cursor-pointer w-full text-left bg-transparent border-0 p-0"
           >
-            <Card className="p-3 bg-card transition-all">
+            <Card className="bg-card p-3 transition-colors">
               <div className="aspect-video bg-background overflow-hidden mb-2">
                 {result.thumbnailUrl ? (
                   <Image

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/ClipResultCard.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/ClipResultCard.test.tsx
@@ -120,8 +120,14 @@ describe('ClipResultCard', () => {
       />,
     );
 
-    expect(screen.getByText('Edit')).toBeInTheDocument();
-    expect(screen.getByText('Publish')).toBeInTheDocument();
+    expect(screen.getByText('Edit').closest('button')).toHaveClass(
+      'min-h-11',
+      'sm:min-h-8',
+    );
+    expect(screen.getByText('Publish').closest('button')).toHaveClass(
+      'min-h-11',
+      'sm:min-h-8',
+    );
   });
 
   it('should create publish handoff before navigating to compose', async () => {
@@ -209,7 +215,12 @@ describe('ClipResultCard', () => {
 
     expect(screen.queryByText('Edit')).not.toBeInTheDocument();
     expect(screen.queryByText('Publish')).not.toBeInTheDocument();
-    expect(screen.getByLabelText('Download video')).toBeInTheDocument();
+    expect(screen.getByLabelText('Download video')).toHaveClass(
+      'min-h-11',
+      'min-w-11',
+      'sm:min-h-8',
+      'sm:min-w-8',
+    );
   });
 
   it('should display virality score', () => {

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/ClipResultCard.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/ClipResultCard.tsx
@@ -9,6 +9,7 @@ import type {
   ClipStatus,
   ViralityBadgeProps,
 } from '@props/studio/clips.props';
+import Card from '@ui/card/Card';
 import Spinner from '@ui/feedback/spinner/Spinner';
 import { Badge } from '@ui/primitives/badge';
 import { Button } from '@ui/primitives/button';
@@ -148,7 +149,10 @@ export default function ClipResultCard({
   }, [videoUrl, clip.title]);
 
   return (
-    <div className="group relative flex flex-col rounded-card border border-zinc-800 bg-zinc-900/50 p-4 transition-all hover:border-zinc-700 hover:bg-zinc-900">
+    <Card
+      className="group h-full transition-colors hover:bg-background-secondary"
+      bodyClassName="h-full gap-0 p-4"
+    >
       {/* Header */}
       <div className="mb-3 flex items-start justify-between gap-2">
         <div className="flex items-center gap-2">
@@ -161,7 +165,7 @@ export default function ClipResultCard({
           {clip.clipType && (
             <Badge
               variant="secondary"
-              className="rounded bg-zinc-800 px-1.5 py-0.5 text-[10px] text-zinc-500"
+              className="rounded bg-secondary px-1.5 py-0.5 text-[10px] text-muted-foreground"
             >
               {clip.clipType}
             </Badge>
@@ -171,13 +175,15 @@ export default function ClipResultCard({
       </div>
 
       {/* Title & Summary */}
-      <h3 className="mb-1 line-clamp-2 text-sm font-medium text-zinc-100">
+      <h3 className="mb-1 line-clamp-2 text-sm font-medium text-foreground">
         {clip.title}
       </h3>
-      <p className="mb-3 line-clamp-2 text-xs text-zinc-500">{clip.summary}</p>
+      <p className="mb-3 line-clamp-2 text-xs text-muted-foreground">
+        {clip.summary}
+      </p>
 
       {/* Metadata */}
-      <div className="mb-3 flex items-center gap-3 text-[10px] text-zinc-600">
+      <div className="mb-3 flex items-center gap-3 text-[10px] text-muted-foreground/80">
         <span>{formatDuration(clip.duration)}</span>
         <span>
           {formatDuration(clip.startTime)} → {formatDuration(clip.endTime)}
@@ -191,13 +197,13 @@ export default function ClipResultCard({
             <Badge
               key={tag}
               variant="secondary"
-              className="rounded bg-zinc-800/50 px-1.5 py-0.5 text-[10px] text-zinc-500"
+              className="rounded bg-secondary/50 px-1.5 py-0.5 text-[10px] text-muted-foreground"
             >
               #{tag}
             </Badge>
           ))}
           {clip.tags.length > 3 && (
-            <span className="text-[10px] text-zinc-600">
+            <span className="text-[10px] text-muted-foreground/80">
               +{clip.tags.length - 3}
             </span>
           )}
@@ -210,7 +216,7 @@ export default function ClipResultCard({
           {canEdit && (
             <Button
               variant={ButtonVariant.UNSTYLED}
-              className="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-zinc-800 px-3 py-2 text-xs font-medium text-zinc-300 hover:bg-zinc-700"
+              className="flex min-h-11 flex-1 items-center justify-center gap-1.5 rounded-lg bg-secondary px-3 py-2 text-xs font-medium text-secondary-foreground transition-colors hover:bg-accent sm:min-h-8"
               onClick={handleEdit}
               title="Edit in video editor"
             >
@@ -221,7 +227,7 @@ export default function ClipResultCard({
           {canPublish && (
             <Button
               variant={ButtonVariant.UNSTYLED}
-              className="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-primary px-3 py-2 text-xs font-medium text-white hover:bg-primary"
+              className="flex min-h-11 flex-1 items-center justify-center gap-1.5 rounded-lg bg-primary px-3 py-2 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90 sm:min-h-8"
               onClick={handlePublish}
               title="Publish to social platforms"
             >
@@ -232,7 +238,7 @@ export default function ClipResultCard({
           {canDownload && (
             <Button
               variant={ButtonVariant.UNSTYLED}
-              className="flex items-center justify-center rounded-lg bg-zinc-800 px-2.5 py-2 text-zinc-300 hover:bg-zinc-700"
+              className="flex min-h-11 min-w-11 items-center justify-center rounded-lg bg-secondary px-2.5 py-2 text-secondary-foreground transition-colors hover:bg-accent sm:min-h-8 sm:min-w-8"
               onClick={handleDownload}
               aria-label="Download video"
               title="Download video"
@@ -258,6 +264,6 @@ export default function ClipResultCard({
           </p>
         </div>
       )}
-    </div>
+    </Card>
   );
 }

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/ClipsProgressView.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/ClipsProgressView.tsx
@@ -46,7 +46,7 @@ export default function ClipsProgressView({
         {project.status !== 'completed' && project.status !== 'failed' && (
           <div className="mt-4 flex items-center gap-3">
             <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-zinc-800">
-              <div className="h-full w-2/3 animate-pulse rounded-full bg-primary transition-all duration-500" />
+              <div className="h-full w-2/3 animate-pulse rounded-full bg-primary transition-[width] duration-500" />
             </div>
             <span className="text-xs capitalize text-zinc-500">
               {project.status}

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/HighlightReviewCard.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/HighlightReviewCard.tsx
@@ -165,7 +165,7 @@ export default function HighlightReviewCard({
 
   return (
     <div
-      className={`rounded-xl border p-4 shadow-border transition-all ${
+      className={`rounded-xl border p-4 shadow-border transition-[background-color,border-color,box-shadow] ${
         selected ? 'border-primary/50 bg-primary/5' : 'bg-secondary opacity-60'
       }`}
     >

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/page.tsx
@@ -181,7 +181,7 @@ export default function StudioClipsPage() {
                     variant={ButtonVariant.UNSTYLED}
                     isDisabled={opt.disabled}
                     onClick={() => setAvatarProvider(opt.value)}
-                    className={`relative rounded-lg border px-3 py-2 text-left transition-all ${
+                    className={`relative rounded-lg border px-3 py-2 text-left transition-colors ${
                       avatarProvider === opt.value
                         ? 'border-primary bg-primary/10'
                         : opt.disabled

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/tasks/[id]/issue-sub-issues-card.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/tasks/[id]/issue-sub-issues-card.tsx
@@ -31,7 +31,7 @@ export default function IssueSubIssuesCard({
           <div className="flex items-center gap-2">
             <div className="h-1.5 w-16 overflow-hidden rounded-full bg-muted">
               <div
-                className="h-full rounded-full bg-emerald-500/60 transition-all"
+                className="h-full rounded-full bg-success/60 transition-[width]"
                 style={{ width: `${pct}%` }}
               />
             </div>

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-dashboard.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-dashboard.tsx
@@ -392,17 +392,17 @@ function RunActivityChart({ trends }: { trends: AgentRunTrendPoint[] }) {
       <BarChart data={data} margin={{ bottom: 0, left: -20, right: 0, top: 0 }}>
         <CartesianGrid
           strokeDasharray="3 3"
-          stroke="rgba(255,255,255,0.04)"
+          stroke="hsl(var(--border))"
           vertical={false}
         />
         <XAxis
           dataKey="date"
-          tick={{ fill: 'rgba(255,255,255,0.3)', fontSize: 10 }}
+          tick={{ fill: 'hsl(var(--muted-foreground))', fontSize: 10 }}
           axisLine={false}
           tickLine={false}
         />
         <YAxis
-          tick={{ fill: 'rgba(255,255,255,0.3)', fontSize: 10 }}
+          tick={{ fill: 'hsl(var(--muted-foreground))', fontSize: 10 }}
           axisLine={false}
           tickLine={false}
           allowDecimals={false}
@@ -441,17 +441,17 @@ function RunsByStatusChart({ runs }: { runs: IAgentRun[] }) {
       <BarChart data={data} margin={{ bottom: 0, left: -20, right: 0, top: 0 }}>
         <CartesianGrid
           strokeDasharray="3 3"
-          stroke="rgba(255,255,255,0.04)"
+          stroke="hsl(var(--border))"
           vertical={false}
         />
         <XAxis
           dataKey="name"
-          tick={{ fill: 'rgba(255,255,255,0.3)', fontSize: 10 }}
+          tick={{ fill: 'hsl(var(--muted-foreground))', fontSize: 10 }}
           axisLine={false}
           tickLine={false}
         />
         <YAxis
-          tick={{ fill: 'rgba(255,255,255,0.3)', fontSize: 10 }}
+          tick={{ fill: 'hsl(var(--muted-foreground))', fontSize: 10 }}
           axisLine={false}
           tickLine={false}
           allowDecimals={false}
@@ -493,17 +493,17 @@ function SuccessRateChart({ trends }: { trends: AgentRunTrendPoint[] }) {
       <BarChart data={data} margin={{ bottom: 0, left: -20, right: 0, top: 0 }}>
         <CartesianGrid
           strokeDasharray="3 3"
-          stroke="rgba(255,255,255,0.04)"
+          stroke="hsl(var(--border))"
           vertical={false}
         />
         <XAxis
           dataKey="date"
-          tick={{ fill: 'rgba(255,255,255,0.3)', fontSize: 10 }}
+          tick={{ fill: 'hsl(var(--muted-foreground))', fontSize: 10 }}
           axisLine={false}
           tickLine={false}
         />
         <YAxis
-          tick={{ fill: 'rgba(255,255,255,0.3)', fontSize: 10 }}
+          tick={{ fill: 'hsl(var(--muted-foreground))', fontSize: 10 }}
           axisLine={false}
           tickLine={false}
           domain={[0, 100]}
@@ -543,17 +543,17 @@ function CreditsByDayChart({ trends }: { trends: AgentRunTrendPoint[] }) {
       <BarChart data={data} margin={{ bottom: 0, left: -20, right: 0, top: 0 }}>
         <CartesianGrid
           strokeDasharray="3 3"
-          stroke="rgba(255,255,255,0.04)"
+          stroke="hsl(var(--border))"
           vertical={false}
         />
         <XAxis
           dataKey="date"
-          tick={{ fill: 'rgba(255,255,255,0.3)', fontSize: 10 }}
+          tick={{ fill: 'hsl(var(--muted-foreground))', fontSize: 10 }}
           axisLine={false}
           tickLine={false}
         />
         <YAxis
-          tick={{ fill: 'rgba(255,255,255,0.3)', fontSize: 10 }}
+          tick={{ fill: 'hsl(var(--muted-foreground))', fontSize: 10 }}
           axisLine={false}
           tickLine={false}
         />

--- a/apps/app/app/(protected)/[orgSlug]/org-landing-content.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/org-landing-content.tsx
@@ -22,6 +22,7 @@ import {
   HiPlus,
 } from 'react-icons/hi2';
 import { ClientFormattedDate } from '@/components/ui/client-formatted-date';
+import { canOptimizeImageSource } from '@/lib/images/can-optimize-image-source';
 
 function BrandCard({ brand, orgSlug }: { brand: Brand; orgSlug: string }) {
   const cardHref = createBrandAppRoute(
@@ -41,8 +42,9 @@ function BrandCard({ brand, orgSlug }: { brand: Brand; orgSlug: string }) {
             alt={brand.label}
             className="size-10 rounded-lg object-cover"
             height={40}
+            sizes="40px"
             src={brand.logoUrl}
-            unoptimized
+            unoptimized={!canOptimizeImageSource(brand.logoUrl)}
             width={40}
           />
         ) : (

--- a/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/personal/settings-profile-page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/personal/settings-profile-page.tsx
@@ -16,9 +16,6 @@ type ExtendedSettingPatch = Partial<ISetting> & {
   isWorkflowNotificationsEmail?: boolean;
 };
 
-const settingsToggleClassName =
-  'border border-white/8 bg-[rgba(249,115,22,0.14)] shadow-[inset_0_1px_0_rgba(255,255,255,0.08)] data-[state=checked]:border-[var(--accent-orange)] data-[state=checked]:bg-[var(--accent-orange)] data-[state=unchecked]:hover:bg-[rgba(249,115,22,0.2)]';
-
 export default function SettingsProfilePage() {
   const { user, isLoaded } = useAuthUser();
   const { currentUser, mutateUser } = useCurrentUser();
@@ -95,7 +92,6 @@ export default function SettingsProfilePage() {
           description="Show studio, workflow editor, automation tools, and individual generation pages. Recommended for power users."
           isChecked={isAdvancedMode}
           isDisabled={isSaving}
-          switchClassName={settingsToggleClassName}
           onChange={(e) => patchSettings({ isAdvancedMode: e.target.checked })}
         />
       </Card>
@@ -108,7 +104,6 @@ export default function SettingsProfilePage() {
             description="Send an email when a workflow completes or fails."
             isChecked={isWorkflowNotificationsEmail}
             isDisabled={isSaving}
-            switchClassName={settingsToggleClassName}
             onChange={(e) =>
               patchSettings({
                 isWorkflowNotificationsEmail: e.target.checked,
@@ -120,7 +115,6 @@ export default function SettingsProfilePage() {
             description="Send an email when a video generation completes or fails."
             isChecked={isVideoNotificationsEmail}
             isDisabled={isSaving}
-            switchClassName={settingsToggleClassName}
             onChange={(e) =>
               patchSettings({
                 isVideoNotificationsEmail: e.target.checked,

--- a/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/personal/settings-progress-checklist-card.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/personal/settings-progress-checklist-card.tsx
@@ -19,7 +19,7 @@ export default function SettingsProgressChecklistCard({
   steps,
 }: Props) {
   return (
-    <Card className="border-white/10 bg-card p-6">
+    <Card className="border-border bg-card p-6">
       <div className="flex items-start justify-between gap-4">
         <div>
           <p className="text-xs uppercase tracking-[0.22em] text-muted-foreground">
@@ -36,7 +36,7 @@ export default function SettingsProgressChecklistCard({
 
       <div className="mt-4 h-2 overflow-hidden rounded-full bg-muted">
         <div
-          className="h-full rounded-full bg-[linear-gradient(90deg,rgba(251,146,60,0.95),rgba(249,115,22,0.65))]"
+          className="h-full rounded-full bg-primary transition-[width]"
           style={{
             width: `${totalCount > 0 ? (completedCount / totalCount) * 100 : 0}%`,
           }}
@@ -50,8 +50,8 @@ export default function SettingsProgressChecklistCard({
             className={cn(
               'flex items-center justify-between gap-3 rounded-2xl border px-4 py-4',
               step.isCompleted
-                ? 'border-emerald-400/15 bg-emerald-400/[0.06]'
-                : 'border-white/10 bg-black/10',
+                ? 'border-success/20 bg-success/[0.06]'
+                : 'border-border bg-background-secondary',
             )}
           >
             <div className="min-w-0">
@@ -66,10 +66,10 @@ export default function SettingsProgressChecklistCard({
             <Link
               href={step.href}
               className={cn(
-                'inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium transition-colors',
+                'inline-flex min-h-11 items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium transition-colors sm:min-h-8',
                 step.isCompleted
-                  ? 'border border-white/10 text-white/55 hover:bg-muted/60'
-                  : 'border border-orange-400/25 bg-orange-400/10 text-orange-100 hover:bg-orange-400/15',
+                  ? 'border border-border text-muted-foreground hover:bg-muted/60'
+                  : 'border border-primary/25 bg-primary/10 text-foreground hover:bg-primary/15',
               )}
             >
               {step.isCompleted ? 'Review' : 'Complete'}

--- a/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/personal/settings-progress-sidebar-card.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/personal/settings-progress-sidebar-card.tsx
@@ -5,9 +5,6 @@ import InsetSurface from '@ui/display/inset-surface/InsetSurface';
 import KeyMetric from '@ui/display/key-metric/KeyMetric';
 import { Switch } from '@ui/primitives/switch';
 
-const settingsToggleClassName =
-  'border border-white/8 bg-[rgba(249,115,22,0.14)] shadow-[inset_0_1px_0_rgba(255,255,255,0.08)] data-[state=checked]:border-[var(--accent-orange)] data-[state=checked]:bg-[var(--accent-orange)] data-[state=unchecked]:hover:bg-[rgba(249,115,22,0.2)]';
-
 type Props = {
   isSaving: boolean;
   isVisible: boolean;
@@ -28,7 +25,7 @@ export default function SettingsProgressSidebarCard({
   setVisibility,
 }: Props) {
   return (
-    <Card className="border-white/10 bg-card p-6">
+    <Card className="border-border bg-card p-6">
       <p className="text-xs uppercase tracking-[0.22em] text-muted-foreground">
         Sidebar module
       </p>
@@ -46,7 +43,6 @@ export default function SettingsProgressSidebarCard({
           description="This controls the compact module that combines setup and streak into one closable block."
           isChecked={isVisible}
           isDisabled={isSaving}
-          switchClassName={settingsToggleClassName}
           onChange={(event) => void setVisibility(event.target.checked)}
         />
       </InsetSurface>

--- a/apps/app/app/(protected)/[orgSlug]/~/settings/brands/brands-list.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/settings/brands/brands-list.tsx
@@ -27,6 +27,7 @@ import {
   HiTrash,
 } from 'react-icons/hi2';
 import { ClientFormattedDate } from '@/components/ui/client-formatted-date';
+import { canOptimizeImageSource } from '@/lib/images/can-optimize-image-source';
 
 const ITEMS_PER_PAGE = 20;
 
@@ -113,7 +114,8 @@ function BrandsListContent() {
                 alt={brand.label}
                 className="size-8 rounded-lg object-cover"
                 src={brand.logoUrl}
-                unoptimized
+                sizes="32px"
+                unoptimized={!canOptimizeImageSource(brand.logoUrl)}
                 width={32}
                 height={32}
               />

--- a/apps/app/app/(protected)/admin/fleet/_components/dataset-uploader.tsx
+++ b/apps/app/app/(protected)/admin/fleet/_components/dataset-uploader.tsx
@@ -203,7 +203,7 @@ export default function DatasetUploader({
           </div>
           <div className="w-full bg-foreground/10 rounded-full h-2 overflow-hidden">
             <div
-              className="bg-primary h-full rounded-full transition-all duration-300 ease-out"
+              className="h-full rounded-full bg-primary transition-[width] duration-300 ease-out"
               style={{ width: `${uploadProgress}%` }}
             />
           </div>

--- a/apps/app/app/(protected)/admin/fleet/characters/characters-list.tsx
+++ b/apps/app/app/(protected)/admin/fleet/characters/characters-list.tsx
@@ -15,6 +15,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { useEffect } from 'react';
 import { HiOutlineUserCircle } from 'react-icons/hi2';
+import { canOptimizeImageSource } from '@/lib/images/can-optimize-image-source';
 
 const LORA_STATUS_COLORS = {
   completed: 'bg-success/10 text-success',
@@ -99,12 +100,15 @@ export default function CharactersList() {
                   <div className="flex items-center gap-3 mb-4">
                     {character.profileImageUrl ? (
                       <Image
-                        unoptimized
                         alt={character.label}
                         className="size-12 rounded-full object-cover border border-foreground/10"
+                        height={48}
+                        sizes="48px"
                         src={character.profileImageUrl}
-                        width={800}
-                        height={600}
+                        unoptimized={
+                          !canOptimizeImageSource(character.profileImageUrl)
+                        }
+                        width={48}
                       />
                     ) : (
                       <div className="size-12 rounded-full bg-foreground/5 flex items-center justify-center text-2xl">

--- a/apps/app/app/(protected)/admin/fleet/generate/generated-images-grid.tsx
+++ b/apps/app/app/(protected)/admin/fleet/generate/generated-images-grid.tsx
@@ -4,6 +4,7 @@ import type { IFleetGenerationJob } from '@genfeedai/interfaces';
 import Card from '@ui/card/Card';
 import { WorkspaceSurface } from '@ui/overview/WorkspaceSurface';
 import Image from 'next/image';
+import { canOptimizeImageSource } from '@/lib/images/can-optimize-image-source';
 
 type GeneratedImage = {
   id: string;
@@ -42,10 +43,11 @@ export default function GeneratedImagesGrid({
             <div className="p-4">
               {img.cdnUrl ? (
                 <Image
-                  unoptimized
                   alt={img.prompt}
                   className="w-full rounded mb-3 aspect-square object-cover"
+                  sizes="(min-width: 1024px) 30vw, (min-width: 768px) 45vw, 100vw"
                   src={img.cdnUrl}
+                  unoptimized={!canOptimizeImageSource(img.cdnUrl)}
                   width={800}
                   height={600}
                 />
@@ -68,7 +70,7 @@ export default function GeneratedImagesGrid({
                   </div>
                   <div className="h-1.5 rounded-full bg-foreground/10 overflow-hidden">
                     <div
-                      className="h-full rounded-full bg-primary transition-all duration-300"
+                      className="h-full rounded-full bg-primary transition-[width] duration-300"
                       style={{ width: `${img.progress ?? 0}%` }}
                     />
                   </div>

--- a/apps/app/app/(protected)/admin/fleet/training/training-progress-panel.tsx
+++ b/apps/app/app/(protected)/admin/fleet/training/training-progress-panel.tsx
@@ -48,7 +48,7 @@ export default function TrainingProgressPanel({ training }: Props) {
             {/* Progress bar */}
             <div className="h-2 rounded-full bg-foreground/10 overflow-hidden">
               <div
-                className="h-full rounded-full bg-primary transition-all duration-300"
+                className="h-full rounded-full bg-primary transition-[width] duration-300"
                 style={{
                   width: `${training.progress ?? 0}%`,
                 }}

--- a/apps/app/packages/components/performance-lab/PatternCard.tsx
+++ b/apps/app/packages/components/performance-lab/PatternCard.tsx
@@ -55,7 +55,7 @@ function ScoreBar({ score }: ScoreBarProps) {
       </div>
       <div className="h-1 w-full bg-white/[0.06]">
         <div
-          className={cn('h-full transition-all duration-300', colorClass)}
+          className={cn('h-full transition-[width] duration-300', colorClass)}
           style={{ width: `${clampedScore}%` }}
         />
       </div>
@@ -70,7 +70,7 @@ export default function PatternCard({ pattern }: PatternCardProps) {
   const previewExamples = pattern.examples.slice(0, 3);
 
   return (
-    <div className="border border-white/[0.08] bg-white/[0.02] hover:border-white/[0.15] hover:bg-white/[0.03] transition-all duration-200 flex flex-col gap-4 p-4">
+    <div className="flex flex-col gap-4 border border-border bg-card p-4 transition-colors duration-200 hover:border-border-strong hover:bg-background-secondary">
       {/* Header row: type badge + source badge + sample size */}
       <div className="flex items-center justify-between gap-2 flex-wrap">
         <div className="flex items-center gap-2">

--- a/apps/app/packages/components/research/ads/AdsResearchAdCards.tsx
+++ b/apps/app/packages/components/research/ads/AdsResearchAdCards.tsx
@@ -43,7 +43,7 @@ export function AdGridCard({
       variant={ButtonVariant.UNSTYLED}
       onClick={() => onSelect(item)}
       className={cn(
-        'group rounded-card border border-white/[0.06] bg-card p-4 text-left transition-all duration-200 hover:border-white/[0.10]',
+        'group rounded-card border border-border bg-card p-4 text-left transition-[border-color,box-shadow] duration-200 hover:border-border-strong',
         isSelected && 'border-primary/45 shadow-lg shadow-primary/10',
       )}
     >

--- a/apps/app/src/components/ui/button.tsx
+++ b/apps/app/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import type * as React from 'react';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all cursor-pointer disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-[color,background-color,border-color,box-shadow,opacity] cursor-pointer disabled:pointer-events-none disabled:opacity-50 disabled:cursor-not-allowed [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     defaultVariants: {
       size: 'default',

--- a/apps/app/src/components/ui/grid-position-selector.tsx
+++ b/apps/app/src/components/ui/grid-position-selector.tsx
@@ -66,7 +66,7 @@ function GridPositionSelectorComponent({
             variant={ButtonVariant.UNSTYLED}
             withWrapper={false}
             className={cn(
-              'w-5 h-5 rounded-sm border transition-all',
+              'h-11 w-11 rounded-sm border transition-colors sm:size-6',
               isSelected(pos)
                 ? 'bg-primary border-primary'
                 : 'bg-secondary border-input hover:border-primary',

--- a/apps/app/src/features/moodboard/MediaAssetNode.tsx
+++ b/apps/app/src/features/moodboard/MediaAssetNode.tsx
@@ -8,6 +8,7 @@ import {
 import Image from 'next/image';
 import { memo } from 'react';
 import type { MediaAssetNodeProps } from '@/features/moodboard/moodboard.types';
+import { canOptimizeImageSource } from '@/lib/images/can-optimize-image-source';
 
 const DEFAULT_ASPECT_RATIO = MOOD_BOARD_DEFAULT_ASPECT_RATIO;
 
@@ -61,10 +62,10 @@ function MediaAssetNodeComponent({
     >
       {src ? (
         <Image
-          unoptimized
           src={src}
           alt={ingredient.metadataLabel || ingredient.promptText || 'asset'}
           fill
+          unoptimized={!canOptimizeImageSource(src)}
           sizes={`${MOOD_BOARD_TILE_WIDTH}px`}
           className="object-cover transition-transform duration-300 group-hover:scale-[1.03]"
           draggable={false}

--- a/apps/app/src/features/workflows/components/ExecutionPanel.tsx
+++ b/apps/app/src/features/workflows/components/ExecutionPanel.tsx
@@ -195,7 +195,7 @@ export function ExecutionPanel({
               </div>
               <div className="h-2 rounded-full bg-muted">
                 <div
-                  className="h-full rounded-full bg-primary transition-all"
+                  className="h-full rounded-full bg-primary transition-[width]"
                   style={{ width: `${execution.progress}%` }}
                 />
               </div>
@@ -267,7 +267,7 @@ export function ExecutionPanel({
                       {result.progress != null && result.progress < 100 && (
                         <div className="mt-1 h-1.5 rounded-full bg-muted">
                           <div
-                            className="h-full rounded-full bg-primary transition-all"
+                            className="h-full rounded-full bg-primary transition-[width]"
                             style={{ width: `${result.progress}%` }}
                           />
                         </div>

--- a/apps/app/src/features/workflows/nodes/saas/BrandAssetNode.tsx
+++ b/apps/app/src/features/workflows/nodes/saas/BrandAssetNode.tsx
@@ -16,6 +16,7 @@ import { NodeCard, NodeHeader } from '@/features/workflows/components/ui/card';
 import { NodeSelect } from '@/features/workflows/components/ui/inputs';
 import { HelpText } from '@/features/workflows/components/ui/status';
 import { coerceNodeData } from '@/features/workflows/nodes/node-data';
+import { canOptimizeImageSource } from '@/lib/images/can-optimize-image-source';
 
 const ASSET_TYPE_OPTIONS: Array<{ value: BrandAssetType; label: string }> = [
   { label: 'Logo', value: 'logo' },
@@ -96,10 +97,11 @@ function BrandAssetNodeComponent(props: NodeProps): React.JSX.Element {
       {data.resolvedUrl && data.assetType !== 'references' && (
         <div className="overflow-hidden bg-black/20">
           <Image
-            unoptimized
             src={data.resolvedUrl}
             alt={`${data.assetType} asset`}
             className="h-24 w-full object-contain"
+            sizes="320px"
+            unoptimized={!canOptimizeImageSource(data.resolvedUrl)}
             width={800}
             height={600}
           />
@@ -121,10 +123,11 @@ function BrandAssetNodeComponent(props: NodeProps): React.JSX.Element {
               className="overflow-hidden bg-black/20 aspect-square"
             >
               <Image
-                unoptimized
                 src={url}
                 alt={`Reference ${index + 1}`}
                 className="h-full w-full object-cover"
+                sizes="104px"
+                unoptimized={!canOptimizeImageSource(url)}
                 width={800}
                 height={600}
               />

--- a/apps/app/src/features/workflows/nodes/saas/BrandNode.tsx
+++ b/apps/app/src/features/workflows/nodes/saas/BrandNode.tsx
@@ -14,6 +14,7 @@ import { NodeSelect } from '@/features/workflows/components/ui/inputs';
 import { HelpText } from '@/features/workflows/components/ui/status';
 import { coerceNodeData } from '@/features/workflows/nodes/node-data';
 import { useCloudWorkflowStore } from '@/features/workflows/stores/cloud-workflow-store';
+import { canOptimizeImageSource } from '@/lib/images/can-optimize-image-source';
 
 /**
  * Store icon for brand nodes
@@ -97,12 +98,13 @@ function BrandNodeComponent(props: NodeProps): React.JSX.Element {
           <div className="flex items-center gap-2">
             {data.resolvedLogoUrl && (
               <Image
-                unoptimized
                 src={data.resolvedLogoUrl}
                 alt={data.resolvedLabel || 'Brand logo'}
                 className="size-8 object-contain rounded"
-                width={800}
-                height={600}
+                sizes="32px"
+                unoptimized={!canOptimizeImageSource(data.resolvedLogoUrl)}
+                width={32}
+                height={32}
               />
             )}
             <div>

--- a/apps/app/src/features/workflows/nodes/saas/PersonaPhotoSessionNode.tsx
+++ b/apps/app/src/features/workflows/nodes/saas/PersonaPhotoSessionNode.tsx
@@ -19,6 +19,7 @@ import {
   ProcessingMessage,
 } from '@/features/workflows/components/ui/status';
 import { coerceNodeData } from '@/features/workflows/nodes/node-data';
+import { canOptimizeImageSource } from '@/lib/images/can-optimize-image-source';
 
 /**
  * Camera icon for photo session nodes
@@ -120,10 +121,11 @@ function PersonaPhotoSessionNodeComponent(props: NodeProps): React.JSX.Element {
                 className="overflow-hidden bg-black/20 aspect-square"
               >
                 <Image
-                  unoptimized
                   src={url}
                   alt={`Generated ${index + 1}`}
                   className="h-full w-full object-cover"
+                  sizes="104px"
+                  unoptimized={!canOptimizeImageSource(url)}
                   width={800}
                   height={600}
                 />

--- a/apps/app/src/features/workflows/pages/batch/BatchComposer.tsx
+++ b/apps/app/src/features/workflows/pages/batch/BatchComposer.tsx
@@ -300,7 +300,7 @@ export default function BatchComposer({
                 <div className="mt-4">
                   <div className="h-2 overflow-hidden rounded-full bg-muted">
                     <div
-                      className="h-full rounded-full bg-primary transition-all"
+                      className="h-full rounded-full bg-primary transition-[width]"
                       style={{ width: `${getProgressPercent(job)}%` }}
                     />
                   </div>

--- a/apps/app/src/features/workflows/pages/batch/BatchDetail.tsx
+++ b/apps/app/src/features/workflows/pages/batch/BatchDetail.tsx
@@ -15,6 +15,7 @@ import type {
   BatchJobStatus,
   WorkflowSummary,
 } from '@/features/workflows/services/workflow-api';
+import { canOptimizeImageSource } from '@/lib/images/can-optimize-image-source';
 
 type OutputEntry = {
   ingredient: IIngredient;
@@ -141,7 +142,7 @@ export default function BatchDetail({
 
         <div className="mt-5 h-2 overflow-hidden rounded-full bg-muted">
           <div
-            className="h-full rounded-full bg-primary transition-all"
+            className="h-full rounded-full bg-primary transition-[width]"
             style={{ width: `${getProgressPercent(activeBatchStatus)}%` }}
           />
         </div>
@@ -273,10 +274,13 @@ export default function BatchDetail({
                 <div className="relative aspect-video bg-muted/50">
                   {ingredient?.thumbnailUrl ? (
                     <Image
-                      unoptimized
                       src={ingredient.thumbnailUrl}
                       alt={`Output ${ingredient.id}`}
                       className="h-full w-full object-cover"
+                      sizes="(min-width: 1280px) 30vw, (min-width: 768px) 45vw, 100vw"
+                      unoptimized={
+                        !canOptimizeImageSource(ingredient.thumbnailUrl)
+                      }
                       width={800}
                       height={600}
                     />

--- a/apps/app/src/features/workflows/pages/executions/WorkflowExecutionsPage.tsx
+++ b/apps/app/src/features/workflows/pages/executions/WorkflowExecutionsPage.tsx
@@ -295,7 +295,7 @@ export default function WorkflowExecutionsPage() {
                           <div className="flex items-center gap-2">
                             <div className="h-2 w-16 rounded-full bg-muted">
                               <div
-                                className="h-full rounded-full bg-primary transition-all"
+                                className="h-full rounded-full bg-primary transition-[width]"
                                 style={{
                                   width: `${execution.progress}%`,
                                 }}

--- a/apps/app/src/features/workflows/pages/library/WorkflowCardPreview.tsx
+++ b/apps/app/src/features/workflows/pages/library/WorkflowCardPreview.tsx
@@ -2,6 +2,7 @@
 
 import Image from 'next/image';
 import { useMemo, useState } from 'react';
+import { canOptimizeImageSource } from '@/lib/images/can-optimize-image-source';
 
 const DEFAULT_WORKFLOW_CARD_CDN =
   process.env.NEXT_PUBLIC_CDN_URL || 'https://cdn.genfeed.ai';
@@ -51,7 +52,7 @@ export default function WorkflowCardPreview({
         />
       ) : (
         <Image
-          unoptimized
+          unoptimized={!canOptimizeImageSource(previewUrl)}
           src={previewUrl}
           alt={
             previewUrl === DEFAULT_WORKFLOW_CARD_IMAGE
@@ -60,6 +61,7 @@ export default function WorkflowCardPreview({
           }
           className="h-full w-full object-cover object-center"
           onError={() => setHasAssetError(true)}
+          sizes="(min-width: 1280px) 30vw, (min-width: 768px) 45vw, 100vw"
           width={800}
           height={600}
         />

--- a/apps/app/src/features/workflows/pages/library/WorkflowLibraryPage.test.tsx
+++ b/apps/app/src/features/workflows/pages/library/WorkflowLibraryPage.test.tsx
@@ -147,6 +147,7 @@ vi.mock('./useWorkflowLibraryPage', () => ({
     filteredWorkflows: [
       {
         _id: 'workflow-1',
+        cloudSync: true,
         createdAt: '2026-07-01T00:00:00.000Z',
         isScheduleEnabled: true,
         lifecycle: 'published',

--- a/apps/app/src/features/workflows/pages/library/WorkflowLibraryPage.test.tsx
+++ b/apps/app/src/features/workflows/pages/library/WorkflowLibraryPage.test.tsx
@@ -1,0 +1,239 @@
+import '@testing-library/jest-dom/vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import WorkflowLibraryPage from './WorkflowLibraryPage';
+
+const mocks = vi.hoisted(() => ({
+  handleDelete: vi.fn(),
+  handleDuplicate: vi.fn(),
+  handleToggleSchedule: vi.fn(),
+  isSystemWorkflow: false,
+}));
+
+vi.mock('@genfeedai/enums', () => ({
+  ButtonVariant: {
+    DEFAULT: 'default',
+    OUTLINE: 'outline',
+    SECONDARY: 'secondary',
+    UNSTYLED: 'unstyled',
+  },
+}));
+
+vi.mock('@ui/card/Card', () => ({
+  default: ({
+    children,
+    headerAction,
+    label,
+  }: {
+    children?: ReactNode;
+    headerAction?: ReactNode;
+    label?: ReactNode;
+  }) => (
+    <article>
+      <h2>{label}</h2>
+      {headerAction}
+      {children}
+    </article>
+  ),
+}));
+
+vi.mock('@ui/layout/container/Container', () => ({
+  default: ({
+    children,
+    right,
+  }: {
+    children?: ReactNode;
+    right?: ReactNode;
+  }) => (
+    <main>
+      {right}
+      {children}
+    </main>
+  ),
+}));
+
+vi.mock('@ui/primitives/button', () => ({
+  Button: ({
+    asChild,
+    children,
+    label,
+    onClick,
+  }: {
+    asChild?: boolean;
+    children?: ReactNode;
+    label?: string;
+    onClick?: () => void;
+  }) =>
+    asChild ? (
+      children
+    ) : (
+      <button type="button" onClick={onClick}>
+        {label ?? children}
+      </button>
+    ),
+}));
+
+vi.mock('@ui/primitives/input', () => ({
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => (
+    <input {...props} />
+  ),
+}));
+
+vi.mock('@ui/primitives/switch', () => ({
+  Switch: ({
+    'aria-label': ariaLabel,
+    checked,
+    onCheckedChange,
+  }: {
+    'aria-label': string;
+    checked?: boolean;
+    onCheckedChange?: (checked: boolean) => void;
+  }) => (
+    <button
+      aria-checked={checked}
+      aria-label={ariaLabel}
+      role="switch"
+      type="button"
+      onClick={() => onCheckedChange?.(!checked)}
+    />
+  ),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children?: ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('@/components/ui/client-formatted-date', () => ({
+  ClientFormattedDate: ({ value }: { value: string }) => <span>{value}</span>,
+}));
+
+vi.mock('@/features/workflows/services/workflow-api', () => ({
+  isCanonicalSystemWorkflow: () => mocks.isSystemWorkflow,
+}));
+
+vi.mock('@/features/workflows/utils/status-helpers', () => ({
+  getLifecycleBadgeClass: () => 'lifecycle-badge',
+}));
+
+vi.mock('./EmptyWorkflowState', () => ({
+  default: () => <div>Empty workflows</div>,
+}));
+
+vi.mock('./WorkflowCardDropdown', () => ({
+  default: ({ onDuplicate }: { onDuplicate: () => void }) => (
+    <button type="button" aria-label="Workflow actions" onClick={onDuplicate} />
+  ),
+}));
+
+vi.mock('./WorkflowCardPreview', () => ({
+  default: ({ name }: { name: string }) => <div>{name} preview</div>,
+}));
+
+vi.mock('./useWorkflowLibraryPage', () => ({
+  useWorkflowLibraryPage: () => ({
+    error: null,
+    filteredWorkflows: [
+      {
+        _id: 'workflow-1',
+        createdAt: '2026-07-01T00:00:00.000Z',
+        isScheduleEnabled: true,
+        lifecycle: 'published',
+        name: 'Scheduled workflow',
+        schedule: '0 9 * * 1',
+        updatedAt: '2026-07-02T00:00:00.000Z',
+      },
+    ],
+    handleDelete: mocks.handleDelete,
+    handleDuplicate: mocks.handleDuplicate,
+    handleToggleSchedule: mocks.handleToggleSchedule,
+    href: (path: string) => `/acme/brand${path}`,
+    isCapable: true,
+    isConnected: true,
+    isLoading: false,
+    loadWorkflows: vi.fn(),
+    searchInput: '',
+    setSearchInput: vi.fn(),
+    workflows: [{ _id: 'workflow-1' }],
+  }),
+}));
+
+describe('WorkflowLibraryPage card semantics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.isSystemWorkflow = false;
+  });
+
+  it('keeps card navigation separate from schedule and menu actions', () => {
+    render(<WorkflowLibraryPage />);
+
+    expect(
+      screen.getByRole('link', { name: 'Templates' }).querySelector('button'),
+    ).toBeNull();
+    for (const link of screen.getAllByRole('link', {
+      name: 'New Workflow',
+    })) {
+      expect(link.querySelector('button')).toBeNull();
+    }
+
+    const cardLink = screen.getByRole('link', {
+      name: 'Open Scheduled workflow',
+    });
+    const scheduleSwitch = screen.getByRole('switch', {
+      name: 'Disable schedule for Scheduled workflow',
+    });
+    const actions = screen.getByRole('button', { name: 'Workflow actions' });
+
+    expect(cardLink).toHaveAttribute(
+      'href',
+      '/acme/brand/workflows/workflow-1',
+    );
+    expect(cardLink).toHaveClass(
+      'absolute',
+      'inset-0',
+      'z-10',
+      'focus-visible:ring-2',
+      'focus-visible:ring-ring',
+    );
+    expect(actions.parentElement).toHaveClass('relative', 'z-20');
+    expect(scheduleSwitch.closest('a')).toBeNull();
+    expect(actions.closest('a')).toBeNull();
+    expect(cardLink.closest('article')).toBe(scheduleSwitch.closest('article'));
+    expect(cardLink.closest('article')).toBe(actions.closest('article'));
+
+    fireEvent.click(scheduleSwitch);
+    expect(mocks.handleToggleSchedule).toHaveBeenCalledWith(
+      'workflow-1',
+      false,
+    );
+
+    fireEvent.click(actions);
+    expect(mocks.handleDuplicate).toHaveBeenCalledWith('workflow-1');
+  });
+
+  it('uses semantic status tokens for cloud and system workflow badges', () => {
+    const { unmount } = render(<WorkflowLibraryPage />);
+
+    expect(screen.getByText('synced')).toHaveClass(
+      'bg-success/10',
+      'text-success',
+    );
+
+    unmount();
+    mocks.isSystemWorkflow = true;
+    render(<WorkflowLibraryPage />);
+
+    expect(screen.getByText('System')).toHaveClass('bg-info/10', 'text-info');
+  });
+});

--- a/apps/app/src/features/workflows/pages/library/WorkflowLibraryPage.tsx
+++ b/apps/app/src/features/workflows/pages/library/WorkflowLibraryPage.tsx
@@ -61,7 +61,7 @@ export default function WorkflowLibraryPage() {
             (skeletonId) => (
               <div
                 key={skeletonId}
-                className="h-64 animate-pulse rounded-lg border border-white/[0.06] bg-card"
+                className="h-64 animate-pulse rounded-lg border border-border bg-card"
               />
             ),
           )}
@@ -100,20 +100,18 @@ export default function WorkflowLibraryPage() {
       icon={HiOutlineBolt}
       right={
         <>
-          <Link href={href('/workflows/templates')}>
-            <Button
-              label="Templates"
-              variant={ButtonVariant.SECONDARY}
-              icon={<HiOutlineDocumentDuplicate className="size-4" />}
-            />
-          </Link>
-          <Link href={href('/workflows/new')}>
-            <Button
-              label="New Workflow"
-              variant={ButtonVariant.DEFAULT}
-              icon={<HiOutlinePlus className="size-4" />}
-            />
-          </Link>
+          <Button asChild variant={ButtonVariant.SECONDARY} withWrapper={false}>
+            <Link href={href('/workflows/templates')}>
+              <HiOutlineDocumentDuplicate className="size-4" />
+              Templates
+            </Link>
+          </Button>
+          <Button asChild variant={ButtonVariant.DEFAULT} withWrapper={false}>
+            <Link href={href('/workflows/new')}>
+              <HiOutlinePlus className="size-4" />
+              New Workflow
+            </Link>
+          </Button>
         </>
       }
     >
@@ -126,7 +124,7 @@ export default function WorkflowLibraryPage() {
             placeholder="Search workflows..."
             value={searchInput}
             onChange={(e) => setSearchInput(e.target.value)}
-            className="h-10 rounded-lg border-white/10 bg-card py-2 pl-9 pr-3 text-sm text-foreground placeholder:text-foreground/40 focus-visible:border-white/20 focus-visible:ring-0"
+            className="h-10 rounded-lg border-border bg-card py-2 pl-9 pr-3 text-sm text-foreground placeholder:text-foreground/40 focus-visible:border-border-strong focus-visible:ring-0"
           />
         </div>
         {isLoading && workflows.length > 0 && (
@@ -135,7 +133,7 @@ export default function WorkflowLibraryPage() {
       </div>
 
       {/* Contextual info */}
-      <div className="mb-4 rounded-lg border border-white/10 bg-muted/30 p-4 text-sm text-foreground/70">
+      <div className="mb-4 rounded-lg border border-border bg-muted/30 p-4 text-sm text-foreground/70">
         <span className="font-medium text-foreground">Workflows</span> are
         explicit automation graphs. Schedule a workflow when the steps should be
         predictable and repeatable. For adaptive agent behavior, use{' '}
@@ -161,13 +159,13 @@ export default function WorkflowLibraryPage() {
           {/* New Workflow card */}
           <Button
             asChild
-            className="group flex items-center justify-center rounded-lg border-2 border-dashed border-white/10 bg-card/40 p-4 transition-all duration-200 hover:border-white/20 hover:bg-card/60"
+            className="group flex items-center justify-center rounded-lg border-2 border-dashed border-border bg-card/40 p-4 transition-[border-color,background-color] duration-200 hover:border-border-strong hover:bg-card/60"
             variant={ButtonVariant.UNSTYLED}
             withWrapper={false}
           >
             <Link href={href('/workflows/new')}>
               <div className="flex flex-col items-center gap-3 py-8">
-                <div className="flex size-14 items-center justify-center rounded-full bg-foreground/5 transition-all duration-300 group-hover:scale-110 group-hover:bg-foreground/10">
+                <div className="flex size-14 items-center justify-center rounded-full bg-foreground/5 transition-[transform,background-color] duration-300 group-hover:scale-110 group-hover:bg-foreground/10">
                   <HiOutlinePlus className="size-7 text-foreground/50" />
                 </div>
                 <span className="text-sm font-medium text-foreground/70">
@@ -182,86 +180,85 @@ export default function WorkflowLibraryPage() {
             const isSystemWorkflow = isCanonicalSystemWorkflow(workflow);
 
             return (
-              <Link
+              <Card
                 key={workflow._id}
-                href={href(`/workflows/${workflow._id}`)}
-              >
-                <Card
-                  className="h-full hover:-translate-y-0.5"
-                  label={workflow.name}
-                  description={
-                    workflow.description ??
-                    'Reusable automation workflow for content operations.'
-                  }
-                  headerAction={
-                    <div className="flex items-center gap-2">
-                      {isSystemWorkflow ? (
-                        <span className="rounded-full bg-sky-500/10 px-2 py-0.5 text-xs text-sky-300">
-                          System
-                        </span>
-                      ) : null}
-                      {isCapable && isConnected && workflow.cloudSync ? (
-                        <span className="flex items-center gap-1 rounded-full bg-emerald-500/10 px-2 py-0.5 text-xs text-emerald-400">
-                          <Cloud className="size-3" />
-                          synced
-                        </span>
-                      ) : isCapable && isConnected && !workflow.cloudSync ? (
-                        <span className="flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
-                          <CloudUpload className="size-3" />
-                          local
-                        </span>
-                      ) : null}
-                      <span
-                        className={`rounded-full px-2 py-0.5 text-xs ${getLifecycleBadgeClass(
-                          workflow.lifecycle,
-                        )}`}
-                      >
-                        {workflow.lifecycle}
+                className="group h-full hover:-translate-y-0.5"
+                label={workflow.name}
+                description={
+                  workflow.description ??
+                  'Reusable automation workflow for content operations.'
+                }
+                headerAction={
+                  <div className="relative z-20 flex items-center gap-2">
+                    {isSystemWorkflow ? (
+                      <span className="rounded-full bg-info/10 px-2 py-0.5 text-xs text-info">
+                        System
                       </span>
-                      {!isSystemWorkflow && workflow.schedule ? (
-                        <span role="none" onClick={(e) => e.preventDefault()}>
-                          <Switch
-                            checked={workflow.isScheduleEnabled ?? false}
-                            aria-label={`${workflow.isScheduleEnabled ? 'Disable' : 'Enable'} schedule for ${workflow.name}`}
-                            onCheckedChange={(checked) =>
-                              handleToggleSchedule(workflow._id, checked)
-                            }
-                          />
-                        </span>
-                      ) : null}
-                      <WorkflowCardDropdown
-                        canDelete={!isSystemWorkflow}
-                        onDuplicate={() => handleDuplicate(workflow._id)}
-                        onDelete={() => handleDelete(workflow._id)}
+                    ) : null}
+                    {isCapable && isConnected && workflow.cloudSync ? (
+                      <span className="flex items-center gap-1 rounded-full bg-success/10 px-2 py-0.5 text-xs text-success">
+                        <Cloud className="size-3" />
+                        synced
+                      </span>
+                    ) : isCapable && isConnected && !workflow.cloudSync ? (
+                      <span className="flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+                        <CloudUpload className="size-3" />
+                        local
+                      </span>
+                    ) : null}
+                    <span
+                      className={`rounded-full px-2 py-0.5 text-xs ${getLifecycleBadgeClass(
+                        workflow.lifecycle,
+                      )}`}
+                    >
+                      {workflow.lifecycle}
+                    </span>
+                    {!isSystemWorkflow && workflow.schedule ? (
+                      <Switch
+                        checked={workflow.isScheduleEnabled ?? false}
+                        aria-label={`${workflow.isScheduleEnabled ? 'Disable' : 'Enable'} schedule for ${workflow.name}`}
+                        onCheckedChange={(checked) =>
+                          handleToggleSchedule(workflow._id, checked)
+                        }
                       />
-                    </div>
-                  }
-                  bodyClassName="h-full justify-between"
-                >
-                  <div className="space-y-3">
-                    <WorkflowCardPreview
-                      name={workflow.name}
-                      thumbnail={workflow.thumbnail}
+                    ) : null}
+                    <WorkflowCardDropdown
+                      canDelete={!isSystemWorkflow}
+                      onDuplicate={() => handleDuplicate(workflow._id)}
+                      onDelete={() => handleDelete(workflow._id)}
                     />
-                    <div className="flex items-center justify-between text-xs text-foreground/50">
-                      <span>
-                        Updated{' '}
-                        <ClientFormattedDate
-                          format="relative"
-                          value={workflow.updatedAt}
-                        />
-                      </span>
-                      <span>
-                        Created{' '}
-                        <ClientFormattedDate
-                          format="date"
-                          value={workflow.createdAt}
-                        />
-                      </span>
-                    </div>
                   </div>
-                </Card>
-              </Link>
+                }
+                bodyClassName="h-full justify-between"
+              >
+                <Link
+                  href={href(`/workflows/${workflow._id}`)}
+                  aria-label={`Open ${workflow.name}`}
+                  className="absolute inset-0 z-10 rounded-card focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset"
+                />
+                <div className="space-y-3">
+                  <WorkflowCardPreview
+                    name={workflow.name}
+                    thumbnail={workflow.thumbnail}
+                  />
+                  <div className="flex items-center justify-between text-xs text-foreground/50">
+                    <span>
+                      Updated{' '}
+                      <ClientFormattedDate
+                        format="relative"
+                        value={workflow.updatedAt}
+                      />
+                    </span>
+                    <span>
+                      Created{' '}
+                      <ClientFormattedDate
+                        format="date"
+                        value={workflow.createdAt}
+                      />
+                    </span>
+                  </div>
+                </div>
+              </Card>
             );
           })}
         </div>

--- a/apps/app/src/lib/images/can-optimize-image-source.test.ts
+++ b/apps/app/src/lib/images/can-optimize-image-source.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { canOptimizeImageSource } from './can-optimize-image-source';
+
+describe('canOptimizeImageSource', () => {
+  it.each([
+    '/images/default-card.webp',
+    'https://cdn.genfeed.ai/image.webp',
+    'https://assets.cloudfront.net/image.webp',
+    'https://bucket.s3.amazonaws.com/image.webp',
+    'https://tenant.supabase.co/storage/v1/object/public/image.webp',
+    'https://images.unsplash.com/photo-1',
+  ])('allows optimizer-configured sources: %s', (source) => {
+    expect(canOptimizeImageSource(source)).toBe(true);
+  });
+
+  it.each([
+    'blob:https://app.genfeed.ai/object-id',
+    'data:image/png;base64,abc',
+    'https://customer-cdn.example.com/image.webp',
+    'https://genfeed.ai/image.webp',
+    '//customer-cdn.example.com/image.webp',
+    'not a URL',
+  ])('bypasses unsupported or non-network sources: %s', (source) => {
+    expect(canOptimizeImageSource(source)).toBe(false);
+  });
+});

--- a/apps/app/src/lib/images/can-optimize-image-source.ts
+++ b/apps/app/src/lib/images/can-optimize-image-source.ts
@@ -1,0 +1,41 @@
+/**
+ * Keep this list aligned with `packages/next-config/next.config.base.ts`.
+ * Arbitrary customer/provider URLs must bypass the Next image optimizer or
+ * Next will reject their host at runtime.
+ */
+const OPTIMIZABLE_EXACT_HOSTS = new Set([
+  'i.pravatar.cc',
+  'images.unsplash.com',
+  'img.authprovider.com',
+  'picsum.photos',
+]);
+
+const OPTIMIZABLE_HOST_SUFFIXES = [
+  '.amazonaws.com',
+  '.cloudfront.net',
+  '.genfeed.ai',
+  '.supabase.co',
+];
+
+export function canOptimizeImageSource(source: string): boolean {
+  const normalizedSource = source.trim();
+
+  if (normalizedSource.startsWith('/') && !normalizedSource.startsWith('//')) {
+    return true;
+  }
+
+  try {
+    const url = new URL(normalizedSource);
+
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      return false;
+    }
+
+    return (
+      OPTIMIZABLE_EXACT_HOSTS.has(url.hostname) ||
+      OPTIMIZABLE_HOST_SUFFIXES.some((suffix) => url.hostname.endsWith(suffix))
+    );
+  } catch {
+    return false;
+  }
+}

--- a/packages/ui/src/components/display/table/Table.test.tsx
+++ b/packages/ui/src/components/display/table/Table.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import Table from '@ui/display/table/Table';
 import { describe, expect, it } from 'vitest';
 
@@ -17,5 +17,40 @@ describe('Table', () => {
     const { container } = render(<Table />);
     const rootElement = container.firstChild as HTMLElement;
     expect(rootElement).toBeInTheDocument();
+  });
+
+  it('reveals touch-safe row actions on keyboard focus', () => {
+    render(
+      <Table
+        items={[{ id: 'item-1', name: 'First item' }]}
+        columns={[
+          {
+            header: 'Name',
+            key: 'name',
+          },
+        ]}
+        actions={[
+          {
+            icon: 'Edit',
+            onClick: () => {},
+            tooltip: 'Edit item',
+          },
+        ]}
+        getRowKey={(item) => item.id}
+      />,
+    );
+
+    const action = screen.getByTestId('action-button');
+    expect(action).toHaveClass(
+      'min-h-11',
+      'min-w-11',
+      'lg:min-h-0',
+      'lg:min-w-0',
+    );
+    expect(action.closest('td')?.firstElementChild).toHaveClass(
+      'group-focus-within:opacity-100',
+      'group-focus-within:translate-x-0',
+      'transition-[opacity,transform]',
+    );
   });
 });

--- a/packages/ui/src/components/display/table/Table.tsx
+++ b/packages/ui/src/components/display/table/Table.tsx
@@ -132,7 +132,7 @@ export default function AppTable<T>({
               hideHeader && 'sr-only',
             )}
           >
-            <tr className="border-b border-white/[0.08] transition-colors">
+            <tr className="border-b border-border transition-colors">
               {selectable && (
                 <th className="size-12 px-4 text-left align-middle font-medium text-muted-foreground">
                   <Checkbox
@@ -179,8 +179,8 @@ export default function AppTable<T>({
                 <tr
                   key={getRowKey ? getRowKey(item, index) : index}
                   className={cn(
-                    'group border-b border-white/[0.06] transition-colors duration-200 odd:bg-white/[0.015] hover:bg-white/[0.04]',
-                    isSelected && 'bg-white/[0.05]',
+                    'group border-b border-border transition-colors duration-200 odd:bg-background-secondary/50 hover:bg-accent/60',
+                    isSelected && 'bg-accent',
                     onRowClick && 'cursor-pointer',
                     getRowClassName?.(item),
                   )}
@@ -211,7 +211,7 @@ export default function AppTable<T>({
 
                   {actions.length > 0 && (
                     <td className="px-4 py-2 relative align-middle">
-                      <div className="flex justify-end opacity-0 group-hover:opacity-100 translate-x-2 group-hover:translate-x-0 transition-all duration-200">
+                      <div className="flex translate-x-0 justify-end opacity-100 transition-[opacity,transform] duration-200 group-focus-within:translate-x-0 group-focus-within:opacity-100 lg:translate-x-2 lg:opacity-0 lg:group-hover:translate-x-0 lg:group-hover:opacity-100">
                         <div className="flex items-center gap-1">
                           {actions.reduce<ReactNode[]>(
                             (acc, action, actionIndex) => {
@@ -247,6 +247,7 @@ export default function AppTable<T>({
                                   variant={ButtonVariant.GHOST}
                                   size={ButtonSize.SM}
                                   className={cn(
+                                    'min-h-11 min-w-11 lg:min-h-0 lg:min-w-0',
                                     action.className,
                                     action.getClassName?.(item),
                                   )}

--- a/packages/ui/src/components/dropdowns/model-selector/ModelSelectorFamilyItem.tsx
+++ b/packages/ui/src/components/dropdowns/model-selector/ModelSelectorFamilyItem.tsx
@@ -17,7 +17,7 @@ function ProviderBadge({
 >) {
   return (
     <div
-      className="mt-0.5 size-5 rounded border border-white/8 flex items-center justify-center shrink-0"
+      className="mt-0.5 flex size-5 shrink-0 items-center justify-center rounded border border-border"
       style={{ backgroundColor: `${brandColor}1f`, color: brandColor }}
     >
       {BrandIcon ? (
@@ -53,8 +53,8 @@ const ModelSelectorFamilyItem = memo(function ModelSelectorFamilyItem({
       aria-expanded={isExpanded}
       ariaLabel={familyLabel}
       className={cn(
-        'group flex w-full items-center gap-2.5 rounded px-2 py-2 text-left transition-colors',
-        'hover:bg-white/[0.06] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/20',
+        'group flex min-h-11 w-full items-center gap-2.5 rounded px-2 py-2 text-left transition-colors lg:min-h-0',
+        'hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
       )}
     >
       <ChevronIcon className="size-3.5 shrink-0 text-foreground/45 transition-transform" />
@@ -68,7 +68,7 @@ const ModelSelectorFamilyItem = memo(function ModelSelectorFamilyItem({
           <span className="truncate text-sm font-medium text-foreground">
             {familyLabel}
           </span>
-          <span className="rounded-full border border-white/8 bg-white/[0.04] px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-foreground/45">
+          <span className="rounded-full border border-border bg-muted px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-foreground/45">
             {count}
           </span>
         </div>

--- a/packages/ui/src/components/dropdowns/model-selector/ModelSelectorModelItem.tsx
+++ b/packages/ui/src/components/dropdowns/model-selector/ModelSelectorModelItem.tsx
@@ -43,8 +43,8 @@ const ModelSelectorModelItem = memo(function ModelSelectorModelItem({
       value={`${model.label} ${brandLabel} ${model.description ?? ''}`}
       onSelect={handleSelect}
       className={cn(
-        'flex items-start gap-2 px-2 py-2 cursor-pointer',
-        isSelected && 'bg-primary/10',
+        'flex min-h-11 cursor-pointer items-start gap-2 px-2 py-2 lg:min-h-0',
+        isSelected && 'bg-accent',
       )}
     >
       <div className="pointer-events-none mt-0.5">
@@ -52,12 +52,12 @@ const ModelSelectorModelItem = memo(function ModelSelectorModelItem({
           name={`model-${model.key}`}
           isChecked={isSelected}
           onChange={() => {}}
-          className="size-3.5 !border-white/20 data-[state=checked]:!bg-foreground data-[state=checked]:!border-foreground data-[state=checked]:!text-background"
+          className="size-3.5 !border-border data-[state=checked]:!border-foreground data-[state=checked]:!bg-foreground data-[state=checked]:!text-background"
         />
       </div>
 
       <div
-        className="mt-0.5 size-4 rounded-sm flex items-center justify-center text-[9px] font-bold shrink-0 border border-white/8"
+        className="mt-0.5 flex size-4 shrink-0 items-center justify-center rounded-sm border border-border text-[9px] font-bold"
         style={{ backgroundColor: `${brandColor}20`, color: brandColor }}
       >
         {BrandIcon ? (
@@ -92,11 +92,12 @@ const ModelSelectorModelItem = memo(function ModelSelectorModelItem({
       </div>
 
       <Button
+        ariaLabel={`${isFavorite ? 'Remove' : 'Add'} ${model.label} ${isFavorite ? 'from' : 'to'} favorites`}
         variant={ButtonVariant.UNSTYLED}
         withWrapper={false}
         onClick={handleFavoriteClick}
         className={cn(
-          'mt-0.5 p-0.5 rounded hover:bg-white/10 transition-colors shrink-0',
+          '-my-2 mt-0.5 flex size-11 shrink-0 items-center justify-center rounded transition-colors hover:bg-accent lg:my-0 lg:size-7',
           isFavorite
             ? 'text-foreground'
             : 'text-foreground/20 hover:text-foreground/40',

--- a/packages/ui/src/components/dropdowns/model-selector/ModelSelectorPopover.test.tsx
+++ b/packages/ui/src/components/dropdowns/model-selector/ModelSelectorPopover.test.tsx
@@ -393,4 +393,32 @@ describe('ModelSelectorPopover', () => {
     expect(screen.getByText('Veo')).toBeInTheDocument();
     expect(screen.getByText('3.1 Fast')).toBeInTheDocument();
   });
+
+  it('gives favorite toggles an accessible model-specific label', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ModelSelectorPopover
+        models={[
+          createModel({
+            key: 'google/nano-banana-pro',
+            label: 'Nano Banana Pro',
+          }),
+        ]}
+        values={[]}
+        onChange={vi.fn()}
+        favoriteModelKeys={[]}
+        onFavoriteToggle={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /select models/i }));
+    await user.click(screen.getByRole('button', { name: /nano banana/i }));
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Add Nano Banana Pro to favorites',
+      }),
+    ).toBeInTheDocument();
+  });
 });

--- a/packages/ui/src/components/dropdowns/model-selector/ModelSelectorPopover.tsx
+++ b/packages/ui/src/components/dropdowns/model-selector/ModelSelectorPopover.tsx
@@ -407,11 +407,16 @@ const ModelSelectorPopover = memo(function ModelSelectorPopover({
         align="start"
         sideOffset={8}
         className={cn(
-          'p-0 bg-popover border border-white/10 rounded-lg overflow-hidden',
-          shouldShowManualCatalog ? 'w-[440px]' : 'w-[320px]',
+          'w-[calc(100vw-2rem)] overflow-hidden rounded-lg bg-popover p-0 shadow-dropdown',
+          shouldShowManualCatalog ? 'sm:w-[440px]' : 'sm:w-[320px]',
         )}
       >
-        <div className={cn('flex', shouldShowManualCatalog && 'h-[500px]')}>
+        <div
+          className={cn(
+            'flex',
+            shouldShowManualCatalog && 'h-[min(500px,calc(100vh-4rem))]',
+          )}
+        >
           {shouldShowManualCatalog && (
             <ModelSelectorProviderSidebar
               brands={brands}
@@ -423,8 +428,8 @@ const ModelSelectorPopover = memo(function ModelSelectorPopover({
 
           <div className="flex min-w-0 flex-1 flex-col">
             {shouldShowManualCatalog && shouldShowSourceTabs && (
-              <div className="border-b border-white/8 px-3 py-2">
-                <div className="inline-flex rounded border border-white/8 bg-white/[0.03] p-1">
+              <div className="overflow-x-auto border-b border-border px-3 py-2">
+                <div className="inline-flex min-w-max rounded border border-border bg-background-secondary p-1">
                   <SourceTabButton
                     isActive={activeSourceGroup === 'all'}
                     label="All"
@@ -459,18 +464,18 @@ const ModelSelectorPopover = memo(function ModelSelectorPopover({
               >
                 {shouldShowAutoCard && (
                   <CommandGroup heading="Auto">
-                    <div className="mb-1 rounded-lg border border-white/[0.04] bg-white/[0.02]">
+                    <div className="mb-1 rounded-lg bg-background-secondary shadow-border">
                       <div
                         className={cn(
                           'transition-colors',
-                          isAutoSelected && 'bg-primary/10',
+                          isAutoSelected && 'bg-accent',
                         )}
                       >
                         <Button
                           onClick={() => handleToggle(AUTO_MODEL_OPTION_VALUE)}
                           className={cn(
-                            'flex w-full items-center gap-2.5 rounded px-3 py-3 text-left transition-colors',
-                            'hover:bg-white/[0.06] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/20',
+                            'flex min-h-11 w-full items-center gap-2.5 rounded px-3 py-3 text-left transition-colors lg:min-h-0',
+                            'hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
                           )}
                           type="button"
                           variant={ButtonVariant.UNSTYLED}
@@ -481,7 +486,7 @@ const ModelSelectorPopover = memo(function ModelSelectorPopover({
                               'flex size-4 items-center justify-center rounded-sm border transition-colors',
                               isAutoSelected
                                 ? 'border-foreground bg-foreground text-background'
-                                : 'border-white/20 bg-transparent text-transparent',
+                                : 'border-border bg-transparent text-transparent',
                             )}
                           >
                             <HiCheck className="size-3" />
@@ -501,7 +506,7 @@ const ModelSelectorPopover = memo(function ModelSelectorPopover({
                       </div>
 
                       {isAutoSelected && onPrioritizeChange && (
-                        <div className="space-y-2 border-t border-white/[0.04] px-3 pb-3 pt-2">
+                        <div className="space-y-2 border-t border-border px-3 pb-3 pt-2">
                           <div className="text-[11px] font-medium uppercase tracking-wide text-foreground/50">
                             Priority
                           </div>
@@ -513,7 +518,7 @@ const ModelSelectorPopover = memo(function ModelSelectorPopover({
                           >
                             <SelectTrigger
                               aria-label="Auto routing priority"
-                              className="h-9 border-white/10 bg-white/[0.03] text-sm"
+                              className="min-h-11 border-border bg-background-tertiary text-sm lg:min-h-9"
                             >
                               <SelectValue placeholder="Select priority" />
                             </SelectTrigger>
@@ -567,7 +572,7 @@ const ModelSelectorPopover = memo(function ModelSelectorPopover({
                               return (
                                 <div
                                   key={family.familyKey}
-                                  className="mb-1 rounded-lg border border-white/[0.04] bg-white/[0.02]"
+                                  className="mb-1 rounded-lg bg-background-secondary shadow-border"
                                 >
                                   <ModelSelectorFamilyItem
                                     brandColor={brandConfig.color}
@@ -636,10 +641,10 @@ function SourceTabButton({
       withWrapper={false}
       onClick={onClick}
       className={cn(
-        'rounded px-2.5 py-1.5 text-xs font-medium transition-colors',
+        'min-h-11 rounded px-2.5 py-1.5 text-xs font-medium transition-colors lg:min-h-0',
         isActive
-          ? 'bg-white/[0.09] text-foreground'
-          : 'text-foreground/55 hover:text-foreground hover:bg-white/[0.05]',
+          ? 'bg-accent text-foreground'
+          : 'text-foreground/55 hover:bg-accent hover:text-foreground',
       )}
     >
       {label}

--- a/packages/ui/src/components/dropdowns/model-selector/ModelSelectorProviderSidebar.tsx
+++ b/packages/ui/src/components/dropdowns/model-selector/ModelSelectorProviderSidebar.tsx
@@ -23,7 +23,7 @@ const ModelSelectorProviderSidebar = memo(
     );
 
     return (
-      <div className="w-12 border-r border-white/10 flex flex-col items-center py-2 gap-1 overflow-y-auto">
+      <div className="flex w-14 flex-col items-center gap-1 overflow-y-auto border-r border-border py-2 sm:w-12">
         {hasFavorites && (
           <SidebarButton
             isActive={activeBrand === 'favorites'}
@@ -39,12 +39,12 @@ const ModelSelectorProviderSidebar = memo(
           isActive={activeBrand === null}
           onClick={() => handleBrandClick(null)}
           tooltip="All"
-          color="#9CA3AF"
+          color="hsl(var(--muted-foreground))"
         >
           <HiSquares2X2 className="size-4" />
         </SidebarButton>
 
-        <div className="w-6 h-px bg-white/10 my-0.5" />
+        <div className="my-0.5 h-px w-6 bg-border" />
 
         {brands.map((brand) => {
           const config = MODEL_BRANDS[brand.slug];
@@ -94,10 +94,10 @@ function SidebarButton({
       onClick={onClick}
       tooltip={tooltip}
       className={cn(
-        'size-8 rounded flex items-center justify-center transition-all relative',
+        'relative flex size-11 items-center justify-center rounded transition-[background-color,color] lg:size-8',
         isActive
-          ? 'bg-white/10'
-          : 'hover:bg-white/5 text-foreground/50 hover:text-foreground/80',
+          ? 'bg-accent'
+          : 'text-foreground/50 hover:bg-accent hover:text-foreground/80',
       )}
       style={isActive ? { color } : undefined}
     >

--- a/packages/ui/src/components/ingredients/children-manager/ChildrenPickerDropdown.tsx
+++ b/packages/ui/src/components/ingredients/children-manager/ChildrenPickerDropdown.tsx
@@ -47,7 +47,7 @@ export default function ChildrenPickerDropdown({
       />
 
       {isDropdownOpen && (
-        <div className="absolute top-full mt-2 left-0 z-50 bg-card shadow-dropdown p-3 min-w-96 max-w-2xl">
+        <div className="absolute left-0 top-full z-50 mt-2 w-[min(32rem,calc(100vw-2rem))] bg-card p-3 shadow-dropdown">
           <div className="text-xs text-foreground/70 mb-2 font-medium">
             Select {parentIngredientCategory}s to add as children
           </div>
@@ -61,14 +61,14 @@ export default function ChildrenPickerDropdown({
               No available {parentIngredientCategory}s to add
             </div>
           ) : (
-            <div className="grid grid-cols-6 gap-2 max-h-72 overflow-y-auto">
+            <div className="grid max-h-72 grid-cols-[repeat(auto-fill,minmax(4rem,1fr))] gap-2 overflow-y-auto">
               {availableIngredients.map((ingredient: IIngredient) => {
                 const metadata = ingredient.metadata as IMetadata;
 
                 return (
                   <Button
                     key={ingredient.id}
-                    className="relative group block cursor-pointer text-left transition-all"
+                    className="group relative block cursor-pointer text-left focus-visible:outline-none"
                     onClick={() => onAddChild(ingredient.id)}
                     title={
                       metadata.label ||
@@ -78,7 +78,7 @@ export default function ChildrenPickerDropdown({
                     variant={ButtonVariant.UNSTYLED}
                     withWrapper={false}
                   >
-                    <div className="relative size-16 overflow-hidden border-2 border-transparent hover:border-primary transition-all hover:scale-105">
+                    <div className="relative size-16 overflow-hidden border-2 border-transparent transition-[border-color,transform] duration-200 group-hover:scale-105 group-hover:border-primary group-focus-visible:ring-2 group-focus-visible:ring-ring group-focus-visible:ring-offset-2 group-focus-visible:ring-offset-background">
                       {isVideo ? (
                         <div className="size-full bg-background">
                           <VideoPlayer

--- a/packages/ui/src/components/ingredients/parents-manager/ParentsPickerDropdown.tsx
+++ b/packages/ui/src/components/ingredients/parents-manager/ParentsPickerDropdown.tsx
@@ -45,7 +45,7 @@ export default function ParentsPickerDropdown({
       />
 
       {isDropdownOpen && (
-        <div className="absolute top-full mt-2 left-0 z-50 bg-card shadow-lg border border-white/[0.08] p-3 min-w-96 max-w-2xl">
+        <div className="absolute left-0 top-full z-50 mt-2 w-[min(32rem,calc(100vw-2rem))] bg-card p-3 shadow-dropdown">
           <div className="text-xs text-foreground/70 mb-2 font-medium">
             Select Parent {ingredientCategory}s
           </div>
@@ -59,11 +59,11 @@ export default function ParentsPickerDropdown({
               No available {ingredientCategory}s
             </div>
           ) : (
-            <div className="grid grid-cols-6 gap-2 max-h-72 overflow-y-auto">
+            <div className="grid max-h-72 grid-cols-[repeat(auto-fill,minmax(4rem,1fr))] gap-2 overflow-y-auto">
               {availableIngredients.map((ing: IIngredient) => (
                 <Button
                   key={ing.id}
-                  className="relative group block cursor-pointer text-left transition-all"
+                  className="group relative block cursor-pointer text-left focus-visible:outline-none"
                   onClick={() => onAddParent(ing.id)}
                   title={
                     (ing.metadata as IMetadata)?.label ||
@@ -73,7 +73,7 @@ export default function ParentsPickerDropdown({
                   variant={ButtonVariant.UNSTYLED}
                   withWrapper={false}
                 >
-                  <div className="relative size-16 overflow-hidden border-2 border-transparent hover:border-primary transition-all hover:scale-105">
+                  <div className="relative size-16 overflow-hidden border-2 border-transparent transition-[border-color,transform] duration-200 group-hover:scale-105 group-hover:border-primary group-focus-visible:ring-2 group-focus-visible:ring-ring group-focus-visible:ring-offset-2 group-focus-visible:ring-offset-background">
                     {isVideo ? (
                       <div className="size-full bg-background">
                         <VideoPlayer

--- a/packages/ui/src/components/kpi/kpi-section/KPISection.test.tsx
+++ b/packages/ui/src/components/kpi/kpi-section/KPISection.test.tsx
@@ -42,4 +42,18 @@ describe('KPISection', () => {
     );
     expect(heading).not.toHaveClass('font-serif-italic');
   });
+
+  it('stacks header actions on narrow screens', () => {
+    render(
+      <KPISection
+        title="Overview"
+        items={items}
+        headerActions={<button type="button">Export</button>}
+      />,
+    );
+
+    expect(
+      screen.getByRole('heading', { name: 'Overview' }).parentElement,
+    ).toHaveClass('flex-col', 'sm:flex-row');
+  });
 });

--- a/packages/ui/src/components/kpi/kpi-section/KPISection.tsx
+++ b/packages/ui/src/components/kpi/kpi-section/KPISection.tsx
@@ -44,7 +44,7 @@ function SectionHeader({
   headerActions,
 }: SectionHeaderProps): React.ReactNode {
   return (
-    <div className="flex justify-between items-center mb-4">
+    <div className="mb-4 flex min-w-0 flex-col items-start justify-between gap-3 sm:flex-row sm:items-center">
       <h2 className="text-xl font-semibold tracking-[-0.02em] text-foreground">
         {title}
       </h2>

--- a/packages/ui/src/components/lists/row-sound/ListRowSound.test.tsx
+++ b/packages/ui/src/components/lists/row-sound/ListRowSound.test.tsx
@@ -53,9 +53,30 @@ describe('ListRowSound', () => {
       .getByText('Rachel')
       .closest('li')?.firstElementChild;
     expect(rootElement).toBeInTheDocument();
-    expect(rootElement?.className).toContain('bg-white/[0.06]');
+    expect(rootElement).toHaveClass(
+      'grid-cols-[auto_minmax(0,1fr)]',
+      'lg:grid-cols-[auto_minmax(0,1fr)_auto]',
+      'bg-accent',
+    );
     expect(screen.getByText('Rachel')).toBeInTheDocument();
     expect(screen.getByText('Narration')).toBeInTheDocument();
     expect(screen.getByText('Action')).toBeInTheDocument();
+  });
+
+  it('stacks metadata before restoring dense desktop columns', () => {
+    render(
+      <ListRowSound
+        metaPrimary="English"
+        stats="12K"
+        subtitle="Narration"
+        title="Rachel"
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: /Rachel/i })).toHaveClass(
+      'grid-cols-1',
+      'sm:grid-cols-[minmax(0,2.4fr)_minmax(8rem,1.4fr)]',
+      'lg:grid-cols-[minmax(0,2.4fr)_minmax(11.25rem,1.4fr)_minmax(7.5rem,0.8fr)]',
+    );
   });
 });

--- a/packages/ui/src/components/lists/row-sound/ListRowSound.tsx
+++ b/packages/ui/src/components/lists/row-sound/ListRowSound.tsx
@@ -26,7 +26,7 @@ function renderLegacyPlaybackControl({
       }
       variant={isActive ? ButtonVariant.SECONDARY : ButtonVariant.DEFAULT}
       size={ButtonSize.ICON}
-      className="transition-all duration-300"
+      className="size-11 transition-colors duration-200 lg:size-8"
       onClick={(event: MouseEvent) => onPlay(event, ingredient)}
     />
   );
@@ -74,16 +74,16 @@ export default function ListRowSound({
     <li>
       <div
         className={cn(
-          'group grid min-h-20 grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-4 rounded-2xl shadow-border bg-white/[0.02] px-4 py-3 transition-colors duration-200',
-          'hover:shadow-border-strong hover:bg-white/[0.04]',
-          (isActive ?? isSelected) && 'shadow-border-strong bg-white/[0.06]',
+          'group grid min-h-20 grid-cols-[auto_minmax(0,1fr)] items-center gap-4 rounded-2xl bg-background-secondary px-4 py-3 shadow-border transition-colors duration-200 lg:grid-cols-[auto_minmax(0,1fr)_auto]',
+          'hover:bg-background-tertiary hover:shadow-border-strong',
+          (isActive ?? isSelected) && 'bg-accent shadow-border-strong',
           onRowClick && 'cursor-pointer',
           className,
         )}
       >
         <div className="flex min-w-0 items-center gap-3">
           {leading ?? (
-            <div className="flex size-10 items-center justify-center rounded-full border border-white/[0.08] bg-white/[0.04] text-sm font-medium text-white/70">
+            <div className="flex size-11 items-center justify-center rounded-full border border-border bg-background-tertiary text-sm font-medium text-foreground/70 lg:size-10">
               {typeof index === 'number' ? (
                 index + 1
               ) : (
@@ -97,14 +97,14 @@ export default function ListRowSound({
         </div>
 
         <Button
-          className="grid min-w-0 grid-cols-[minmax(0,2.4fr)_minmax(180px,1.4fr)_minmax(120px,0.8fr)] items-center gap-4 text-left"
+          className="grid min-w-0 grid-cols-1 items-center gap-3 rounded text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring sm:grid-cols-[minmax(0,2.4fr)_minmax(8rem,1.4fr)] lg:grid-cols-[minmax(0,2.4fr)_minmax(11.25rem,1.4fr)_minmax(7.5rem,0.8fr)] lg:gap-4"
           onClick={activateRow}
           type="button"
           variant={ButtonVariant.UNSTYLED}
           withWrapper={false}
         >
           <div className="min-w-0 space-y-1">
-            <div className="truncate text-sm font-semibold text-white">
+            <div className="truncate text-sm font-semibold text-foreground">
               {resolvedTitle}
             </div>
             {resolvedSubtitle ? (
@@ -119,7 +119,7 @@ export default function ListRowSound({
 
           <div className="min-w-0 space-y-1 text-sm text-muted-foreground">
             {resolvedProvider ? (
-              <div className="truncate font-medium text-white/85">
+              <div className="truncate font-medium text-foreground/85">
                 {resolvedProvider}
               </div>
             ) : null}
@@ -140,12 +140,16 @@ export default function ListRowSound({
             ) : null}
           </div>
 
-          <div className="min-w-0 text-sm text-muted-foreground">{stats}</div>
+          <div className="min-w-0 text-sm text-muted-foreground sm:col-span-2 lg:col-span-1">
+            {stats}
+          </div>
         </Button>
 
-        <div className="flex shrink-0 items-center justify-start gap-2 lg:justify-end">
-          {actions}
-        </div>
+        {actions ? (
+          <div className="col-start-2 flex min-h-11 shrink-0 items-center justify-start gap-2 lg:col-start-3 lg:min-h-0 lg:justify-end">
+            {actions}
+          </div>
+        ) : null}
       </div>
     </li>
   );

--- a/packages/ui/src/components/shell/app-switcher/AppSwitcher.test.tsx
+++ b/packages/ui/src/components/shell/app-switcher/AppSwitcher.test.tsx
@@ -165,6 +165,38 @@ describe('AppSwitcher', () => {
     ).toBeInTheDocument();
   });
 
+  it('keeps grayscale focus indicators on the trigger and app links', () => {
+    const { rerender } = render(
+      <AppSwitcher orgSlug="acme" currentApp="workspace" />,
+    );
+
+    const iconTrigger = screen.getByRole('button', { name: 'Switch app' });
+    expect(iconTrigger).toHaveClass(
+      'focus-visible:ring-2',
+      'focus-visible:ring-ring',
+      'focus-visible:ring-offset-background',
+    );
+    expect(iconTrigger.className).not.toContain('focus-visible:!ring-0');
+
+    expect(screen.getByRole('link', { name: 'Workspace' })).toHaveClass(
+      'focus-visible:ring-2',
+      'focus-visible:ring-ring',
+      'focus-visible:ring-offset-popover',
+    );
+
+    rerender(
+      <AppSwitcher orgSlug="acme" currentApp="workspace" variant="labeled" />,
+    );
+
+    const labeledTrigger = screen.getByRole('button', { name: 'Switch app' });
+    expect(labeledTrigger).toHaveClass(
+      'focus-visible:ring-2',
+      'focus-visible:ring-ring',
+      'focus-visible:ring-offset-background',
+    );
+    expect(labeledTrigger.className).not.toContain('focus-visible:!ring-0');
+  });
+
   it('renders the compact primary app grid', () => {
     render(<AppSwitcher orgSlug="acme" currentApp="workspace" />);
 

--- a/packages/ui/src/components/shell/app-switcher/AppSwitcher.tsx
+++ b/packages/ui/src/components/shell/app-switcher/AppSwitcher.tsx
@@ -385,8 +385,8 @@ function AppSwitcherGridItem({
         aria-current={isActive ? 'page' : undefined}
         onClick={onNavigateStart}
         className={cn(
-          'group grid min-h-[5.75rem] min-w-0 grid-rows-[2.75rem_1.25rem] place-items-center gap-1.5 rounded-lg border border-transparent px-1.5 py-2 text-center outline-none transition-colors',
-          'hover:border-border hover:bg-foreground/[0.04] focus:border-border focus:bg-foreground/[0.06]',
+          'group grid min-h-[5.75rem] min-w-0 grid-rows-[2.75rem_1.25rem] place-items-center gap-1.5 rounded-lg border border-transparent px-1.5 py-2 text-center outline-none transition-[border-color,background-color,box-shadow]',
+          'hover:border-border hover:bg-foreground/[0.04] focus-visible:border-border focus-visible:bg-foreground/[0.06] focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-popover',
           isActive &&
             'border-border-strong bg-foreground/[0.08] shadow-border-strong',
         )}
@@ -510,7 +510,7 @@ export function AppSwitcher({
           <Button
             type="button"
             variant={ButtonVariant.GHOST}
-            className="flex h-7 items-center gap-2 rounded-md px-2 focus-visible:!outline-none focus-visible:!ring-0 focus-visible:!ring-offset-0"
+            className="flex h-7 items-center gap-2 rounded-md px-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
             ariaLabel="Switch app"
           >
             <ActiveIcon className="size-4 shrink-0 text-foreground/70" />
@@ -524,7 +524,7 @@ export function AppSwitcher({
             type="button"
             variant={ButtonVariant.GHOST}
             size={ButtonSize.ICON}
-            className="size-7 focus-visible:!outline-none focus-visible:!ring-0 focus-visible:!ring-offset-0"
+            className="size-7 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
             ariaLabel="Switch app"
           >
             <TbGridDots className="size-4" />

--- a/packages/ui/src/components/workflow-builder/WorkflowBuilder.tsx
+++ b/packages/ui/src/components/workflow-builder/WorkflowBuilder.tsx
@@ -155,7 +155,7 @@ export default function WorkflowBuilder({
         <div className="flex flex-1 overflow-hidden">
           {/* Left Panel - Node Palette */}
           <div
-            className={`border-r border-white/[0.08] bg-background transition-all duration-300 ${
+            className={`border-r border-border bg-background transition-[width] duration-300 ${
               isPaletteCollapsed ? 'w-12' : 'w-64'
             }`}
           >
@@ -184,7 +184,7 @@ export default function WorkflowBuilder({
           </div>
 
           {/* Right Panel - Config + Variables + Schedule + History */}
-          <div className="flex w-80 flex-col border-l border-white/[0.08] bg-card">
+          <div className="flex w-80 flex-col border-l border-border bg-card">
             {selectedNode && (
               <NodeConfigPanel
                 selectedNode={selectedNode}

--- a/packages/ui/src/components/workflow-builder/nodes/BaseNode.tsx
+++ b/packages/ui/src/components/workflow-builder/nodes/BaseNode.tsx
@@ -33,7 +33,7 @@ function BaseNode({
   return (
     <div
       className={cn(
-        'min-w-node border-2 transition-all',
+        'min-w-node border-2 transition-[background-color,border-color,box-shadow]',
         bgColor,
         borderColor,
         selected && 'ring-2 ring-primary ring-offset-2',
@@ -48,7 +48,7 @@ function BaseNode({
           id={key}
           isConnectable={isConnectable}
           style={{
-            background: '#6b7280',
+            background: 'hsl(var(--muted-foreground))',
             height: 10,
             top: `${((index + 1) / (inputKeys.length + 1)) * 100}%`,
             width: 10,
@@ -58,7 +58,7 @@ function BaseNode({
       ))}
 
       {/* Node Header */}
-      <div className="flex items-center gap-2 border-b border-white/[0.08] px-3 py-2">
+      <div className="flex items-center gap-2 border-b border-border px-3 py-2">
         <div className="text-lg">{icon}</div>
         <span className="font-medium text-sm">{label}</span>
       </div>
@@ -85,7 +85,7 @@ function BaseNode({
           id={key}
           isConnectable={isConnectable}
           style={{
-            background: '#6b7280',
+            background: 'hsl(var(--muted-foreground))',
             height: 10,
             top: `${((index + 1) / (outputKeys.length + 1)) * 100}%`,
             width: 10,


### PR DESCRIPTION
## Summary

- restore visible keyboard focus in AppSwitcher and separate Workflow Library navigation from nested schedule/menu actions
- optimize `next/image` only for configured hosts via a shared predicate while preserving bypasses for custom, blob, provider, and unsupported URLs
- replace high-value `transition-all` and hard-coded product chrome with explicit transitions and semantic design tokens
- make shared model selectors, ingredient pickers, tables, KPI headers, audio rows, review cards, and clip actions responsive and touch-safe
- add focused regression coverage for semantics, focus, image-host policy, responsive classes, touch targets, and shared-surface behavior

## Verification

Passed locally:

- changed-file Biome check: 66 files, no fixes required
- `bun run design:check` (0 errors; 9 existing unused-token warnings)
- design-system boundary check
- app UI boundary check
- raw-control guard
- bespoke-card guard
- modal, org-scoped navigation, and hard-coded route guards
- pre-commit secretlint and lint-staged checks
- independent QA review after fixes: approved

Local limitations:

- focused Vitest specs could not start because this isolated worktree has no installed `vitest` binary/module; PR CI owns test/type/build verification per repository policy
- the aggregate UI-guard runner's nested-card phase crashes locally in the existing checker at `ts.ScriptTarget.Latest`; all other phases were run directly and passed

## Scope

- OSS `apps/app` and `packages/ui` only
- no EE changes
- no deployment or external configuration changes
