### PR TITLE
refactor(agent): extract completion card builder

### DIFF
--- a/apps/server/api/src/services/agent-orchestrator/agent-completion-card-builder.service.spec.ts
+++ b/apps/server/api/src/services/agent-orchestrator/agent-completion-card-builder.service.spec.ts
@@ -1,0 +1,332 @@
+import { AgentCompletionCardBuilderService } from '@api/services/agent-orchestrator/agent-completion-card-builder.service';
+import { AgentToolName, type AgentUiAction } from '@genfeedai/interfaces';
+
+describe('AgentCompletionCardBuilderService', () => {
+  const service = new AgentCompletionCardBuilderService();
+
+  it('builds a workflow completion card with the existing CTA and suggestion priority', () => {
+    const workflowAction: AgentUiAction = {
+      ctas: [
+        { href: '/automations/editor/workflow-1', label: 'Open workflow' },
+      ],
+      id: 'workflow-created-1',
+      scheduleSummary: 'Every weekday at 17:00',
+      title: 'Automation installed',
+      type: 'workflow_created_card',
+      workflowId: 'workflow-1',
+      workflowName: 'LinkedIn launch',
+    };
+
+    const result = service.buildAssistantUiActions({
+      reviewRequired: false,
+      toolCalls: [
+        { status: 'completed', toolName: AgentToolName.CREATE_WORKFLOW },
+      ],
+      uiActions: [workflowAction],
+    });
+
+    expect(result.suggestedActions).toEqual([
+      {
+        id: 'workflow-tune',
+        label: 'Tune this workflow',
+        prompt:
+          'Show me how to customize this automation for my brand and goals',
+      },
+      {
+        id: 'workflow-channel',
+        label: 'Add another channel',
+        prompt:
+          'Create a second automation for another channel using this workflow as the base',
+      },
+      {
+        id: 'workflow-schedule',
+        label: 'Review schedule',
+        prompt:
+          'Review the schedule for this automation and suggest the best posting windows',
+      },
+    ]);
+    expect(result.uiActions).toEqual([
+      {
+        id: 'completion-summary-workflow-created-1',
+        outcomeBullets: [
+          'Automation ready to edit and run',
+          'Workflow: LinkedIn launch',
+          'Every weekday at 17:00',
+        ],
+        primaryCta: {
+          href: '/automations/editor/workflow-1',
+          label: 'Use in Workflow',
+        },
+        secondaryCtas: [
+          {
+            action: 'send_prompt',
+            label: 'Tune this workflow',
+            payload: {
+              prompt:
+                'Show me how to customize this automation for my brand and goals',
+            },
+          },
+          {
+            action: 'send_prompt',
+            label: 'Add another channel',
+            payload: {
+              prompt:
+                'Create a second automation for another channel using this workflow as the base',
+            },
+          },
+          {
+            action: 'send_prompt',
+            label: 'Review schedule',
+            payload: {
+              prompt:
+                'Review the schedule for this automation and suggest the best posting windows',
+            },
+          },
+        ],
+        status: 'completed',
+        summaryText: 'Created a recurring automation for this request.',
+        title: 'Done',
+        type: 'completion_summary_card',
+      },
+      workflowAction,
+    ]);
+  });
+
+  it('preserves content counts, output order, the four-variant cap, and the review CTA label', () => {
+    const contentAction: AgentUiAction = {
+      audio: ['https://cdn.example.com/audio.mp3'],
+      ctas: [{ href: '/posts/drafts', label: 'View all drafts' }],
+      id: 'content-preview-1',
+      images: [
+        'https://cdn.example.com/image-1.png',
+        'https://cdn.example.com/image-2.png',
+      ],
+      ingredients: [
+        {
+          id: 'ingredient-1',
+          title: 'Ingredient image',
+          type: 'image',
+          url: 'https://cdn.example.com/ingredient.png',
+        },
+      ],
+      textContent: 'Long-form caption',
+      title: 'Generated drafts',
+      tweets: ['Hook one', 'Hook two'],
+      type: 'content_preview_card',
+      videos: ['https://cdn.example.com/video.mp4'],
+    };
+
+    const result = service.buildAssistantUiActions({
+      reviewRequired: false,
+      toolCalls: [
+        { status: 'completed', toolName: AgentToolName.GENERATE_CONTENT },
+      ],
+      uiActions: [contentAction],
+    });
+
+    expect(result.uiActions[0]).toEqual(
+      expect.objectContaining({
+        outcomeBullets: [
+          '3 text variants',
+          '3 image assets',
+          '1 video asset',
+          '1 audio asset',
+        ],
+        outputVariants: [
+          {
+            id: 'content-preview-1:image:0',
+            kind: 'image',
+            title: 'Generated drafts',
+            url: 'https://cdn.example.com/image-1.png',
+          },
+          {
+            id: 'content-preview-1:image:1',
+            kind: 'image',
+            title: 'Generated drafts',
+            url: 'https://cdn.example.com/image-2.png',
+          },
+          {
+            id: 'content-preview-1:video:0',
+            kind: 'video',
+            title: 'Generated drafts',
+            url: 'https://cdn.example.com/video.mp4',
+          },
+          {
+            id: 'content-preview-1:audio:0',
+            kind: 'audio',
+            title: 'Generated drafts',
+            url: 'https://cdn.example.com/audio.mp3',
+          },
+        ],
+        primaryCta: {
+          href: '/posts/drafts',
+          label: 'Review Draft',
+        },
+        summaryText: 'Generated content for this request.',
+        type: 'completion_summary_card',
+      }),
+    );
+  });
+
+  it('uses the ready-for-review fallback when a content action has no assets', () => {
+    const result = service.buildAssistantUiActions({
+      reviewRequired: false,
+      toolCalls: [],
+      uiActions: [
+        {
+          id: 'empty-content-preview',
+          title: 'Draft',
+          type: 'content_preview_card',
+        },
+      ],
+    });
+
+    expect(result.uiActions[0]).toMatchObject({
+      outcomeBullets: ['Ready for review'],
+      outputVariants: [],
+      type: 'completion_summary_card',
+    });
+  });
+
+  it('builds the generic completed-tool card and formats tool names', () => {
+    const result = service.buildAssistantUiActions({
+      reviewRequired: false,
+      toolCalls: [
+        { status: 'completed', toolName: AgentToolName.CREATE_POST },
+        { status: 'failed', toolName: AgentToolName.SCHEDULE_POST },
+      ],
+      uiActions: [],
+    });
+
+    expect(result.uiActions).toEqual([
+      {
+        id: `completion-summary-tools-${AgentToolName.CREATE_POST}`,
+        outcomeBullets: ['1 tool action completed', 'Tool: Create Post'],
+        secondaryCtas: [
+          {
+            action: 'send_prompt',
+            label: 'Create follow-ups',
+            payload: {
+              prompt: 'Create two follow-up posts that build on this result',
+            },
+          },
+          {
+            action: 'send_prompt',
+            label: 'Map the next slot',
+            payload: {
+              prompt:
+                'Find the best next slot in my calendar for related content',
+            },
+          },
+          {
+            action: 'send_prompt',
+            label: 'Cross-post versions',
+            payload: {
+              prompt: 'Adapt this into versions for my other active channels',
+            },
+          },
+        ],
+        status: 'completed',
+        summaryText: 'Completed this request successfully.',
+        title: 'Done',
+        type: 'completion_summary_card',
+      },
+    ]);
+  });
+
+  it('does not add a generic card for failed tools or when another UI action exists', () => {
+    const existingAction: AgentUiAction = {
+      id: 'credits-1',
+      title: 'Credits',
+      type: 'credits_balance_card',
+    };
+
+    expect(
+      service.buildAssistantUiActions({
+        reviewRequired: false,
+        toolCalls: [{ status: 'failed', toolName: AgentToolName.CREATE_POST }],
+        uiActions: [],
+      }).uiActions,
+    ).toEqual([]);
+    expect(
+      service.buildAssistantUiActions({
+        reviewRequired: false,
+        toolCalls: [
+          { status: 'completed', toolName: AgentToolName.GET_CREDITS_BALANCE },
+        ],
+        uiActions: [existingAction],
+      }).uiActions,
+    ).toEqual([existingAction]);
+  });
+
+  it('suppresses suggestions during review without suppressing the completion card', () => {
+    const result = service.buildAssistantUiActions({
+      reviewRequired: true,
+      toolCalls: [
+        { status: 'completed', toolName: AgentToolName.GENERATE_IMAGE },
+      ],
+      uiActions: [
+        {
+          id: 'content-preview-1',
+          images: ['https://cdn.example.com/image.png'],
+          title: 'Preview',
+          type: 'content_preview_card',
+        },
+      ],
+    });
+
+    expect(result.suggestedActions).toEqual([]);
+    expect(result.uiActions[0]).toMatchObject({
+      secondaryCtas: [],
+      type: 'completion_summary_card',
+    });
+  });
+
+  it('keeps workflow suggestions ahead of later matching domains and caps them at three', () => {
+    const result = service.buildAssistantUiActions({
+      reviewRequired: false,
+      toolCalls: [
+        { status: 'completed', toolName: AgentToolName.CREATE_WORKFLOW },
+        { status: 'completed', toolName: AgentToolName.GENERATE_IMAGE },
+        { status: 'completed', toolName: AgentToolName.GET_ANALYTICS },
+      ],
+      uiActions: [],
+    });
+
+    expect(result.suggestedActions.map((suggestion) => suggestion.id)).toEqual([
+      'workflow-tune',
+      'workflow-channel',
+      'workflow-schedule',
+    ]);
+  });
+
+  it.each([
+    {
+      expectedId: 'analytics-repeat',
+      toolName: AgentToolName.GET_ANALYTICS,
+    },
+    {
+      expectedId: 'publish-followup',
+      toolName: AgentToolName.CREATE_POST,
+    },
+    {
+      expectedId: 'review-ready',
+      toolName: AgentToolName.LIST_REVIEW_QUEUE,
+    },
+    {
+      expectedId: 'trends-batch',
+      toolName: AgentToolName.GET_TRENDS,
+    },
+  ])('preserves $expectedId as the first suggestion for $toolName', ({
+    expectedId,
+    toolName,
+  }) => {
+    const result = service.buildAssistantUiActions({
+      reviewRequired: false,
+      toolCalls: [{ status: 'completed', toolName }],
+      uiActions: [],
+    });
+
+    expect(result.suggestedActions[0]?.id).toBe(expectedId);
+  });
+});

--- a/apps/server/api/src/services/agent-orchestrator/agent-completion-card-builder.service.ts
+++ b/apps/server/api/src/services/agent-orchestrator/agent-completion-card-builder.service.ts
@@ -1,0 +1,508 @@
+import {
+  AgentToolName,
+  type AgentUiAction,
+  type AgentUiActionCta,
+} from '@genfeedai/interfaces';
+import { Injectable } from '@nestjs/common';
+
+export interface AgentCompletionSuggestedAction {
+  id: string;
+  label: string;
+  prompt: string;
+}
+
+export interface AgentCompletionToolCall {
+  status: 'completed' | 'failed';
+  toolName: string;
+}
+
+export interface BuildAssistantUiActionsParams {
+  reviewRequired: boolean;
+  toolCalls: AgentCompletionToolCall[];
+  uiActions: AgentUiAction[];
+}
+
+export interface BuildAssistantUiActionsResult {
+  suggestedActions: AgentCompletionSuggestedAction[];
+  uiActions: AgentUiAction[];
+}
+
+interface BuildCompletionSummaryCardParams {
+  suggestedActions: AgentCompletionSuggestedAction[];
+  toolCalls: AgentCompletionToolCall[];
+  uiActions: AgentUiAction[];
+}
+
+@Injectable()
+export class AgentCompletionCardBuilderService {
+  buildAssistantUiActions(
+    params: BuildAssistantUiActionsParams,
+  ): BuildAssistantUiActionsResult {
+    const suggestedActions = this.buildCompletionSuggestedActions(params);
+    const completionSummaryCard = this.buildCompletionSummaryCard({
+      suggestedActions,
+      toolCalls: params.toolCalls,
+      uiActions: params.uiActions,
+    });
+
+    return {
+      suggestedActions,
+      uiActions: completionSummaryCard
+        ? [completionSummaryCard, ...params.uiActions]
+        : params.uiActions,
+    };
+  }
+
+  private buildCompletionSecondaryCtas(
+    suggestedActions: AgentCompletionSuggestedAction[],
+  ): AgentUiActionCta[] {
+    return suggestedActions.slice(0, 3).map((suggestion) => ({
+      action: 'send_prompt',
+      label: suggestion.label,
+      payload: { prompt: suggestion.prompt },
+    }));
+  }
+
+  private buildCompletionPrimaryCta(
+    label: string,
+    cta?: AgentUiActionCta,
+  ): AgentUiActionCta | undefined {
+    if (!cta) {
+      return undefined;
+    }
+
+    return {
+      ...cta,
+      label,
+    };
+  }
+
+  private buildContentCompletionOutputVariants(
+    uiActions: AgentUiAction[],
+  ): NonNullable<AgentUiAction['outputVariants']> {
+    const variants: NonNullable<AgentUiAction['outputVariants']> = [];
+
+    uiActions.forEach((action) => {
+      action.images?.forEach((url, index) => {
+        if (!url) {
+          return;
+        }
+
+        variants.push({
+          id: `${action.id}:image:${index}`,
+          kind: 'image',
+          title: action.title,
+          url,
+        });
+      });
+
+      action.videos?.forEach((url, index) => {
+        if (!url) {
+          return;
+        }
+
+        variants.push({
+          id: `${action.id}:video:${index}`,
+          kind: 'video',
+          title: action.title,
+          url,
+        });
+      });
+
+      action.audio?.forEach((url, index) => {
+        if (!url) {
+          return;
+        }
+
+        variants.push({
+          id: `${action.id}:audio:${index}`,
+          kind: 'audio',
+          title: action.title,
+          url,
+        });
+      });
+
+      action.tweets?.forEach((tweet, index) => {
+        if (!tweet.trim()) {
+          return;
+        }
+
+        variants.push({
+          id: `${action.id}:tweet:${index}`,
+          kind: 'text',
+          textContent: tweet,
+          title: `Text ${index + 1}`,
+        });
+      });
+
+      if (action.textContent?.trim()) {
+        variants.push({
+          id: `${action.id}:text-content`,
+          kind: 'text',
+          textContent: action.textContent,
+          title: action.title,
+        });
+      }
+
+      action.ingredients?.forEach((ingredient, index) => {
+        if (!ingredient.url) {
+          return;
+        }
+
+        variants.push({
+          id: `${action.id}:ingredient:${index}`,
+          kind: ingredient.type === 'video' ? 'video' : 'image',
+          thumbnailUrl: ingredient.thumbnailUrl,
+          title: ingredient.title ?? action.title,
+          url: ingredient.url,
+        });
+      });
+    });
+
+    return variants.slice(0, 4);
+  }
+
+  private buildCompletionSummaryCard(
+    params: BuildCompletionSummaryCardParams,
+  ): AgentUiAction | null {
+    const workflowAction = params.uiActions.find(
+      (action) => action.type === 'workflow_created_card',
+    );
+
+    if (workflowAction) {
+      return {
+        id: `completion-summary-${workflowAction.id}`,
+        outcomeBullets: [
+          'Automation ready to edit and run',
+          workflowAction.workflowName
+            ? `Workflow: ${workflowAction.workflowName}`
+            : null,
+          workflowAction.scheduleSummary ?? null,
+        ].filter((bullet): bullet is string => Boolean(bullet)),
+        primaryCta: this.buildCompletionPrimaryCta(
+          'Use in Workflow',
+          workflowAction.ctas?.[0],
+        ) ?? {
+          href: workflowAction.workflowId
+            ? `/automations/editor/${workflowAction.workflowId}`
+            : '/automations/editor/',
+          label: 'Use in Workflow',
+        },
+        secondaryCtas: this.buildCompletionSecondaryCtas(
+          params.suggestedActions,
+        ),
+        status: 'completed',
+        summaryText: 'Created a recurring automation for this request.',
+        title: 'Done',
+        type: 'completion_summary_card',
+      };
+    }
+
+    const contentActions = params.uiActions.filter(
+      (action) =>
+        action.type === 'content_preview_card' ||
+        action.type === 'batch_generation_card' ||
+        action.type === 'batch_generation_result_card' ||
+        action.type === 'clip_run_card' ||
+        action.type === 'clip_workflow_run_card',
+    );
+
+    if (contentActions.length > 0) {
+      const textCount = contentActions.reduce(
+        (total, action) =>
+          total +
+          (action.tweets?.length ?? 0) +
+          (action.textContent?.trim().length ? 1 : 0),
+        0,
+      );
+      const imageCount = contentActions.reduce(
+        (total, action) =>
+          total +
+          (action.images?.length ?? 0) +
+          (action.ingredients?.filter(
+            (ingredient) => ingredient.type === 'image',
+          ).length ?? 0),
+        0,
+      );
+      const videoCount = contentActions.reduce(
+        (total, action) =>
+          total +
+          (action.videos?.length ?? 0) +
+          (action.ingredients?.filter(
+            (ingredient) => ingredient.type === 'video',
+          ).length ?? 0),
+        0,
+      );
+      const audioCount = contentActions.reduce(
+        (total, action) => total + (action.audio?.length ?? 0),
+        0,
+      );
+      const outcomeBullets = [
+        textCount > 0
+          ? `${textCount} text variant${textCount === 1 ? '' : 's'}`
+          : null,
+        imageCount > 0
+          ? `${imageCount} image asset${imageCount === 1 ? '' : 's'}`
+          : null,
+        videoCount > 0
+          ? `${videoCount} video asset${videoCount === 1 ? '' : 's'}`
+          : null,
+        audioCount > 0
+          ? `${audioCount} audio asset${audioCount === 1 ? '' : 's'}`
+          : null,
+      ].filter((bullet): bullet is string => Boolean(bullet));
+
+      return {
+        id: `completion-summary-${contentActions[0].id}`,
+        outcomeBullets:
+          outcomeBullets.length > 0 ? outcomeBullets : ['Ready for review'],
+        outputVariants:
+          this.buildContentCompletionOutputVariants(contentActions),
+        primaryCta: this.buildCompletionPrimaryCta(
+          'Review Draft',
+          contentActions.flatMap((action) => action.ctas ?? [])[0],
+        ),
+        secondaryCtas: this.buildCompletionSecondaryCtas(
+          params.suggestedActions,
+        ),
+        status: 'completed',
+        summaryText: 'Generated content for this request.',
+        title: 'Done',
+        type: 'completion_summary_card',
+      };
+    }
+
+    const hasCompletedTool = params.toolCalls.some(
+      (toolCall) => toolCall.status === 'completed',
+    );
+
+    if (!hasCompletedTool) {
+      return null;
+    }
+
+    if (params.uiActions.length > 0) {
+      return null;
+    }
+
+    const completedToolNames = params.toolCalls
+      .filter((toolCall) => toolCall.status === 'completed')
+      .map((toolCall) => toolCall.toolName)
+      .filter((toolName): toolName is string => typeof toolName === 'string');
+
+    const outcomeBullets = [
+      `${completedToolNames.length} tool action${completedToolNames.length === 1 ? '' : 's'} completed`,
+      ...completedToolNames
+        .slice(0, 3)
+        .map((toolName) => `Tool: ${this.formatCompletionToolName(toolName)}`),
+    ];
+
+    return {
+      id: `completion-summary-tools-${completedToolNames[0] ?? 'generic'}`,
+      outcomeBullets,
+      secondaryCtas: this.buildCompletionSecondaryCtas(params.suggestedActions),
+      status: 'completed',
+      summaryText: 'Completed this request successfully.',
+      title: 'Done',
+      type: 'completion_summary_card',
+    };
+  }
+
+  private formatCompletionToolName(toolName: string): string {
+    return toolName
+      .split('_')
+      .filter((segment) => segment.length > 0)
+      .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+      .join(' ');
+  }
+
+  private buildCompletionSuggestedActions(
+    params: BuildAssistantUiActionsParams,
+  ): AgentCompletionSuggestedAction[] {
+    if (params.reviewRequired) {
+      return [];
+    }
+
+    const completedToolNames = params.toolCalls
+      .filter((toolCall) => toolCall.status === 'completed')
+      .map((toolCall) => toolCall.toolName);
+
+    if (completedToolNames.length === 0 && params.uiActions.length === 0) {
+      return [];
+    }
+
+    const uiActionTypes = new Set(
+      params.uiActions.map((action) => action.type),
+    );
+    const suggestions: AgentCompletionSuggestedAction[] = [];
+    const seenPrompts = new Set<string>();
+
+    const addSuggestion = (id: string, label: string, prompt: string): void => {
+      if (seenPrompts.has(prompt) || suggestions.length >= 3) {
+        return;
+      }
+
+      seenPrompts.add(prompt);
+      suggestions.push({ id, label, prompt });
+    };
+
+    const hasCompletedTool = (...toolNames: string[]): boolean =>
+      completedToolNames.some((toolName) => toolNames.includes(toolName));
+
+    if (
+      uiActionTypes.has('workflow_created_card') ||
+      hasCompletedTool(
+        AgentToolName.CREATE_WORKFLOW,
+        'install_official_workflow',
+      )
+    ) {
+      addSuggestion(
+        'workflow-tune',
+        'Tune this workflow',
+        'Show me how to customize this automation for my brand and goals',
+      );
+      addSuggestion(
+        'workflow-channel',
+        'Add another channel',
+        'Create a second automation for another channel using this workflow as the base',
+      );
+      addSuggestion(
+        'workflow-schedule',
+        'Review schedule',
+        'Review the schedule for this automation and suggest the best posting windows',
+      );
+    }
+
+    if (
+      uiActionTypes.has('content_preview_card') ||
+      uiActionTypes.has('batch_generation_card') ||
+      uiActionTypes.has('batch_generation_result_card') ||
+      uiActionTypes.has('clip_run_card') ||
+      uiActionTypes.has('clip_workflow_run_card') ||
+      hasCompletedTool(
+        AgentToolName.GENERATE_CONTENT,
+        AgentToolName.GENERATE_CONTENT_BATCH,
+        AgentToolName.GENERATE_IMAGE,
+        AgentToolName.GENERATE_VIDEO,
+        AgentToolName.GENERATE_AS_IDENTITY,
+        AgentToolName.GENERATE_VOICE,
+      )
+    ) {
+      addSuggestion(
+        'content-variations',
+        'Make variations',
+        'Make three stronger variations of this result',
+      );
+      addSuggestion(
+        'content-publish',
+        'Turn this into a post',
+        'Turn this result into a publish-ready post with caption and CTA',
+      );
+      addSuggestion(
+        'content-analyze',
+        'Pressure-test it',
+        'Rate this result and tell me what to improve before I publish it',
+      );
+    }
+
+    if (
+      uiActionTypes.has('analytics_snapshot_card') ||
+      hasCompletedTool(
+        AgentToolName.GET_ANALYTICS,
+        AgentToolName.ANALYZE_PERFORMANCE,
+        'get_top_ingredients',
+        'rate_content',
+      )
+    ) {
+      addSuggestion(
+        'analytics-repeat',
+        'Find repeatable winners',
+        'Show me the strongest patterns here and what I should repeat next',
+      );
+      addSuggestion(
+        'analytics-remix',
+        'Create a remix',
+        'Take the best performer and give me a fresh remix to test next',
+      );
+      addSuggestion(
+        'analytics-schedule',
+        'Plan the next batch',
+        'Plan my next batch around the winners from this analysis',
+      );
+    }
+
+    if (
+      uiActionTypes.has('publish_post_card') ||
+      uiActionTypes.has('schedule_post_card') ||
+      uiActionTypes.has('content_calendar_card') ||
+      hasCompletedTool(AgentToolName.CREATE_POST, AgentToolName.SCHEDULE_POST)
+    ) {
+      addSuggestion(
+        'publish-followup',
+        'Create follow-ups',
+        'Create two follow-up posts that build on this result',
+      );
+      addSuggestion(
+        'publish-calendar',
+        'Map the next slot',
+        'Find the best next slot in my calendar for related content',
+      );
+      addSuggestion(
+        'publish-variants',
+        'Cross-post versions',
+        'Adapt this into versions for my other active channels',
+      );
+    }
+
+    if (
+      uiActionTypes.has('review_gate_card') ||
+      hasCompletedTool(
+        AgentToolName.LIST_REVIEW_QUEUE,
+        AgentToolName.BATCH_APPROVE_REJECT,
+        AgentToolName.GET_APPROVAL_SUMMARY,
+      )
+    ) {
+      addSuggestion(
+        'review-ready',
+        'Approve the ready ones',
+        'Show me the items that are safe to approve right now',
+      );
+      addSuggestion(
+        'review-fix',
+        'Fix the weak spots',
+        'Take the weakest review items and rewrite them so they are ready to publish',
+      );
+      addSuggestion(
+        'review-schedule',
+        'Queue approved content',
+        'Schedule the approved content into the best available slots',
+      );
+    }
+
+    if (
+      uiActionTypes.has('trending_topics_card') ||
+      hasCompletedTool(
+        AgentToolName.GET_TRENDS,
+        'list_ads_research',
+        'get_ad_research_detail',
+      )
+    ) {
+      addSuggestion(
+        'trends-batch',
+        'Turn this into content',
+        'Turn these trends into a batch of content ideas I can ship this week',
+      );
+      addSuggestion(
+        'trends-angle',
+        'Pick the best angle',
+        'Tell me which trend has the best upside for my brand and why',
+      );
+      addSuggestion(
+        'trends-automation',
+        'Automate this loop',
+        'Create an automation that checks this trend pattern and drafts follow-up content',
+      );
+    }
+
+    return suggestions;
+  }
+}

--- a/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.module.ts
+++ b/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.module.ts
@@ -30,6 +30,7 @@ import { AnalyticsModule } from '@api/endpoints/analytics/analytics.module';
 import { MarketplaceIntegrationModule } from '@api/marketplace-integration/marketplace-integration.module';
 import { AgentMessageBusModule } from '@api/services/agent-campaign/agent-message-bus.module';
 import { AgentContextAssemblyModule } from '@api/services/agent-context-assembly/agent-context-assembly.module';
+import { AgentCompletionCardBuilderService } from '@api/services/agent-orchestrator/agent-completion-card-builder.service';
 import { AgentOrchestratorController } from '@api/services/agent-orchestrator/agent-orchestrator.controller';
 import { AgentOrchestratorService } from '@api/services/agent-orchestrator/agent-orchestrator.service';
 import { AgentStreamPublisherModule } from '@api/services/agent-orchestrator/agent-stream-publisher.module';
@@ -94,6 +95,7 @@ import { forwardRef, Module } from '@nestjs/common';
     forwardRef(() => SkillRuntimeModule),
   ],
   providers: [
+    AgentCompletionCardBuilderService,
     AgentOrchestratorService,
     AgentRouteRewriteService,
     AgentToolExecutorService,

--- a/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.spec.ts
+++ b/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.spec.ts
@@ -9,6 +9,7 @@ import { OrganizationSettingsService } from '@api/collections/organization-setti
 import { OrganizationsService } from '@api/collections/organizations/services/organizations.service';
 import { SettingsService } from '@api/collections/settings/services/settings.service';
 import { AgentContextAssemblyService } from '@api/services/agent-context-assembly/agent-context-assembly.service';
+import { AgentCompletionCardBuilderService } from '@api/services/agent-orchestrator/agent-completion-card-builder.service';
 import { AgentOrchestratorService } from '@api/services/agent-orchestrator/agent-orchestrator.service';
 import { AgentStreamPublisherService } from '@api/services/agent-orchestrator/agent-stream-publisher.service';
 import { AGENT_ORCHESTRATOR_SYSTEM_PROMPT } from '@api/services/agent-orchestrator/constants/agent-orchestrator-system-prompt.constant';
@@ -276,6 +277,7 @@ describe('AgentOrchestratorService', () => {
             AgentContextAssemblyService,
             CreditsUtilsService,
             AgentToolExecutorService,
+            AgentCompletionCardBuilderService,
             OrganizationsService,
             OrganizationSettingsService,
             SettingsService,
@@ -296,6 +298,7 @@ describe('AgentOrchestratorService', () => {
             contextAssemblySvc: AgentContextAssemblyService,
             creditsUtilsSvc: CreditsUtilsService,
             toolExecutorSvc: AgentToolExecutorService,
+            completionCardBuilderSvc: AgentCompletionCardBuilderService,
             organizationsSvc: OrganizationsService,
             organizationSettingsSvc: OrganizationSettingsService,
             settingsSvc: SettingsService,
@@ -315,6 +318,7 @@ describe('AgentOrchestratorService', () => {
               contextAssemblySvc,
               creditsUtilsSvc,
               toolExecutorSvc,
+              completionCardBuilderSvc,
               organizationsSvc,
               organizationSettingsSvc,
               settingsSvc,
@@ -368,6 +372,7 @@ describe('AgentOrchestratorService', () => {
           provide: AgentToolExecutorService,
           useValue: toolExecutorServiceMock,
         },
+        AgentCompletionCardBuilderService,
         {
           provide: OrganizationsService,
           useValue: organizationsServiceMock,

--- a/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.ts
+++ b/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.ts
@@ -23,6 +23,7 @@ import {
 import { isEntityId } from '@api/helpers/validation/entity-id.validator';
 import { AgentMessageBusService } from '@api/services/agent-campaign/agent-message-bus.service';
 import { AgentContextAssemblyService } from '@api/services/agent-context-assembly/agent-context-assembly.service';
+import { AgentCompletionCardBuilderService } from '@api/services/agent-orchestrator/agent-completion-card-builder.service';
 import { AgentStreamPublisherService } from '@api/services/agent-orchestrator/agent-stream-publisher.service';
 import {
   AGENT_CREDIT_COSTS,
@@ -76,7 +77,6 @@ import {
   type AgentUIBlock,
   type AgentUIBlocksEvent,
   type AgentUiAction,
-  type AgentUiActionCta,
 } from '@genfeedai/interfaces';
 import type { ResolvedRuntimeSkill } from '@genfeedai/interfaces/ai';
 import { TIMEZONES } from '@helpers/formatting/timezone/timezone.helper';
@@ -126,12 +126,6 @@ type AgentRoutingPolicyReason =
 interface AgentRoutingPolicy {
   plugins?: OpenRouterPlugin[];
   reason: AgentRoutingPolicyReason;
-}
-
-interface AgentCompletionSuggestedAction {
-  id: string;
-  label: string;
-  prompt: string;
 }
 
 interface ThreadResolutionResult {
@@ -360,6 +354,7 @@ export class AgentOrchestratorService {
     private readonly contextAssemblyService: AgentContextAssemblyService,
     private readonly creditsUtilsService: CreditsUtilsService,
     private readonly toolExecutorService: AgentToolExecutorService,
+    private readonly completionCardBuilder: AgentCompletionCardBuilderService,
     private readonly organizationsService: OrganizationsService,
     private readonly organizationSettingsService: OrganizationSettingsService,
     private readonly settingsService: SettingsService,
@@ -800,11 +795,12 @@ export class AgentOrchestratorService {
           const memoryInfluence =
             this.buildMemoryInfluenceMetadata(resolvedMemories);
           const reasoning = assistantMessage.reasoning_content ?? null;
-          const enhancedUiActions = this.buildAssistantUiActions({
-            reviewRequired,
-            toolCalls: allToolCalls,
-            uiActions: allUiActions,
-          });
+          const enhancedUiActions =
+            this.completionCardBuilder.buildAssistantUiActions({
+              reviewRequired,
+              toolCalls: allToolCalls,
+              uiActions: allUiActions,
+            });
           const assistantMetadata = {
             ...this.buildRoutingMetadata({
               model,
@@ -1628,11 +1624,12 @@ export class AgentOrchestratorService {
             }),
           );
 
-          const enhancedUiActions = this.buildAssistantUiActions({
-            reviewRequired,
-            toolCalls: allToolCalls,
-            uiActions: allUiActions,
-          });
+          const enhancedUiActions =
+            this.completionCardBuilder.buildAssistantUiActions({
+              reviewRequired,
+              toolCalls: allToolCalls,
+              uiActions: allUiActions,
+            });
 
           // Save assistant message to DB
           await this.agentMessagesService.addMessage({
@@ -2896,11 +2893,12 @@ export class AgentOrchestratorService {
       await this.creditsUtilsService.getOrganizationCreditsBalance(
         params.context.organizationId,
       );
-    const enhancedUiActions = this.buildAssistantUiActions({
-      reviewRequired: result.requiresConfirmation ?? false,
-      toolCalls: [{ status: summary.status, toolName }],
-      uiActions: result.nextActions ?? [],
-    });
+    const enhancedUiActions =
+      this.completionCardBuilder.buildAssistantUiActions({
+        reviewRequired: result.requiresConfirmation ?? false,
+        toolCalls: [{ status: summary.status, toolName }],
+        uiActions: result.nextActions ?? [],
+      });
     const assistantMetadata = {
       creditsRemaining,
       ...this.buildResolvedModelMetadata(params.model),
@@ -3137,16 +3135,17 @@ export class AgentOrchestratorService {
       creditsUsed: result.success ? (result.creditsUsed ?? 0) : 0,
       metadata: result.success
         ? (() => {
-            const enhancedUiActions = this.buildAssistantUiActions({
-              reviewRequired: result.requiresConfirmation ?? false,
-              toolCalls: [
-                {
-                  status: 'completed',
-                  toolName: AgentToolName.CREATE_WORKFLOW,
-                },
-              ],
-              uiActions: result.nextActions ?? [],
-            });
+            const enhancedUiActions =
+              this.completionCardBuilder.buildAssistantUiActions({
+                reviewRequired: result.requiresConfirmation ?? false,
+                toolCalls: [
+                  {
+                    status: 'completed',
+                    toolName: AgentToolName.CREATE_WORKFLOW,
+                  },
+                ],
+                uiActions: result.nextActions ?? [],
+              });
 
             return {
               ...this.buildResolvedModelMetadata(params.model),
@@ -5728,11 +5727,12 @@ export class AgentOrchestratorService {
     }
 
     const uiActions = params.result.nextActions ?? [];
-    const enhancedUiActions = this.buildAssistantUiActions({
-      reviewRequired: params.result.requiresConfirmation ?? false,
-      toolCalls: params.toolCalls,
-      uiActions,
-    });
+    const enhancedUiActions =
+      this.completionCardBuilder.buildAssistantUiActions({
+        reviewRequired: params.result.requiresConfirmation ?? false,
+        toolCalls: params.toolCalls,
+        uiActions,
+      });
     const normalizedContent = this.normalizeFinalAssistantContent(
       sanitizeAgentOutputText(params.content),
       params.toolCalls,
@@ -6049,511 +6049,6 @@ export class AgentOrchestratorService {
       model: actualModel,
       requestedModel,
     };
-  }
-
-  private buildCompletionSecondaryCtas(
-    suggestedActions: AgentCompletionSuggestedAction[],
-  ): Array<{
-    action: string;
-    label: string;
-    payload: Record<string, unknown>;
-  }> {
-    return suggestedActions.slice(0, 3).map((suggestion) => ({
-      action: 'send_prompt',
-      label: suggestion.label,
-      payload: { prompt: suggestion.prompt },
-    }));
-  }
-
-  private buildCompletionPrimaryCta(
-    label: string,
-    cta?: AgentUiActionCta,
-  ):
-    | {
-        action?: string;
-        href?: string;
-        label: string;
-        payload?: Record<string, unknown>;
-      }
-    | undefined {
-    if (!cta) {
-      return undefined;
-    }
-
-    return {
-      ...cta,
-      label,
-    };
-  }
-
-  private buildContentCompletionOutputVariants(
-    uiActions: AgentUiAction[],
-  ): Array<{
-    id: string;
-    kind: 'audio' | 'image' | 'text' | 'video';
-    textContent?: string;
-    thumbnailUrl?: string;
-    title?: string;
-    url?: string;
-  }> {
-    const variants: Array<{
-      id: string;
-      kind: 'audio' | 'image' | 'text' | 'video';
-      textContent?: string;
-      thumbnailUrl?: string;
-      title?: string;
-      url?: string;
-    }> = [];
-
-    uiActions.forEach((action) => {
-      action.images?.forEach((url, index) => {
-        if (!url) {
-          return;
-        }
-
-        variants.push({
-          id: `${action.id}:image:${index}`,
-          kind: 'image',
-          title: action.title,
-          url,
-        });
-      });
-
-      action.videos?.forEach((url, index) => {
-        if (!url) {
-          return;
-        }
-
-        variants.push({
-          id: `${action.id}:video:${index}`,
-          kind: 'video',
-          title: action.title,
-          url,
-        });
-      });
-
-      action.audio?.forEach((url, index) => {
-        if (!url) {
-          return;
-        }
-
-        variants.push({
-          id: `${action.id}:audio:${index}`,
-          kind: 'audio',
-          title: action.title,
-          url,
-        });
-      });
-
-      action.tweets?.forEach((tweet, index) => {
-        if (!tweet.trim()) {
-          return;
-        }
-
-        variants.push({
-          id: `${action.id}:tweet:${index}`,
-          kind: 'text',
-          textContent: tweet,
-          title: `Text ${index + 1}`,
-        });
-      });
-
-      if (action.textContent?.trim()) {
-        variants.push({
-          id: `${action.id}:text-content`,
-          kind: 'text',
-          textContent: action.textContent,
-          title: action.title,
-        });
-      }
-
-      action.ingredients?.forEach((ingredient, index) => {
-        if (!ingredient.url) {
-          return;
-        }
-
-        variants.push({
-          id: `${action.id}:ingredient:${index}`,
-          kind: ingredient.type === 'video' ? 'video' : 'image',
-          thumbnailUrl: ingredient.thumbnailUrl,
-          title: ingredient.title ?? action.title,
-          url: ingredient.url,
-        });
-      });
-    });
-
-    return variants.slice(0, 4);
-  }
-
-  private buildCompletionSummaryCard(params: {
-    suggestedActions: AgentCompletionSuggestedAction[];
-    toolCalls: Array<Pick<ToolCallSummary, 'status' | 'toolName'>>;
-    uiActions: AgentUiAction[];
-  }): AgentUiAction | null {
-    const workflowAction = params.uiActions.find(
-      (action) => action.type === 'workflow_created_card',
-    );
-
-    if (workflowAction) {
-      return {
-        id: `completion-summary-${workflowAction.id}`,
-        outcomeBullets: [
-          'Automation ready to edit and run',
-          workflowAction.workflowName
-            ? `Workflow: ${workflowAction.workflowName}`
-            : null,
-          workflowAction.scheduleSummary ?? null,
-        ].filter((bullet): bullet is string => Boolean(bullet)),
-        primaryCta: this.buildCompletionPrimaryCta(
-          'Use in Workflow',
-          workflowAction.ctas?.[0],
-        ) ?? {
-          href: workflowAction.workflowId
-            ? `/automations/editor/${workflowAction.workflowId}`
-            : '/automations/editor/',
-          label: 'Use in Workflow',
-        },
-        secondaryCtas: this.buildCompletionSecondaryCtas(
-          params.suggestedActions,
-        ),
-        status: 'completed',
-        summaryText: 'Created a recurring automation for this request.',
-        title: 'Done',
-        type: 'completion_summary_card',
-      } as AgentUiAction;
-    }
-
-    const contentActions = params.uiActions.filter(
-      (action) =>
-        action.type === 'content_preview_card' ||
-        action.type === 'batch_generation_card' ||
-        action.type === 'batch_generation_result_card' ||
-        action.type === 'clip_run_card' ||
-        action.type === 'clip_workflow_run_card',
-    );
-
-    if (contentActions.length > 0) {
-      const textCount = contentActions.reduce(
-        (total, action) =>
-          total +
-          (action.tweets?.length ?? 0) +
-          (action.textContent?.trim().length ? 1 : 0),
-        0,
-      );
-      const imageCount = contentActions.reduce(
-        (total, action) =>
-          total +
-          (action.images?.length ?? 0) +
-          (action.ingredients?.filter(
-            (ingredient) => ingredient.type === 'image',
-          ).length ?? 0),
-        0,
-      );
-      const videoCount = contentActions.reduce(
-        (total, action) =>
-          total +
-          (action.videos?.length ?? 0) +
-          (action.ingredients?.filter(
-            (ingredient) => ingredient.type === 'video',
-          ).length ?? 0),
-        0,
-      );
-      const audioCount = contentActions.reduce(
-        (total, action) => total + (action.audio?.length ?? 0),
-        0,
-      );
-      const outcomeBullets = [
-        textCount > 0
-          ? `${textCount} text variant${textCount === 1 ? '' : 's'}`
-          : null,
-        imageCount > 0
-          ? `${imageCount} image asset${imageCount === 1 ? '' : 's'}`
-          : null,
-        videoCount > 0
-          ? `${videoCount} video asset${videoCount === 1 ? '' : 's'}`
-          : null,
-        audioCount > 0
-          ? `${audioCount} audio asset${audioCount === 1 ? '' : 's'}`
-          : null,
-      ].filter((bullet): bullet is string => Boolean(bullet));
-
-      return {
-        id: `completion-summary-${contentActions[0].id}`,
-        outcomeBullets:
-          outcomeBullets.length > 0 ? outcomeBullets : ['Ready for review'],
-        outputVariants:
-          this.buildContentCompletionOutputVariants(contentActions),
-        primaryCta: this.buildCompletionPrimaryCta(
-          'Review Draft',
-          contentActions.flatMap((action) => action.ctas ?? [])[0],
-        ),
-        secondaryCtas: this.buildCompletionSecondaryCtas(
-          params.suggestedActions,
-        ),
-        status: 'completed',
-        summaryText: 'Generated content for this request.',
-        title: 'Done',
-        type: 'completion_summary_card',
-      } as AgentUiAction;
-    }
-
-    const hasCompletedTool = params.toolCalls.some(
-      (toolCall) => toolCall.status === 'completed',
-    );
-
-    if (!hasCompletedTool) {
-      return null;
-    }
-
-    if (params.uiActions.length > 0) {
-      return null;
-    }
-
-    const completedToolNames = params.toolCalls
-      .filter((toolCall) => toolCall.status === 'completed')
-      .map((toolCall) => toolCall.toolName)
-      .filter((toolName): toolName is string => typeof toolName === 'string');
-
-    const outcomeBullets = [
-      `${completedToolNames.length} tool action${completedToolNames.length === 1 ? '' : 's'} completed`,
-      ...completedToolNames
-        .slice(0, 3)
-        .map((toolName) => `Tool: ${this.formatCompletionToolName(toolName)}`),
-    ];
-
-    return {
-      id: `completion-summary-tools-${completedToolNames[0] ?? 'generic'}`,
-      outcomeBullets,
-      secondaryCtas: this.buildCompletionSecondaryCtas(params.suggestedActions),
-      status: 'completed',
-      summaryText: 'Completed this request successfully.',
-      title: 'Done',
-      type: 'completion_summary_card',
-    } as AgentUiAction;
-  }
-
-  private formatCompletionToolName(toolName: string): string {
-    return toolName
-      .split('_')
-      .filter((segment) => segment.length > 0)
-      .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
-      .join(' ');
-  }
-
-  private buildAssistantUiActions(params: {
-    reviewRequired: boolean;
-    toolCalls: Array<Pick<ToolCallSummary, 'status' | 'toolName'>>;
-    uiActions: AgentUiAction[];
-  }): {
-    suggestedActions: AgentCompletionSuggestedAction[];
-    uiActions: AgentUiAction[];
-  } {
-    const suggestedActions = this.buildCompletionSuggestedActions(params);
-    const completionSummaryCard = this.buildCompletionSummaryCard({
-      suggestedActions,
-      toolCalls: params.toolCalls,
-      uiActions: params.uiActions,
-    });
-
-    return {
-      suggestedActions,
-      uiActions: completionSummaryCard
-        ? [completionSummaryCard, ...params.uiActions]
-        : params.uiActions,
-    };
-  }
-
-  private buildCompletionSuggestedActions(params: {
-    reviewRequired: boolean;
-    toolCalls: Array<Pick<ToolCallSummary, 'status' | 'toolName'>>;
-    uiActions: AgentUiAction[];
-  }): AgentCompletionSuggestedAction[] {
-    if (params.reviewRequired) {
-      return [];
-    }
-
-    const completedToolNames = params.toolCalls
-      .filter((toolCall) => toolCall.status === 'completed')
-      .map((toolCall) => toolCall.toolName);
-
-    if (completedToolNames.length === 0 && params.uiActions.length === 0) {
-      return [];
-    }
-
-    const uiActionTypes = new Set(
-      params.uiActions.map((action) => action.type),
-    );
-    const suggestions: AgentCompletionSuggestedAction[] = [];
-    const seenPrompts = new Set<string>();
-
-    const addSuggestion = (id: string, label: string, prompt: string): void => {
-      if (seenPrompts.has(prompt) || suggestions.length >= 3) {
-        return;
-      }
-
-      seenPrompts.add(prompt);
-      suggestions.push({ id, label, prompt });
-    };
-
-    const hasCompletedTool = (...toolNames: string[]): boolean =>
-      completedToolNames.some((toolName) => toolNames.includes(toolName));
-
-    if (
-      uiActionTypes.has('workflow_created_card') ||
-      hasCompletedTool(
-        AgentToolName.CREATE_WORKFLOW,
-        'install_official_workflow',
-      )
-    ) {
-      addSuggestion(
-        'workflow-tune',
-        'Tune this workflow',
-        'Show me how to customize this automation for my brand and goals',
-      );
-      addSuggestion(
-        'workflow-channel',
-        'Add another channel',
-        'Create a second automation for another channel using this workflow as the base',
-      );
-      addSuggestion(
-        'workflow-schedule',
-        'Review schedule',
-        'Review the schedule for this automation and suggest the best posting windows',
-      );
-    }
-
-    if (
-      uiActionTypes.has('content_preview_card') ||
-      uiActionTypes.has('batch_generation_card') ||
-      uiActionTypes.has('batch_generation_result_card') ||
-      uiActionTypes.has('clip_run_card') ||
-      uiActionTypes.has('clip_workflow_run_card') ||
-      hasCompletedTool(
-        AgentToolName.GENERATE_CONTENT,
-        AgentToolName.GENERATE_CONTENT_BATCH,
-        AgentToolName.GENERATE_IMAGE,
-        AgentToolName.GENERATE_VIDEO,
-        AgentToolName.GENERATE_AS_IDENTITY,
-        AgentToolName.GENERATE_VOICE,
-      )
-    ) {
-      addSuggestion(
-        'content-variations',
-        'Make variations',
-        'Make three stronger variations of this result',
-      );
-      addSuggestion(
-        'content-publish',
-        'Turn this into a post',
-        'Turn this result into a publish-ready post with caption and CTA',
-      );
-      addSuggestion(
-        'content-analyze',
-        'Pressure-test it',
-        'Rate this result and tell me what to improve before I publish it',
-      );
-    }
-
-    if (
-      uiActionTypes.has('analytics_snapshot_card') ||
-      hasCompletedTool(
-        AgentToolName.GET_ANALYTICS,
-        AgentToolName.ANALYZE_PERFORMANCE,
-        'get_top_ingredients',
-        'rate_content',
-      )
-    ) {
-      addSuggestion(
-        'analytics-repeat',
-        'Find repeatable winners',
-        'Show me the strongest patterns here and what I should repeat next',
-      );
-      addSuggestion(
-        'analytics-remix',
-        'Create a remix',
-        'Take the best performer and give me a fresh remix to test next',
-      );
-      addSuggestion(
-        'analytics-schedule',
-        'Plan the next batch',
-        'Plan my next batch around the winners from this analysis',
-      );
-    }
-
-    if (
-      uiActionTypes.has('publish_post_card') ||
-      uiActionTypes.has('schedule_post_card') ||
-      uiActionTypes.has('content_calendar_card') ||
-      hasCompletedTool(AgentToolName.CREATE_POST, AgentToolName.SCHEDULE_POST)
-    ) {
-      addSuggestion(
-        'publish-followup',
-        'Create follow-ups',
-        'Create two follow-up posts that build on this result',
-      );
-      addSuggestion(
-        'publish-calendar',
-        'Map the next slot',
-        'Find the best next slot in my calendar for related content',
-      );
-      addSuggestion(
-        'publish-variants',
-        'Cross-post versions',
-        'Adapt this into versions for my other active channels',
-      );
-    }
-
-    if (
-      uiActionTypes.has('review_gate_card') ||
-      hasCompletedTool(
-        AgentToolName.LIST_REVIEW_QUEUE,
-        AgentToolName.BATCH_APPROVE_REJECT,
-        AgentToolName.GET_APPROVAL_SUMMARY,
-      )
-    ) {
-      addSuggestion(
-        'review-ready',
-        'Approve the ready ones',
-        'Show me the items that are safe to approve right now',
-      );
-      addSuggestion(
-        'review-fix',
-        'Fix the weak spots',
-        'Take the weakest review items and rewrite them so they are ready to publish',
-      );
-      addSuggestion(
-        'review-schedule',
-        'Queue approved content',
-        'Schedule the approved content into the best available slots',
-      );
-    }
-
-    if (
-      uiActionTypes.has('trending_topics_card') ||
-      hasCompletedTool(
-        AgentToolName.GET_TRENDS,
-        'list_ads_research',
-        'get_ad_research_detail',
-      )
-    ) {
-      addSuggestion(
-        'trends-batch',
-        'Turn this into content',
-        'Turn these trends into a batch of content ideas I can ship this week',
-      );
-      addSuggestion(
-        'trends-angle',
-        'Pick the best angle',
-        'Tell me which trend has the best upside for my brand and why',
-      );
-      addSuggestion(
-        'trends-automation',
-        'Automate this loop',
-        'Create an automation that checks this trend pattern and drafts follow-up content',
-      );
-    }
-
-    return suggestions;
   }
 
   private normalizeResponseModel(


### PR DESCRIPTION
## Summary

- extract completion summary cards and suggested-action assembly into a typed internal `AgentCompletionCardBuilderService`
- register the service through existing Nest DI and delegate all five sync/stream/UI-action call sites
- reduce `agent-orchestrator.service.ts` from 6,618 to 6,113 lines
- add direct characterization coverage for workflow, content, generic, review-gated, cap/order, and domain suggestion behavior

## Behavior preserved

- tool schemas and dispatch remain unchanged
- authorization and tenant scoping remain unchanged
- credit checks/deductions remain unchanged
- thread and stream event publication remain unchanged
- card payloads, fallback rules, output order/cap, suggestion order/cap, and summary prepend order remain unchanged

## Verification

- focused Biome checks passed for the new service/spec and DI wiring
- `git diff --check` passed
- pre-commit secretlint, staged Biome, and UI control guard passed
- independent QA found no code defects and verified the extraction mechanically
- focused Vitest could not start in this isolated worktree because installed `vitest`/`unplugin-swc` dependencies are absent; PR CI is the broad verification source of truth

Part of #520.
Related to #519.