### PR TITLE
Enrich brand headers and connected social profiles

### DIFF
--- a/.agents/memory/MEMORY.md
+++ b/.agents/memory/MEMORY.md
@@ -2,6 +2,8 @@
 
 ## Project State
 
+- [Brand and Social Visual Enrichment Spec](spec-brand-social-visual-enrichment.md) — S3-backed website headers and connected-account PFPs with platform badges
+- [Brand and Social Visual Enrichment Decisions](decisions-brand-social-visual-enrichment.md) — storage, overwrite, and failure-isolation decisions
 - [Project Overview](project_overview.md) — Genfeed.ai monorepo structure and key context
 - [One API Epic](project_one_api_epic.md) — Epic #95: consolidate self-hosted + cloud into one NestJS API, 20 issues, 8 phases
 - [Fallow Health](project_fallow.md) — Fallow codebase health analysis (#83), weekly CI, score 72/100

--- a/.agents/memory/decisions-brand-social-visual-enrichment.md
+++ b/.agents/memory/decisions-brand-social-visual-enrichment.md
@@ -1,0 +1,31 @@
+---
+name: Brand and social visual enrichment decisions
+description: Storage and overwrite-policy decisions for automatic brand headers and connected-account avatars.
+type: project
+status: active
+last_verified: 2026-07-10
+topics: [brands, oauth, assets, s3]
+---
+
+# Brand and Social Visual Enrichment Decisions
+
+**Why:** Website and provider image URLs are not a durable ownership boundary.
+**How to apply:** Use the existing files-service/S3 path for all automatic visual enrichment and never replace user-selected brand visuals implicitly.
+
+## Decision: own both image classes in S3
+
+Provider and website hotlinks are mutable, may expire, may block referrers, and leak client requests to third parties. Both brand headers and account PFPs are therefore copied through the files service into Genfeed-owned S3/CDN storage.
+
+## Decision: reuse existing import mechanisms
+
+Website headers use the existing guarded Brand Kit asset importer so they become normal brand assets with the same serializer and cache behavior as uploaded/generated banners. Social avatars use the same files-service upload boundary with a credential-scoped deterministic object key; they do not become library ingredients.
+
+## Decision: enrichment is additive
+
+Automatic enrichment fills missing brand visuals and refreshes the avatar for the same connected credential. It never replaces a user-selected brand banner or logo. OAuth success is independent from media-import success.
+
+## Rejected approaches
+
+- **Hotlink everything:** quickest, but unreliable and inconsistent with the brand asset model.
+- **S3 for headers only:** leaves the connected-account UI dependent on provider URL lifetimes.
+- **Create Asset rows for social PFPs:** adds library-visible assets and lifecycle complexity for what is credential metadata, not reusable creative media.

--- a/.agents/memory/spec-brand-social-visual-enrichment.md
+++ b/.agents/memory/spec-brand-social-visual-enrichment.md
@@ -1,0 +1,69 @@
+---
+name: Brand and social visual enrichment
+description: Automatically import website headers and connected-account avatars into stable Genfeed-owned media.
+type: project
+status: active
+last_verified: 2026-07-10
+topics: [brands, onboarding, oauth, assets, s3, ui]
+---
+
+# Brand and Social Visual Enrichment Spec
+
+**Why:** Brands and connected channels need stable, recognizable visuals without depending on mutable third-party hotlinks.
+**How to apply:** Import website headers and provider PFPs through Genfeed-owned storage, preserve manual brand assets, and keep media failures non-blocking.
+
+## Purpose
+
+Make a newly configured brand visually recognizable without manual asset work: a saved website supplies the brand header, while a connected social account supplies its profile photo and identity label.
+
+## Non-Goals
+
+- Replacing an existing user-uploaded brand logo or banner.
+- Making currently incomplete OAuth providers connectable.
+- Periodically refreshing remote images outside an explicit website scan or account reconnect.
+- Treating provider-hosted URLs as durable application state.
+
+## Interfaces
+
+- `POST /brands/:id/scrape` imports the discovered website banner candidate into a brand-owned `BANNER` asset when the brand has no banner.
+- Credential OAuth verification persists `externalName`, `externalHandle`, and an S3-backed `externalAvatar` when the provider exposes them.
+- `PATCH /credentials/:credentialId` accepts provider identity data for selection flows such as Instagram, but the server imports the submitted avatar URL before persistence.
+- Serialized credentials expose `externalName` and `externalAvatar` to trusted application clients.
+- Brand connected-account views render the profile photo with a small platform-icon badge and fall back to identity initials/platform icon.
+
+## Key Decisions
+
+- Remote images are copied into the existing files-service/S3 pipeline.
+- Website banner precedence remains hero/banner DOM image, then `og:image`, then `twitter:image`/first discovered image.
+- Automatic website enrichment uses `replaceExisting: false`.
+- Social avatar imports use a deterministic key per credential so reconnects refresh the object without accumulating rows.
+- Avatar import failures do not fail OAuth; the connected account remains usable with a fallback illustration.
+- External URL imports reject private-network destinations before the files service fetches them.
+
+## Edge Cases and Failure Modes
+
+- A website with no usable image still completes brand setup without a banner.
+- Unsupported image extensions or private URLs are skipped without overwriting existing assets.
+- An existing brand banner is preserved.
+- A provider with no avatar still persists its name and handle.
+- S3/files-service failure leaves the previous S3 avatar untouched and does not disconnect the account.
+- Missing or broken avatar images render deterministic initials and the platform badge.
+- Every credential read/update remains organization-scoped and soft-delete guarded.
+
+## Acceptance Criteria
+
+- WHEN a website scrape finds a valid banner candidate and the brand has no banner, THE SYSTEM SHALL import it as a brand-owned S3-backed banner asset.
+- WHEN a brand already has a banner, THE SYSTEM SHALL preserve it during automatic website enrichment.
+- WHEN a supported OAuth provider returns a profile photo, THE SYSTEM SHALL copy it to S3 and persist the copied URL as `externalAvatar`.
+- IF avatar import fails, THE SYSTEM SHALL keep the account connected and preserve any previous avatar.
+- WHEN credentials are serialized, THE SYSTEM SHALL expose `externalName` and `externalAvatar` without exposing credential secrets.
+- WHEN connected accounts are displayed, THE SYSTEM SHALL show a circular PFP or fallback with a platform-icon badge.
+- WHEN multiple accounts for the same platform are connected, THE SYSTEM SHALL render each credential independently.
+
+## Test Plan
+
+- Brand setup service tests for import, no candidate, existing-banner preservation, and non-blocking failure.
+- Credential service tests for S3 import, private URL rejection, previous-avatar preservation, and profile-only updates.
+- Provider callback tests for Twitter, TikTok, YouTube, Instagram selection, Facebook, LinkedIn, Reddit, and Threads profile mapping where fixtures already exist.
+- Serializer attribute tests for public identity fields and secret exclusion.
+- Brand social-card tests for PFP, fallback, platform badge, multiple accounts, and non-link rows.

--- a/apps/server/api/src/collections/brands/services/brand-persistence.service.spec.ts
+++ b/apps/server/api/src/collections/brands/services/brand-persistence.service.spec.ts
@@ -16,6 +16,7 @@ describe('BrandPersistenceService', () => {
   let brandsService: {
     findOne: ReturnType<typeof vi.fn>;
     generateUniqueSlug: ReturnType<typeof vi.fn>;
+    importBrandKitAssets: ReturnType<typeof vi.fn>;
     patch: ReturnType<typeof vi.fn>;
     selectBrandForUser: ReturnType<typeof vi.fn>;
   };
@@ -38,6 +39,7 @@ describe('BrandPersistenceService', () => {
     brandsService = {
       findOne: vi.fn(),
       generateUniqueSlug: vi.fn(),
+      importBrandKitAssets: vi.fn(),
       patch: vi.fn(),
       selectBrandForUser: vi.fn(),
     };
@@ -146,6 +148,94 @@ describe('BrandPersistenceService', () => {
         label: 'Website',
         url: 'https://acme.com',
       });
+    });
+  });
+
+  describe('importScrapedBrandBanner', () => {
+    it('imports the scraped banner through the guarded Brand Kit pipeline', async () => {
+      brandsService.importBrandKitAssets.mockResolvedValue({
+        diagnostics: [],
+        status: 'accepted',
+      });
+
+      await service.importScrapedBrandBanner('brand_1', 'org_1', 'user_1', {
+        bannerUrl: 'https://acme.com/hero.jpg',
+        ogImage: 'https://acme.com/og.jpg',
+        scrapedAt: new Date(),
+        sourceUrl: 'https://acme.com',
+      });
+
+      expect(brandsService.importBrandKitAssets).toHaveBeenCalledWith(
+        'brand_1',
+        'org_1',
+        'user_1',
+        {
+          assets: [
+            {
+              candidateId: 'website-banner:brand_1',
+              label: 'Website header',
+              replaceExisting: false,
+              role: 'banner',
+              sourceType: 'website',
+              sourceUrl: 'https://acme.com/hero.jpg',
+            },
+          ],
+        },
+      );
+    });
+
+    it('falls back to og:image when no banner candidate is present', async () => {
+      brandsService.importBrandKitAssets.mockResolvedValue({
+        diagnostics: [],
+        status: 'accepted',
+      });
+
+      await service.importScrapedBrandBanner('brand_1', 'org_1', 'user_1', {
+        ogImage: 'https://acme.com/og.jpg',
+        scrapedAt: new Date(),
+        sourceUrl: 'https://acme.com',
+      });
+
+      expect(brandsService.importBrandKitAssets).toHaveBeenCalledWith(
+        'brand_1',
+        'org_1',
+        'user_1',
+        expect.objectContaining({
+          assets: [
+            expect.objectContaining({
+              sourceUrl: 'https://acme.com/og.jpg',
+            }),
+          ],
+        }),
+      );
+    });
+
+    it('does not call the importer when the website has no header image', async () => {
+      await service.importScrapedBrandBanner('brand_1', 'org_1', 'user_1', {
+        scrapedAt: new Date(),
+        sourceUrl: 'https://acme.com',
+      });
+
+      expect(brandsService.importBrandKitAssets).not.toHaveBeenCalled();
+    });
+
+    it('keeps onboarding non-blocking when banner import fails', async () => {
+      brandsService.importBrandKitAssets.mockRejectedValue(
+        new Error('files unavailable'),
+      );
+
+      await expect(
+        service.importScrapedBrandBanner('brand_1', 'org_1', 'user_1', {
+          bannerUrl: 'https://acme.com/hero.jpg',
+          scrapedAt: new Date(),
+          sourceUrl: 'https://acme.com',
+        }),
+      ).resolves.toBeUndefined();
+
+      expect(loggerService.warn).toHaveBeenCalledWith(
+        'Website banner import failed',
+        expect.objectContaining({ brandId: 'brand_1' }),
+      );
     });
   });
 

--- a/apps/server/api/src/collections/brands/services/brand-persistence.service.ts
+++ b/apps/server/api/src/collections/brands/services/brand-persistence.service.ts
@@ -142,6 +142,57 @@ export class BrandPersistenceService {
     });
   }
 
+  /**
+   * Import the strongest website header candidate as a normal brand banner.
+   * The Brand Kit importer owns URL validation, S3 upload, asset creation, and
+   * the preserve-existing policy. Enrichment is deliberately best-effort so a
+   * media-service outage cannot block brand onboarding.
+   */
+  async importScrapedBrandBanner(
+    brandId: string,
+    organizationId: string,
+    userId: string,
+    scrapedData: IScrapedBrandData,
+  ): Promise<void> {
+    const bannerUrl = scrapedData.bannerUrl ?? scrapedData.ogImage;
+
+    if (!bannerUrl) {
+      return;
+    }
+
+    try {
+      const result = await this.brandsService.importBrandKitAssets(
+        brandId,
+        organizationId,
+        userId,
+        {
+          assets: [
+            {
+              candidateId: `website-banner:${brandId}`,
+              label: 'Website header',
+              replaceExisting: false,
+              role: 'banner',
+              sourceType: 'website',
+              sourceUrl: bannerUrl,
+            },
+          ],
+        },
+      );
+
+      if (result.status === 'blocked') {
+        this.loggerService.warn('Website banner import was skipped', {
+          brandId,
+          diagnostics: result.diagnostics,
+        });
+      }
+    } catch (error: unknown) {
+      this.loggerService.warn('Website banner import failed', {
+        brandId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
   async updateBrandGuidance(
     brandId: string,
     extractedData: IExtractedBrandData,

--- a/apps/server/api/src/collections/brands/services/brand-setup.service.ts
+++ b/apps/server/api/src/collections/brands/services/brand-setup.service.ts
@@ -283,6 +283,12 @@ export class BrandSetupService {
           targetBrandId,
           dto.brandUrl,
         );
+        await this.brandPersistenceService.importScrapedBrandBanner(
+          targetBrandId,
+          organizationId,
+          userId,
+          scrapedData,
+        );
         await this.brandPersistenceService.updateBrandGuidance(
           targetBrandId,
           extractedData,

--- a/apps/server/api/src/collections/credentials/controllers/credentials.controller.spec.ts
+++ b/apps/server/api/src/collections/credentials/controllers/credentials.controller.spec.ts
@@ -92,6 +92,7 @@ describe('CredentialsController', () => {
       findOne: vi.fn(),
       patch: vi.fn(),
       remove: vi.fn(),
+      updateExternalProfile: vi.fn(),
     };
     accountPublishingContextService = {
       resolve: vi.fn().mockResolvedValue({
@@ -424,6 +425,38 @@ describe('CredentialsController', () => {
           mockUser,
         ),
       ).rejects.toThrow(HttpException);
+    });
+
+    it('imports submitted provider avatars instead of persisting hotlinks', async () => {
+      credentialsService.findOne.mockResolvedValue({ id: credId });
+      credentialsService.updateExternalProfile.mockResolvedValue({
+        externalAvatar:
+          'https://cdn.genfeed.ai/ingredients/social-avatars/credential-1',
+        id: credId,
+      });
+
+      await controller.update(
+        mockRequest,
+        credId,
+        {
+          externalAvatar: 'https://instagram.example/avatar.jpg',
+          externalHandle: 'genfeed',
+          externalName: 'Genfeed',
+        } as never,
+        mockUser,
+      );
+
+      expect(credentialsService.patch).not.toHaveBeenCalled();
+      expect(credentialsService.updateExternalProfile).toHaveBeenCalledWith(
+        credId,
+        orgId,
+        {
+          avatarUrl: 'https://instagram.example/avatar.jpg',
+          handle: 'genfeed',
+          id: undefined,
+          name: 'Genfeed',
+        },
+      );
     });
   });
 

--- a/apps/server/api/src/collections/credentials/controllers/credentials.controller.ts
+++ b/apps/server/api/src/collections/credentials/controllers/credentials.controller.ts
@@ -3,7 +3,6 @@ import { BrandsService } from '@api/collections/brands/services/brands.service';
 import { AssessAccountHealthDto } from '@api/collections/credentials/dto/assess-account-health.dto';
 import { ManualAccountHealthOverrideDto } from '@api/collections/credentials/dto/manual-account-health-override.dto';
 import { UpdateCredentialDto } from '@api/collections/credentials/dto/update-credential.dto';
-import { CredentialEntity } from '@api/collections/credentials/entities/credential.entity';
 import { type CredentialDocument } from '@api/collections/credentials/schemas/credential.schema';
 import { AccountHealthService } from '@api/collections/credentials/services/account-health.service';
 import { AccountPublishingContextService } from '@api/collections/credentials/services/account-publishing-context.service';
@@ -496,8 +495,10 @@ export class CredentialsController {
       'accessTokenExpiry',
       'accessTokenSecret',
       'description',
+      'externalAvatar',
       'externalHandle',
       'externalId',
+      'externalName',
       'isConnected',
       'isDeleted',
       'label',
@@ -522,10 +523,35 @@ export class CredentialsController {
       }
     });
 
-    const data: CredentialDocument = await this.credentialsService.patch(
-      credential.id,
-      sanitizedUpdate as Partial<UpdateCredentialDto>,
-    );
+    const {
+      externalAvatar,
+      externalHandle,
+      externalId,
+      externalName,
+      ...credentialUpdate
+    } = sanitizedUpdate;
+
+    let data: CredentialDocument = credential;
+
+    if (Object.keys(credentialUpdate).length > 0) {
+      data = await this.credentialsService.patch(
+        credential.id,
+        credentialUpdate as Partial<UpdateCredentialDto>,
+      );
+    }
+
+    if (externalAvatar || externalHandle || externalId || externalName) {
+      data = await this.credentialsService.updateExternalProfile(
+        credential.id,
+        publicMetadata.organization,
+        {
+          avatarUrl: externalAvatar,
+          handle: externalHandle,
+          id: externalId,
+          name: externalName,
+        },
+      );
+    }
 
     return data
       ? serializeSingle(request, CredentialSerializer, data)

--- a/apps/server/api/src/collections/credentials/controllers/credentials.controller.ts
+++ b/apps/server/api/src/collections/credentials/controllers/credentials.controller.ts
@@ -540,16 +540,19 @@ export class CredentialsController {
       );
     }
 
-    if (externalAvatar || externalHandle || externalId || externalName) {
+    const externalProfile = {
+      avatarUrl:
+        typeof externalAvatar === 'string' ? externalAvatar : undefined,
+      handle: typeof externalHandle === 'string' ? externalHandle : undefined,
+      id: typeof externalId === 'string' ? externalId : undefined,
+      name: typeof externalName === 'string' ? externalName : undefined,
+    };
+
+    if (Object.values(externalProfile).some(Boolean)) {
       data = await this.credentialsService.updateExternalProfile(
         credential.id,
         publicMetadata.organization,
-        {
-          avatarUrl: externalAvatar,
-          handle: externalHandle,
-          id: externalId,
-          name: externalName,
-        },
+        externalProfile,
       );
     }
 

--- a/apps/server/api/src/collections/credentials/credentials-core.module.ts
+++ b/apps/server/api/src/collections/credentials/credentials-core.module.ts
@@ -2,7 +2,8 @@ import { AccountHealthService } from '@api/collections/credentials/services/acco
 import { AccountPublishingContextService } from '@api/collections/credentials/services/account-publishing-context.service';
 import { CredentialCryptoService } from '@api/collections/credentials/services/credential-crypto.service';
 import { CredentialsService } from '@api/collections/credentials/services/credentials.service';
-import { Module } from '@nestjs/common';
+import { FilesClientModule } from '@api/services/files-microservice/client/files-client.module';
+import { forwardRef, Module } from '@nestjs/common';
 
 @Module({
   exports: [
@@ -11,6 +12,7 @@ import { Module } from '@nestjs/common';
     CredentialCryptoService,
     CredentialsService,
   ],
+  imports: [forwardRef(() => FilesClientModule)],
   providers: [
     AccountHealthService,
     AccountPublishingContextService,

--- a/apps/server/api/src/collections/credentials/services/credentials.service.spec.ts
+++ b/apps/server/api/src/collections/credentials/services/credentials.service.spec.ts
@@ -23,6 +23,7 @@ describe('CredentialsService', () => {
   let crypto: CredentialCryptoService;
   let prisma: Record<string, Record<string, ReturnType<typeof vi.fn>>>;
   let logger: Record<string, ReturnType<typeof vi.fn>>;
+  let filesClient: { uploadToS3: ReturnType<typeof vi.fn> };
 
   const orgId = 'test-org-id';
   const brandId = 'test-brand-id';
@@ -50,8 +51,19 @@ describe('CredentialsService', () => {
     crypto = new CredentialCryptoService({
       tokenEncryptionKey: KEY,
     } as unknown as ConfigService);
+    filesClient = {
+      uploadToS3: vi.fn().mockResolvedValue({
+        publicUrl:
+          'https://cdn.genfeed.ai/ingredients/social-avatars/existing-id',
+      }),
+    };
 
-    service = new CredentialsService(prisma as never, logger as never, crypto);
+    service = new CredentialsService(
+      prisma as never,
+      logger as never,
+      crypto,
+      filesClient as never,
+    );
   });
 
   describe('countConnected', () => {
@@ -214,6 +226,72 @@ describe('CredentialsService', () => {
       >;
       expect(data.accessToken).toMatch(CIPHERTEXT_PATTERN);
       expect(crypto.decrypt(data.accessToken)).toBe('save-raw');
+    });
+  });
+
+  describe('updateExternalProfile', () => {
+    beforeEach(() => {
+      prisma.credential.findFirst.mockResolvedValue({ id: 'existing-id' });
+    });
+
+    it('uploads a provider avatar to S3 and persists public identity', async () => {
+      await service.updateExternalProfile('existing-id', orgId, {
+        avatarUrl: 'https://platform.example/avatar.jpg',
+        handle: 'acme',
+        id: 'provider-1',
+        name: 'Acme Studio',
+      });
+
+      expect(filesClient.uploadToS3).toHaveBeenCalledWith(
+        'existing-id',
+        'social-avatars',
+        {
+          type: 'url',
+          url: 'https://platform.example/avatar.jpg',
+        },
+      );
+      expect(prisma.credential.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            externalAvatar:
+              'https://cdn.genfeed.ai/ingredients/social-avatars/existing-id',
+            externalHandle: 'acme',
+            externalId: 'provider-1',
+            externalName: 'Acme Studio',
+          }),
+        }),
+      );
+    });
+
+    it('rejects private avatar URLs before the files service fetches them', async () => {
+      await service.updateExternalProfile('existing-id', orgId, {
+        avatarUrl: 'http://127.0.0.1/avatar.jpg',
+        handle: 'acme',
+      });
+
+      expect(filesClient.uploadToS3).not.toHaveBeenCalled();
+      expect(prisma.credential.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ externalHandle: 'acme' }),
+        }),
+      );
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Failed to import credential avatar',
+        expect.objectContaining({ credentialId: 'existing-id' }),
+      );
+    });
+
+    it('preserves the previous avatar when S3 import fails', async () => {
+      filesClient.uploadToS3.mockRejectedValue(new Error('files unavailable'));
+
+      await service.updateExternalProfile('existing-id', orgId, {
+        avatarUrl: 'https://platform.example/avatar.jpg',
+        name: 'Acme Studio',
+      });
+
+      const data = prisma.credential.update.mock.calls[0][0].data;
+      expect(data).not.toHaveProperty('externalAvatar');
+      expect(data.externalName).toBe('Acme Studio');
     });
   });
 

--- a/apps/server/api/src/collections/credentials/services/credentials.service.ts
+++ b/apps/server/api/src/collections/credentials/services/credentials.service.ts
@@ -3,14 +3,23 @@ import { UpdateCredentialDto } from '@api/collections/credentials/dto/update-cre
 import { CredentialEntity } from '@api/collections/credentials/entities/credential.entity';
 import type { CredentialDocument } from '@api/collections/credentials/schemas/credential.schema';
 import { CredentialCryptoService } from '@api/collections/credentials/services/credential-crypto.service';
+import { assertUrlNotPrivate } from '@api/helpers/utils/ssrf/ssrf.util';
+import { FilesClientService } from '@api/services/files-microservice/client/files-client.service';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { BaseService } from '@api/shared/services/base/base.service';
-import { CredentialPlatform } from '@genfeedai/enums';
+import { CredentialPlatform, FileInputType } from '@genfeedai/enums';
 import type { PopulateOption } from '@genfeedai/interfaces';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
 
 type PopulateInput = (string | PopulateOption)[] | 'none';
+
+export interface ExternalCredentialProfile {
+  avatarUrl?: string | null;
+  handle?: string | null;
+  id?: string | null;
+  name?: string | null;
+}
 
 @Injectable()
 export class CredentialsService extends BaseService<
@@ -22,6 +31,7 @@ export class CredentialsService extends BaseService<
     public readonly prisma: PrismaService,
     public readonly logger: LoggerService,
     private readonly cryptoService: CredentialCryptoService,
+    private readonly filesClientService: FilesClientService,
   ) {
     super(prisma, 'credential', logger);
   }
@@ -136,5 +146,71 @@ export class CredentialsService extends BaseService<
     }
 
     return this.create(entity as unknown as CreateCredentialDto);
+  }
+
+  /**
+   * Persist public provider identity and mirror its avatar into Genfeed-owned
+   * storage. OAuth remains successful when avatar import fails; in that case
+   * the previous S3 avatar is preserved and the UI uses its fallback.
+   */
+  async updateExternalProfile(
+    credentialId: string,
+    organizationId: string,
+    profile: ExternalCredentialProfile,
+  ): Promise<CredentialDocument> {
+    const credential = await this.findOne({
+      id: credentialId,
+      isDeleted: false,
+      organization: organizationId,
+    });
+
+    if (!credential) {
+      throw new Error(`Credential ${credentialId} not found`);
+    }
+
+    const update: Record<string, string> = {};
+
+    if (profile.handle) {
+      update.externalHandle = profile.handle;
+    }
+    if (profile.id) {
+      update.externalId = profile.id;
+    }
+    if (profile.name) {
+      update.externalName = profile.name;
+    }
+
+    if (profile.avatarUrl) {
+      try {
+        const parsedAvatarUrl = new URL(profile.avatarUrl);
+        if (!['http:', 'https:'].includes(parsedAvatarUrl.protocol)) {
+          throw new Error('Credential avatar URL must use http or https');
+        }
+        assertUrlNotPrivate(profile.avatarUrl);
+        const metadata = await this.filesClientService.uploadToS3(
+          credentialId,
+          'social-avatars',
+          {
+            type: FileInputType.URL,
+            url: profile.avatarUrl,
+          },
+        );
+
+        if (metadata.publicUrl) {
+          update.externalAvatar = metadata.publicUrl;
+        }
+      } catch (error: unknown) {
+        this.logger.warn('Failed to import credential avatar', {
+          credentialId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    if (Object.keys(update).length === 0) {
+      return credential;
+    }
+
+    return this.patch(credential.id, update);
   }
 }

--- a/apps/server/api/src/services/brand-scraper/brand-scraper.service.spec.ts
+++ b/apps/server/api/src/services/brand-scraper/brand-scraper.service.spec.ts
@@ -332,6 +332,24 @@ describe('BrandScraperService', () => {
       );
     });
 
+    it('uses a Twitter card image when no Open Graph image exists', async () => {
+      fetchMock.mockResolvedValue(
+        makeResponse(`<!DOCTYPE html>
+          <html>
+            <head>
+              <title>Acme</title>
+              <meta name="twitter:image" content="/twitter-card.jpg" />
+            </head>
+            <body></body>
+          </html>`),
+      );
+
+      const result = await service.scrapeWebsite('https://acme.com');
+
+      expect(result.ogImage).toBe('/twitter-card.jpg');
+      expect(result.bannerUrl).toBe('https://acme.com/twitter-card.jpg');
+    });
+
     it('extracts value propositions from bullet characters', async () => {
       const body = [
         '<p>&#8226; Ship faster than competitors</p>',
@@ -367,6 +385,26 @@ describe('BrandScraperService', () => {
       const result = await service.scrapeWebsite('https://acme.com');
       expect(result).toBeDefined();
       expect(result.description).toBeDefined();
+    });
+
+    it('uses a Twitter card image in the meta-tag fallback', async () => {
+      fetchMock
+        .mockResolvedValueOnce(makeResponse('', 500))
+        .mockResolvedValueOnce(
+          makeResponse(`<!DOCTYPE html>
+            <html>
+              <head>
+                <title>FallbackCo</title>
+                <meta name="twitter:image:src" content="https://cdn.acme.com/card.jpg" />
+              </head>
+              <body></body>
+            </html>`),
+        );
+
+      const result = await service.scrapeWebsite('https://acme.com');
+
+      expect(result.ogImage).toBe('https://cdn.acme.com/card.jpg');
+      expect(result.bannerUrl).toBe('https://cdn.acme.com/card.jpg');
     });
 
     it('falls back to meta tags when scrape fails (503)', async () => {

--- a/apps/server/api/src/services/brand-scraper/brand-scraper.service.ts
+++ b/apps/server/api/src/services/brand-scraper/brand-scraper.service.ts
@@ -571,7 +571,14 @@ export class BrandScraperService {
       ogDescription: $('meta[property="og:description"]')
         .attr('content')
         ?.trim(),
-      ogImage: $('meta[property="og:image"]').attr('content')?.trim(),
+      ogImage:
+        $('meta[property="og:image"]').attr('content')?.trim() ||
+        $(
+          'meta[name="twitter:image"], meta[property="twitter:image"], meta[name="twitter:image:src"]',
+        )
+          .first()
+          .attr('content')
+          ?.trim(),
       ogTitle: $('meta[property="og:title"]').attr('content')?.trim(),
       scrapedAt: new Date(),
       siteName: $('meta[property="og:site_name"]').attr('content')?.trim(),
@@ -595,7 +602,14 @@ export class BrandScraperService {
     const ogDescription =
       $('meta[property="og:description"]').attr('content')?.trim() || undefined;
     const ogImage =
-      $('meta[property="og:image"]').attr('content')?.trim() || undefined;
+      $('meta[property="og:image"]').attr('content')?.trim() ||
+      $(
+        'meta[name="twitter:image"], meta[property="twitter:image"], meta[name="twitter:image:src"]',
+      )
+        .first()
+        .attr('content')
+        ?.trim() ||
+      undefined;
     const favicon =
       $('link[rel="icon"]').attr('href')?.trim() ||
       $('link[rel="shortcut icon"]').attr('href')?.trim() ||

--- a/apps/server/api/src/services/integrations/facebook/controllers/facebook.controller.spec.ts
+++ b/apps/server/api/src/services/integrations/facebook/controllers/facebook.controller.spec.ts
@@ -42,6 +42,7 @@ describe('FacebookController', () => {
     }),
     patch: vi.fn().mockResolvedValue({ id: 'cred-1' }),
     saveCredentials: vi.fn(),
+    updateExternalProfile: vi.fn().mockResolvedValue({ id: 'cred-1' }),
   };
 
   const mockBrandsService = {

--- a/apps/server/api/src/services/integrations/facebook/controllers/facebook.controller.ts
+++ b/apps/server/api/src/services/integrations/facebook/controllers/facebook.controller.ts
@@ -140,18 +140,26 @@ export class FacebookController {
         await this.facebookService.exchangeAuthCodeForAccessToken(body.code);
       const profile = await this.facebookService.getUserProfile(accessToken);
 
-      const updatedCredential = await this.credentialsService.patch(
+      let updatedCredential = await this.credentialsService.patch(
         credential.id,
         {
           accessToken,
           accessTokenExpiry: expiresIn
             ? new Date(Date.now() + expiresIn * 1000)
             : undefined,
-          externalHandle: profile.email || profile.name,
-          externalId: credential.externalId || profile.id,
-          externalName: profile.name,
           isConnected: true,
           isDeleted: false,
+        },
+      );
+
+      updatedCredential = await this.credentialsService.updateExternalProfile(
+        updatedCredential.id,
+        stateData.organizationId,
+        {
+          avatarUrl: profile.picture?.data?.url,
+          handle: profile.email || profile.name,
+          id: credential.externalId || profile.id,
+          name: profile.name,
         },
       );
 

--- a/apps/server/api/src/services/integrations/facebook/services/facebook.service.ts
+++ b/apps/server/api/src/services/integrations/facebook/services/facebook.service.ts
@@ -115,6 +115,7 @@ export class FacebookService {
     id: string;
     name: string;
     email: string;
+    picture?: { data?: { url?: string } };
   }> {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
 
@@ -123,7 +124,7 @@ export class FacebookService {
         this.httpService.get(`${this.graphUrl}/${this.apiVersion}/me`, {
           params: {
             access_token: accessToken,
-            fields: 'id,name,email',
+            fields: 'id,name,email,picture.width(256).height(256)',
           },
         }),
       );

--- a/apps/server/api/src/services/integrations/linkedin/controllers/linkedin.controller.spec.ts
+++ b/apps/server/api/src/services/integrations/linkedin/controllers/linkedin.controller.spec.ts
@@ -25,9 +25,6 @@ import type { Request } from 'express';
 
 describe('LinkedInController', () => {
   let controller: LinkedInController;
-  let brandsService: BrandsService;
-  let credentialsService: CredentialsService;
-  let linkedInService: LinkedInService;
 
   const mockBrandsService = { findOne: vi.fn() };
   const mockCredentialsService = {
@@ -35,6 +32,7 @@ describe('LinkedInController', () => {
     findOne: vi.fn(),
     patch: vi.fn(),
     saveCredentials: vi.fn(),
+    updateExternalProfile: vi.fn(),
   };
   const mockLinkedInService = {
     exchangeAuthCodeForAccessToken: vi.fn(),
@@ -71,9 +69,6 @@ describe('LinkedInController', () => {
       .compile();
 
     controller = module.get<LinkedInController>(LinkedInController);
-    brandsService = module.get<BrandsService>(BrandsService);
-    credentialsService = module.get<CredentialsService>(CredentialsService);
-    linkedInService = module.get<LinkedInService>(LinkedInService);
   });
 
   it('should be defined', () => {
@@ -154,6 +149,10 @@ describe('LinkedInController', () => {
         id: credId,
         isConnected: true,
       });
+      mockCredentialsService.updateExternalProfile.mockResolvedValue({
+        id: credId,
+        isConnected: true,
+      });
 
       const result = await controller.verify(mockRequest, {
         code: 'auth-code',
@@ -165,10 +164,17 @@ describe('LinkedInController', () => {
         credId,
         expect.objectContaining({
           accessToken: 'linkedin-token',
-          externalHandle: 'John Doe',
-          externalId: 'li-user-123',
           isConnected: true,
           isDeleted: false,
+        }),
+      );
+      expect(mockCredentialsService.updateExternalProfile).toHaveBeenCalledWith(
+        credId,
+        orgId,
+        expect.objectContaining({
+          handle: 'John Doe',
+          id: 'li-user-123',
+          name: 'John Doe',
         }),
       );
     });

--- a/apps/server/api/src/services/integrations/linkedin/controllers/linkedin.controller.ts
+++ b/apps/server/api/src/services/integrations/linkedin/controllers/linkedin.controller.ts
@@ -134,15 +134,25 @@ export class LinkedInController {
 
       // Update the credential with the access token
       // If reconnecting the same account, reactivate previously deleted credential
-      const credential = await this.credentialsService.patch(
+      let credential = await this.credentialsService.patch(
         existingCredential.id,
         {
           accessToken,
-          externalHandle: `${profile.firstName} ${profile.lastName}`,
-          externalId: profile.id,
           isConnected: true,
           isDeleted: false, // Reactivate if previously disconnected
           refreshTokenExpiry: expiryDate,
+        },
+      );
+
+      const profileName = `${profile.firstName} ${profile.lastName}`.trim();
+      credential = await this.credentialsService.updateExternalProfile(
+        credential.id,
+        organizationId,
+        {
+          avatarUrl: profile.picture,
+          handle: profileName,
+          id: profile.id,
+          name: profileName,
         },
       );
 

--- a/apps/server/api/src/services/integrations/linkedin/services/linkedin.service.ts
+++ b/apps/server/api/src/services/integrations/linkedin/services/linkedin.service.ts
@@ -266,6 +266,7 @@ export class LinkedInService {
     firstName: string;
     lastName: string;
     email: string;
+    picture?: string;
   }> {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
 
@@ -274,6 +275,7 @@ export class LinkedInService {
         email: string;
         family_name: string;
         given_name: string;
+        picture?: string;
         sub: string;
       }>({
         headers: {
@@ -289,6 +291,7 @@ export class LinkedInService {
         firstName: response.given_name,
         id: response.sub,
         lastName: response.family_name,
+        ...(response.picture ? { picture: response.picture } : {}),
       };
     } catch (error: unknown) {
       this.loggerService.error(`${url} failed`, error);

--- a/apps/server/api/src/services/integrations/reddit/controllers/reddit.controller.spec.ts
+++ b/apps/server/api/src/services/integrations/reddit/controllers/reddit.controller.spec.ts
@@ -33,6 +33,7 @@ describe('RedditController', () => {
     findOne: ReturnType<typeof vi.fn>;
     patch: ReturnType<typeof vi.fn>;
     saveCredentials: ReturnType<typeof vi.fn>;
+    updateExternalProfile: ReturnType<typeof vi.fn>;
   };
   let redditService: { generateAuthUrl: ReturnType<typeof vi.fn> };
   let httpService: {
@@ -61,6 +62,17 @@ describe('RedditController', () => {
           Promise.resolve({ id: credentialId, ...data }),
         ),
       saveCredentials: vi.fn().mockResolvedValue({ id: credentialId }),
+      updateExternalProfile: vi
+        .fn()
+        .mockImplementation((_id, _organizationId, data) =>
+          Promise.resolve({
+            externalAvatar: data.avatarUrl,
+            externalHandle: data.handle,
+            externalId: data.id,
+            externalName: data.name,
+            id: credentialId,
+          }),
+        ),
     };
     redditService = {
       generateAuthUrl: vi
@@ -152,7 +164,11 @@ describe('RedditController', () => {
       );
       httpService.get.mockReturnValue(
         of({
-          data: { id: 'reddit_user_id', name: 'reddit_username' },
+          data: {
+            icon_img: 'https://reddit.example/avatar.png',
+            id: 'reddit_user_id',
+            name: 'reddit_username',
+          },
         }),
       );
     });
@@ -171,6 +187,15 @@ describe('RedditController', () => {
         expect.objectContaining({
           externalHandle: 'reddit_username',
           externalId: 'reddit_user_id',
+        }),
+      );
+      expect(credentialsService.updateExternalProfile).toHaveBeenCalledWith(
+        credentialId,
+        orgId,
+        expect.objectContaining({
+          avatarUrl: 'https://reddit.example/avatar.png',
+          handle: 'reddit_username',
+          id: 'reddit_user_id',
         }),
       );
     });

--- a/apps/server/api/src/services/integrations/reddit/controllers/reddit.controller.ts
+++ b/apps/server/api/src/services/integrations/reddit/controllers/reddit.controller.ts
@@ -189,10 +189,16 @@ export class RedditController {
         }),
       );
 
-      credential = await this.credentialsService.patch(credential.id, {
-        externalHandle: profileRes.data?.name,
-        externalId: profileRes.data?.id,
-      });
+      credential = await this.credentialsService.updateExternalProfile(
+        credential.id,
+        organizationId,
+        {
+          avatarUrl: profileRes.data?.icon_img,
+          handle: profileRes.data?.name,
+          id: profileRes.data?.id,
+          name: profileRes.data?.name,
+        },
+      );
 
       return serializeSingle(request, CredentialSerializer, credential);
     } catch (error: unknown) {

--- a/apps/server/api/src/services/integrations/threads/controllers/threads.controller.spec.ts
+++ b/apps/server/api/src/services/integrations/threads/controllers/threads.controller.spec.ts
@@ -36,6 +36,7 @@ describe('ThreadsController', () => {
     findOne: vi.fn(),
     patch: vi.fn(),
     saveCredentials: vi.fn(),
+    updateExternalProfile: vi.fn(),
   };
   const mockThreadsService = {
     getAccountDetails: vi.fn(),

--- a/apps/server/api/src/services/integrations/threads/controllers/threads.controller.ts
+++ b/apps/server/api/src/services/integrations/threads/controllers/threads.controller.ts
@@ -256,6 +256,7 @@ export class ThreadsController {
         access_token,
       )) as {
         id?: string;
+        threads_profile_picture_url?: string;
         username?: string;
       };
 
@@ -271,17 +272,26 @@ export class ThreadsController {
       }
 
       // Update the credential with the access token
-      const credential = await this.credentialsService.patch(
+      let credential = await this.credentialsService.patch(
         existingCredential.id,
         {
           accessToken: access_token,
           accessTokenExpiry: expires_in
             ? new Date(Date.now() + expires_in * 1000)
             : undefined,
-          externalHandle: accountDetails?.username,
-          externalId: userId || accountDetails?.id,
           isConnected: true,
           isDeleted: false,
+        },
+      );
+
+      credential = await this.credentialsService.updateExternalProfile(
+        credential.id,
+        organizationId,
+        {
+          avatarUrl: accountDetails?.threads_profile_picture_url,
+          handle: accountDetails?.username,
+          id: userId || accountDetails?.id,
+          name: accountDetails?.username,
         },
       );
 

--- a/apps/server/api/src/services/integrations/tiktok/controllers/tiktok.controller.spec.ts
+++ b/apps/server/api/src/services/integrations/tiktok/controllers/tiktok.controller.spec.ts
@@ -31,6 +31,7 @@ describe('TiktokController', () => {
     findOne: ReturnType<typeof vi.fn>;
     patch: ReturnType<typeof vi.fn>;
     saveCredentials: ReturnType<typeof vi.fn>;
+    updateExternalProfile: ReturnType<typeof vi.fn>;
   };
   let tiktokService: {
     getTiktokInfo: ReturnType<typeof vi.fn>;
@@ -56,9 +57,22 @@ describe('TiktokController', () => {
           Promise.resolve({ id: credentialId, ...data }),
         ),
       saveCredentials: vi.fn().mockResolvedValue({ id: credentialId }),
+      updateExternalProfile: vi
+        .fn()
+        .mockImplementation((_id, _organizationId, data) =>
+          Promise.resolve({
+            externalAvatar: data.avatarUrl,
+            externalHandle: data.handle,
+            externalId: data.id,
+            externalName: data.name,
+            id: credentialId,
+          }),
+        ),
     };
     tiktokService = {
       getTiktokInfo: vi.fn().mockResolvedValue({
+        avatarUrl: 'https://tiktok.example/avatar.jpg',
+        displayName: 'TikTok Creator',
         userId: 'tiktok_ext_id',
         username: 'tiktok_handle',
       }),
@@ -182,6 +196,16 @@ describe('TiktokController', () => {
         expect.objectContaining({
           externalHandle: 'tiktok_handle',
           externalId: 'tiktok_ext_id',
+        }),
+      );
+      expect(credentialsService.updateExternalProfile).toHaveBeenCalledWith(
+        credentialId,
+        orgId,
+        expect.objectContaining({
+          avatarUrl: 'https://tiktok.example/avatar.jpg',
+          handle: 'tiktok_handle',
+          id: 'tiktok_ext_id',
+          name: 'TikTok Creator',
         }),
       );
     });

--- a/apps/server/api/src/services/integrations/tiktok/controllers/tiktok.controller.ts
+++ b/apps/server/api/src/services/integrations/tiktok/controllers/tiktok.controller.ts
@@ -206,18 +206,20 @@ export class TiktokController {
       );
 
       // Pass access_token directly to avoid race condition (no DB re-query)
-      const { userId: externalId, username: externalHandle } =
-        await this.tiktokService.getTiktokInfo(
-          organizationId,
-          brandId,
-          access_token,
-        );
+      const profile = await this.tiktokService.getTiktokInfo(
+        organizationId,
+        brandId,
+        access_token,
+      );
 
-      credential = await this.credentialsService.patch(
+      credential = await this.credentialsService.updateExternalProfile(
         credential.id.toString(),
+        organizationId,
         {
-          externalHandle,
-          externalId,
+          avatarUrl: profile.avatarUrl,
+          handle: profile.username,
+          id: profile.userId,
+          name: profile.displayName,
         },
       );
 

--- a/apps/server/api/src/services/integrations/twitter/controllers/twitter.controller.spec.ts
+++ b/apps/server/api/src/services/integrations/twitter/controllers/twitter.controller.spec.ts
@@ -31,9 +31,6 @@ import type { Request } from 'express';
 
 describe('TwitterController', () => {
   let controller: TwitterController;
-  let brandsService: BrandsService;
-  let credentialsService: CredentialsService;
-  let twitterService: TwitterService;
 
   const mockBrandsService = {
     findOne: vi.fn(),
@@ -43,6 +40,9 @@ describe('TwitterController', () => {
     findOne: vi.fn(),
     patch: vi.fn().mockResolvedValue({ id: 'cred', isConnected: true }),
     saveCredentials: vi.fn(),
+    updateExternalProfile: vi
+      .fn()
+      .mockResolvedValue({ id: 'cred', isConnected: true }),
   };
 
   const mockTwitterService = {
@@ -63,9 +63,14 @@ describe('TwitterController', () => {
       accessToken: 'oauth2-access-token',
       client: {
         v2: {
-          me: vi
-            .fn()
-            .mockResolvedValue({ data: { id: '1', username: 'testuser' } }),
+          me: vi.fn().mockResolvedValue({
+            data: {
+              id: '1',
+              name: 'Test User',
+              profile_image_url: 'https://twitter.example/avatar.jpg',
+              username: 'testuser',
+            },
+          }),
         },
       },
       expiresIn: 7200,
@@ -87,9 +92,6 @@ describe('TwitterController', () => {
       .compile();
 
     controller = module.get<TwitterController>(TwitterController);
-    brandsService = module.get<BrandsService>(BrandsService);
-    credentialsService = module.get<CredentialsService>(CredentialsService);
-    twitterService = module.get<TwitterService>(TwitterService);
   });
 
   it('should be defined', () => {
@@ -174,7 +176,7 @@ describe('TwitterController', () => {
         organization: organizationId,
       });
 
-      const result = await controller.verify({} as Request, {
+      await controller.verify({} as Request, {
         code: 'auth-code',
         state,
       });
@@ -184,11 +186,19 @@ describe('TwitterController', () => {
         'cred',
         expect.objectContaining({
           accessToken: 'oauth2-access-token',
-          externalHandle: 'testuser',
-          externalId: '1',
           isConnected: true,
           refreshToken: 'oauth2-refresh-token',
         }),
+      );
+      expect(mockCredentialsService.updateExternalProfile).toHaveBeenCalledWith(
+        'cred',
+        organizationId,
+        {
+          avatarUrl: 'https://twitter.example/avatar.jpg',
+          handle: 'testuser',
+          id: '1',
+          name: 'Test User',
+        },
       );
     });
 

--- a/apps/server/api/src/services/integrations/twitter/controllers/twitter.controller.ts
+++ b/apps/server/api/src/services/integrations/twitter/controllers/twitter.controller.ts
@@ -199,23 +199,34 @@ export class TwitterController {
       });
 
       // Get authenticated user profile
-      const { data: me } = await loggedClient.v2.me();
+      const { data: me } = await loggedClient.v2.me({
+        'user.fields': ['profile_image_url'],
+      });
 
       // Update credential with OAuth 2.0 tokens
-      const updatedCredential = await this.credentialsService.patch(
+      let updatedCredential = await this.credentialsService.patch(
         credential.id,
         {
           accessToken,
           accessTokenExpiry: expiresIn
             ? new Date(Date.now() + expiresIn * 1000)
             : undefined,
-          externalHandle: me.username,
-          externalId: me.id,
           isConnected: true,
           isDeleted: false,
           oauthToken: undefined,
           oauthTokenSecret: undefined,
           refreshToken,
+        },
+      );
+
+      updatedCredential = await this.credentialsService.updateExternalProfile(
+        updatedCredential.id,
+        organizationId,
+        {
+          avatarUrl: me.profile_image_url,
+          handle: me.username,
+          id: me.id,
+          name: me.name,
         },
       );
 

--- a/apps/server/api/src/services/integrations/youtube/controllers/youtube.controller.spec.ts
+++ b/apps/server/api/src/services/integrations/youtube/controllers/youtube.controller.spec.ts
@@ -38,6 +38,7 @@ describe('YoutubeController', () => {
     findOne: ReturnType<typeof vi.fn>;
     patch: ReturnType<typeof vi.fn>;
     saveCredentials: ReturnType<typeof vi.fn>;
+    updateExternalProfile: ReturnType<typeof vi.fn>;
   };
   let youtubeService: {
     exchangeCodeForTokens: ReturnType<typeof vi.fn>;
@@ -67,6 +68,17 @@ describe('YoutubeController', () => {
           Promise.resolve({ id: credentialId, ...data }),
         ),
       saveCredentials: vi.fn().mockResolvedValue({ id: credentialId }),
+      updateExternalProfile: vi
+        .fn()
+        .mockImplementation((_id, _organizationId, data) =>
+          Promise.resolve({
+            externalAvatar: data.avatarUrl,
+            externalHandle: data.handle,
+            externalId: data.id,
+            externalName: data.name,
+            id: credentialId,
+          }),
+        ),
     };
     youtubeService = {
       exchangeCodeForTokens: vi.fn().mockResolvedValue({
@@ -84,7 +96,11 @@ describe('YoutubeController', () => {
           'https://accounts.google.com/o/oauth2/v2/auth?scope=youtube',
         ),
       getChannelDetails: vi.fn().mockResolvedValue({
+        customUrl: '@mychannel',
         id: 'UCxxxxxx',
+        thumbnails: {
+          high: { url: 'https://youtube.example/avatar.jpg' },
+        },
         title: 'My Channel',
       }),
       getTrends: vi.fn().mockResolvedValue([{ title: 'trending video' }]),
@@ -178,6 +194,16 @@ describe('YoutubeController', () => {
           accessToken: 'yt_access',
           isConnected: true,
           refreshToken: 'yt_refresh',
+        }),
+      );
+      expect(credentialsService.updateExternalProfile).toHaveBeenCalledWith(
+        credentialId,
+        orgId,
+        expect.objectContaining({
+          avatarUrl: 'https://youtube.example/avatar.jpg',
+          handle: 'mychannel',
+          id: 'UCxxxxxx',
+          name: 'My Channel',
         }),
       );
     });

--- a/apps/server/api/src/services/integrations/youtube/controllers/youtube.controller.ts
+++ b/apps/server/api/src/services/integrations/youtube/controllers/youtube.controller.ts
@@ -240,16 +240,32 @@ export class YoutubeController {
           brandId,
           oauth2Client,
         )) as {
+          customUrl?: string;
           id?: string;
+          thumbnails?: {
+            default?: { url?: string | null };
+            high?: { url?: string | null };
+            medium?: { url?: string | null };
+          };
           title?: string;
         };
-        const externalId = channelDetails.id;
-        const externalHandle = channelDetails.title;
+        const externalHandle =
+          channelDetails.customUrl?.replace(/^@/, '') ?? channelDetails.title;
+        const avatarUrl =
+          channelDetails.thumbnails?.high?.url ??
+          channelDetails.thumbnails?.medium?.url ??
+          channelDetails.thumbnails?.default?.url;
 
-        credential = await this.credentialsService.patch(credential.id, {
-          externalHandle,
-          externalId,
-        });
+        credential = await this.credentialsService.updateExternalProfile(
+          credential.id,
+          organizationId,
+          {
+            avatarUrl,
+            handle: externalHandle,
+            id: channelDetails.id,
+            name: channelDetails.title,
+          },
+        );
       } catch (verifyError: unknown) {
         this.loggerService.error(
           'Failed to verify YouTube connection',

--- a/packages/client/src/models/organization/credential.model.ts
+++ b/packages/client/src/models/organization/credential.model.ts
@@ -17,6 +17,8 @@ export class BaseCredential extends BaseEntity implements ICredential {
   public declare brand: string;
   public declare externalId: string;
   public declare externalHandle: string;
+  public declare externalName?: string;
+  public declare externalAvatar?: string;
   public declare handle: string;
   public declare label: string;
   public declare description?: string;

--- a/packages/helpers/src/social-url.helper.test.ts
+++ b/packages/helpers/src/social-url.helper.test.ts
@@ -1,8 +1,45 @@
+import { CredentialPlatform } from '@genfeedai/enums';
 import { describe, expect, it } from 'vitest';
 
 import { SocialUrlHelper } from './social-url.helper';
 
 describe('SocialUrlHelper', () => {
+  describe('buildProfileUrl', () => {
+    it('prefers the stable YouTube channel id', () => {
+      expect(
+        SocialUrlHelper.buildProfileUrl(
+          CredentialPlatform.YOUTUBE,
+          '@genfeed',
+          'channel-1',
+        ),
+      ).toBe('https://www.youtube.com/channel/channel-1');
+    });
+
+    it('normalizes account handles for profile routes', () => {
+      expect(
+        SocialUrlHelper.buildProfileUrl(CredentialPlatform.TWITTER, '@genfeed'),
+      ).toBe('https://x.com/genfeed');
+      expect(
+        SocialUrlHelper.buildProfileUrl(CredentialPlatform.THREADS, '@genfeed'),
+      ).toBe('https://www.threads.net/@genfeed');
+    });
+
+    it('returns undefined when a reliable profile route cannot be built', () => {
+      expect(
+        SocialUrlHelper.buildProfileUrl(CredentialPlatform.MASTODON, 'genfeed'),
+      ).toBeUndefined();
+      expect(
+        SocialUrlHelper.buildProfileUrl(CredentialPlatform.INSTAGRAM),
+      ).toBeUndefined();
+      expect(
+        SocialUrlHelper.buildProfileUrl(
+          CredentialPlatform.LINKEDIN,
+          'Jane Founder',
+        ),
+      ).toBeUndefined();
+    });
+  });
+
   describe('buildTwitterUrl', () => {
     it('builds a valid Twitter/X URL', () => {
       expect(SocialUrlHelper.buildTwitterUrl('123456', 'testuser')).toBe(

--- a/packages/helpers/src/social-url.helper.ts
+++ b/packages/helpers/src/social-url.helper.ts
@@ -1,4 +1,59 @@
+import { CredentialPlatform } from '@genfeedai/enums';
+
 export class SocialUrlHelper {
+  static buildProfileUrl(
+    platform: CredentialPlatform,
+    handle?: string | null,
+    externalId?: string | null,
+  ): string | undefined {
+    const cleanHandle = handle?.trim().replace(/^@/, '');
+
+    switch (platform) {
+      case CredentialPlatform.YOUTUBE:
+        return externalId
+          ? `https://www.youtube.com/channel/${externalId}`
+          : cleanHandle
+            ? `https://www.youtube.com/@${cleanHandle}`
+            : undefined;
+      case CredentialPlatform.TIKTOK:
+        return cleanHandle
+          ? `https://www.tiktok.com/@${cleanHandle}`
+          : undefined;
+      case CredentialPlatform.INSTAGRAM:
+        return cleanHandle
+          ? `https://www.instagram.com/${cleanHandle}`
+          : undefined;
+      case CredentialPlatform.TWITTER:
+        return cleanHandle ? `https://x.com/${cleanHandle}` : undefined;
+      case CredentialPlatform.LINKEDIN:
+        return cleanHandle && !/\s/.test(cleanHandle)
+          ? `https://www.linkedin.com/in/${cleanHandle}`
+          : undefined;
+      case CredentialPlatform.FACEBOOK:
+        return externalId
+          ? `https://www.facebook.com/${externalId}`
+          : undefined;
+      case CredentialPlatform.PINTEREST:
+        return cleanHandle
+          ? `https://www.pinterest.com/${cleanHandle}`
+          : undefined;
+      case CredentialPlatform.REDDIT:
+        return cleanHandle
+          ? `https://www.reddit.com/user/${cleanHandle}`
+          : undefined;
+      case CredentialPlatform.THREADS:
+        return cleanHandle
+          ? `https://www.threads.net/@${cleanHandle}`
+          : undefined;
+      case CredentialPlatform.FANVUE:
+        return cleanHandle
+          ? `https://www.fanvue.com/${cleanHandle}`
+          : undefined;
+      default:
+        return undefined;
+    }
+  }
+
   static buildTwitterUrl(tweetId: string, username: string): string {
     if (!tweetId) {
       throw new Error('Tweet ID is required');

--- a/packages/hooks/pages/use-brand-detail/use-brand-detail.ts
+++ b/packages/hooks/pages/use-brand-detail/use-brand-detail.ts
@@ -10,11 +10,11 @@ import {
   ArticleStatus,
   AssetCategory,
   AssetParent,
-  CredentialPlatform,
   IngredientCategory,
   IngredientStatus,
   ModalEnum,
 } from '@genfeedai/enums';
+import { SocialUrlHelper } from '@genfeedai/helpers';
 import type {
   IArticle,
   IBrand,
@@ -506,71 +506,28 @@ export function useBrandDetail(): UseBrandDetailReturn {
   }, [brandId, findOneBrand, notificationsService, pendingAssetId, subscribe]);
 
   const socialConnections = useMemo(() => {
-    const connections: UseBrandDetailReturn['socialConnections'] = [];
-
     const connectedCredentials =
       state.brand?.credentials?.filter(
         (cred: ICredential) => cred.isConnected === true,
       ) ?? [];
 
-    const findCredential = (platform: CredentialPlatform) =>
-      connectedCredentials.find(
-        (credential: ICredential) => credential.platform === platform,
-      );
-
-    const pushConnection = (
-      platform: CredentialPlatform,
-      url?: string | null,
-      handle?: string | null,
-    ) => {
-      const credential = findCredential(platform);
-      if (!credential || !url) {
-        return;
-      }
-
-      connections.push({
+    return connectedCredentials.map((credential) => {
+      return {
         accountHealth: credential.accountHealth,
+        avatarUrl: credential.externalAvatar,
         credentialId: credential.id,
-        handle: handle ?? credential.externalHandle,
+        handle: credential.externalHandle,
         label: credential.label,
-        platform,
-        url,
-      });
-    };
-
-    pushConnection(
-      CredentialPlatform.YOUTUBE,
-      state.brand?.youtubeUrl,
-      state.brand?.youtubeHandle,
-    );
-    pushConnection(
-      CredentialPlatform.TIKTOK,
-      state.brand?.tiktokUrl,
-      state.brand?.tiktokHandle,
-    );
-    pushConnection(
-      CredentialPlatform.INSTAGRAM,
-      state.brand?.instagramUrl,
-      state.brand?.instagramHandle,
-    );
-    pushConnection(
-      CredentialPlatform.TWITTER,
-      state.brand?.twitterUrl,
-      state.brand?.twitterHandle,
-    );
-
-    return connections;
-  }, [
-    state.brand?.credentials,
-    state.brand?.instagramHandle,
-    state.brand?.instagramUrl,
-    state.brand?.tiktokHandle,
-    state.brand?.tiktokUrl,
-    state.brand?.twitterHandle,
-    state.brand?.twitterUrl,
-    state.brand?.youtubeHandle,
-    state.brand?.youtubeUrl,
-  ]);
+        name: credential.externalName,
+        platform: credential.platform,
+        url: SocialUrlHelper.buildProfileUrl(
+          credential.platform,
+          credential.externalHandle,
+          credential.externalId,
+        ),
+      };
+    });
+  }, [state.brand?.credentials]);
 
   const connectedPlatformsCount = useMemo(
     () =>

--- a/packages/interfaces/src/organization/credential.interface.ts
+++ b/packages/interfaces/src/organization/credential.interface.ts
@@ -9,6 +9,8 @@ export interface ICredential extends IBaseEntity {
 
   externalId: string;
   externalHandle: string;
+  externalName?: string;
+  externalAvatar?: string;
   externalUrl?: string;
 
   platform: CredentialPlatform;

--- a/packages/pages/brands/components/sidebar/BrandDetailSocialMediaCard.test.tsx
+++ b/packages/pages/brands/components/sidebar/BrandDetailSocialMediaCard.test.tsx
@@ -113,10 +113,13 @@ vi.mock('@ui/card/Card', () => ({
   ),
 }));
 
-vi.mock('@ui/media/social-media-link/SocialMediaLink', () => ({
-  __esModule: true,
-  default: ({ handle, url }: { handle?: string; url: string }) => (
-    <a href={url}>{handle ?? url}</a>
+vi.mock('@ui/primitives/avatar', () => ({
+  Avatar: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+  AvatarFallback: ({ children }: { children: ReactNode }) => (
+    <span>{children}</span>
+  ),
+  AvatarImage: ({ alt, src }: { alt: string; src: string }) => (
+    <img alt={alt} src={src} />
   ),
 }));
 
@@ -153,8 +156,10 @@ describe('BrandDetailSocialMediaCard', () => {
         brandId="brand-1"
         connections={[
           {
+            avatarUrl: 'https://cdn.example.com/genfeed.jpg',
             credentialId: 'credential-1',
             handle: 'genfeed',
+            name: 'Genfeed',
             platform: CredentialPlatform.TWITTER,
             url: 'https://x.com/genfeed',
           },
@@ -163,7 +168,62 @@ describe('BrandDetailSocialMediaCard', () => {
       />,
     );
 
-    expect(screen.getByRole('link', { name: 'genfeed' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Open Genfeed on twitter' }),
+    ).toHaveAttribute('href', 'https://x.com/genfeed');
+    expect(screen.getByAltText('Genfeed profile picture')).toHaveAttribute(
+      'src',
+      'https://cdn.example.com/genfeed.jpg',
+    );
+    expect(screen.getByText('@genfeed')).toBeInTheDocument();
+  });
+
+  it('renders an initials fallback when an account has no avatar or profile url', () => {
+    render(
+      <BrandDetailSocialMediaCard
+        brandId="brand-1"
+        connections={[
+          {
+            credentialId: 'credential-1',
+            name: 'Acme Studio',
+            platform: CredentialPlatform.THREADS,
+          },
+        ]}
+        connectedPlatformsCount={1}
+      />,
+    );
+
+    expect(screen.getByText('Acme Studio')).toBeInTheDocument();
+    expect(screen.getByText('AS')).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('renders multiple accounts from the same platform independently', () => {
+    render(
+      <BrandDetailSocialMediaCard
+        brandId="brand-1"
+        connections={[
+          {
+            credentialId: 'credential-1',
+            handle: 'genfeed',
+            name: 'Genfeed',
+            platform: CredentialPlatform.TWITTER,
+            url: 'https://x.com/genfeed',
+          },
+          {
+            credentialId: 'credential-2',
+            handle: 'genfeedlabs',
+            name: 'Genfeed Labs',
+            platform: CredentialPlatform.TWITTER,
+            url: 'https://x.com/genfeedlabs',
+          },
+        ]}
+        connectedPlatformsCount={2}
+      />,
+    );
+
+    expect(screen.getByText('Genfeed')).toBeInTheDocument();
+    expect(screen.getByText('Genfeed Labs')).toBeInTheDocument();
   });
 
   it('starts oauth directly from the social card', async () => {
@@ -204,7 +264,9 @@ describe('BrandDetailSocialMediaCard', () => {
       />,
     );
 
-    expect(screen.getByRole('link', { name: 'genfeed' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Open genfeed on twitter' }),
+    ).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: /manage/i }));
 

--- a/packages/pages/brands/components/sidebar/BrandDetailSocialMediaCard.tsx
+++ b/packages/pages/brands/components/sidebar/BrandDetailSocialMediaCard.tsx
@@ -14,7 +14,8 @@ import { NotificationsService } from '@services/core/notifications.service';
 import { ServicesService } from '@services/external/services.service';
 import { CredentialsService } from '@services/organization/credentials.service';
 import Card from '@ui/card/Card';
-import SocialMediaLink from '@ui/media/social-media-link/SocialMediaLink';
+import PlatformBadge from '@ui/display/platform-badge/PlatformBadge';
+import { Avatar, AvatarFallback, AvatarImage } from '@ui/primitives/avatar';
 import { Button } from '@ui/primitives/button';
 import {
   Dialog,
@@ -23,7 +24,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@ui/primitives/dialog';
-import type { ReactNode } from 'react';
+import Link from 'next/link';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   FaFacebook,
@@ -41,23 +42,6 @@ import {
   FaXTwitter,
   FaYoutube,
 } from 'react-icons/fa6';
-
-const platformIconMap: Partial<Record<CredentialPlatform, ReactNode>> = {
-  [CredentialPlatform.YOUTUBE]: <FaYoutube />,
-  [CredentialPlatform.TIKTOK]: <FaTiktok />,
-  [CredentialPlatform.INSTAGRAM]: <FaInstagram />,
-  [CredentialPlatform.TWITTER]: <FaXTwitter />,
-  [CredentialPlatform.FANVUE]: <FaStar />,
-  [CredentialPlatform.FACEBOOK]: <FaFacebook />,
-  [CredentialPlatform.LINKEDIN]: <FaLinkedin />,
-  [CredentialPlatform.PINTEREST]: <FaPinterest />,
-  [CredentialPlatform.REDDIT]: <FaReddit />,
-  [CredentialPlatform.THREADS]: <FaThreads />,
-  [CredentialPlatform.WORDPRESS]: <FaWordpress />,
-  [CredentialPlatform.SNAPCHAT]: <FaSnapchat />,
-  [CredentialPlatform.MASTODON]: <FaMastodon />,
-  [CredentialPlatform.SHOPIFY]: <FaShopify />,
-};
 
 const OAUTH_PLATFORMS = [
   {
@@ -139,6 +123,84 @@ const STATE_LABELS: Record<AccountHealthSummary['state'], string> = {
   warming: 'Warming',
 };
 
+type SocialConnection = BrandDetailSocialMediaCardProps['connections'][number];
+
+function getConnectionLabel(connection: SocialConnection): string {
+  return (
+    connection.name ||
+    connection.label ||
+    connection.handle ||
+    connection.platform
+  );
+}
+
+function getConnectionInitials(connection: SocialConnection): string {
+  const label = getConnectionLabel(connection).trim();
+  const initials = label
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase())
+    .join('');
+
+  return initials || connection.platform.slice(0, 2).toUpperCase();
+}
+
+function ConnectedAccount({ connection }: { connection: SocialConnection }) {
+  const label = getConnectionLabel(connection);
+  const content = (
+    <>
+      <span className="relative shrink-0">
+        <Avatar className="size-10 bg-background shadow-border">
+          {connection.avatarUrl ? (
+            <AvatarImage
+              src={connection.avatarUrl}
+              alt={`${label} profile picture`}
+              className="object-cover"
+            />
+          ) : null}
+          <AvatarFallback className="text-xs font-semibold text-foreground/70">
+            {getConnectionInitials(connection)}
+          </AvatarFallback>
+        </Avatar>
+        <span className="absolute -bottom-1 -right-1 rounded-full bg-background p-0.5 shadow-border-strong">
+          <PlatformBadge
+            platform={connection.platform}
+            showLabel={false}
+            className="size-4 justify-center rounded-full p-0"
+          />
+        </span>
+      </span>
+
+      <span className="min-w-0 text-left">
+        <span className="block truncate text-sm font-medium">{label}</span>
+        {connection.handle ? (
+          <span className="block truncate text-xs text-muted-foreground">
+            @{connection.handle.replace(/^@/, '')}
+          </span>
+        ) : null}
+      </span>
+    </>
+  );
+  const className =
+    'flex min-w-0 items-center gap-3 rounded-md bg-background-secondary px-3 py-2 shadow-border transition-colors hover:bg-background';
+
+  if (!connection.url) {
+    return <div className={className}>{content}</div>;
+  }
+
+  return (
+    <Link
+      href={connection.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label={`Open ${label} on ${connection.platform}`}
+      className={className}
+    >
+      {content}
+    </Link>
+  );
+}
+
 function getHealthToneClass(summary: AccountHealthSummary): string {
   if (summary.override.isActive) {
     return 'border-info/30 bg-info/10 text-info';
@@ -182,15 +244,7 @@ export default function BrandDetailSocialMediaCard({
   >(null);
   const [isOverrideSubmitting, setIsOverrideSubmitting] = useState(false);
 
-  const connectedConnections = useMemo(
-    () =>
-      connections.filter(
-        (connection) =>
-          Boolean(connection.url) &&
-          Boolean(platformIconMap[connection.platform]),
-      ),
-    [connections],
-  );
+  const connectedConnections = connections;
   const connectedPlatforms = useMemo(
     () =>
       new Set(connectedConnections.map((connection) => connection.platform)),
@@ -332,7 +386,7 @@ export default function BrandDetailSocialMediaCard({
               <h2 className="text-lg font-semibold">Social Media</h2>
               <p className="mt-1 text-sm text-muted-foreground">
                 {connectedPlatformsCount > 0
-                  ? `${connectedPlatformsCount} connected platform${connectedPlatformsCount === 1 ? '' : 's'} with ${unconnectedPlatforms.length} available to add.`
+                  ? `${connectedPlatformsCount} connected account${connectedPlatformsCount === 1 ? '' : 's'} with ${unconnectedPlatforms.length} platform${unconnectedPlatforms.length === 1 ? '' : 's'} available to add.`
                   : 'Connect your social media accounts to display them here.'}
               </p>
             </div>
@@ -347,16 +401,11 @@ export default function BrandDetailSocialMediaCard({
           </div>
 
           {connectedConnections.length > 0 ? (
-            <div className="flex flex-wrap gap-2">
+            <div className="grid gap-2 sm:grid-cols-2">
               {connectedConnections.map((connection) => (
-                <SocialMediaLink
-                  key={connection.platform}
-                  url={connection.url ?? ''}
-                  handle={connection.handle || undefined}
-                  icon={platformIconMap[connection.platform] ?? null}
-                  variant={ButtonVariant.SECONDARY}
-                  size={ButtonSize.SM}
-                  enableUTM={false}
+                <ConnectedAccount
+                  key={connection.credentialId}
+                  connection={connection}
                 />
               ))}
             </div>
@@ -431,16 +480,11 @@ export default function BrandDetailSocialMediaCard({
 
           {connectedPlatformsCount > 0 ? (
             <div className="space-y-4">
-              <div className="flex flex-wrap gap-2">
+              <div className="grid gap-2 sm:grid-cols-2">
                 {connectedConnections.map((connection) => (
-                  <SocialMediaLink
-                    key={connection.platform}
-                    url={connection.url ?? ''}
-                    handle={connection.handle || undefined}
-                    icon={platformIconMap[connection.platform] ?? null}
-                    variant={ButtonVariant.SECONDARY}
-                    size={ButtonSize.SM}
-                    enableUTM={false}
+                  <ConnectedAccount
+                    key={connection.credentialId}
+                    connection={connection}
                   />
                 ))}
               </div>

--- a/packages/props/pages/brand-detail.props.ts
+++ b/packages/props/pages/brand-detail.props.ts
@@ -43,8 +43,10 @@ export interface BrandDetailLatestArticlesProps {
 
 export interface BrandDetailSocialConnection {
   accountHealth?: AccountHealthSummary;
+  avatarUrl?: string | null;
   credentialId: string;
   label?: string | null;
+  name?: string | null;
   platform: CredentialPlatform;
   url?: string | null;
   handle?: string | null;

--- a/packages/serializers/__tests__/attributes.test.ts
+++ b/packages/serializers/__tests__/attributes.test.ts
@@ -605,6 +605,15 @@ describe('Serializer Attributes', () => {
       const unique = new Set(credentialAttributes);
       expect(unique.size).toBe(credentialAttributes.length);
     });
+
+    it('exposes public profile identity without credential secrets', () => {
+      expect(credentialAttributes).toEqual(
+        expect.arrayContaining(['externalAvatar', 'externalName']),
+      );
+      expect(credentialAttributes).not.toEqual(
+        expect.arrayContaining(['accessToken', 'oauthToken', 'refreshToken']),
+      );
+    });
   });
 
   describe('credentialInstagramAttributes', () => {

--- a/packages/serializers/src/attributes/organizations/credential.attributes.ts
+++ b/packages/serializers/src/attributes/organizations/credential.attributes.ts
@@ -8,6 +8,8 @@ const publicFields = [
   'platform',
   'externalId',
   'externalHandle',
+  'externalName',
+  'externalAvatar',
   'accessTokenExpiry',
   'label',
   'description',

--- a/packages/services/social/brands.service.test.ts
+++ b/packages/services/social/brands.service.test.ts
@@ -322,6 +322,38 @@ describe('BrandsService', () => {
       });
       expect(result).toEqual(applyResult);
     });
+
+    it('posts selected asset candidates and unwraps the import result', async () => {
+      const importResult = {
+        brandId: mockBrandId,
+        diagnostics: [],
+        failedCandidateIds: [],
+        importedAssetIds: ['asset-1'],
+        results: [],
+        skippedCandidateIds: [],
+        status: 'accepted',
+      };
+      mockPost.mockResolvedValue({ data: { data: importResult } });
+
+      const payload = {
+        assets: [
+          {
+            candidateId: 'banner-1',
+            replaceExisting: false,
+            role: 'banner' as const,
+            sourceType: 'website' as const,
+            sourceUrl: 'https://acme.test/og.jpg',
+          },
+        ],
+      };
+      const result = await service.importBrandKitAssets(mockBrandId, payload);
+
+      expect(mockPost).toHaveBeenCalledWith(
+        `/${mockBrandId}/brand-kit/assets/import`,
+        payload,
+      );
+      expect(result).toEqual(importResult);
+    });
   });
 
   describe('generateFastlaneIdeas', () => {

--- a/packages/services/social/brands.service.ts
+++ b/packages/services/social/brands.service.ts
@@ -9,6 +9,8 @@ import type {
   IArticle,
   IBrandKitApplyRequest,
   IBrandKitApplyResult,
+  IBrandKitAssetImportRequest,
+  IBrandKitAssetImportResponse,
   IBrandKitDraft,
   IBrandKitManualInput,
   IBrandSetupRequest,
@@ -286,6 +288,18 @@ export class BrandsService extends BaseService<Brand> {
   ): Promise<IBrandKitApplyResult> {
     return await this.instance
       .post<{ data: IBrandKitApplyResult }>(`/${id}/brand-kit/apply`, data)
+      .then((res) => res.data.data);
+  }
+
+  public async importBrandKitAssets(
+    id: string,
+    data: IBrandKitAssetImportRequest,
+  ): Promise<IBrandKitAssetImportResponse> {
+    return await this.instance
+      .post<{ data: IBrandKitAssetImportResponse }>(
+        `/${id}/brand-kit/assets/import`,
+        data,
+      )
       .then((res) => res.data.data);
   }
 

--- a/packages/ui/src/components/modals/brands/brand/ModalBrand.test.tsx
+++ b/packages/ui/src/components/modals/brands/brand/ModalBrand.test.tsx
@@ -19,6 +19,23 @@ const findBrandMock = vi.fn().mockResolvedValue({
   label: 'Acme',
   slug: 'acme',
 });
+const crawlBrandKitMock = vi.fn().mockResolvedValue({
+  assetCandidates: [
+    {
+      candidateId: 'banner-1',
+      label: 'Website banner',
+      role: 'banner',
+      sourceUrl: 'https://acme.test/og.jpg',
+    },
+  ],
+});
+const importBrandKitAssetsMock = vi.fn().mockResolvedValue({
+  importedAssetIds: ['asset-1'],
+  status: 'accepted',
+});
+const formValues = vi.hoisted(() => ({
+  current: {} as Record<string, string>,
+}));
 
 vi.mock('@ui/overlays/entity/EntityOverlayShell', () => ({
   __esModule: true,
@@ -140,14 +157,20 @@ vi.mock('@genfeedai/hooks/auth/use-authed-service/use-authed-service', () => ({
   default: () => () =>
     Promise.resolve({
       findOne: findBrandMock,
+      crawlBrandKitWebsite: crawlBrandKitMock,
+      importBrandKitAssets: importBrandKitAssetsMock,
       patch: vi.fn(),
       post: postBrandMock,
+      scrape: vi.fn(),
     }),
   useAuthedService: () => () =>
     Promise.resolve({
       findOne: findBrandMock,
+      crawlBrandKitWebsite: crawlBrandKitMock,
+      importBrandKitAssets: importBrandKitAssetsMock,
       patch: vi.fn(),
       post: postBrandMock,
+      scrape: vi.fn(),
     }),
 }));
 
@@ -250,7 +273,9 @@ vi.mock('react-hook-form', () => ({
   useForm: () => ({
     control: {},
     formState: { errors: {}, isValid: true },
-    getValues: vi.fn((name?: string) => (name ? '' : {})),
+    getValues: vi.fn((name?: string) =>
+      name ? (formValues.current[name] ?? '') : formValues.current,
+    ),
     handleSubmit: vi.fn((fn) => fn),
     register: vi.fn(),
     reset: vi.fn(),
@@ -269,6 +294,9 @@ describe('ModalBrand', () => {
     pushMock.mockReset();
     postBrandMock.mockClear();
     findBrandMock.mockClear();
+    crawlBrandKitMock.mockClear();
+    importBrandKitAssetsMock.mockClear();
+    formValues.current = {};
   });
 
   it('renders the create brand form in a dialog', () => {
@@ -290,6 +318,41 @@ describe('ModalBrand', () => {
 
     await waitFor(() => {
       expect(pushMock).toHaveBeenCalledWith('/acme-org/acme/settings');
+    });
+  });
+
+  it('stores and imports a website banner when creating a brand', async () => {
+    formValues.current = {
+      label: 'Acme',
+      slug: 'acme',
+      websiteUrl: 'https://acme.test',
+    };
+    render(<ModalBrand {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create brand' }));
+
+    await waitFor(() => {
+      expect(postBrandMock).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          brand: 'brand-created',
+          category: 'website',
+          url: 'https://acme.test',
+        }),
+      );
+      expect(crawlBrandKitMock).toHaveBeenCalledWith('brand-created', {
+        url: 'https://acme.test',
+      });
+      expect(importBrandKitAssetsMock).toHaveBeenCalledWith('brand-created', {
+        assets: [
+          expect.objectContaining({
+            candidateId: 'banner-1',
+            replaceExisting: false,
+            role: 'banner',
+            sourceUrl: 'https://acme.test/og.jpg',
+          }),
+        ],
+      });
     });
   });
 

--- a/packages/ui/src/components/modals/brands/brand/ModalBrand.tsx
+++ b/packages/ui/src/components/modals/brands/brand/ModalBrand.tsx
@@ -182,6 +182,17 @@ export default function BrandOverlay({
                   isDisabled={isSubmitting}
                 />
               </FormControl>
+
+              <FormControl label="Website">
+                <Input
+                  type="url"
+                  name="websiteUrl"
+                  control={form.control}
+                  onChange={handleCreateFieldChange}
+                  placeholder="https://example.com"
+                  isDisabled={isSubmitting}
+                />
+              </FormControl>
             </Modal.Body>
 
             <Modal.Footer>

--- a/packages/ui/src/components/modals/brands/brand/ModalBrand.types.ts
+++ b/packages/ui/src/components/modals/brands/brand/ModalBrand.types.ts
@@ -1,4 +1,4 @@
-import { CredentialPlatform } from '@genfeedai/enums';
+import { SocialUrlHelper } from '@genfeedai/helpers';
 import type { IBrand, ILink } from '@genfeedai/interfaces';
 import type { Brand } from '@genfeedai/models/organization/brand.model';
 import type { BrandDetailSocialConnection } from '@genfeedai/props/pages/brand-detail.props';
@@ -22,56 +22,22 @@ export function buildSocialConnections(
     return [];
   }
 
-  const connections: BrandDetailSocialConnection[] = [];
-  const findConnectedCredential = (platform: CredentialPlatform) =>
-    brand.credentials?.find(
-      (credential) =>
-        credential.platform === platform && credential.isConnected === true,
-    );
-
-  const youtubeCredential = findConnectedCredential(CredentialPlatform.YOUTUBE);
-  if (youtubeCredential && brand.youtubeUrl) {
-    connections.push({
-      credentialId: youtubeCredential.id,
-      handle: brand.youtubeHandle,
-      platform: CredentialPlatform.YOUTUBE,
-      url: brand.youtubeUrl,
-    });
-  }
-
-  const tiktokCredential = findConnectedCredential(CredentialPlatform.TIKTOK);
-  if (tiktokCredential && brand.tiktokUrl) {
-    connections.push({
-      credentialId: tiktokCredential.id,
-      handle: brand.tiktokHandle,
-      platform: CredentialPlatform.TIKTOK,
-      url: brand.tiktokUrl,
-    });
-  }
-
-  const instagramCredential = findConnectedCredential(
-    CredentialPlatform.INSTAGRAM,
-  );
-  if (instagramCredential && brand.instagramUrl) {
-    connections.push({
-      credentialId: instagramCredential.id,
-      handle: brand.instagramHandle,
-      platform: CredentialPlatform.INSTAGRAM,
-      url: brand.instagramUrl,
-    });
-  }
-
-  const twitterCredential = findConnectedCredential(CredentialPlatform.TWITTER);
-  if (twitterCredential && brand.twitterUrl) {
-    connections.push({
-      credentialId: twitterCredential.id,
-      handle: brand.twitterHandle,
-      platform: CredentialPlatform.TWITTER,
-      url: brand.twitterUrl,
-    });
-  }
-
-  return connections;
+  return (brand.credentials ?? [])
+    .filter((credential) => credential.isConnected === true)
+    .map((credential) => ({
+      accountHealth: credential.accountHealth,
+      avatarUrl: credential.externalAvatar,
+      credentialId: credential.id,
+      handle: credential.externalHandle,
+      label: credential.label,
+      name: credential.externalName,
+      platform: credential.platform,
+      url: SocialUrlHelper.buildProfileUrl(
+        credential.platform,
+        credential.externalHandle,
+        credential.externalId,
+      ),
+    }));
 }
 
 export type BrandFormValues = {
@@ -88,4 +54,5 @@ export type BrandFormValues = {
   primaryColor: string;
   secondaryColor: string;
   text: string;
+  websiteUrl: string;
 };

--- a/packages/ui/src/components/modals/brands/brand/useModalBrand.ts
+++ b/packages/ui/src/components/modals/brands/brand/useModalBrand.ts
@@ -81,6 +81,7 @@ const DEFAULT_BRAND_FORM_VALUES: BrandFormValues = {
   secondaryColor: THEME_COLORS.SECONDARY,
   slug: '',
   text: '',
+  websiteUrl: '',
 };
 
 export type OrganizationOption = {
@@ -355,6 +356,7 @@ export function useModalBrand(
         activeBrand.secondaryColor || DEFAULT_BRAND_FORM_VALUES.secondaryColor,
       slug: activeBrand.slug || '',
       text: activeBrand.text || '',
+      websiteUrl: '',
     });
   }, [activeBrand, form, overlayBrandId]);
 
@@ -695,8 +697,9 @@ export function useModalBrand(
     async (isOrganizationChange: boolean) => {
       try {
         const service = await getBrandsService();
+        const { websiteUrl = '', ...brandFormValues } = form.getValues();
         const formData = {
-          ...form.getValues(),
+          ...brandFormValues,
           isDeleted: false,
           isSelected: false,
         };
@@ -714,6 +717,50 @@ export function useModalBrand(
           const createdBrand = await service.post(
             new Brand(formData as Partial<IBrand>),
           );
+
+          if (websiteUrl.trim()) {
+            try {
+              const normalizedWebsiteUrl = websiteUrl.trim();
+              const linksService = await getLinksService();
+              await linksService.post({
+                brand: createdBrand.id,
+                category: LinkCategory.WEBSITE,
+                label: 'Website',
+                url: normalizedWebsiteUrl,
+              } as unknown as Partial<Link>);
+
+              const draft = await service.crawlBrandKitWebsite(
+                createdBrand.id,
+                { url: normalizedWebsiteUrl },
+              );
+              const bannerCandidate = draft.assetCandidates.find(
+                (candidate) => candidate.role === 'banner',
+              );
+
+              if (bannerCandidate) {
+                await service.importBrandKitAssets(createdBrand.id, {
+                  assets: [
+                    {
+                      candidateId: bannerCandidate.candidateId,
+                      label: bannerCandidate.label,
+                      mimeType: bannerCandidate.mimeType,
+                      replaceExisting: false,
+                      role: 'banner',
+                      sourceType: 'website',
+                      sourceUrl:
+                        bannerCandidate.sourceUrl ?? bannerCandidate.url,
+                    },
+                  ],
+                });
+              }
+            } catch (enrichmentError) {
+              logger.error(
+                'Brand created but website enrichment failed',
+                enrichmentError,
+              );
+            }
+          }
+
           const createdBrandDetail = await service.findOne(createdBrand.id);
           const createdBrandSlug =
             createdBrandDetail.slug || createdBrand.slug || '';
@@ -764,6 +811,7 @@ export function useModalBrand(
     [
       form,
       getBrandsService,
+      getLinksService,
       mutateBrand,
       onConfirm,
       onClose,

--- a/packages/ui/src/components/modals/brands/instagram/ModalBrandInstagram.tsx
+++ b/packages/ui/src/components/modals/brands/instagram/ModalBrandInstagram.tsx
@@ -142,8 +142,10 @@ export default function ModalBrandInstagram({
       const service = await getCredentialsService();
 
       const data = await service.patch(credential.id, {
+        externalAvatar: selectedHandle.image,
         externalHandle: selectedHandle.username,
         externalId: selectedHandle.id,
+        externalName: selectedHandle.label,
       });
 
       logger.info(`${url} success`, data);


### PR DESCRIPTION
## Summary

- import the strongest website hero, Open Graph, or Twitter Card image as a brand banner while preserving an existing banner
- mirror provider profile pictures into Genfeed-owned S3/CDN storage and expose the public identity fields through the credential serializer
- render every connected account with its PFP or initials fallback plus a platform badge, including multiple accounts on the same platform
- add website enrichment to both onboarding scrape and the standard New Brand flow

## Storage decision

External images are copied into Genfeed-owned S3/CDN storage instead of hotlinked. This avoids expiring OAuth image URLs, remote tracking, and broken profile/header visuals. Avatar import is best-effort so a provider image outage cannot fail OAuth.

## Verification

- focused API specs: brand persistence, scraper, credentials service/controller, and Twitter/TikTok/YouTube/Facebook/LinkedIn/Reddit/Threads callbacks
- focused frontend/package specs: New Brand modal, brand service client, social URL builder, and connected-account card
- changed-file Biome and design lint
- staged secretlint and Gitleaks scans
- broad monorepo checks delegated to PR CI
