### PR TITLE
fix(release): harden public npm package distribution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,6 +269,10 @@ jobs:
         run: bun run check:ui-guards
       - name: Design System
         run: bun run design:check
+      - name: Public Package Manifests
+        run: bun run check:public-packages
+      - name: Package Release Scripts
+        run: bunx vitest run --config scripts/package-release/vitest.config.ts
       # Fail the build if the committed Prisma model metadata (enum-field-map)
       # has drifted from schema.prisma — soft-delete filtering + enum
       # normalization under the Prisma 7 driver adapter depend on it, and it

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -4,11 +4,11 @@ on:
   workflow_dispatch:
     inputs:
       packages_json:
-        description: 'JSON array of package publish requests, e.g. [{"path":"packages/ui","bump":"patch"}]'
+        description: 'Exact versions already merged to master, e.g. [{"path":"packages/ui","version":"2.0.2"}]'
         required: true
         type: string
       dry_run:
-        description: 'Validate, build, and simulate publish without pushing releases or git changes'
+        description: 'Build, pack, inspect, and simulate every publish without registry changes'
         required: false
         default: true
         type: boolean
@@ -18,28 +18,28 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  publish:
-    name: Publish selected npm packages
+  preflight:
+    name: Preflight immutable package tarballs
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     permissions:
-      contents: write
-      id-token: write
+      contents: read
     env:
-      PACKAGE_RELEASE_OUTPUT: .package-release-output.json
+      RELEASE_DIR: ${{ github.workspace }}/.package-release
     steps:
-      - name: Checkout master
-        uses: actions/checkout@v5
-        with:
-          ref: master
-          fetch-depth: 0
-
-      - name: Verify workflow is running on master
+      - name: Require a master dispatch
         run: |
-          if [ "${GITHUB_REF_NAME}" != "master" ]; then
-            echo "Package publishing is only allowed from master. Current ref: ${GITHUB_REF_NAME}"
+          if [ "${GITHUB_REF}" != "refs/heads/master" ]; then
+            echo "::error::Package releases must be dispatched from master. Current ref: ${GITHUB_REF}"
             exit 1
           fi
+
+      - name: Checkout the dispatched master commit
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Bun environment
         uses: ./.github/actions/setup-bun-env
@@ -47,47 +47,120 @@ jobs:
           node-version: '24.x'
           bun-version: '1.3.14'
 
-      - name: Configure git author
+      - name: Require npm trusted-publishing support
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          # shellcheck disable=SC2016
+          node -e '
+            const [major, minor] = process.argv[1].split(".").map(Number);
+            if (major < 11 || (major === 11 && minor < 5)) {
+              throw new Error(`npm >=11.5.1 is required for OIDC trusted publishing; found ${process.argv[1]}`);
+            }
+          ' "$(npm --version)"
 
-      - name: Publish packages
+      - name: Build, pack, and dry-run the complete release
         env:
           PACKAGES_JSON: ${{ inputs.packages_json }}
         run: |
-          if [ "${{ inputs.dry_run }}" = "true" ]; then
-            node scripts/publish-packages-from-json.mjs --packages-json "${PACKAGES_JSON}" --dry-run
-          else
-            node scripts/publish-packages-from-json.mjs --packages-json "${PACKAGES_JSON}"
-          fi
+          node scripts/publish-packages-from-json.mjs \
+            --packages-json "${PACKAGES_JSON}" \
+            --output-dir "${RELEASE_DIR}"
 
-      - name: Commit version bumps
-        if: ${{ inputs.dry_run == false }}
-        run: |
-          if git diff --quiet -- packages ee/packages; then
-            echo "No package version changes to commit"
-            exit 0
-          fi
+      - name: Upload immutable release plan and tarballs
+        uses: actions/upload-artifact@v4
+        with:
+          name: package-release-${{ github.run_id }}
+          path: ${{ env.RELEASE_DIR }}
+          if-no-files-found: error
+          include-hidden-files: true
+          overwrite: true
+          retention-days: 1
 
-          git diff --name-only -- packages ee/packages | grep '/package.json$' > /tmp/package-version-files
-          if [ ! -s /tmp/package-version-files ]; then
-            echo "No package version files changed"
-            exit 0
-          fi
-
-          xargs -a /tmp/package-version-files git add --
-          if git diff --cached --quiet; then
-            echo "No staged package version changes to commit"
-            exit 0
-          fi
-          git commit -m "chore(release): publish npm packages"
-          git push origin HEAD:master
-
-      - name: Release summary
+      - name: Preflight summary
         if: always()
         run: |
-          if [ -f "${PACKAGE_RELEASE_OUTPUT}" ]; then
-            echo "## Package release summary" >> "$GITHUB_STEP_SUMMARY"
-            cat "${PACKAGE_RELEASE_OUTPUT}" >> "$GITHUB_STEP_SUMMARY"
+          if [ -f "${RELEASE_DIR}/release-status.json" ]; then
+            {
+              echo '## Package release preflight'
+              echo '```json'
+              cat "${RELEASE_DIR}/release-status.json"
+              echo '```'
+            } >> "${GITHUB_STEP_SUMMARY}"
           fi
+
+  publish:
+    name: Publish preflighted package tarballs
+    if: ${{ inputs.dry_run == false }}
+    needs: preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      RELEASE_DIR: ${{ github.workspace }}/.package-release
+    steps:
+      - name: Checkout the preflighted commit
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Node for npm trusted publishing
+        uses: actions/setup-node@v5
+        with:
+          node-version: '24.x'
+
+      - name: Require npm trusted-publishing support
+        run: |
+          # shellcheck disable=SC2016
+          node -e '
+            const [major, minor] = process.argv[1].split(".").map(Number);
+            if (major < 11 || (major === 11 && minor < 5)) {
+              throw new Error(`npm >=11.5.1 is required for OIDC trusted publishing; found ${process.argv[1]}`);
+            }
+          ' "$(npm --version)"
+
+      - name: Require unchanged master
+        run: |
+          if [ "${GITHUB_REF}" != "refs/heads/master" ]; then
+            echo "::error::Package releases are only allowed from master. Current ref: ${GITHUB_REF}"
+            exit 1
+          fi
+          git fetch origin master
+          if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/master)" ]; then
+            echo "::error::Master advanced after this release was dispatched. Run a new dry-run from current master."
+            exit 1
+          fi
+
+      - name: Download immutable release plan and tarballs
+        uses: actions/download-artifact@v4
+        with:
+          name: package-release-${{ github.run_id }}
+          path: ${{ env.RELEASE_DIR }}
+
+      - name: Publish dependency-first with resumable collision checks
+        run: |
+          node scripts/publish-packages-from-json.mjs \
+            --publish-plan "${RELEASE_DIR}/release-plan.json"
+
+      - name: Publication summary
+        if: always()
+        run: |
+          if [ -f "${RELEASE_DIR}/release-status.json" ]; then
+            {
+              echo '## Package publication status'
+              echo '```json'
+              cat "${RELEASE_DIR}/release-status.json"
+              echo '```'
+            } >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
+      - name: Upload publication journal
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: package-publication-status-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ env.RELEASE_DIR }}/release-status.json
+          if-no-files-found: warn
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ apps/desktop/app/release/
 .agents/memory/local/
 .clawpatch/
 .genfeed/
+.package-release/
 
 # Playwright generated artifacts: reports, traces, videos, screenshots, and legacy auth provider storageState
 playwright/artifacts/

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Genfeed.ai
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -97,3 +97,45 @@ If a release needs to cover the hosted product, desktop app, and browser extensi
 4. Push `extension-browser-v1.2.3`.
 
 The version numbers should match, but the workflows are intentionally separate so each surface can be shipped independently when needed.
+
+## Public npm Packages
+
+npm versions are release state and follow the same trunk gate as code:
+
+1. Update every package version in a normal PR to `master`. Include all
+   unpublished workspace dependencies needed by the release.
+2. From the `master` Actions page, run `Publish Packages` with `dry_run=true`
+   and exact merged versions, for example:
+
+   ```json
+   [{"path":"packages/enums","version":"2.3.3"},{"path":"packages/constants","version":"2.2.10"}]
+   ```
+
+3. Inspect the preflight artifact and summary. The workflow builds from clean
+   outputs, orders workspace dependencies, packs with Bun, validates the
+   resolved tarball, injects the matching complete license text, and runs
+   `npm publish --dry-run` before registry access is granted. An abbreviated
+   root AGPL notice fails preflight instead of producing an incomplete package.
+4. Rerun the same input with `dry_run=false`. The publish job uploads only the
+   preflighted tarballs and never commits or pushes to `master`. If npm fails
+   partway through, rerun the exact release: matching registry tarballs are
+   verified and skipped before pending packages continue.
+
+Do not pass `bump` requests to the workflow and do not publish a workspace
+directory with npm. Bun resolves `workspace:*` while creating the immutable
+tarball; npm 11.5.1 or newer uploads that tarball with trusted-publisher OIDC
+and provenance.
+
+An npm owner must configure each existing `@genfeedai/*` package with this
+trusted publisher before its first workflow release:
+
+- organization: `genfeedai`
+- repository: `genfeed.ai`
+- workflow: `publish-packages.yml`
+- environment: unset unless the workflow is updated to use one
+
+Package names that do not yet exist on npm (`api-types`, `auth-client`,
+`harness`, `pricing`, and `queue-contracts` as of July 2026) require one
+owner-authenticated bootstrap publication before npm allows trusted-publisher
+configuration. Bootstrap from a preflight tarball; never bypass the version PR
+or publish directly from a workspace directory.

--- a/bun.lock
+++ b/bun.lock
@@ -152,7 +152,6 @@
         "@types/react-dom": "19.2.3",
         "@vitejs/plugin-react": "6.0.3",
         "clsx": "2.1.1",
-        "es-module-lexer": "2.3.0",
         "glob": "13.0.6",
         "lint-staged": "17.0.8",
         "monocart-reporter": "2.12.2",

--- a/bun.lock
+++ b/bun.lock
@@ -152,6 +152,7 @@
         "@types/react-dom": "19.2.3",
         "@vitejs/plugin-react": "6.0.3",
         "clsx": "2.1.1",
+        "es-module-lexer": "2.3.0",
         "glob": "13.0.6",
         "lint-staged": "17.0.8",
         "monocart-reporter": "2.12.2",

--- a/bun.lock
+++ b/bun.lock
@@ -719,6 +719,7 @@
       },
       "devDependencies": {
         "openapi-typescript": "7.13.0",
+        "tsc-alias": "1.9.0",
         "typescript": "6.0.2",
       },
     },
@@ -733,6 +734,7 @@
         "@types/node": "26.1.1",
         "@types/react": "19.2.17",
         "react": "19.2.7",
+        "tsc-alias": "1.9.0",
         "typescript": "6.0.2",
       },
       "peerDependencies": {
@@ -741,7 +743,7 @@
     },
     "packages/cli": {
       "name": "@genfeedai/cli",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "bin": {
         "genfeed": "dist/index.js",
         "gf": "dist/index.js",
@@ -771,7 +773,7 @@
     },
     "packages/client": {
       "name": "@genfeedai/client",
-      "version": "2.3.1",
+      "version": "2.3.2",
       "dependencies": {
         "@genfeedai/constants": "workspace:*",
         "@genfeedai/enums": "workspace:*",
@@ -779,6 +781,7 @@
         "zod": "4.4.3",
       },
       "devDependencies": {
+        "tsc-alias": "1.9.0",
         "typescript": "6.0.2",
       },
     },
@@ -797,12 +800,13 @@
     },
     "packages/constants": {
       "name": "@genfeedai/constants",
-      "version": "2.2.9",
+      "version": "2.2.10",
       "dependencies": {
         "@genfeedai/enums": "workspace:*",
+        "react-icons": "5.7.0",
       },
       "devDependencies": {
-        "react-icons": "5.7.0",
+        "tsc-alias": "1.9.0",
         "typescript": "6.0.2",
       },
     },
@@ -857,6 +861,7 @@
       },
       "devDependencies": {
         "@types/node": "26.1.1",
+        "tsc-alias": "1.9.0",
         "typescript": "6.0.2",
         "vitest": "4.1.10",
       },
@@ -884,14 +889,15 @@
     },
     "packages/enums": {
       "name": "@genfeedai/enums",
-      "version": "2.3.2",
+      "version": "2.3.3",
       "devDependencies": {
+        "tsc-alias": "1.9.0",
         "typescript": "6.0.2",
       },
     },
     "packages/errors": {
       "name": "@genfeedai/errors",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "chalk": "5.6.2",
       },
@@ -922,7 +928,7 @@
     },
     "packages/helpers": {
       "name": "@genfeedai/helpers",
-      "version": "2.2.12",
+      "version": "2.2.13",
       "dependencies": {
         "@genfeedai/auth-client": "workspace:*",
         "@genfeedai/constants": "workspace:*",
@@ -944,6 +950,7 @@
         "react-dom": "19.2.7",
         "react-hook-form": "7.81.0",
         "react-icons": "5.7.0",
+        "tsc-alias": "1.9.0",
         "typescript": "6.0.2",
       },
     },
@@ -985,7 +992,7 @@
     },
     "packages/interfaces": {
       "name": "@genfeedai/interfaces",
-      "version": "2.3.20",
+      "version": "2.3.21",
       "dependencies": {
         "@genfeedai/constants": "workspace:*",
         "@genfeedai/enums": "workspace:*",
@@ -999,6 +1006,7 @@
         "react-dom": "19.2.7",
         "react-hook-form": "7.81.0",
         "react-icons": "5.7.0",
+        "tsc-alias": "1.9.0",
         "typescript": "6.0.2",
       },
     },
@@ -1064,6 +1072,7 @@
       },
       "devDependencies": {
         "@types/node": "26.1.1",
+        "tsc-alias": "1.9.0",
         "typescript": "6.0.2",
       },
     },
@@ -1080,7 +1089,7 @@
     },
     "packages/prompts": {
       "name": "@genfeedai/prompts",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "devDependencies": {
         "@genfeedai/types": "workspace:*",
         "@types/node": "26.1.1",
@@ -1112,12 +1121,13 @@
         "@genfeedai/enums": "workspace:*",
       },
       "devDependencies": {
+        "tsc-alias": "1.9.0",
         "typescript": "6.0.2",
       },
     },
     "packages/serializers": {
       "name": "@genfeedai/serializers",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "dependencies": {
         "@genfeedai/constants": "workspace:*",
         "@genfeedai/enums": "workspace:*",
@@ -1159,8 +1169,9 @@
     },
     "packages/tools": {
       "name": "@genfeedai/tools",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "devDependencies": {
+        "tsc-alias": "1.9.0",
         "typescript": "6.0.2",
       },
     },
@@ -1170,7 +1181,7 @@
     },
     "packages/types": {
       "name": "@genfeedai/types",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "devDependencies": {
         "@xyflow/react": "12.11.2",
         "tsup": "8.5.1",
@@ -1184,17 +1195,13 @@
         "@fullcalendar/core": "6.1.21",
         "@fullcalendar/interaction": "6.1.21",
         "@fullcalendar/timegrid": "6.1.21",
+        "@genfeedai/client": "workspace:*",
         "@genfeedai/constants": "workspace:*",
-        "@genfeedai/contexts": "workspace:*",
         "@genfeedai/enums": "workspace:*",
         "@genfeedai/helpers": "workspace:*",
-        "@genfeedai/hooks": "workspace:*",
         "@genfeedai/interfaces": "workspace:*",
-        "@genfeedai/models": "workspace:*",
         "@genfeedai/pricing": "workspace:*",
-        "@genfeedai/props": "workspace:*",
-        "@genfeedai/services": "workspace:*",
-        "@genfeedai/utils": "workspace:*",
+        "@hookform/resolvers": "5.4.0",
         "@shipshitdev/ui": "0.8.3",
         "@tanstack/react-query": "5.101.2",
         "@tiptap/extension-blockquote": "3.27.3",
@@ -1211,11 +1218,23 @@
         "@tiptap/extension-strike": "3.27.3",
         "@tiptap/react": "3.27.3",
         "@tiptap/starter-kit": "3.27.3",
+        "cmdk": "1.1.1",
+        "date-fns": "4.4.0",
         "html-react-parser": "6.1.4",
+        "react-color": "2.19.3",
+        "react-day-picker": "10.0.1",
+        "react-dropzone": "15.0.0",
+        "react-hook-form": "7.81.0",
         "react-icons": "5.7.0",
+        "vaul": "1.1.2",
       },
       "devDependencies": {
-        "@genfeedai/client": "workspace:*",
+        "@genfeedai/contexts": "workspace:*",
+        "@genfeedai/hooks": "workspace:*",
+        "@genfeedai/models": "workspace:*",
+        "@genfeedai/props": "workspace:*",
+        "@genfeedai/services": "workspace:*",
+        "@genfeedai/utils": "workspace:*",
         "@tanstack/react-query-devtools": "5.101.2",
         "@testing-library/jest-dom": "6.9.1",
         "@testing-library/react": "16.3.2",
@@ -1226,11 +1245,9 @@
         "@vitejs/plugin-react": "6.0.3",
         "jsdom": "29.1.1",
         "react": "19.2.7",
-        "react-day-picker": "10.0.1",
         "react-dom": "19.2.7",
         "tsc-alias": "1.9.0",
         "typescript": "6.0.2",
-        "vaul": "1.1.2",
         "vitest": "4.1.10",
       },
       "peerDependencies": {
@@ -1286,19 +1303,20 @@
     },
     "packages/workflow-engine": {
       "name": "@genfeedai/workflow-engine",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@genfeedai/enums": "workspace:*",
         "@genfeedai/interfaces": "workspace:*",
         "recheck": "4.5.0",
       },
       "devDependencies": {
+        "tsup": "8.5.1",
         "typescript": "6.0.2",
       },
     },
     "packages/workflow-saas": {
       "name": "@genfeedai/workflow-saas",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@genfeedai/enums": "workspace:*",
         "@genfeedai/interfaces": "workspace:*",
@@ -1306,12 +1324,13 @@
         "@genfeedai/workflows": "workspace:*",
       },
       "devDependencies": {
+        "tsup": "8.5.1",
         "typescript": "6.0.2",
       },
     },
     "packages/workflow-ui": {
       "name": "@genfeedai/workflow-ui",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "dependencies": {
         "@dagrejs/dagre": "3.0.0",
         "@genfeedai/core": "workspace:*",
@@ -1356,7 +1375,7 @@
     },
     "packages/workflows": {
       "name": "@genfeedai/workflows",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "@genfeedai/types": "workspace:*",
       },

--- a/bun.lock
+++ b/bun.lock
@@ -719,7 +719,6 @@
       },
       "devDependencies": {
         "openapi-typescript": "7.13.0",
-        "tsc-alias": "1.9.0",
         "typescript": "6.0.2",
       },
     },
@@ -734,7 +733,6 @@
         "@types/node": "26.1.1",
         "@types/react": "19.2.17",
         "react": "19.2.7",
-        "tsc-alias": "1.9.0",
         "typescript": "6.0.2",
       },
       "peerDependencies": {
@@ -781,7 +779,6 @@
         "zod": "4.4.3",
       },
       "devDependencies": {
-        "tsc-alias": "1.9.0",
         "typescript": "6.0.2",
       },
     },
@@ -806,7 +803,6 @@
         "react-icons": "5.7.0",
       },
       "devDependencies": {
-        "tsc-alias": "1.9.0",
         "typescript": "6.0.2",
       },
     },
@@ -861,7 +857,6 @@
       },
       "devDependencies": {
         "@types/node": "26.1.1",
-        "tsc-alias": "1.9.0",
         "typescript": "6.0.2",
         "vitest": "4.1.10",
       },
@@ -891,7 +886,6 @@
       "name": "@genfeedai/enums",
       "version": "2.3.3",
       "devDependencies": {
-        "tsc-alias": "1.9.0",
         "typescript": "6.0.2",
       },
     },
@@ -950,7 +944,6 @@
         "react-dom": "19.2.7",
         "react-hook-form": "7.81.0",
         "react-icons": "5.7.0",
-        "tsc-alias": "1.9.0",
         "typescript": "6.0.2",
       },
     },
@@ -1006,7 +999,6 @@
         "react-dom": "19.2.7",
         "react-hook-form": "7.81.0",
         "react-icons": "5.7.0",
-        "tsc-alias": "1.9.0",
         "typescript": "6.0.2",
       },
     },
@@ -1072,7 +1064,6 @@
       },
       "devDependencies": {
         "@types/node": "26.1.1",
-        "tsc-alias": "1.9.0",
         "typescript": "6.0.2",
       },
     },
@@ -1121,7 +1112,6 @@
         "@genfeedai/enums": "workspace:*",
       },
       "devDependencies": {
-        "tsc-alias": "1.9.0",
         "typescript": "6.0.2",
       },
     },
@@ -1135,7 +1125,6 @@
         "ts-jsonapi": "2.1.3",
       },
       "devDependencies": {
-        "tsc-alias": "1.9.0",
         "typescript": "6.0.2",
       },
     },
@@ -1171,7 +1160,6 @@
       "name": "@genfeedai/tools",
       "version": "0.1.4",
       "devDependencies": {
-        "tsc-alias": "1.9.0",
         "typescript": "6.0.2",
       },
     },
@@ -1246,7 +1234,6 @@
         "jsdom": "29.1.1",
         "react": "19.2.7",
         "react-dom": "19.2.7",
-        "tsc-alias": "1.9.0",
         "typescript": "6.0.2",
         "vitest": "4.1.10",
       },
@@ -5110,7 +5097,7 @@
 
     "globalthis": ["globalthis@1.0.4", "", { "dependencies": { "define-properties": "^1.2.1", "gopd": "^1.0.1" } }, "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ=="],
 
-    "globby": ["globby@11.1.0", "", { "dependencies": { "array-union": "^2.1.0", "dir-glob": "^3.0.1", "fast-glob": "^3.2.9", "ignore": "^5.2.0", "merge2": "^1.4.1", "slash": "^3.0.0" } }, "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g=="],
+    "globby": ["globby@14.1.0", "", { "dependencies": { "@sindresorhus/merge-streams": "^2.1.0", "fast-glob": "^3.3.3", "ignore": "^7.0.3", "path-type": "^6.0.0", "slash": "^5.1.0", "unicorn-magic": "^0.3.0" } }, "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA=="],
 
     "google-auth-library": ["google-auth-library@10.9.0", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg=="],
 
@@ -5988,8 +5975,6 @@
 
     "mute-stream": ["mute-stream@2.0.0", "", {}, "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA=="],
 
-    "mylas": ["mylas@2.1.14", "", {}, "sha512-BzQguy9W9NJgoVn2mRWzbFrFWWztGCcng2QI9+41frfk+Athwgx3qhqhvStz7ExeUUu7Kzw427sNzHpEZNINog=="],
-
     "mysql2": ["mysql2@3.15.3", "", { "dependencies": { "aws-ssl-profiles": "^1.1.1", "denque": "^2.1.0", "generate-function": "^2.3.1", "iconv-lite": "^0.7.0", "long": "^5.2.1", "lru.min": "^1.0.0", "named-placeholders": "^1.1.3", "seq-queue": "^0.0.5", "sqlstring": "^2.3.2" } }, "sha512-FBrGau0IXmuqg4haEZRBfHNWB5mUARw6hNwPDXXGg0XzVJ50mr/9hb267lvpVMnhZ1FON3qNd4Xfcez1rbFwSg=="],
 
     "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
@@ -6318,8 +6303,6 @@
 
     "playwright-core": ["playwright-core@1.61.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg=="],
 
-    "plimit-lit": ["plimit-lit@1.6.1", "", { "dependencies": { "queue-lit": "^1.5.1" } }, "sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA=="],
-
     "plist": ["plist@3.1.0", "", { "dependencies": { "@xmldom/xmldom": "^0.8.8", "base64-js": "^1.5.1", "xmlbuilder": "^15.1.1" } }, "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ=="],
 
     "pluralize": ["pluralize@8.0.0", "", {}, "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="],
@@ -6459,8 +6442,6 @@
     "querystringify": ["querystringify@2.2.0", "", {}, "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="],
 
     "queue": ["queue@6.0.2", "", { "dependencies": { "inherits": "~2.0.3" } }, "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA=="],
-
-    "queue-lit": ["queue-lit@1.5.2", "", {}, "sha512-tLc36IOPeMAubu8BkW8YDBV+WyIgKlYU7zUNs0J5Vk9skSZ4JfGlPOqplP0aHdfv7HL0B2Pg6nwiq60Qc6M2Hw=="],
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
@@ -7235,8 +7216,6 @@
     "ts-morph": ["ts-morph@17.0.1", "", { "dependencies": { "@ts-morph/common": "~0.18.0", "code-block-writer": "^11.0.3" } }, "sha512-10PkHyXmrtsTvZSL+cqtJLTgFXkU43Gd0JCc0Rw6GchWbqKe0Rwgt1v3ouobTZwQzF1mGhDeAlWYBMGRV7y+3g=="],
 
     "ts-toolbelt": ["ts-toolbelt@9.6.0", "", {}, "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w=="],
-
-    "tsc-alias": ["tsc-alias@1.9.0", "", { "dependencies": { "chokidar": "^3.5.3", "commander": "^9.0.0", "get-tsconfig": "^4.10.0", "globby": "^11.0.4", "mylas": "^2.1.9", "normalize-path": "^3.0.0", "plimit-lit": "^1.2.6" }, "bin": { "tsc-alias": "dist/bin/index.js" } }, "sha512-IZrCInovKxVCwXyKhcdr/HaxSYugKT0w4zyktOE/4115Nzo6gbp/NhkaEeyOG0/H7QoTeXtv+3UHffBYta9oWw=="],
 
     "tsconfig-paths": ["tsconfig-paths@4.2.0", "", { "dependencies": { "json5": "^2.2.2", "minimist": "^1.2.6", "strip-bom": "^3.0.0" } }, "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg=="],
 
@@ -8478,6 +8457,8 @@
 
     "@web/test-runner-core/cli-cursor": ["cli-cursor@3.1.0", "", { "dependencies": { "restore-cursor": "^3.1.0" } }, "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw=="],
 
+    "@web/test-runner-core/globby": ["globby@11.1.0", "", { "dependencies": { "array-union": "^2.1.0", "dir-glob": "^3.0.1", "fast-glob": "^3.2.9", "ignore": "^5.2.0", "merge2": "^1.4.1", "slash": "^3.0.0" } }, "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g=="],
+
     "@web/test-runner-core/log-update": ["log-update@4.0.0", "", { "dependencies": { "ansi-escapes": "^4.3.0", "cli-cursor": "^3.1.0", "slice-ansi": "^4.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg=="],
 
     "@web/test-runner-core/nanoid": ["nanoid@3.3.15", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA=="],
@@ -8828,7 +8809,13 @@
 
     "global-agent/serialize-error": ["serialize-error@7.0.1", "", { "dependencies": { "type-fest": "^0.13.1" } }, "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw=="],
 
-    "globby/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+    "globby/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+
+    "globby/path-type": ["path-type@6.0.0", "", {}, "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ=="],
+
+    "globby/slash": ["slash@5.1.0", "", {}, "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg=="],
+
+    "globby/unicorn-magic": ["unicorn-magic@0.3.0", "", {}, "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA=="],
 
     "googleapis/google-auth-library": ["google-auth-library@10.6.2", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw=="],
 
@@ -9263,10 +9250,6 @@
     "tr46/punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "ts-loader/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
-
-    "tsc-alias/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
-
-    "tsc-alias/commander": ["commander@9.5.0", "", {}, "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ=="],
 
     "tsconfig-paths-webpack-plugin/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -10124,6 +10107,8 @@
 
     "@plasmohq/parcel-resolver-post/tsup/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 
+    "@plasmohq/parcel-resolver-post/tsup/globby": ["globby@11.1.0", "", { "dependencies": { "array-union": "^2.1.0", "dir-glob": "^3.0.1", "fast-glob": "^3.2.9", "ignore": "^5.2.0", "merge2": "^1.4.1", "slash": "^3.0.0" } }, "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g=="],
+
     "@plasmohq/parcel-resolver-post/tsup/postcss-load-config": ["postcss-load-config@4.0.2", "", { "dependencies": { "lilconfig": "^3.0.0", "yaml": "^2.3.4" }, "peerDependencies": { "postcss": ">=8.0.9", "ts-node": ">=9.0.0" }, "optionalPeers": ["postcss", "ts-node"] }, "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ=="],
 
     "@plasmohq/parcel-resolver-post/tsup/rollup": ["rollup@3.30.0", "", { "optionalDependencies": { "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-kQvGasUgN+AlWGliFn2POSajRQEsULVYFGTvOZmK06d7vCD+YhZztt70kGk3qaeAXeWYL5eO7zx+rAubBc55eA=="],
@@ -10838,8 +10823,6 @@
 
     "@vscode/vsce/secretlint/@secretlint/profiler": ["@secretlint/profiler@10.2.2", "", {}, "sha512-qm9rWfkh/o8OvzMIfY8a5bCmgIniSpltbVlUVl983zDG1bUuQNd1/5lUEeWx5o/WJ99bXxS7yNI4/KIXfHexig=="],
 
-    "@vscode/vsce/secretlint/globby": ["globby@14.1.0", "", { "dependencies": { "@sindresorhus/merge-streams": "^2.1.0", "fast-glob": "^3.3.3", "ignore": "^7.0.3", "path-type": "^6.0.0", "slash": "^5.1.0", "unicorn-magic": "^0.3.0" } }, "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA=="],
-
     "@vscode/vsce/secretlint/read-pkg": ["read-pkg@9.0.1", "", { "dependencies": { "@types/normalize-package-data": "^2.4.3", "normalize-package-data": "^6.0.0", "parse-json": "^8.0.0", "type-fest": "^4.6.0", "unicorn-magic": "^0.1.0" } }, "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA=="],
 
     "@web/dev-server-core/@types/ws/@types/node": ["@types/node@26.0.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw=="],
@@ -10863,6 +10846,8 @@
     "@web/test-runner-core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "@web/test-runner-core/cli-cursor/restore-cursor": ["restore-cursor@3.1.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA=="],
+
+    "@web/test-runner-core/globby/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "@web/test-runner-core/log-update/slice-ansi": ["slice-ansi@4.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "astral-regex": "^2.0.0", "is-fullwidth-code-point": "^3.0.0" } }, "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ=="],
 
@@ -11537,12 +11522,6 @@
     "temp/rimraf/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
     "ts-loader/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
-
-    "tsc-alias/chokidar/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
-
-    "tsc-alias/chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
-
-    "tsc-alias/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
     "tsconfig-paths-webpack-plugin/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
@@ -12268,6 +12247,8 @@
 
     "@plasmohq/parcel-resolver-post/tsup/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
 
+    "@plasmohq/parcel-resolver-post/tsup/globby/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
     "@plasmohq/parcel-resolver-post/tsup/rollup/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "@plasmohq/parcel-resolver-post/tsup/source-map/whatwg-url": ["whatwg-url@7.1.0", "", { "dependencies": { "lodash.sortby": "^4.7.0", "tr46": "^1.0.1", "webidl-conversions": "^4.0.2" } }, "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg=="],
@@ -12664,14 +12645,6 @@
 
     "@vscode/vsce/secretlint/@secretlint/formatter/terminal-link": ["terminal-link@4.0.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "supports-hyperlinks": "^3.2.0" } }, "sha512-lk+vH+MccxNqgVqSnkMVKx4VLJfnLjDBGzH16JVZjKE2DoxP57s6/vt6JmXV5I3jBcfGrxNrYtC+mPtU7WJztA=="],
 
-    "@vscode/vsce/secretlint/globby/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
-
-    "@vscode/vsce/secretlint/globby/path-type": ["path-type@6.0.0", "", {}, "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ=="],
-
-    "@vscode/vsce/secretlint/globby/slash": ["slash@5.1.0", "", {}, "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg=="],
-
-    "@vscode/vsce/secretlint/globby/unicorn-magic": ["unicorn-magic@0.3.0", "", {}, "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA=="],
-
     "@vscode/vsce/secretlint/read-pkg/normalize-package-data": ["normalize-package-data@6.0.2", "", { "dependencies": { "hosted-git-info": "^7.0.0", "semver": "^7.3.5", "validate-npm-package-license": "^3.0.4" } }, "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g=="],
 
     "@vscode/vsce/secretlint/read-pkg/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
@@ -12905,8 +12878,6 @@
     "svgo/css-select/domutils/dom-serializer": ["dom-serializer@1.4.1", "", { "dependencies": { "domelementtype": "^2.0.1", "domhandler": "^4.2.0", "entities": "^2.0.0" } }, "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag=="],
 
     "temp/rimraf/glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
-
-    "tsc-alias/chokidar/readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "vaul/@radix-ui/react-dialog/@radix-ui/react-dismissable-layer/@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg=="],
 

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "check:nested-node-modules": "bun run scripts/check-nested-node-modules.ts",
     "check:pages-boundary": "bun run scripts/check-pages-boundary.ts",
     "check:package-api-surface": "bun run scripts/check-package-api-surface.ts",
+    "check:public-packages": "node scripts/check-public-package-manifests.mjs",
     "check:design-system": "bun run scripts/check-design-system.ts",
     "check:desktop-schema-drift": "bun run scripts/check-desktop-schema-drift.ts",
     "check:generated-source": "bun run scripts/check-generated-source-artifacts.ts",

--- a/package.json
+++ b/package.json
@@ -167,6 +167,7 @@
     "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "6.0.3",
     "clsx": "2.1.1",
+    "es-module-lexer": "2.3.0",
     "glob": "13.0.6",
     "lint-staged": "17.0.8",
     "monocart-reporter": "2.12.2",

--- a/package.json
+++ b/package.json
@@ -167,7 +167,6 @@
     "@types/react-dom": "19.2.3",
     "@vitejs/plugin-react": "6.0.3",
     "clsx": "2.1.1",
-    "es-module-lexer": "2.3.0",
     "glob": "13.0.6",
     "lint-staged": "17.0.8",
     "monocart-reporter": "2.12.2",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -100,6 +100,7 @@
   },
   "main": "src/index.ts",
   "name": "@genfeedai/agent",
+  "private": true,
   "type": "module",
   "peerDependencies": {
     "react": ">=18"

--- a/packages/api-types/package.json
+++ b/packages/api-types/package.json
@@ -6,6 +6,7 @@
   "description": "Auto-generated TypeScript types from OpenAPI spec with Zod validation schemas",
   "devDependencies": {
     "openapi-typescript": "7.13.0",
+    "tsc-alias": "1.9.0",
     "typescript": "6.0.2"
   },
   "exports": {
@@ -32,12 +33,12 @@
     "registry": "https://registry.npmjs.org/"
   },
   "repository": {
-    "directory": "api-types",
+    "directory": "packages/api-types",
     "type": "git",
-    "url": "git+https://github.com/genfeedai/packages.git"
+    "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "scripts": {
-    "build": "tsc --build",
+    "build": "tsc --build && mkdir -p dist/generated && cp src/generated/api.d.ts dist/generated/api.d.ts && bunx tsc-alias -p tsconfig.json -f -fe .js",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "dev": "tsc --watch",
     "generate": "bun run scripts/generate.ts --skip-on-error",

--- a/packages/api-types/package.json
+++ b/packages/api-types/package.json
@@ -6,7 +6,6 @@
   "description": "Auto-generated TypeScript types from OpenAPI spec with Zod validation schemas",
   "devDependencies": {
     "openapi-typescript": "7.13.0",
-    "tsc-alias": "1.9.0",
     "typescript": "6.0.2"
   },
   "exports": {
@@ -38,7 +37,7 @@
     "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "scripts": {
-    "build": "tsc --build && mkdir -p dist/generated && cp src/generated/api.d.ts dist/generated/api.d.ts && bunx tsc-alias -p tsconfig.json -f -fe .js",
+    "build": "tsc --build && mkdir -p dist/generated && cp src/generated/api.d.ts dist/generated/api.d.ts && node ../../scripts/fix-esm-relative-imports.mjs --project tsconfig.json dist",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "dev": "tsc --watch",
     "generate": "bun run scripts/generate.ts --skip-on-error",

--- a/packages/api-types/src/contracts/posts.contract.ts
+++ b/packages/api-types/src/contracts/posts.contract.ts
@@ -5,7 +5,6 @@
  * Types are derived from OpenAPI spec, with Zod schemas for runtime validation.
  */
 
-import type { components } from '@api-types/generated/api';
 import {
   dateStringSchema,
   daysOfWeekSchema,
@@ -17,6 +16,7 @@ import {
 } from '@api-types/helpers/common-schemas';
 import { PostCategory, PostFrequency, PostStatus } from '@genfeedai/enums';
 import { z } from 'zod';
+import type { components } from '../generated/api.js';
 
 // ============================================================================
 // Type Aliases from OpenAPI

--- a/packages/api-types/src/index.ts
+++ b/packages/api-types/src/index.ts
@@ -16,5 +16,5 @@
  */
 
 export * from '@api-types/contracts';
-export type { components, paths } from '@api-types/generated/api';
 export * from '@api-types/helpers';
+export type { components, paths } from './generated/api.js';

--- a/packages/auth-client/package.json
+++ b/packages/auth-client/package.json
@@ -8,6 +8,7 @@
     "@types/node": "26.1.1",
     "@types/react": "19.2.17",
     "react": "19.2.7",
+    "tsc-alias": "1.9.0",
     "typescript": "6.0.2"
   },
   "exports": {
@@ -42,12 +43,12 @@
     "registry": "https://registry.npmjs.org/"
   },
   "repository": {
-    "directory": "auth-client",
+    "directory": "packages/auth-client",
     "type": "git",
-    "url": "git+https://github.com/genfeedai/packages.git"
+    "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "scripts": {
-    "build": "tsc --build && test -f dist/index.js",
+    "build": "tsc --build && bunx tsc-alias -p tsconfig.json -f -fe .js && test -f dist/index.js",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "deps:update": "bunx npm-check-updates -u && bun install",
     "test": "vitest run --config vitest.config.ts",

--- a/packages/auth-client/package.json
+++ b/packages/auth-client/package.json
@@ -8,7 +8,6 @@
     "@types/node": "26.1.1",
     "@types/react": "19.2.17",
     "react": "19.2.7",
-    "tsc-alias": "1.9.0",
     "typescript": "6.0.2"
   },
   "exports": {
@@ -48,7 +47,7 @@
     "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "scripts": {
-    "build": "tsc --build && bunx tsc-alias -p tsconfig.json -f -fe .js && test -f dist/index.js",
+    "build": "tsc --build && node ../../scripts/fix-esm-relative-imports.mjs --project tsconfig.json dist && test -f dist/index.js",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "deps:update": "bunx npm-check-updates -u && bun install",
     "test": "vitest run --config vitest.config.ts",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -49,7 +49,8 @@
   "main": "dist/index.js",
   "name": "@genfeedai/cli",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   },
   "repository": {
     "directory": "packages/cli",
@@ -71,5 +72,5 @@
     "type-check": "tsc --noEmit"
   },
   "type": "module",
-  "version": "0.4.0"
+  "version": "0.4.1"
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -7,7 +7,6 @@
   },
   "description": "Genfeed.ai shared client models and schemas",
   "devDependencies": {
-    "tsc-alias": "1.9.0",
     "typescript": "6.0.2"
   },
   "exports": {
@@ -53,7 +52,7 @@
     "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "scripts": {
-    "build": "tsc --build && bunx tsc-alias -p tsconfig.json -f -fe .js && test -f dist/index.js",
+    "build": "tsc --build && node ../../scripts/fix-esm-relative-imports.mjs --project tsconfig.json dist && test -f dist/index.js",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "deps:update": "bunx npm-check-updates -u && bun install",
     "test": "vitest run --config vitest.config.ts",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -7,6 +7,7 @@
   },
   "description": "Genfeed.ai shared client models and schemas",
   "devDependencies": {
+    "tsc-alias": "1.9.0",
     "typescript": "6.0.2"
   },
   "exports": {
@@ -47,12 +48,12 @@
     "registry": "https://registry.npmjs.org/"
   },
   "repository": {
-    "directory": "client",
+    "directory": "packages/client",
     "type": "git",
-    "url": "git+https://github.com/genfeedai/packages.git"
+    "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "scripts": {
-    "build": "tsc --build && test -f dist/index.js",
+    "build": "tsc --build && bunx tsc-alias -p tsconfig.json -f -fe .js && test -f dist/index.js",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "deps:update": "bunx npm-check-updates -u && bun install",
     "test": "vitest run --config vitest.config.ts",
@@ -78,5 +79,5 @@
       ]
     }
   },
-  "version": "2.3.1"
+  "version": "2.3.2"
 }

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -4,7 +4,6 @@
     "react-icons": "5.7.0"
   },
   "devDependencies": {
-    "tsc-alias": "1.9.0",
     "typescript": "6.0.2"
   },
   "exports": {
@@ -36,7 +35,7 @@
     "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "scripts": {
-    "build": "tsc --build && bunx tsc-alias -p tsconfig.json -f -fe .js",
+    "build": "tsc --build && node ../../scripts/fix-esm-relative-imports.mjs --project tsconfig.json dist",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "dev": "tsc --watch",
     "prepack": "npm run build",

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -1,9 +1,10 @@
 {
   "dependencies": {
-    "@genfeedai/enums": "workspace:*"
+    "@genfeedai/enums": "workspace:*",
+    "react-icons": "5.7.0"
   },
   "devDependencies": {
-    "react-icons": "5.7.0",
+    "tsc-alias": "1.9.0",
     "typescript": "6.0.2"
   },
   "exports": {
@@ -30,12 +31,12 @@
     "registry": "https://registry.npmjs.org/"
   },
   "repository": {
-    "directory": "constants",
+    "directory": "packages/constants",
     "type": "git",
-    "url": "git+https://github.com/genfeedai/packages.git"
+    "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "scripts": {
-    "build": "tsc --build",
+    "build": "tsc --build && bunx tsc-alias -p tsconfig.json -f -fe .js",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "dev": "tsc --watch",
     "prepack": "npm run build",
@@ -45,5 +46,5 @@
   },
   "sideEffects": false,
   "types": "./dist/index.d.ts",
-  "version": "2.2.9"
+  "version": "2.2.10"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -35,9 +35,9 @@
     "registry": "https://registry.npmjs.org/"
   },
   "repository": {
-    "directory": "core",
+    "directory": "packages/core",
     "type": "git",
-    "url": "git+https://github.com/genfeedai/packages.git"
+    "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -13,6 +13,7 @@
   "description": "Genfeed.ai — AI OS for content creation. Self-host for free.",
   "devDependencies": {
     "@types/node": "26.1.1",
+    "tsc-alias": "1.9.0",
     "typescript": "6.0.2",
     "vitest": "4.1.10"
   },
@@ -31,7 +32,8 @@
   "name": "@genfeedai/create",
   "type": "module",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   },
   "repository": {
     "directory": "packages/create",
@@ -39,7 +41,7 @@
     "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "tsc -p tsconfig.json && bunx tsc-alias -p tsconfig.json -f -fe .js",
     "check": "tsc --noEmit -p tsconfig.json",
     "test": "vitest run"
   },

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -13,7 +13,6 @@
   "description": "Genfeed.ai — AI OS for content creation. Self-host for free.",
   "devDependencies": {
     "@types/node": "26.1.1",
-    "tsc-alias": "1.9.0",
     "typescript": "6.0.2",
     "vitest": "4.1.10"
   },
@@ -41,7 +40,7 @@
     "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json && bunx tsc-alias -p tsconfig.json -f -fe .js",
+    "build": "tsc -p tsconfig.json && node ../../scripts/fix-esm-relative-imports.mjs --project tsconfig.json dist",
     "check": "tsc --noEmit -p tsconfig.json",
     "test": "vitest run"
   },

--- a/packages/enums/package.json
+++ b/packages/enums/package.json
@@ -1,6 +1,5 @@
 {
   "devDependencies": {
-    "tsc-alias": "1.9.0",
     "typescript": "6.0.2"
   },
   "exports": {
@@ -27,7 +26,7 @@
     "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "scripts": {
-    "build": "tsc --build && bunx tsc-alias -p tsconfig.json -f -fe .js",
+    "build": "tsc --build && node ../../scripts/fix-esm-relative-imports.mjs --project tsconfig.json dist",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "dev": "tsc --watch",
     "prepack": "npm run build",

--- a/packages/enums/package.json
+++ b/packages/enums/package.json
@@ -1,5 +1,6 @@
 {
   "devDependencies": {
+    "tsc-alias": "1.9.0",
     "typescript": "6.0.2"
   },
   "exports": {
@@ -21,12 +22,12 @@
     "registry": "https://registry.npmjs.org/"
   },
   "repository": {
-    "directory": "enums",
+    "directory": "packages/enums",
     "type": "git",
-    "url": "git+https://github.com/genfeedai/packages.git"
+    "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "scripts": {
-    "build": "tsc --build",
+    "build": "tsc --build && bunx tsc-alias -p tsconfig.json -f -fe .js",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "dev": "tsc --watch",
     "prepack": "npm run build",
@@ -34,5 +35,5 @@
   },
   "sideEffects": false,
   "types": "./dist/index.d.ts",
-  "version": "2.3.2"
+  "version": "2.3.3"
 }

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -25,9 +25,9 @@
     "registry": "https://registry.npmjs.org/"
   },
   "repository": {
-    "directory": "errors",
+    "directory": "packages/errors",
     "type": "git",
-    "url": "git+https://github.com/genfeedai/packages.git"
+    "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "scripts": {
     "build": "tsup",
@@ -37,5 +37,5 @@
   "sideEffects": false,
   "type": "module",
   "types": "./dist/index.d.ts",
-  "version": "0.1.1"
+  "version": "0.1.2"
 }

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -28,9 +28,9 @@
     "registry": "https://registry.npmjs.org/"
   },
   "repository": {
-    "directory": "harness",
+    "directory": "packages/harness",
     "type": "git",
-    "url": "git+https://github.com/genfeedai/packages.git"
+    "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -21,6 +21,7 @@
     "react-dom": "19.2.7",
     "react-hook-form": "7.81.0",
     "react-icons": "5.7.0",
+    "tsc-alias": "1.9.0",
     "typescript": "6.0.2"
   },
   "exports": {
@@ -41,21 +42,7 @@
     }
   },
   "files": [
-    "dist",
-    "src/index.ts",
-    "src/async/sleep",
-    "src/async/sleep.helper.ts",
-    "src/aspect-ratio.helper.ts",
-    "src/business/pricing/pricing.helper.ts",
-    "src/business/tier-models/tier-models.helper.ts",
-    "src/deserializer.helper.ts",
-    "src/formatting/cn",
-    "src/model-capability.helper.ts",
-    "src/quality-routing.helper.ts",
-    "src/serializer.helper.ts",
-    "src/social-url.helper.ts",
-    "src/types/model-like.type.ts",
-    "src/video-duration.helper.ts"
+    "dist"
   ],
   "license": "MIT",
   "main": "./dist/index.js",
@@ -66,12 +53,12 @@
     "registry": "https://registry.npmjs.org/"
   },
   "repository": {
-    "directory": "helpers",
+    "directory": "packages/helpers",
     "type": "git",
-    "url": "git+https://github.com/genfeedai/packages.git"
+    "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "scripts": {
-    "build": "tsc --build",
+    "build": "tsc --build && bunx tsc-alias -p tsconfig.json -f -fe .js",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "deps:update": "bunx npm-check-updates -u && bun install",
     "dev": "tsc --watch",
@@ -84,5 +71,5 @@
   },
   "sideEffects": false,
   "types": "./dist/index.d.ts",
-  "version": "2.2.12"
+  "version": "2.2.13"
 }

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -21,7 +21,6 @@
     "react-dom": "19.2.7",
     "react-hook-form": "7.81.0",
     "react-icons": "5.7.0",
-    "tsc-alias": "1.9.0",
     "typescript": "6.0.2"
   },
   "exports": {
@@ -58,7 +57,7 @@
     "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "scripts": {
-    "build": "tsc --build && bunx tsc-alias -p tsconfig.json -f -fe .js",
+    "build": "tsc --build && node ../../scripts/fix-esm-relative-imports.mjs --project tsconfig.json dist",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "deps:update": "bunx npm-check-updates -u && bun install",
     "dev": "tsc --watch",

--- a/packages/interfaces/package.json
+++ b/packages/interfaces/package.json
@@ -12,6 +12,7 @@
     "react-dom": "19.2.7",
     "react-hook-form": "7.81.0",
     "react-icons": "5.7.0",
+    "tsc-alias": "1.9.0",
     "typescript": "6.0.2"
   },
   "exports": {
@@ -38,12 +39,12 @@
     "registry": "https://registry.npmjs.org/"
   },
   "repository": {
-    "directory": "interfaces",
+    "directory": "packages/interfaces",
     "type": "git",
-    "url": "git+https://github.com/genfeedai/packages.git"
+    "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "scripts": {
-    "build": "tsc --build",
+    "build": "tsc --build && bunx tsc-alias -p tsconfig.json -f -fe .js",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "deps:update": "bunx npm-check-updates -u && bun install",
     "dev": "tsc --watch",
@@ -51,5 +52,5 @@
   },
   "sideEffects": false,
   "types": "./dist/index.d.ts",
-  "version": "2.3.20"
+  "version": "2.3.21"
 }

--- a/packages/interfaces/package.json
+++ b/packages/interfaces/package.json
@@ -12,7 +12,6 @@
     "react-dom": "19.2.7",
     "react-hook-form": "7.81.0",
     "react-icons": "5.7.0",
-    "tsc-alias": "1.9.0",
     "typescript": "6.0.2"
   },
   "exports": {
@@ -44,7 +43,7 @@
     "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "scripts": {
-    "build": "tsc --build && bunx tsc-alias -p tsconfig.json -f -fe .js",
+    "build": "tsc --build && node ../../scripts/fix-esm-relative-imports.mjs --project tsconfig.json dist",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "deps:update": "bunx npm-check-updates -u && bun install",
     "dev": "tsc --watch",

--- a/packages/pricing/package.json
+++ b/packages/pricing/package.json
@@ -5,6 +5,7 @@
   },
   "devDependencies": {
     "@types/node": "26.1.1",
+    "tsc-alias": "1.9.0",
     "typescript": "6.0.2"
   },
   "exports": {
@@ -30,13 +31,13 @@
     "registry": "https://registry.npmjs.org/"
   },
   "repository": {
-    "directory": "pricing",
+    "directory": "packages/pricing",
     "type": "git",
-    "url": "git+https://github.com/genfeedai/packages.git"
+    "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "type": "module",
   "scripts": {
-    "build": "bun run clean && tsc --build",
+    "build": "bun run clean && tsc --build && bunx tsc-alias -p tsconfig.json -f -fe .js",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "dev": "tsc --watch",
     "type-check": "tsc --noEmit"

--- a/packages/pricing/package.json
+++ b/packages/pricing/package.json
@@ -5,7 +5,6 @@
   },
   "devDependencies": {
     "@types/node": "26.1.1",
-    "tsc-alias": "1.9.0",
     "typescript": "6.0.2"
   },
   "exports": {
@@ -37,7 +36,7 @@
   },
   "type": "module",
   "scripts": {
-    "build": "bun run clean && tsc --build && bunx tsc-alias -p tsconfig.json -f -fe .js",
+    "build": "bun run clean && tsc --build && node ../../scripts/fix-esm-relative-imports.mjs --project tsconfig.json dist",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "dev": "tsc --watch",
     "type-check": "tsc --noEmit"

--- a/packages/prompts/package.json
+++ b/packages/prompts/package.json
@@ -25,9 +25,9 @@
     "registry": "https://registry.npmjs.org/"
   },
   "repository": {
-    "directory": "prompts",
+    "directory": "packages/prompts",
     "type": "git",
-    "url": "git+https://github.com/genfeedai/packages.git"
+    "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts --clean --sourcemap",
@@ -38,5 +38,5 @@
   "sideEffects": false,
   "type": "module",
   "types": "./dist/index.d.ts",
-  "version": "0.2.2"
+  "version": "0.2.3"
 }

--- a/packages/queue-contracts/package.json
+++ b/packages/queue-contracts/package.json
@@ -3,6 +3,7 @@
     "@genfeedai/enums": "workspace:*"
   },
   "devDependencies": {
+    "tsc-alias": "1.9.0",
     "typescript": "6.0.2"
   },
   "exports": {
@@ -29,12 +30,12 @@
     "registry": "https://registry.npmjs.org/"
   },
   "repository": {
-    "directory": "queue-contracts",
+    "directory": "packages/queue-contracts",
     "type": "git",
-    "url": "git+https://github.com/genfeedai/packages.git"
+    "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "scripts": {
-    "build": "tsc --build",
+    "build": "tsc --build && bunx tsc-alias -p tsconfig.json -f -fe .js",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "dev": "tsc --watch",
     "test": "vitest run --config vitest.config.ts",

--- a/packages/queue-contracts/package.json
+++ b/packages/queue-contracts/package.json
@@ -3,7 +3,6 @@
     "@genfeedai/enums": "workspace:*"
   },
   "devDependencies": {
-    "tsc-alias": "1.9.0",
     "typescript": "6.0.2"
   },
   "exports": {
@@ -35,7 +34,7 @@
     "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "scripts": {
-    "build": "tsc --build && bunx tsc-alias -p tsconfig.json -f -fe .js",
+    "build": "tsc --build && node ../../scripts/fix-esm-relative-imports.mjs --project tsconfig.json dist",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "dev": "tsc --watch",
     "test": "vitest run --config vitest.config.ts",

--- a/packages/serializers/package.json
+++ b/packages/serializers/package.json
@@ -23,8 +23,7 @@
     }
   },
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "main": "./dist/index.js",
   "license": "AGPL-3.0",
@@ -35,12 +34,12 @@
     "registry": "https://registry.npmjs.org/"
   },
   "repository": {
-    "directory": "serializers",
+    "directory": "packages/serializers",
     "type": "git",
-    "url": "git+https://github.com/genfeedai/packages.git"
+    "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "scripts": {
-    "build": "tsc --build && bunx tsc-alias -p tsconfig.json && test -f dist/index.js",
+    "build": "tsc --build && bunx tsc-alias -p tsconfig.json -f -fe .js && test -f dist/index.js",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "deps:update": "bunx npm-check-updates -u --reject typescript && bun install",
     "dev": "tsc --watch",
@@ -52,5 +51,5 @@
   },
   "sideEffects": false,
   "types": "./dist/index.d.ts",
-  "version": "2.3.0"
+  "version": "2.3.1"
 }

--- a/packages/serializers/package.json
+++ b/packages/serializers/package.json
@@ -7,7 +7,6 @@
   },
   "description": "Genfeed.ai canonical JSON:API serializers",
   "devDependencies": {
-    "tsc-alias": "1.9.0",
     "typescript": "6.0.2"
   },
   "exports": {
@@ -39,7 +38,7 @@
     "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "scripts": {
-    "build": "tsc --build && bunx tsc-alias -p tsconfig.json -f -fe .js && test -f dist/index.js",
+    "build": "tsc --build && node ../../scripts/fix-esm-relative-imports.mjs --project tsconfig.json dist && test -f dist/index.js",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "deps:update": "bunx npm-check-updates -u --reject typescript && bun install",
     "dev": "tsc --watch",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,6 +1,5 @@
 {
   "devDependencies": {
-    "tsc-alias": "1.9.0",
     "typescript": "6.0.2"
   },
   "exports": {
@@ -27,7 +26,7 @@
     "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "scripts": {
-    "build": "tsc --build && bunx tsc-alias -p tsconfig.json -f -fe .js && test -f dist/index.js",
+    "build": "tsc --build && node ../../scripts/fix-esm-relative-imports.mjs --project tsconfig.json dist && test -f dist/index.js",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "dev": "tsc --watch",
     "generate:mcp-tools": "bun run scripts/generate-mcp-tools.ts",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,5 +1,6 @@
 {
   "devDependencies": {
+    "tsc-alias": "1.9.0",
     "typescript": "6.0.2"
   },
   "exports": {
@@ -21,12 +22,12 @@
     "registry": "https://registry.npmjs.org/"
   },
   "repository": {
-    "directory": "tools",
+    "directory": "packages/tools",
     "type": "git",
-    "url": "git+https://github.com/genfeedai/packages.git"
+    "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "scripts": {
-    "build": "tsc --build && test -f dist/index.js",
+    "build": "tsc --build && bunx tsc-alias -p tsconfig.json -f -fe .js && test -f dist/index.js",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "dev": "tsc --watch",
     "generate:mcp-tools": "bun run scripts/generate-mcp-tools.ts",
@@ -36,5 +37,5 @@
   },
   "sideEffects": false,
   "types": "./dist/index.d.ts",
-  "version": "0.1.3"
+  "version": "0.1.4"
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -40,9 +40,9 @@
     "registry": "https://registry.npmjs.org/"
   },
   "repository": {
-    "directory": "types",
+    "directory": "packages/types",
     "type": "git",
-    "url": "git+https://github.com/genfeedai/packages.git"
+    "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "scripts": {
     "build": "tsup",
@@ -52,5 +52,5 @@
   "sideEffects": false,
   "type": "module",
   "types": "./dist/index.d.ts",
-  "version": "0.3.1"
+  "version": "0.3.2"
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -55,7 +55,6 @@
     "jsdom": "29.1.1",
     "react": "19.2.7",
     "react-dom": "19.2.7",
-    "tsc-alias": "1.9.0",
     "typescript": "6.0.2",
     "vitest": "4.1.10"
   },
@@ -124,7 +123,7 @@
     "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "scripts": {
-    "build": "tsc --build && bunx tsc-alias -p tsconfig.json -f -fe .js",
+    "build": "tsc --build && node ../../scripts/fix-esm-relative-imports.mjs --project tsconfig.json dist",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "test": "../../scripts/sh/sanitize-node-color-env.sh vitest run --config vitest.config.ts",
     "test:watch": "vitest watch --config vitest.config.ts"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -3,17 +3,13 @@
     "@fullcalendar/core": "6.1.21",
     "@fullcalendar/interaction": "6.1.21",
     "@fullcalendar/timegrid": "6.1.21",
+    "@genfeedai/client": "workspace:*",
     "@genfeedai/constants": "workspace:*",
-    "@genfeedai/contexts": "workspace:*",
     "@genfeedai/enums": "workspace:*",
     "@genfeedai/helpers": "workspace:*",
-    "@genfeedai/hooks": "workspace:*",
     "@genfeedai/interfaces": "workspace:*",
-    "@genfeedai/models": "workspace:*",
     "@genfeedai/pricing": "workspace:*",
-    "@genfeedai/props": "workspace:*",
-    "@genfeedai/services": "workspace:*",
-    "@genfeedai/utils": "workspace:*",
+    "@hookform/resolvers": "5.4.0",
     "@shipshitdev/ui": "0.8.3",
     "@tanstack/react-query": "5.101.2",
     "@tiptap/extension-blockquote": "3.27.3",
@@ -30,12 +26,24 @@
     "@tiptap/extension-strike": "3.27.3",
     "@tiptap/react": "3.27.3",
     "@tiptap/starter-kit": "3.27.3",
+    "cmdk": "1.1.1",
+    "date-fns": "4.4.0",
     "html-react-parser": "6.1.4",
-    "react-icons": "5.7.0"
+    "react-color": "2.19.3",
+    "react-day-picker": "10.0.1",
+    "react-dropzone": "15.0.0",
+    "react-hook-form": "7.81.0",
+    "react-icons": "5.7.0",
+    "vaul": "1.1.2"
   },
   "description": "Shared design tokens and UI primitives for Genfeed web, mobile, and extension surfaces",
   "devDependencies": {
-    "@genfeedai/client": "workspace:*",
+    "@genfeedai/contexts": "workspace:*",
+    "@genfeedai/hooks": "workspace:*",
+    "@genfeedai/models": "workspace:*",
+    "@genfeedai/props": "workspace:*",
+    "@genfeedai/services": "workspace:*",
+    "@genfeedai/utils": "workspace:*",
     "@tanstack/react-query-devtools": "5.101.2",
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.2",
@@ -46,11 +54,9 @@
     "@vitejs/plugin-react": "6.0.3",
     "jsdom": "29.1.1",
     "react": "19.2.7",
-    "react-day-picker": "10.0.1",
     "react-dom": "19.2.7",
     "tsc-alias": "1.9.0",
     "typescript": "6.0.2",
-    "vaul": "1.1.2",
     "vitest": "4.1.10"
   },
   "exports": {
@@ -67,7 +73,6 @@
   },
   "files": [
     "dist",
-    "presets",
     "web-tokens.css"
   ],
   "license": "MIT",
@@ -114,12 +119,12 @@
     "registry": "https://registry.npmjs.org/"
   },
   "repository": {
-    "directory": "ui",
+    "directory": "packages/ui",
     "type": "git",
-    "url": "git+https://github.com/genfeedai/packages.git"
+    "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "scripts": {
-    "build": "tsc --build && bunx tsc-alias -p tsconfig.json",
+    "build": "tsc --build && bunx tsc-alias -p tsconfig.json -f -fe .js",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "test": "../../scripts/sh/sanitize-node-color-env.sh vitest run --config vitest.config.ts",
     "test:watch": "vitest watch --config vitest.config.ts"

--- a/packages/workflow-engine/package.json
+++ b/packages/workflow-engine/package.json
@@ -5,6 +5,7 @@
     "recheck": "4.5.0"
   },
   "devDependencies": {
+    "tsup": "8.5.1",
     "typescript": "6.0.2"
   },
   "exports": {
@@ -50,8 +51,7 @@
     }
   },
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "main": "./dist/index.js",
   "license": "AGPL-3.0",
@@ -62,18 +62,19 @@
     "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsup src/index.ts src/execution/index.ts src/executors/index.ts src/presets/index.ts src/services/index.ts src/templates/index.ts src/utils/index.ts src/validation/index.ts --format esm --dts --clean --sourcemap",
+    "clean": "rm -rf dist",
     "deps:update": "bunx npm-check-updates -u --reject typescript && bun install",
-    "dev": "tsc --watch",
+    "dev": "tsup src/index.ts src/execution/index.ts src/executors/index.ts src/presets/index.ts src/services/index.ts src/templates/index.ts src/utils/index.ts src/validation/index.ts --format esm --dts --watch --sourcemap",
     "prepublishOnly": "bun run build",
     "test": "vitest run"
   },
   "repository": {
-    "directory": "workflow-engine",
+    "directory": "packages/workflow-engine",
     "type": "git",
-    "url": "git+https://github.com/genfeedai/packages.git"
+    "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "sideEffects": false,
   "types": "./dist/index.d.ts",
-  "version": "0.2.0"
+  "version": "0.2.1"
 }

--- a/packages/workflow-engine/tsconfig.json
+++ b/packages/workflow-engine/tsconfig.json
@@ -3,6 +3,7 @@
     "declaration": true,
     "declarationMap": true,
     "esModuleInterop": true,
+    "ignoreDeprecations": "6.0",
     "module": "ESNext",
     "moduleResolution": "bundler",
     "outDir": "./dist",

--- a/packages/workflow-saas/package.json
+++ b/packages/workflow-saas/package.json
@@ -6,6 +6,7 @@
     "@genfeedai/workflows": "workspace:*"
   },
   "devDependencies": {
+    "tsup": "8.5.1",
     "typescript": "6.0.2"
   },
   "exports": {
@@ -31,8 +32,7 @@
     }
   },
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "main": "./dist/index.js",
   "license": "AGPL-3.0",
@@ -43,17 +43,18 @@
     "registry": "https://registry.npmjs.org/"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsup src/index.ts src/nodes/index.ts src/registry/index.ts src/types.ts --format esm --dts --clean --sourcemap",
+    "clean": "rm -rf dist",
     "deps:update": "bunx npm-check-updates -u --reject typescript && bun install",
-    "dev": "tsc --watch",
+    "dev": "tsup src/index.ts src/nodes/index.ts src/registry/index.ts src/types.ts --format esm --dts --watch --sourcemap",
     "prepublishOnly": "bun run build"
   },
   "repository": {
-    "directory": "workflow-saas",
+    "directory": "packages/workflow-saas",
     "type": "git",
-    "url": "git+https://github.com/genfeedai/packages.git"
+    "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "sideEffects": false,
   "types": "./dist/index.d.ts",
-  "version": "0.2.0"
+  "version": "0.2.1"
 }

--- a/packages/workflow-saas/tsconfig.json
+++ b/packages/workflow-saas/tsconfig.json
@@ -3,6 +3,7 @@
     "declaration": true,
     "declarationMap": true,
     "esModuleInterop": true,
+    "ignoreDeprecations": "6.0",
     "module": "ESNext",
     "moduleResolution": "bundler",
     "outDir": "./dist",

--- a/packages/workflow-ui/package.json
+++ b/packages/workflow-ui/package.json
@@ -106,16 +106,16 @@
     "registry": "https://registry.npmjs.org/"
   },
   "repository": {
-    "directory": "workflow-ui",
+    "directory": "packages/workflow-ui",
     "type": "git",
-    "url": "git+https://github.com/genfeedai/packages.git"
+    "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "scripts": {
     "build": "tsup && bun run scripts/prepend-use-client.ts",
     "dev": "tsup --watch",
     "prepublishOnly": "bun run build",
-    "release:npm": "../../scripts/publish-package.sh . --no-bump",
-    "release:npm:dry-run": "../../scripts/publish-package.sh . --no-bump --dry-run",
+    "release:npm": "../../scripts/publish-package.sh . --publish",
+    "release:npm:dry-run": "../../scripts/publish-package.sh . --dry-run",
     "test": "vitest run"
   },
   "sideEffects": [
@@ -123,5 +123,5 @@
   ],
   "type": "module",
   "types": "./dist/index.d.ts",
-  "version": "0.2.8"
+  "version": "0.2.9"
 }

--- a/packages/workflows/package.json
+++ b/packages/workflows/package.json
@@ -47,5 +47,5 @@
   "sideEffects": false,
   "type": "module",
   "types": "./dist/index.d.ts",
-  "version": "0.3.2"
+  "version": "0.3.3"
 }

--- a/scripts/check-public-package-manifests.mjs
+++ b/scripts/check-public-package-manifests.mjs
@@ -2,98 +2,267 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-const root = process.cwd();
-const packagesRoot = path.join(root, 'packages');
-const requestedDirs = process.argv
-  .slice(2)
-  .map((dir) => path.resolve(root, dir));
-const packageDirs =
-  requestedDirs.length > 0
-    ? requestedDirs.filter(
-        (dir) =>
-          fs.existsSync(path.join(dir, 'package.json')) &&
-          fs.statSync(dir).isDirectory(),
-      )
-    : fs
-        .readdirSync(packagesRoot)
-        .map((d) => path.join(packagesRoot, d))
-        .filter(
-          (d) =>
-            fs.existsSync(path.join(d, 'package.json')) &&
-            fs.statSync(d).isDirectory(),
-        );
+const EXPECTED_REPOSITORY_URL =
+  'git+https://github.com/genfeedai/genfeed.ai.git';
+const SUPPORTED_LICENSES = new Set(['AGPL-3.0', 'AGPL-3.0-or-later', 'MIT']);
+const RUNTIME_DEPENDENCY_FIELDS = [
+  'dependencies',
+  'optionalDependencies',
+  'peerDependencies',
+];
 
-const violations = [];
+function isPathInside(parentPath, childPath) {
+  const relativePath = path.relative(parentPath, childPath);
+  return (
+    relativePath === '' ||
+    (!relativePath.startsWith('..') && !path.isAbsolute(relativePath))
+  );
+}
 
-const isPublic = (pkg) => pkg.private !== true;
-const isSrcPath = (value) =>
-  typeof value === 'string' && value.includes('src/');
-const isAllowedSrcAsset = (value) =>
-  typeof value === 'string' &&
-  (value.endsWith('.css') || value.endsWith('.json'));
+function isSrcPath(value) {
+  return (
+    typeof value === 'string' && value.replace(/^\.\//, '').startsWith('src/')
+  );
+}
 
-for (const dir of packageDirs) {
-  const packagePath = path.join(dir, 'package.json');
-  const pkg = JSON.parse(fs.readFileSync(packagePath, 'utf8'));
-  if (!isPublic(pkg)) continue;
+function isAllowedSourceAsset(value) {
+  return typeof value === 'string' && /\.(css|json)$/.test(value);
+}
 
-  const rel = path.relative(root, packagePath);
-
-  if (!pkg.license) violations.push(`${rel}: missing "license"`);
-  if (!pkg.repository) violations.push(`${rel}: missing "repository"`);
-  if (!Array.isArray(pkg.files) || pkg.files.length === 0) {
-    violations.push(`${rel}: missing/empty "files"`);
+function collectStringValues(value, values = []) {
+  if (typeof value === 'string') {
+    values.push(value);
+    return values;
   }
 
-  if (pkg.main && isSrcPath(pkg.main)) {
-    violations.push(`${rel}: "main" points to src path (${pkg.main})`);
-  }
-  if (pkg.types && isSrcPath(pkg.types)) {
-    violations.push(`${rel}: "types" points to src path (${pkg.types})`);
+  if (value && typeof value === 'object') {
+    for (const child of Object.values(value))
+      collectStringValues(child, values);
   }
 
-  if (pkg.exports) {
-    const stack = [pkg.exports];
-    while (stack.length) {
-      const current = stack.pop();
-      if (typeof current === 'string') {
-        if (isSrcPath(current) && !isAllowedSrcAsset(current)) {
-          violations.push(
-            `${rel}: "exports" contains source-code src path (${current})`,
-          );
-        }
-        continue;
+  return values;
+}
+
+function isPublishedByFiles(target, files) {
+  const normalizedTarget = target.replace(/^\.\//, '');
+  return files.some((entry) => {
+    const normalizedEntry = entry.replace(/^\.\//, '').replace(/\/$/, '');
+    return (
+      normalizedTarget === normalizedEntry ||
+      normalizedTarget.startsWith(`${normalizedEntry}/`)
+    );
+  });
+}
+
+function sourceEntryContainsOnlyAssets(packageDir, entry) {
+  const absoluteEntry = path.join(packageDir, entry);
+  if (!fs.existsSync(absoluteEntry)) return false;
+
+  const stack = [absoluteEntry];
+  let foundFile = false;
+  while (stack.length > 0) {
+    const current = stack.pop();
+    const stat = fs.statSync(current);
+    if (stat.isDirectory()) {
+      for (const child of fs.readdirSync(current)) {
+        stack.push(path.join(current, child));
       }
-      if (current && typeof current === 'object') {
-        for (const value of Object.values(current)) stack.push(value);
-      }
+      continue;
+    }
+
+    foundFile = true;
+    if (!isAllowedSourceAsset(current)) return false;
+  }
+
+  return foundFile;
+}
+
+function validatePublicPackage({ dir, pkg, packageByName, root, violations }) {
+  const rel = path.relative(root, path.join(dir, 'package.json'));
+  const packageRel = path.relative(root, dir).split(path.sep).join('/');
+
+  if (!pkg.name?.startsWith('@genfeedai/')) {
+    violations.push(
+      `${rel}: public package name must use the @genfeedai scope`,
+    );
+  }
+  if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(pkg.version ?? '')) {
+    violations.push(`${rel}: missing or unsupported semantic "version"`);
+  }
+  if (!SUPPORTED_LICENSES.has(pkg.license)) {
+    violations.push(
+      `${rel}: license must be an explicit supported SPDX identifier (${Array.from(SUPPORTED_LICENSES).join(', ')})`,
+    );
+  }
+  if (!pkg.scripts?.build) violations.push(`${rel}: missing "scripts.build"`);
+
+  if (!pkg.repository || typeof pkg.repository !== 'object') {
+    violations.push(`${rel}: missing object-form "repository"`);
+  } else {
+    if (pkg.repository.type !== 'git') {
+      violations.push(`${rel}: repository.type must be "git"`);
+    }
+    if (pkg.repository.url !== EXPECTED_REPOSITORY_URL) {
+      violations.push(
+        `${rel}: repository.url must be ${EXPECTED_REPOSITORY_URL}`,
+      );
+    }
+    if (pkg.repository.directory !== packageRel) {
+      violations.push(`${rel}: repository.directory must be ${packageRel}`);
     }
   }
 
-  if (
-    pkg.publishConfig?.registry &&
-    pkg.publishConfig.registry !== 'https://registry.npmjs.org/'
-  ) {
+  if (pkg.publishConfig?.access !== 'public') {
+    violations.push(`${rel}: publishConfig.access must be "public"`);
+  }
+  if (pkg.publishConfig?.registry !== 'https://registry.npmjs.org/') {
     violations.push(
-      `${rel}: public package uses non-npm registry (${pkg.publishConfig.registry})`,
+      `${rel}: publishConfig.registry must be https://registry.npmjs.org/`,
     );
   }
 
-  for (const [name, version] of Object.entries(pkg.dependencies || {})) {
-    if (typeof version === 'string' && version.startsWith('file:')) {
+  if (!Array.isArray(pkg.files) || pkg.files.length === 0) {
+    violations.push(`${rel}: missing/empty "files"`);
+    return;
+  }
+
+  for (const entry of pkg.files) {
+    if (typeof entry !== 'string' || entry.length === 0) {
+      violations.push(`${rel}: "files" entries must be non-empty strings`);
+      continue;
+    }
+    if (
+      isSrcPath(entry) &&
+      !sourceEntryContainsOnlyAssets(dir, entry.replace(/^\.\//, ''))
+    ) {
       violations.push(
-        `${rel}: dependencies.${name} uses non-publishable file specifier (${version})`,
+        `${rel}: "files" includes source code instead of build output (${entry})`,
       );
+    }
+  }
+
+  const publishedTargets = [
+    ...(pkg.main ? [pkg.main] : []),
+    ...(pkg.module ? [pkg.module] : []),
+    ...(pkg.types ? [pkg.types] : []),
+    ...collectStringValues(pkg.exports),
+    ...collectStringValues(pkg.bin),
+  ];
+
+  for (const target of publishedTargets) {
+    if (isSrcPath(target) && !isAllowedSourceAsset(target)) {
+      violations.push(
+        `${rel}: published entry points to source code (${target})`,
+      );
+    }
+    if (!isPublishedByFiles(target, pkg.files)) {
+      violations.push(
+        `${rel}: published entry is excluded by "files" (${target})`,
+      );
+    }
+  }
+
+  for (const field of RUNTIME_DEPENDENCY_FIELDS) {
+    for (const [name, version] of Object.entries(pkg[field] ?? {})) {
+      if (typeof version !== 'string') continue;
+      if (/^(file|link):/.test(version)) {
+        violations.push(
+          `${rel}: ${field}.${name} uses non-publishable specifier (${version})`,
+        );
+      }
+      if (!version.startsWith('workspace:')) continue;
+
+      const dependency = packageByName.get(name);
+      if (!dependency) {
+        violations.push(
+          `${rel}: ${field}.${name} references a missing workspace package`,
+        );
+      } else if (
+        dependency.pkg.private === true ||
+        !dependency.pkg.publishConfig
+      ) {
+        violations.push(
+          `${rel}: ${field}.${name} references private workspace package ${dependency.rel}`,
+        );
+      }
     }
   }
 }
 
-if (violations.length > 0) {
-  console.error('Public package policy violations found:\n');
-  for (const v of violations) console.error(`- ${v}`);
-  process.exit(1);
+export function checkPublicPackageManifests({
+  root = process.cwd(),
+  requestedDirs = [],
+} = {}) {
+  const packagesRoot = path.join(root, 'packages');
+  const allPackageDirs = fs
+    .readdirSync(packagesRoot)
+    .map((entry) => path.join(packagesRoot, entry))
+    .filter(
+      (dir) =>
+        fs.existsSync(path.join(dir, 'package.json')) &&
+        fs.statSync(dir).isDirectory(),
+    );
+  const packageDirs =
+    requestedDirs.length > 0
+      ? requestedDirs.map((dir) => path.resolve(root, dir))
+      : allPackageDirs;
+  const violations = [];
+  const packageByName = new Map();
+  let publicChecked = 0;
+
+  for (const dir of allPackageDirs) {
+    const packageJsonPath = path.join(dir, 'package.json');
+    const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+    packageByName.set(pkg.name, {
+      pkg,
+      rel: path.relative(root, packageJsonPath),
+    });
+  }
+
+  for (const dir of packageDirs) {
+    const packageJsonPath = path.join(dir, 'package.json');
+    if (!isPathInside(packagesRoot, dir) || !fs.existsSync(packageJsonPath)) {
+      violations.push(
+        `${path.relative(root, dir)}: expected a package directory under packages/`,
+      );
+      continue;
+    }
+
+    const pkg = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+    const rel = path.relative(root, packageJsonPath);
+    const isPublic = pkg.private !== true && Boolean(pkg.publishConfig);
+
+    if (!isPublic) {
+      if (pkg.private !== true) {
+        violations.push(
+          `${rel}: package must declare "private": true or a public publishConfig`,
+        );
+      }
+      continue;
+    }
+
+    publicChecked += 1;
+    validatePublicPackage({ dir, pkg, packageByName, root, violations });
+  }
+
+  return { checked: publicChecked, violations };
 }
 
-console.log(
-  `Public package policy check passed for ${packageDirs.length} package directories.`,
-);
+function runCli() {
+  const result = checkPublicPackageManifests({
+    requestedDirs: process.argv.slice(2),
+  });
+
+  if (result.violations.length > 0) {
+    console.error('Public package policy violations found:\n');
+    for (const violation of result.violations) console.error(`- ${violation}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(
+    `Public package policy check passed for ${result.checked} package directories.`,
+  );
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) runCli();

--- a/scripts/fix-esm-relative-imports.mjs
+++ b/scripts/fix-esm-relative-imports.mjs
@@ -2,11 +2,12 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { initSync, parse } from 'es-module-lexer';
 
 const OUTPUT_FILE = /(?:\.[cm]?js|\.d\.[cm]?ts)$/;
-const MODULE_SPECIFIER =
-  /(\b(?:from\s*|import\s*(?:\(\s*)?|require\s*\()\s*)(['"])([^'"]+)\2/g;
 const OUTPUT_EXTENSIONS = ['.js', '.mjs', '.cjs'];
+
+initSync();
 
 function isPathInside(parentPath, childPath) {
   const relativePath = path.relative(parentPath, childPath);
@@ -119,14 +120,22 @@ export function rewriteRelativeModuleSpecifiers(
   filePath,
   aliases = [],
 ) {
-  return source.replace(MODULE_SPECIFIER, (match, prefix, quote, specifier) => {
+  const [imports] = parse(source, filePath);
+  let rewritten = source;
+  for (const moduleImport of [...imports].reverse()) {
+    const specifier = moduleImport.n;
+    if (!specifier) continue;
     const resolved = specifier.startsWith('.')
       ? resolveRelativeSpecifier(filePath, specifier)
       : resolveInternalAlias(filePath, specifier, aliases);
-    return resolved === specifier
-      ? match
-      : `${prefix}${quote}${resolved}${quote}`;
-  });
+    if (resolved === specifier) continue;
+    const replacement =
+      moduleImport.d >= 0
+        ? `${source[moduleImport.s]}${resolved}${source[moduleImport.e - 1]}`
+        : resolved;
+    rewritten = `${rewritten.slice(0, moduleImport.s)}${replacement}${rewritten.slice(moduleImport.e)}`;
+  }
+  return rewritten;
 }
 
 export function fixEsmRelativeImports(outputDirs, { projectPath } = {}) {

--- a/scripts/fix-esm-relative-imports.mjs
+++ b/scripts/fix-esm-relative-imports.mjs
@@ -2,12 +2,10 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
-import { initSync, parse } from 'es-module-lexer';
+import ts from 'typescript';
 
 const OUTPUT_FILE = /(?:\.[cm]?js|\.d\.[cm]?ts)$/;
 const OUTPUT_EXTENSIONS = ['.js', '.mjs', '.cjs'];
-
-initSync();
 
 function isPathInside(parentPath, childPath) {
   const relativePath = path.relative(parentPath, childPath);
@@ -115,25 +113,67 @@ function resolveInternalAlias(filePath, specifier, aliases) {
   return specifier;
 }
 
+function moduleSpecifiers(source, filePath) {
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+  );
+  const specifiers = [];
+  const seen = new Set();
+
+  const addSpecifier = (node) => {
+    if (!node || !ts.isStringLiteralLike(node)) return;
+    const start = node.getStart(sourceFile) + 1;
+    const end = node.getEnd() - 1;
+    const key = `${start}:${end}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    specifiers.push({ end, specifier: node.text, start });
+  };
+
+  const visit = (node) => {
+    if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
+      addSpecifier(node.moduleSpecifier);
+    } else if (
+      ts.isImportEqualsDeclaration(node) &&
+      ts.isExternalModuleReference(node.moduleReference)
+    ) {
+      addSpecifier(node.moduleReference.expression);
+    } else if (
+      ts.isCallExpression(node) &&
+      (node.expression.kind === ts.SyntaxKind.ImportKeyword ||
+        (ts.isIdentifier(node.expression) &&
+          node.expression.text === 'require'))
+    ) {
+      addSpecifier(node.arguments[0]);
+    } else if (
+      ts.isImportTypeNode(node) &&
+      ts.isLiteralTypeNode(node.argument)
+    ) {
+      addSpecifier(node.argument.literal);
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  return specifiers;
+}
+
 export function rewriteRelativeModuleSpecifiers(
   source,
   filePath,
   aliases = [],
 ) {
-  const [imports] = parse(source, filePath);
   let rewritten = source;
-  for (const moduleImport of [...imports].reverse()) {
-    const specifier = moduleImport.n;
-    if (!specifier) continue;
+  for (const moduleImport of moduleSpecifiers(source, filePath).reverse()) {
+    const { specifier } = moduleImport;
     const resolved = specifier.startsWith('.')
       ? resolveRelativeSpecifier(filePath, specifier)
       : resolveInternalAlias(filePath, specifier, aliases);
     if (resolved === specifier) continue;
-    const replacement =
-      moduleImport.d >= 0
-        ? `${source[moduleImport.s]}${resolved}${source[moduleImport.e - 1]}`
-        : resolved;
-    rewritten = `${rewritten.slice(0, moduleImport.s)}${replacement}${rewritten.slice(moduleImport.e)}`;
+    rewritten = `${rewritten.slice(0, moduleImport.start)}${resolved}${rewritten.slice(moduleImport.end)}`;
   }
   return rewritten;
 }

--- a/scripts/fix-esm-relative-imports.mjs
+++ b/scripts/fix-esm-relative-imports.mjs
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const OUTPUT_FILE = /(?:\.[cm]?js|\.d\.[cm]?ts)$/;
+const MODULE_SPECIFIER =
+  /(\b(?:from\s*|import\s*(?:\(\s*)?|require\s*\()\s*)(['"])([^'"]+)\2/g;
+const OUTPUT_EXTENSIONS = ['.js', '.mjs', '.cjs'];
+
+function isPathInside(parentPath, childPath) {
+  const relativePath = path.relative(parentPath, childPath);
+  return (
+    relativePath === '' ||
+    (!relativePath.startsWith('..') && !path.isAbsolute(relativePath))
+  );
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function splitSuffix(specifier) {
+  const suffixIndex = specifier.search(/[?#]/);
+  if (suffixIndex === -1) return [specifier, ''];
+  return [specifier.slice(0, suffixIndex), specifier.slice(suffixIndex)];
+}
+
+function resolveRelativeSpecifier(filePath, specifier) {
+  const [modulePath, suffix] = splitSuffix(specifier);
+  const absoluteTarget = path.resolve(path.dirname(filePath), modulePath);
+
+  if (fs.existsSync(absoluteTarget) && fs.statSync(absoluteTarget).isFile()) {
+    return specifier;
+  }
+
+  for (const extension of OUTPUT_EXTENSIONS) {
+    if (fs.existsSync(`${absoluteTarget}${extension}`)) {
+      return `${modulePath}${extension}${suffix}`;
+    }
+  }
+
+  for (const extension of OUTPUT_EXTENSIONS) {
+    if (fs.existsSync(path.join(absoluteTarget, `index${extension}`))) {
+      return `${modulePath.replace(/\/$/, '')}/index${extension}${suffix}`;
+    }
+  }
+
+  return specifier;
+}
+
+function resolveOutputTarget(absoluteTarget) {
+  if (fs.existsSync(absoluteTarget) && fs.statSync(absoluteTarget).isFile()) {
+    return absoluteTarget;
+  }
+  for (const extension of OUTPUT_EXTENSIONS) {
+    if (fs.existsSync(`${absoluteTarget}${extension}`)) {
+      return `${absoluteTarget}${extension}`;
+    }
+  }
+  for (const extension of OUTPUT_EXTENSIONS) {
+    const indexPath = path.join(absoluteTarget, `index${extension}`);
+    if (fs.existsSync(indexPath)) return indexPath;
+  }
+  return null;
+}
+
+function projectAliases(projectPath, outputDir) {
+  if (!projectPath) return [];
+  const project = JSON.parse(fs.readFileSync(projectPath, 'utf8'));
+  const projectDir = path.dirname(projectPath);
+  const compilerOptions = project.compilerOptions ?? {};
+  const baseUrl = path.resolve(projectDir, compilerOptions.baseUrl ?? '.');
+  const rootDir = path.resolve(projectDir, compilerOptions.rootDir ?? '.');
+
+  return Object.entries(compilerOptions.paths ?? {})
+    .flatMap(([aliasPattern, targets]) => {
+      const targetPattern = Array.isArray(targets) ? targets[0] : null;
+      if (typeof targetPattern !== 'string') return [];
+      const aliasExpression = new RegExp(
+        `^${escapeRegExp(aliasPattern).replace('\\*', '(.+)')}$`,
+      );
+      const targetPrefix = targetPattern.split('*')[0];
+      if (!isPathInside(rootDir, path.resolve(baseUrl, targetPrefix)))
+        return [];
+      return [{ aliasExpression, baseUrl, rootDir, targetPattern }];
+    })
+    .map((alias) => ({ ...alias, outputDir }));
+}
+
+function resolveInternalAlias(filePath, specifier, aliases) {
+  for (const alias of aliases) {
+    const match = specifier.match(alias.aliasExpression);
+    if (!match) continue;
+    const sourceTarget = path.resolve(
+      alias.baseUrl,
+      alias.targetPattern.replace('*', match[1] ?? ''),
+    );
+    if (!isPathInside(alias.rootDir, sourceTarget)) continue;
+    const outputRelative = path
+      .relative(alias.rootDir, sourceTarget)
+      .replace(/(?:\.d)?\.[cm]?tsx?$/, '');
+    const outputTarget = resolveOutputTarget(
+      path.resolve(alias.outputDir, outputRelative),
+    );
+    if (!outputTarget) continue;
+    let relativeTarget = path
+      .relative(path.dirname(filePath), outputTarget)
+      .split(path.sep)
+      .join('/');
+    if (!relativeTarget.startsWith('.')) relativeTarget = `./${relativeTarget}`;
+    return relativeTarget;
+  }
+  return specifier;
+}
+
+export function rewriteRelativeModuleSpecifiers(
+  source,
+  filePath,
+  aliases = [],
+) {
+  return source.replace(MODULE_SPECIFIER, (match, prefix, quote, specifier) => {
+    const resolved = specifier.startsWith('.')
+      ? resolveRelativeSpecifier(filePath, specifier)
+      : resolveInternalAlias(filePath, specifier, aliases);
+    return resolved === specifier
+      ? match
+      : `${prefix}${quote}${resolved}${quote}`;
+  });
+}
+
+export function fixEsmRelativeImports(outputDirs, { projectPath } = {}) {
+  let changedFiles = 0;
+  let checkedFiles = 0;
+
+  for (const outputDir of outputDirs) {
+    if (!fs.existsSync(outputDir) || !fs.statSync(outputDir).isDirectory()) {
+      throw new Error(`Build output directory does not exist: ${outputDir}`);
+    }
+    const aliases = projectAliases(projectPath, outputDir);
+
+    const stack = [outputDir];
+    while (stack.length > 0) {
+      const current = stack.pop();
+      for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+        const entryPath = path.join(current, entry.name);
+        if (entry.isDirectory()) {
+          stack.push(entryPath);
+          continue;
+        }
+        if (!entry.isFile() || !OUTPUT_FILE.test(entry.name)) continue;
+
+        checkedFiles += 1;
+        const source = fs.readFileSync(entryPath, 'utf8');
+        const rewritten = rewriteRelativeModuleSpecifiers(
+          source,
+          entryPath,
+          aliases,
+        );
+        if (rewritten === source) continue;
+        fs.writeFileSync(entryPath, rewritten);
+        changedFiles += 1;
+      }
+    }
+  }
+
+  return { changedFiles, checkedFiles };
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const projectIndex = args.indexOf('--project');
+  const projectArg =
+    projectIndex === -1 ? null : (args[projectIndex + 1] ?? null);
+  if (projectIndex !== -1) args.splice(projectIndex, 2);
+  const outputDirs = args.map((entry) => path.resolve(entry));
+  if (outputDirs.length === 0) {
+    throw new Error(
+      'Usage: node scripts/fix-esm-relative-imports.mjs [--project tsconfig.json] <output-dir> [...]',
+    );
+  }
+  const result = fixEsmRelativeImports(outputDirs, {
+    projectPath: projectArg ? path.resolve(projectArg) : undefined,
+  });
+  console.log(
+    `Fixed relative ESM imports in ${result.changedFiles}/${result.checkedFiles} build files.`,
+  );
+}
+
+const isDirectInvocation =
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+
+if (isDirectInvocation) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/package-release/check-public-package-manifests.test.ts
+++ b/scripts/package-release/check-public-package-manifests.test.ts
@@ -1,0 +1,146 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { checkPublicPackageManifests } from '../check-public-package-manifests.mjs';
+
+const REPOSITORY_URL = 'git+https://github.com/genfeedai/genfeed.ai.git';
+
+describe('check-public-package-manifests', () => {
+  let root = '';
+
+  beforeEach(() => {
+    root = mkdtempSync(path.join(tmpdir(), 'public-package-policy-'));
+    mkdirSync(path.join(root, 'packages'), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(root, { force: true, recursive: true });
+  });
+
+  it('requires internal packages to opt out explicitly', () => {
+    writePackage('agent', {
+      name: '@genfeedai/agent',
+      version: '1.0.0',
+    });
+
+    expect(checkPublicPackageManifests({ root }).violations).toEqual([
+      'packages/agent/package.json: package must declare "private": true or a public publishConfig',
+    ]);
+
+    writePackage('agent', {
+      name: '@genfeedai/agent',
+      private: true,
+      version: '1.0.0',
+    });
+    expect(checkPublicPackageManifests({ root }).violations).toEqual([]);
+  });
+
+  it('accepts canonical build-output metadata', () => {
+    writePackage('enums', publicManifest('enums'));
+    writePackage('client', {
+      ...publicManifest('client'),
+      license: 'MIT',
+    });
+
+    expect(checkPublicPackageManifests({ root })).toEqual({
+      checked: 2,
+      violations: [],
+    });
+  });
+
+  it('rejects ambiguous license metadata', () => {
+    writePackage('enums', {
+      ...publicManifest('enums'),
+      license: 'SEE LICENSE IN LICENSE',
+    });
+
+    expect(checkPublicPackageManifests({ root }).violations).toContain(
+      'packages/enums/package.json: license must be an explicit supported SPDX identifier (AGPL-3.0, AGPL-3.0-or-later, MIT)',
+    );
+  });
+
+  it('fails closed when a requested package directory does not exist', () => {
+    expect(
+      checkPublicPackageManifests({
+        requestedDirs: ['packages/missing'],
+        root,
+      }).violations,
+    ).toEqual([
+      'packages/missing: expected a package directory under packages/',
+    ]);
+  });
+
+  it('rejects private runtime dependencies and source-code tarball entries', () => {
+    writePackage('private-lib', {
+      name: '@genfeedai/private-lib',
+      private: true,
+      version: '1.0.0',
+    });
+    writeFixture('packages/client/src/index.ts', 'export const client = true;');
+    writePackage('client', {
+      ...publicManifest('client'),
+      dependencies: {
+        '@genfeedai/private-lib': 'workspace:*',
+      },
+      exports: {
+        '.': './src/index.ts',
+      },
+      files: ['src/index.ts'],
+      main: './dist/index.js',
+    });
+
+    const violations = checkPublicPackageManifests({ root }).violations;
+    expect(violations).toContain(
+      'packages/client/package.json: "files" includes source code instead of build output (src/index.ts)',
+    );
+    expect(violations).toContain(
+      'packages/client/package.json: published entry points to source code (./src/index.ts)',
+    );
+    expect(violations).toContain(
+      'packages/client/package.json: dependencies.@genfeedai/private-lib references private workspace package packages/private-lib/package.json',
+    );
+  });
+
+  function publicManifest(directory: string) {
+    return {
+      exports: {
+        '.': {
+          default: './dist/index.js',
+          types: './dist/index.d.ts',
+        },
+      },
+      files: ['dist'],
+      license: 'AGPL-3.0',
+      main: './dist/index.js',
+      name: `@genfeedai/${directory}`,
+      publishConfig: {
+        access: 'public',
+        registry: 'https://registry.npmjs.org/',
+      },
+      repository: {
+        directory: `packages/${directory}`,
+        type: 'git',
+        url: REPOSITORY_URL,
+      },
+      scripts: {
+        build: 'tsc --build',
+      },
+      types: './dist/index.d.ts',
+      version: '1.0.0',
+    };
+  }
+
+  function writePackage(directory: string, manifest: object): void {
+    writeFixture(
+      `packages/${directory}/package.json`,
+      `${JSON.stringify(manifest, null, 2)}\n`,
+    );
+  }
+
+  function writeFixture(relativePath: string, content: string): void {
+    const filePath = path.join(root, relativePath);
+    mkdirSync(path.dirname(filePath), { recursive: true });
+    writeFileSync(filePath, content, 'utf8');
+  }
+});

--- a/scripts/package-release/fix-esm-relative-imports.test.ts
+++ b/scripts/package-release/fix-esm-relative-imports.test.ts
@@ -51,6 +51,9 @@ describe('fix-esm-relative-imports', () => {
         "import { client } from './client';",
         "export { folder } from './folder';",
         "const lazy = import('./client?worker');",
+        `const message = "load from './client' now";`,
+        "const template = `import './client'`;",
+        "// export { client } from './client';",
         '',
       ].join('\n'),
     );
@@ -71,6 +74,9 @@ describe('fix-esm-relative-imports', () => {
         "import { client } from './client.js';",
         "export { folder } from './folder/index.js';",
         "const lazy = import('./client.js?worker');",
+        `const message = "load from './client' now";`,
+        "const template = `import './client'`;",
+        "// export { client } from './client';",
         '',
       ].join('\n'),
     );

--- a/scripts/package-release/fix-esm-relative-imports.test.ts
+++ b/scripts/package-release/fix-esm-relative-imports.test.ts
@@ -57,14 +57,23 @@ describe('fix-esm-relative-imports', () => {
         '',
       ].join('\n'),
     );
+    writeOutput(
+      'types.d.ts',
+      [
+        "export type { Client } from './client';",
+        "type Folder = import('./folder').Folder;",
+        "import Client = require('./client');",
+        '',
+      ].join('\n'),
+    );
 
     expect(
       fixEsmRelativeImports([outputDir], {
         projectPath: path.join(root, 'tsconfig.json'),
       }),
     ).toEqual({
-      changedFiles: 1,
-      checkedFiles: 5,
+      changedFiles: 2,
+      checkedFiles: 6,
     });
     expect(readFileSync(path.join(outputDir, 'session.js'), 'utf8')).toBe(
       [
@@ -77,6 +86,14 @@ describe('fix-esm-relative-imports', () => {
         `const message = "load from './client' now";`,
         "const template = `import './client'`;",
         "// export { client } from './client';",
+        '',
+      ].join('\n'),
+    );
+    expect(readFileSync(path.join(outputDir, 'types.d.ts'), 'utf8')).toBe(
+      [
+        "export type { Client } from './client.js';",
+        "type Folder = import('./folder/index.js').Folder;",
+        "import Client = require('./client.js');",
         '',
       ].join('\n'),
     );

--- a/scripts/package-release/fix-esm-relative-imports.test.ts
+++ b/scripts/package-release/fix-esm-relative-imports.test.ts
@@ -1,0 +1,84 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { fixEsmRelativeImports } from '../fix-esm-relative-imports.mjs';
+
+describe('fix-esm-relative-imports', () => {
+  let root = '';
+  let outputDir = '';
+
+  beforeEach(() => {
+    root = mkdtempSync(path.join(tmpdir(), 'fix-esm-imports-'));
+    outputDir = path.join(root, 'dist');
+    mkdirSync(outputDir);
+  });
+
+  afterEach(() => {
+    rmSync(root, { force: true, recursive: true });
+  });
+
+  it('extends only relative modules and preserves colliding bare packages', () => {
+    writeOutput('client.js', 'export const client = true;\n');
+    writeOutput('react.js', 'export const localReact = true;\n');
+    writeOutput('folder/index.js', 'export const folder = true;\n');
+    writeOutput('internal.js', 'export const internal = true;\n');
+    writeFileSync(
+      path.join(root, 'tsconfig.json'),
+      JSON.stringify({
+        compilerOptions: {
+          baseUrl: '.',
+          paths: {
+            '@fixture/*': ['./src/*'],
+            '@workspace/*': ['../workspace/*'],
+          },
+          rootDir: './src',
+        },
+      }),
+    );
+    writeOutput(
+      'session.js',
+      [
+        "import { useCallback } from 'react';",
+        "import { internal } from '@fixture/internal';",
+        "import { workspace } from '@workspace/module';",
+        "import { client } from './client';",
+        "export { folder } from './folder';",
+        "const lazy = import('./client?worker');",
+        '',
+      ].join('\n'),
+    );
+
+    expect(
+      fixEsmRelativeImports([outputDir], {
+        projectPath: path.join(root, 'tsconfig.json'),
+      }),
+    ).toEqual({
+      changedFiles: 1,
+      checkedFiles: 5,
+    });
+    expect(readFileSync(path.join(outputDir, 'session.js'), 'utf8')).toBe(
+      [
+        "import { useCallback } from 'react';",
+        "import { internal } from './internal.js';",
+        "import { workspace } from '@workspace/module';",
+        "import { client } from './client.js';",
+        "export { folder } from './folder/index.js';",
+        "const lazy = import('./client.js?worker');",
+        '',
+      ].join('\n'),
+    );
+  });
+
+  function writeOutput(relativePath: string, content: string) {
+    const filePath = path.join(outputDir, relativePath);
+    mkdirSync(path.dirname(filePath), { recursive: true });
+    writeFileSync(filePath, content);
+  }
+});

--- a/scripts/package-release/publish-packages-from-json.test.ts
+++ b/scripts/package-release/publish-packages-from-json.test.ts
@@ -1,0 +1,262 @@
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  assertCleanWorkingTree,
+  normalizeReleaseRequests,
+  registryAction,
+  sortReleaseRequests,
+  validatePackedPackage,
+} from '../publish-packages-from-json.mjs';
+
+describe('publish package release planning', () => {
+  it('requires exact PR-merged versions and rejects live bump requests', () => {
+    const inventory = inventoryFor([
+      packageEntry('packages/enums', '@genfeedai/enums', '2.3.2'),
+    ]);
+
+    expect(() =>
+      normalizeReleaseRequests(
+        [{ bump: 'patch', path: 'packages/enums' }],
+        inventory,
+      ),
+    ).toThrow('version changes must merge through a PR');
+    expect(() =>
+      normalizeReleaseRequests(
+        [{ path: 'packages/enums', version: '2.3.3' }],
+        inventory,
+      ),
+    ).toThrow('master contains 2.3.2');
+  });
+
+  it('rejects paths outside the direct OSS packages directory', () => {
+    const inventory = inventoryFor([]);
+    expect(() =>
+      normalizeReleaseRequests(
+        [{ path: 'ee/packages/billing', version: '1.0.0' }],
+        inventory,
+      ),
+    ).toThrow('must be a direct package directory under packages/');
+  });
+
+  it('sorts requests dependency-first regardless of input order', () => {
+    const enums = packageEntry('packages/enums', '@genfeedai/enums', '2.3.2');
+    const constants = packageEntry(
+      'packages/constants',
+      '@genfeedai/constants',
+      '2.2.9',
+      { '@genfeedai/enums': 'workspace:*' },
+    );
+    const interfaces = packageEntry(
+      'packages/interfaces',
+      '@genfeedai/interfaces',
+      '2.3.20',
+      {
+        '@genfeedai/constants': 'workspace:*',
+        '@genfeedai/enums': 'workspace:*',
+      },
+    );
+    const inventory = inventoryFor([interfaces, constants, enums]);
+    const requests = normalizeReleaseRequests(
+      [
+        { path: interfaces.path, version: interfaces.pkg.version },
+        { path: constants.path, version: constants.pkg.version },
+        { path: enums.path, version: enums.pkg.version },
+      ],
+      inventory,
+    );
+
+    expect(
+      sortReleaseRequests(requests, inventory).map((entry) => entry.name),
+    ).toEqual([
+      '@genfeedai/enums',
+      '@genfeedai/constants',
+      '@genfeedai/interfaces',
+    ]);
+  });
+
+  it('rejects dependency cycles before any build or publish', () => {
+    const first = packageEntry('packages/first', '@genfeedai/first', '1.0.0', {
+      '@genfeedai/second': 'workspace:*',
+    });
+    const second = packageEntry(
+      'packages/second',
+      '@genfeedai/second',
+      '1.0.0',
+      { '@genfeedai/first': 'workspace:*' },
+    );
+    const inventory = inventoryFor([first, second]);
+    const requests = normalizeReleaseRequests(
+      [
+        { path: first.path, version: first.pkg.version },
+        { path: second.path, version: second.pkg.version },
+      ],
+      inventory,
+    );
+
+    expect(() => sortReleaseRequests(requests, inventory)).toThrow(
+      'dependency cycle',
+    );
+  });
+
+  it('validates resolved workspace versions and packed entry points', () => {
+    const dependency = packageEntry(
+      'packages/enums',
+      '@genfeedai/enums',
+      '2.3.2',
+    );
+    const request = packageEntry(
+      'packages/constants',
+      '@genfeedai/constants',
+      '2.2.9',
+      { '@genfeedai/enums': 'workspace:*' },
+    );
+    const inventory = inventoryFor([dependency, request]);
+
+    expect(() =>
+      validatePackedPackage({
+        archiveFiles: [
+          'package/LICENSE',
+          'package/package.json',
+          'package/dist/index.d.ts',
+          'package/dist/index.js',
+        ],
+        inventory,
+        packedManifest: {
+          dependencies: { '@genfeedai/enums': 'workspace:*' },
+          exports: {
+            '.': {
+              default: './dist/index.js',
+              types: './dist/index.d.ts',
+            },
+          },
+          name: request.pkg.name,
+          version: request.pkg.version,
+        },
+        request: {
+          ...request,
+          name: request.pkg.name,
+          version: request.pkg.version,
+        },
+      }),
+    ).toThrow('retained workspace:*');
+  });
+
+  it('requires a license payload in every tarball', () => {
+    const request = packageEntry('packages/enums', '@genfeedai/enums', '2.3.2');
+    const inventory = inventoryFor([request]);
+
+    expect(() =>
+      validatePackedPackage({
+        archiveFiles: ['package/package.json', 'package/dist/index.js'],
+        inventory,
+        packedManifest: {
+          name: request.pkg.name,
+          version: request.pkg.version,
+        },
+        request: {
+          ...request,
+          name: request.pkg.name,
+          version: request.pkg.version,
+        },
+      }),
+    ).toThrow('tarball is missing LICENSE');
+  });
+
+  it('rejects platform metadata from repacked tarballs', () => {
+    const request = packageEntry('packages/enums', '@genfeedai/enums', '2.3.2');
+    const inventory = inventoryFor([request]);
+
+    expect(() =>
+      validatePackedPackage({
+        archiveFiles: [
+          'package/LICENSE',
+          'package/._LICENSE',
+          'package/package.json',
+        ],
+        inventory,
+        packedManifest: {
+          name: request.pkg.name,
+          version: request.pkg.version,
+        },
+        request: {
+          ...request,
+          name: request.pkg.name,
+          version: request.pkg.version,
+        },
+      }),
+    ).toThrow('tarball includes macOS metadata');
+  });
+
+  it('rejects non-ignored untracked files before artifact preparation', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'package-release-git-'));
+    try {
+      writeFileSync(path.join(root, 'tracked.txt'), 'tracked\n');
+      execFileSync('git', ['init', '--quiet'], { cwd: root });
+      execFileSync('git', ['add', 'tracked.txt'], { cwd: root });
+      execFileSync(
+        'git',
+        [
+          '-c',
+          'user.name=Package Test',
+          '-c',
+          'user.email=package-test@example.com',
+          'commit',
+          '--quiet',
+          '-m',
+          'fixture',
+        ],
+        { cwd: root },
+      );
+
+      expect(() => assertCleanWorkingTree(root)).not.toThrow();
+      mkdirSync(path.join(root, 'packages', 'fixture', 'src'), {
+        recursive: true,
+      });
+      writeFileSync(
+        path.join(root, 'packages', 'fixture', 'src', 'injected.ts'),
+        'export const injected = true;\n',
+      );
+      expect(() => assertCleanWorkingTree(root)).toThrow('untracked files');
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
+  it('resumes only when an existing registry tarball matches the plan', () => {
+    expect(registryAction('sha256-matching', null)).toBe('publish');
+    expect(registryAction('sha256-matching', 'sha256-matching')).toBe('skip');
+    expect(() => registryAction('sha256-expected', 'sha256-different')).toThrow(
+      'does not match the plan',
+    );
+  });
+});
+
+function packageEntry(
+  packagePath: string,
+  name: string,
+  version: string,
+  dependencies: Record<string, string> = {},
+) {
+  return {
+    manifestPath: `${packagePath}/package.json`,
+    packageDir: packagePath,
+    path: packagePath,
+    pkg: {
+      dependencies,
+      name,
+      publishConfig: { access: 'public' },
+      version,
+    },
+  };
+}
+
+function inventoryFor(packages: ReturnType<typeof packageEntry>[]) {
+  return {
+    byName: new Map(packages.map((entry) => [entry.pkg.name, entry])),
+    byPath: new Map(packages.map((entry) => [entry.path, entry])),
+    packages,
+  };
+}

--- a/scripts/package-release/vitest.config.ts
+++ b/scripts/package-release/vitest.config.ts
@@ -1,0 +1,11 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  root: fileURLToPath(new URL('.', import.meta.url)),
+  test: {
+    environment: 'node',
+    include: ['*.test.ts'],
+    name: 'scripts/package-release',
+  },
+});

--- a/scripts/publish-package.sh
+++ b/scripts/publish-package.sh
@@ -1,172 +1,70 @@
 #!/usr/bin/env bash
 #
-# Publish a @genfeedai/* package to npm.
-#
-# Uses `bun publish` which automatically resolves workspace:* protocols
-# to real versions. Never use `npm publish` — it publishes workspace:*
-# literally, breaking external consumers.
+# Prepare or publish one already-versioned @genfeedai/* package.
+# Version changes must land on master through a pull request first.
 #
 # Usage:
-#   ./scripts/publish-package.sh packages/enums                    # patch bump + publish
-#   ./scripts/publish-package.sh packages/interfaces minor         # minor bump + publish
-#   ./scripts/publish-package.sh packages/cli major               # major bump + publish
-#   ./scripts/publish-package.sh packages/enums --no-bump         # publish current version
-#   ./scripts/publish-package.sh packages/enums patch --dry-run   # dry-run publish
-#
-# Requirements:
-#   - bun >= 1.2 (for workspace:* resolution)
-#   - NPM_TOKEN env var or ~/.npmrc with auth
-#   - Clean git working tree unless PUBLISH_SKIP_CLEAN_CHECK=true
+#   ./scripts/publish-package.sh packages/enums
+#   ./scripts/publish-package.sh packages/enums --dry-run
+#   ./scripts/publish-package.sh packages/enums --publish
 
 set -euo pipefail
 
 usage() {
-  echo "Usage: $0 <package-dir> [patch|minor|major|--no-bump] [--dry-run]"
+  echo "Usage: $0 <package-dir> [--dry-run|--publish]"
   exit 1
 }
 
 PKG_DIR="${1:-}"
-if [ -z "$PKG_DIR" ]; then
+if [ -z "${PKG_DIR}" ]; then
   usage
 fi
 shift
 
-BUMP="patch"
-DRY_RUN=false
-
+MODE="dry-run"
 for arg in "$@"; do
-  case "$arg" in
-    patch|minor|major|--no-bump)
-      BUMP="$arg"
-      ;;
+  case "${arg}" in
     --dry-run)
-      DRY_RUN=true
+      MODE="dry-run"
+      ;;
+    --publish)
+      MODE="publish"
+      ;;
+    patch|minor|major|--no-bump)
+      echo "Error: version bumps are not allowed during publication. Merge the version through a PR first."
+      exit 1
       ;;
     *)
-      echo "Unknown argument: $arg"
+      echo "Unknown argument: ${arg}"
       usage
       ;;
   esac
 done
 
-if [ ! -f "$PKG_DIR/package.json" ]; then
-  echo "Error: $PKG_DIR/package.json not found"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+ABS_PKG_DIR="$(cd "${PKG_DIR}" && pwd -P)"
+PACKAGE_PATH="${ABS_PKG_DIR#"${REPO_ROOT}/"}"
+
+if [ ! -f "${ABS_PKG_DIR}/package.json" ]; then
+  echo "Error: ${PKG_DIR}/package.json not found"
   exit 1
 fi
 
-PKG_NAME=$(grep '"name"' "$PKG_DIR/package.json" | head -1 | sed 's/.*"\(@[^"]*\)".*/\1/')
-HAS_PUBLISH_CONFIG=$(grep -c '"publishConfig"' "$PKG_DIR/package.json" || true)
+PACKAGE_REQUEST="$(node -e '
+  const fs = require("node:fs");
+  const packagePath = process.argv[1];
+  const packageDir = process.argv[2];
+  const pkg = JSON.parse(fs.readFileSync(packagePath, "utf8"));
+  process.stdout.write(JSON.stringify([{ path: packageDir, version: pkg.version }]));
+' "${ABS_PKG_DIR}/package.json" "${PACKAGE_PATH}")"
 
-if [ "$HAS_PUBLISH_CONFIG" -eq 0 ]; then
-  echo "Error: $PKG_NAME has no publishConfig — not a publishable package"
-  exit 1
-fi
+OUTPUT_DIR="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/genfeed-package-release"
+cd "${REPO_ROOT}"
+node scripts/publish-packages-from-json.mjs \
+  --packages-json "${PACKAGE_REQUEST}" \
+  --output-dir "${OUTPUT_DIR}"
 
-echo "=== Publishing $PKG_NAME ==="
-
-# Ensure clean working tree before publishing
-if [ "${PUBLISH_SKIP_CLEAN_CHECK:-false}" != "true" ] && ! git diff-index --quiet HEAD --; then
-  echo "Error: Working tree must be clean before publishing."
-  exit 1
-fi
-
-cd "$PKG_DIR"
-ORIGINAL_VERSION=$(grep '"version"' package.json | head -1 | sed 's/.*"\([0-9][^"]*\)".*/\1/')
-ROLLBACK_VERSION=false
-
-restore_original_version() {
-  if [ "$ROLLBACK_VERSION" = true ]; then
-    node -e '
-      const fs = require("node:fs");
-      const packageJson = JSON.parse(fs.readFileSync("package.json", "utf8"));
-      packageJson.version = process.argv[1];
-      fs.writeFileSync("package.json", `${JSON.stringify(packageJson, null, 2)}\n`);
-    ' "$ORIGINAL_VERSION"
-  fi
-}
-
-if [ "$DRY_RUN" = true ] && [ "$BUMP" != "--no-bump" ]; then
-  ROLLBACK_VERSION=true
-  trap restore_original_version EXIT
-fi
-
-# Bump version (unless --no-bump)
-if [ "$BUMP" != "--no-bump" ]; then
-  echo "Bumping version ($BUMP)..."
-  node -e '
-    const fs = require("node:fs");
-    const path = require("node:path");
-
-    const packageJsonPath = path.join(process.cwd(), "package.json");
-    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
-    const [major, minor, patch] = packageJson.version.split(".").map(Number);
-
-    if (![major, minor, patch].every((part) => Number.isInteger(part))) {
-      throw new Error(`Unsupported version format: ${packageJson.version}`);
-    }
-
-    const bump = process.argv[1];
-    let nextVersion;
-    switch (bump) {
-      case "major":
-        nextVersion = `${major + 1}.0.0`;
-        break;
-      case "minor":
-        nextVersion = `${major}.${minor + 1}.0`;
-        break;
-      case "patch":
-        nextVersion = `${major}.${minor}.${patch + 1}`;
-        break;
-      default:
-        throw new Error(`Unsupported bump type: ${bump}`);
-    }
-
-    packageJson.version = nextVersion;
-    fs.writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`);
-    console.log(nextVersion);
-  ' "$BUMP"
-fi
-
-VERSION=$(grep '"version"' package.json | head -1 | sed 's/.*"\([0-9][^"]*\)".*/\1/')
-echo "Version: $VERSION"
-
-# Build after the version bump so any versioned artifacts match the package
-# version that will be published.
-echo "Building $PKG_NAME..."
-if grep -q '"build"' package.json; then
-  bun run build
-fi
-
-# Publish with bun (resolves workspace:* → real versions)
-if [ "$DRY_RUN" = true ]; then
-  echo "Dry-run publishing $PKG_NAME@$VERSION..."
-  bun publish --access public --provenance --dry-run
-else
-  echo "Publishing $PKG_NAME@$VERSION..."
-  bun publish --access public --provenance
-fi
-
-echo ""
-if [ "$DRY_RUN" = true ]; then
-  if [ "$BUMP" != "--no-bump" ]; then
-    restore_original_version
-    ROLLBACK_VERSION=false
-    trap - EXIT
-  fi
-  echo "=== Dry run complete for $PKG_NAME@$VERSION ==="
-else
-  echo "=== Published $PKG_NAME@$VERSION ==="
-  echo ""
-  echo "Verifying published manifest..."
-  DEPENDENCIES_JSON=$(npm view "$PKG_NAME@$VERSION" dependencies --json)
-  echo "$DEPENDENCIES_JSON"
-  node -e '
-    const dependencies = process.argv[1] ? JSON.parse(process.argv[1]) : {};
-    for (const [name, version] of Object.entries(dependencies ?? {})) {
-      if (typeof version === "string" && version.startsWith("workspace:")) {
-        console.error(`Published dependency ${name} retained workspace protocol (${version})`);
-        process.exit(1);
-      }
-    }
-  ' "$DEPENDENCIES_JSON"
+if [ "${MODE}" = "publish" ]; then
+  node scripts/publish-packages-from-json.mjs \
+    --publish-plan "${OUTPUT_DIR}/release-plan.json"
 fi

--- a/scripts/publish-packages-from-json.mjs
+++ b/scripts/publish-packages-from-json.mjs
@@ -1,221 +1,862 @@
+#!/usr/bin/env node
 import { spawnSync } from 'node:child_process';
+import crypto from 'node:crypto';
 import fs from 'node:fs';
+import { builtinModules } from 'node:module';
+import os from 'node:os';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 
-const root = process.cwd();
-const scriptPath = path.join(root, 'scripts', 'publish-package.sh');
+const RUNTIME_DEPENDENCY_FIELDS = [
+  'dependencies',
+  'optionalDependencies',
+  'peerDependencies',
+];
+const LOCAL_PROTOCOL = /^(?:file|link|workspace):/;
+const BUILTIN_MODULES = new Set([
+  ...builtinModules,
+  ...builtinModules.map((name) => `node:${name}`),
+]);
+
+class ReleaseError extends Error {}
 
 function fail(message) {
-  console.error(message);
-  process.exit(1);
-}
-
-function bumpVersion(version, bump) {
-  const [major, minor, patch] = version.split('.').map(Number);
-
-  if (![major, minor, patch].every((part) => Number.isInteger(part))) {
-    fail(`Unsupported version format: ${version}`);
-  }
-
-  switch (bump) {
-    case 'major':
-      return `${major + 1}.0.0`;
-    case 'minor':
-      return `${major}.${minor + 1}.0`;
-    case 'patch':
-      return `${major}.${minor}.${patch + 1}`;
-    default:
-      fail(`Unsupported bump type: ${bump}`);
-  }
+  throw new ReleaseError(message);
 }
 
 function run(command, args, options = {}) {
-  const { env, exitOnError = true, ...spawnOptions } = options;
+  const {
+    capture = false,
+    cwd = process.cwd(),
+    env,
+    ...spawnOptions
+  } = options;
   const result = spawnSync(command, args, {
-    cwd: root,
-    encoding: 'utf8',
+    cwd,
+    encoding: capture ? 'utf8' : undefined,
     env: { ...process.env, ...(env ?? {}) },
-    stdio: 'inherit',
+    stdio: capture ? 'pipe' : 'inherit',
     ...spawnOptions,
   });
 
   if (result.status !== 0) {
-    const exitCode = result.status ?? 1;
-    if (exitOnError) {
-      process.exit(exitCode);
-    }
-
-    const error = new Error(`${command} ${args.join(' ')} failed`);
-    error.exitCode = exitCode;
-    throw error;
+    const detail = capture
+      ? `\n${[result.stdout, result.stderr].filter(Boolean).join('\n').trim()}`
+      : '';
+    fail(`${command} ${args.join(' ')} failed${detail}`);
   }
+
+  return capture ? result.stdout.trim() : '';
 }
 
-function assertCleanWorkingTree() {
-  const result = spawnSync('git', ['diff-index', '--quiet', 'HEAD', '--'], {
-    cwd: root,
-    encoding: 'utf8',
-    stdio: 'inherit',
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function writeJson(filePath, value) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function directPackageDirectories(root) {
+  const packagesRoot = path.join(root, 'packages');
+  return fs
+    .readdirSync(packagesRoot)
+    .map((entry) => path.join(packagesRoot, entry))
+    .filter(
+      (dir) =>
+        fs.lstatSync(dir).isDirectory() &&
+        !fs.lstatSync(dir).isSymbolicLink() &&
+        fs.existsSync(path.join(dir, 'package.json')),
+    );
+}
+
+export function readPackageInventory(root) {
+  const packages = directPackageDirectories(root).map((packageDir) => {
+    const manifestPath = path.join(packageDir, 'package.json');
+    return {
+      manifestPath,
+      packageDir,
+      path: path.relative(root, packageDir).split(path.sep).join('/'),
+      pkg: readJson(manifestPath),
+    };
   });
 
-  if (result.status !== 0) {
-    fail('Working tree must be clean before publishing packages.');
-  }
+  return {
+    byName: new Map(packages.map((entry) => [entry.pkg.name, entry])),
+    byPath: new Map(packages.map((entry) => [entry.path, entry])),
+    packages,
+  };
 }
 
-function isPathInside(parentPath, childPath) {
-  const relativePath = path.relative(parentPath, childPath);
-  return (
-    relativePath === '' ||
-    (!relativePath.startsWith('..') && !path.isAbsolute(relativePath))
-  );
-}
-
-function readPackageJson(packageJsonPath) {
-  return JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
-}
-
-function writePackageVersion(packageJsonPath, version) {
-  const pkg = readPackageJson(packageJsonPath);
-  pkg.version = version;
-  fs.writeFileSync(packageJsonPath, `${JSON.stringify(pkg, null, 2)}\n`);
-}
-
-const args = process.argv.slice(2);
-const packagesArgIndex = args.indexOf('--packages-json');
-const dryRun = args.includes('--dry-run');
-
-if (packagesArgIndex === -1 || !args[packagesArgIndex + 1]) {
-  fail(
-    "Usage: node scripts/publish-packages-from-json.mjs --packages-json '<json>' [--dry-run]",
-  );
-}
-
-let requests;
-try {
-  requests = JSON.parse(args[packagesArgIndex + 1]);
-} catch (error) {
-  fail(
-    `Failed to parse --packages-json: ${error instanceof Error ? error.message : String(error)}`,
-  );
-}
-
-if (!Array.isArray(requests) || requests.length === 0) {
-  fail('--packages-json must be a non-empty array');
-}
-
-const validBumps = new Set(['patch', 'minor', 'major']);
-const seenPaths = new Set();
-
-const normalizedRequests = requests.map((request, index) => {
-  if (!request || typeof request !== 'object') {
-    fail(`packages_json[${index}] must be an object`);
+export function normalizeReleaseRequests(requests, inventory) {
+  if (!Array.isArray(requests) || requests.length === 0) {
+    fail('--packages-json must be a non-empty array');
   }
 
-  const candidatePath =
-    typeof request.path === 'string' ? request.path.trim() : '';
-  const bump = typeof request.bump === 'string' ? request.bump.trim() : '';
+  const seenPaths = new Set();
+  return requests.map((request, index) => {
+    if (!request || typeof request !== 'object' || Array.isArray(request)) {
+      fail(`packages_json[${index}] must be an object`);
+    }
+    if ('bump' in request) {
+      fail(
+        `packages_json[${index}].bump is not allowed; version changes must merge through a PR before publication`,
+      );
+    }
 
-  if (!candidatePath) {
-    fail(`packages_json[${index}].path is required`);
+    const requestPath =
+      typeof request.path === 'string' ? request.path.trim() : '';
+    const expectedVersion =
+      typeof request.version === 'string' ? request.version.trim() : '';
+    if (!requestPath) fail(`packages_json[${index}].path is required`);
+    if (!expectedVersion) {
+      fail(`packages_json[${index}].version is required`);
+    }
+
+    const entry = inventory.byPath.get(requestPath);
+    if (!entry) {
+      fail(`${requestPath} must be a direct package directory under packages/`);
+    }
+    if (seenPaths.has(requestPath)) {
+      fail(`Duplicate package path in request: ${requestPath}`);
+    }
+    seenPaths.add(requestPath);
+
+    if (entry.pkg.private === true || !entry.pkg.publishConfig) {
+      fail(`${requestPath} is private and cannot be published`);
+    }
+    if (entry.pkg.version !== expectedVersion) {
+      fail(
+        `${requestPath} expected version ${expectedVersion}, but master contains ${entry.pkg.version}`,
+      );
+    }
+
+    return {
+      ...entry,
+      name: entry.pkg.name,
+      version: entry.pkg.version,
+    };
+  });
+}
+
+function workspaceRuntimeDependencies(entry, inventory) {
+  const dependencies = [];
+  for (const field of RUNTIME_DEPENDENCY_FIELDS) {
+    for (const [name, specifier] of Object.entries(entry.pkg[field] ?? {})) {
+      if (
+        typeof specifier !== 'string' ||
+        !specifier.startsWith('workspace:')
+      ) {
+        continue;
+      }
+      const target = inventory.byName.get(name);
+      if (!target)
+        fail(`${entry.path} references missing workspace package ${name}`);
+      if (target.pkg.private === true || !target.pkg.publishConfig) {
+        fail(`${entry.path} references private workspace package ${name}`);
+      }
+      dependencies.push({ field, name, target });
+    }
   }
-  if (!validBumps.has(bump)) {
+  return dependencies;
+}
+
+export function sortReleaseRequests(requests, inventory) {
+  const selectedByName = new Map(requests.map((entry) => [entry.name, entry]));
+  const dependenciesByName = new Map();
+  const dependentsByName = new Map(requests.map((entry) => [entry.name, []]));
+  const indegree = new Map(requests.map((entry) => [entry.name, 0]));
+
+  for (const entry of requests) {
+    const selectedDependencies = workspaceRuntimeDependencies(entry, inventory)
+      .map(({ target }) => target.pkg.name)
+      .filter((name) => selectedByName.has(name));
+    dependenciesByName.set(entry.name, selectedDependencies);
+    indegree.set(entry.name, selectedDependencies.length);
+    for (const dependencyName of selectedDependencies) {
+      dependentsByName.get(dependencyName).push(entry.name);
+    }
+  }
+
+  const ready = requests
+    .filter((entry) => indegree.get(entry.name) === 0)
+    .map((entry) => entry.name)
+    .sort();
+  const ordered = [];
+
+  while (ready.length > 0) {
+    const name = ready.shift();
+    ordered.push(selectedByName.get(name));
+    for (const dependentName of dependentsByName.get(name).sort()) {
+      const nextIndegree = indegree.get(dependentName) - 1;
+      indegree.set(dependentName, nextIndegree);
+      if (nextIndegree === 0) {
+        ready.push(dependentName);
+        ready.sort();
+      }
+    }
+  }
+
+  if (ordered.length !== requests.length) {
+    const cyclePackages = requests
+      .map((entry) => entry.name)
+      .filter((name) => indegree.get(name) > 0)
+      .sort();
     fail(
-      `packages_json[${index}].bump must be one of: ${Array.from(validBumps).join(', ')}`,
+      `Selected packages contain a dependency cycle: ${cyclePackages.join(', ')}`,
     );
   }
 
-  const packageDir = path.resolve(root, candidatePath);
-  const packageJsonPath = path.join(packageDir, 'package.json');
-  if (!isPathInside(root, packageDir)) {
-    fail(`packages_json[${index}].path resolves outside the repo`);
-  }
-  if (!fs.existsSync(packageJsonPath)) {
-    fail(`No package.json found for ${candidatePath}`);
-  }
-  if (seenPaths.has(packageDir)) {
-    fail(`Duplicate package path in request: ${candidatePath}`);
-  }
-  seenPaths.add(packageDir);
+  return ordered.map((entry) => ({
+    ...entry,
+    selectedDependencies: dependenciesByName.get(entry.name),
+  }));
+}
 
-  const pkg = readPackageJson(packageJsonPath);
-  if (pkg.private === true) {
-    fail(`${candidatePath} is private and cannot be published`);
+function npmView(packageSpec) {
+  const result = spawnSync('npm', ['view', packageSpec, '--json'], {
+    encoding: 'utf8',
+    stdio: 'pipe',
+  });
+  if (result.status === 0) return JSON.parse(result.stdout || 'null');
+
+  const output = `${result.stdout ?? ''}\n${result.stderr ?? ''}`;
+  if (/E404|No match found|Not Found/i.test(output)) return null;
+  fail(`npm view ${packageSpec} failed\n${output.trim()}`);
+}
+
+function assertRegistryDependencyClosure(ordered, inventory) {
+  const selectedNames = new Set(ordered.map((entry) => entry.name));
+  const checked = new Set();
+
+  for (const entry of ordered) {
+    for (const { name, target } of workspaceRuntimeDependencies(
+      entry,
+      inventory,
+    )) {
+      if (selectedNames.has(name)) continue;
+      const packageSpec = `${name}@${target.pkg.version}`;
+      if (checked.has(packageSpec)) continue;
+      checked.add(packageSpec);
+      if (!npmView(packageSpec)) {
+        fail(
+          `${entry.name} requires unpublished ${packageSpec}; include ${target.path} in this release`,
+        );
+      }
+    }
   }
-  if (!pkg.publishConfig) {
-    fail(`${candidatePath} has no publishConfig and cannot be published`);
+}
+
+function collectStringValues(value, values = []) {
+  if (typeof value === 'string') {
+    values.push(value);
+  } else if (value && typeof value === 'object') {
+    for (const child of Object.values(value))
+      collectStringValues(child, values);
+  }
+  return values;
+}
+
+function globTargetMatches(target, archiveFiles) {
+  const normalized = `package/${target.replace(/^\.\//, '')}`;
+  const expression = new RegExp(
+    `^${normalized
+      .replace(/[.+?^${}()|[\]\\]/g, '\\$&')
+      .replaceAll('*', '[^/]+')}$`,
+  );
+  return archiveFiles.some((file) => expression.test(file));
+}
+
+export function validatePackedPackage({
+  archiveFiles,
+  inventory,
+  packedManifest,
+  request,
+}) {
+  const violations = [];
+  if (packedManifest.name !== request.name) {
+    violations.push(`packed name is ${packedManifest.name}`);
+  }
+  if (packedManifest.version !== request.version) {
+    violations.push(`packed version is ${packedManifest.version}`);
+  }
+  if (packedManifest.license !== request.pkg.license) {
+    violations.push(`packed license is ${packedManifest.license}`);
+  }
+  if (
+    JSON.stringify(packedManifest.repository) !==
+    JSON.stringify(request.pkg.repository)
+  ) {
+    violations.push('packed repository metadata differs from the source');
+  }
+  if (!archiveFiles.includes('package/LICENSE')) {
+    violations.push('tarball is missing LICENSE');
+  }
+
+  for (const field of RUNTIME_DEPENDENCY_FIELDS) {
+    for (const [name, specifier] of Object.entries(
+      packedManifest[field] ?? {},
+    )) {
+      if (typeof specifier === 'string' && LOCAL_PROTOCOL.test(specifier)) {
+        violations.push(`${field}.${name} retained ${specifier}`);
+      }
+
+      const sourceSpecifier = request.pkg[field]?.[name];
+      if (sourceSpecifier?.startsWith('workspace:')) {
+        const workspacePackage = inventory.byName.get(name);
+        if (specifier !== workspacePackage?.pkg.version) {
+          violations.push(
+            `${field}.${name} resolved to ${specifier}, expected ${workspacePackage?.pkg.version}`,
+          );
+        }
+      }
+    }
+  }
+
+  const targets = [
+    ...(packedManifest.main ? [packedManifest.main] : []),
+    ...(packedManifest.module ? [packedManifest.module] : []),
+    ...(packedManifest.types ? [packedManifest.types] : []),
+    ...collectStringValues(packedManifest.exports),
+    ...collectStringValues(packedManifest.bin),
+  ];
+  for (const target of targets) {
+    if (!globTargetMatches(target, archiveFiles)) {
+      violations.push(`published target is missing from tarball: ${target}`);
+    }
+  }
+
+  for (const archiveFile of archiveFiles) {
+    if (
+      archiveFile.split('/').some((segment) => segment.startsWith('._')) ||
+      archiveFile.includes('__MACOSX')
+    ) {
+      violations.push(`tarball includes macOS metadata: ${archiveFile}`);
+    }
+    if (
+      /\.(?:spec|test)\.[cm]?[jt]sx?$/.test(archiveFile) ||
+      (/\.[cm]?tsx?$/.test(archiveFile) && !/\.d\.[cm]?ts$/.test(archiveFile))
+    ) {
+      violations.push(`tarball includes source/test code: ${archiveFile}`);
+    }
+  }
+
+  if (violations.length > 0) {
+    fail(
+      `${request.name}@${request.version} tarball is invalid:\n- ${violations.join('\n- ')}`,
+    );
+  }
+}
+
+function archiveIntegrity(tarballPath) {
+  const bytes = fs.readFileSync(tarballPath);
+  return `sha512-${crypto.createHash('sha512').update(bytes).digest('base64')}`;
+}
+
+function archiveContentDigest(tarballPath) {
+  const extractDir = fs.mkdtempSync(path.join(os.tmpdir(), 'package-content-'));
+  try {
+    run('tar', ['-xzf', tarballPath, '-C', extractDir]);
+    const packageRoot = path.join(extractDir, 'package');
+    const files = [];
+    const stack = [packageRoot];
+    while (stack.length > 0) {
+      const current = stack.pop();
+      for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+        const absolutePath = path.join(current, entry.name);
+        if (entry.isDirectory()) stack.push(absolutePath);
+        else files.push(absolutePath);
+      }
+    }
+
+    const hash = crypto.createHash('sha256');
+    for (const filePath of files.sort()) {
+      hash.update(
+        path.relative(packageRoot, filePath).split(path.sep).join('/'),
+      );
+      hash.update('\0');
+      hash.update(fs.readFileSync(filePath));
+      hash.update('\0');
+    }
+    return `sha256-${hash.digest('hex')}`;
+  } finally {
+    fs.rmSync(extractDir, { force: true, recursive: true });
+  }
+}
+
+function dependencyNameFromSpecifier(specifier) {
+  if (specifier.startsWith('@'))
+    return specifier.split('/').slice(0, 2).join('/');
+  return specifier.split('/')[0];
+}
+
+function validatePackedImports(tarballPath, packedManifest) {
+  const extractDir = fs.mkdtempSync(path.join(os.tmpdir(), 'package-imports-'));
+  try {
+    run('tar', ['-xzf', tarballPath, '-C', extractDir]);
+    const packageRoot = path.join(extractDir, 'package');
+    const declaredDependencies = new Set(
+      RUNTIME_DEPENDENCY_FIELDS.flatMap((field) =>
+        Object.keys(packedManifest[field] ?? {}),
+      ),
+    );
+    const files = [];
+    const stack = [packageRoot];
+    while (stack.length > 0) {
+      const current = stack.pop();
+      for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+        const absolutePath = path.join(current, entry.name);
+        if (entry.isDirectory()) stack.push(absolutePath);
+        else if (/\.(?:[cm]?js|d\.[cm]?ts)$/.test(entry.name)) {
+          files.push(absolutePath);
+        }
+      }
+    }
+
+    const missing = new Set();
+    const importPattern =
+      /(?:\bfrom\s*|\bimport\s*(?:\(\s*)?|\brequire\s*\()\s*['"]([^'"]+)['"]/g;
+    for (const filePath of files) {
+      const source = fs.readFileSync(filePath, 'utf8');
+      for (const match of source.matchAll(importPattern)) {
+        const specifier = match[1];
+        if (specifier?.startsWith('.')) {
+          if (
+            /\.[cm]?js$/.test(filePath) &&
+            !fs.existsSync(path.resolve(path.dirname(filePath), specifier))
+          ) {
+            missing.add(
+              `${specifier} (${path.relative(packageRoot, filePath)} has a non-resolvable relative import)`,
+            );
+          }
+          continue;
+        }
+        if (
+          !specifier ||
+          specifier.startsWith('/') ||
+          BUILTIN_MODULES.has(specifier)
+        ) {
+          continue;
+        }
+        const dependencyName = dependencyNameFromSpecifier(specifier);
+        if (
+          dependencyName !== packedManifest.name &&
+          !declaredDependencies.has(dependencyName)
+        ) {
+          missing.add(
+            `${dependencyName} (${path.relative(packageRoot, filePath)})`,
+          );
+        }
+      }
+    }
+
+    if (missing.size > 0) {
+      fail(
+        `${packedManifest.name}@${packedManifest.version} has undeclared packed imports:\n- ${Array.from(missing).sort().join('\n- ')}`,
+      );
+    }
+  } finally {
+    fs.rmSync(extractDir, { force: true, recursive: true });
+  }
+}
+
+function packRegistryVersion(packageSpec) {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'registry-package-'));
+  try {
+    const result = spawnSync(
+      'npm',
+      [
+        'pack',
+        packageSpec,
+        '--ignore-scripts',
+        '--pack-destination',
+        tempDir,
+        '--silent',
+      ],
+      { encoding: 'utf8', stdio: 'pipe' },
+    );
+    if (result.status !== 0) {
+      const output = `${result.stdout ?? ''}\n${result.stderr ?? ''}`;
+      if (/E404|No match found|Not Found/i.test(output)) return null;
+      fail(`npm pack ${packageSpec} failed\n${output.trim()}`);
+    }
+    const tarball = fs
+      .readdirSync(tempDir)
+      .find((fileName) => fileName.endsWith('.tgz'));
+    if (!tarball) fail(`npm pack ${packageSpec} produced no tarball`);
+    return archiveContentDigest(path.join(tempDir, tarball));
+  } finally {
+    fs.rmSync(tempDir, { force: true, recursive: true });
+  }
+}
+
+export function registryAction(expectedDigest, registryDigest) {
+  if (registryDigest === null) return 'publish';
+  if (registryDigest === expectedDigest) return 'skip';
+  fail('registry version exists with content that does not match the plan');
+}
+
+function waitForRegistryContent(packageSpec, expectedDigest) {
+  for (let attempt = 1; attempt <= 10; attempt += 1) {
+    if (npmView(packageSpec)) {
+      const registryDigest = packRegistryVersion(packageSpec);
+      if (registryDigest === expectedDigest) return;
+      if (registryDigest !== null) {
+        fail(`${packageSpec} reached npm with unexpected tarball content`);
+      }
+    }
+    if (attempt < 10) run('sleep', ['3']);
+  }
+  fail(`${packageSpec} was not readable from npm after publication`);
+}
+
+export function assertCleanWorkingTree(root) {
+  const status = run(
+    'git',
+    ['status', '--porcelain=v1', '--untracked-files=all'],
+    { capture: true, cwd: root },
+  );
+  if (status) {
+    fail(
+      `package release requires a clean working tree, including untracked files:\n${status}`,
+    );
+  }
+}
+
+function assertMasterPublication(root, sourceSha) {
+  assertCleanWorkingTree(root);
+  const headSha = run('git', ['rev-parse', 'HEAD'], {
+    capture: true,
+    cwd: root,
+  });
+  if (headSha !== sourceSha) {
+    fail(
+      `release plan was built from ${sourceSha}, but checkout is ${headSha}`,
+    );
+  }
+
+  const masterRef = run(
+    'git',
+    ['ls-remote', '--exit-code', 'origin', 'refs/heads/master'],
+    {
+      capture: true,
+      cwd: root,
+    },
+  );
+  const masterSha = masterRef.split(/\s+/)[0];
+  if (!masterSha) {
+    fail('could not resolve the current origin/master commit');
+  }
+  if (headSha !== masterSha) {
+    fail(
+      `real package publication requires current origin/master (${masterSha}); checkout is ${headSha}`,
+    );
+  }
+}
+
+function tarballName(request) {
+  return `${request.name.replace(/^@/, '').replace('/', '-')}-${request.version}.tgz`;
+}
+
+function licenseSourcePath(root, request) {
+  const packageLicense = path.join(request.packageDir, 'LICENSE');
+  let licensePath;
+  if (fs.existsSync(packageLicense)) {
+    licensePath = packageLicense;
+  } else if (request.pkg.license === 'MIT') {
+    licensePath = path.join(root, 'LICENSES', 'MIT.txt');
+  } else if (
+    request.pkg.license === 'AGPL-3.0' ||
+    request.pkg.license === 'AGPL-3.0-or-later'
+  ) {
+    licensePath = path.join(root, 'LICENSE');
+  } else {
+    fail(`${request.name} uses unsupported license ${request.pkg.license}`);
+  }
+
+  if (!fs.existsSync(licensePath)) {
+    fail(`${request.name} license text is missing: ${licensePath}`);
+  }
+  const licenseText = fs.readFileSync(licensePath, 'utf8');
+  if (
+    request.pkg.license === 'MIT' &&
+    (!licenseText.includes('MIT License') ||
+      !licenseText.includes('Permission is hereby granted'))
+  ) {
+    fail(`${request.name} MIT license text is incomplete`);
+  }
+  if (
+    request.pkg.license.startsWith('AGPL-3.0') &&
+    (!licenseText.includes('GNU AFFERO GENERAL PUBLIC LICENSE') ||
+      !licenseText.includes('END OF TERMS AND CONDITIONS') ||
+      !licenseText.includes('How to Apply These Terms to Your New Programs'))
+  ) {
+    fail(
+      `${request.name} requires the complete GNU AGPL v3 text in the root LICENSE`,
+    );
+  }
+  return licensePath;
+}
+
+function injectLicenseIntoTarball({ licensePath, tarballPath }) {
+  const extractDir = fs.mkdtempSync(path.join(os.tmpdir(), 'package-license-'));
+  try {
+    run('tar', ['-xzf', tarballPath, '-C', extractDir]);
+    const packageRoot = path.join(extractDir, 'package');
+    if (!fs.existsSync(path.join(packageRoot, 'package.json'))) {
+      fail(`${tarballPath} has no package root`);
+    }
+    fs.copyFileSync(licensePath, path.join(packageRoot, 'LICENSE'));
+    fs.rmSync(tarballPath, { force: true });
+    run('tar', ['-czf', tarballPath, '-C', extractDir, 'package'], {
+      env: { COPYFILE_DISABLE: '1' },
+    });
+  } finally {
+    fs.rmSync(extractDir, { force: true, recursive: true });
+  }
+}
+
+function preparePackage({ artifactsDir, inventory, request, root }) {
+  if (request.pkg.scripts?.clean) {
+    run('bun', ['run', 'clean'], { cwd: request.packageDir });
+  } else {
+    fs.rmSync(path.join(request.packageDir, 'dist'), {
+      force: true,
+      recursive: true,
+    });
+    for (const entry of fs.readdirSync(request.packageDir)) {
+      if (entry.endsWith('.tsbuildinfo')) {
+        fs.rmSync(path.join(request.packageDir, entry), { force: true });
+      }
+    }
+  }
+  run('bun', ['run', 'build'], { cwd: request.packageDir });
+
+  const fileName = tarballName(request);
+  const tarballPath = path.join(artifactsDir, fileName);
+  const existingTarballs = new Set(fs.readdirSync(artifactsDir));
+  run(
+    'bun',
+    ['pm', 'pack', '--ignore-scripts', '--destination', artifactsDir],
+    { cwd: request.packageDir },
+  );
+  const packedFileName = fs
+    .readdirSync(artifactsDir)
+    .find((entry) => entry.endsWith('.tgz') && !existingTarballs.has(entry));
+  if (!packedFileName) fail(`${request.name} produced no tarball`);
+  const packedPath = path.join(artifactsDir, packedFileName);
+  if (packedPath !== tarballPath) fs.renameSync(packedPath, tarballPath);
+  injectLicenseIntoTarball({
+    licensePath: licenseSourcePath(root, request),
+    tarballPath,
+  });
+
+  const packedManifest = JSON.parse(
+    run('tar', ['-xOzf', tarballPath, 'package/package.json'], {
+      capture: true,
+    }),
+  );
+  const archiveFiles = run('tar', ['-tzf', tarballPath], { capture: true })
+    .split('\n')
+    .filter(Boolean);
+  validatePackedPackage({
+    archiveFiles,
+    inventory,
+    packedManifest,
+    request,
+  });
+  validatePackedImports(tarballPath, packedManifest);
+
+  const contentDigest = archiveContentDigest(tarballPath);
+  const existing = npmView(`${request.name}@${request.version}`);
+  if (existing) {
+    const registryDigest = packRegistryVersion(
+      `${request.name}@${request.version}`,
+    );
+    if (registryDigest === null) {
+      fail(
+        `${request.name}@${request.version} exists but its tarball is unavailable`,
+      );
+    }
+    try {
+      registryAction(contentDigest, registryDigest);
+    } catch {
+      fail(
+        `${request.name}@${request.version} already exists with different tarball content; bump the version through a PR`,
+      );
+    }
+  } else {
+    run('npm', [
+      'publish',
+      tarballPath,
+      '--access',
+      'public',
+      '--dry-run',
+      '--ignore-scripts',
+    ]);
   }
 
   return {
-    bump,
-    currentVersion: pkg.version,
-    name: pkg.name,
-    nextVersion: bumpVersion(pkg.version, bump),
-    packageDir,
-    packageJsonPath,
-    path: candidatePath,
+    contentDigest,
+    integrity: archiveIntegrity(tarballPath),
+    name: request.name,
+    path: request.path,
+    registryStatus: existing ? 'already-published' : 'pending',
+    selectedDependencies: request.selectedDependencies,
+    tarball: fileName,
+    version: request.version,
   };
-});
-
-run('node', [
-  'scripts/check-public-package-manifests.mjs',
-  ...normalizedRequests.map((request) => request.path),
-]);
-
-assertCleanWorkingTree();
-
-const releases = [];
-let exitCode = 0;
-
-for (const request of normalizedRequests) {
-  writePackageVersion(request.packageJsonPath, request.nextVersion);
 }
 
-try {
-  for (const request of normalizedRequests) {
-    const publishArgs = [request.path, '--no-bump'];
-
-    if (dryRun) {
-      publishArgs.push('--dry-run');
-    }
-
-    console.log(`\n=== ${dryRun ? 'Dry Run' : 'Publish'} ${request.path} ===`);
-    run(scriptPath, publishArgs, {
-      env: { PUBLISH_SKIP_CLEAN_CHECK: 'true' },
-      exitOnError: false,
-    });
-    releases.push({
-      name: request.name,
-      path: request.path,
-      version: request.nextVersion,
-    });
+export function prepareRelease({ outputDir, packagesJson, root }) {
+  assertCleanWorkingTree(root);
+  const inventory = readPackageInventory(root);
+  let requests;
+  try {
+    requests = JSON.parse(packagesJson);
+  } catch (error) {
+    fail(`Failed to parse --packages-json: ${error.message}`);
   }
-} catch (error) {
-  exitCode = error?.exitCode ?? 1;
-} finally {
-  if (dryRun) {
-    for (const request of normalizedRequests) {
-      writePackageVersion(request.packageJsonPath, request.currentVersion);
-    }
-  }
-}
 
-if (exitCode !== 0) {
-  process.exit(exitCode);
-}
+  const normalized = normalizeReleaseRequests(requests, inventory);
+  const ordered = sortReleaseRequests(normalized, inventory);
+  run('node', [
+    path.join(root, 'scripts', 'check-public-package-manifests.mjs'),
+    ...ordered.map((entry) => entry.path),
+  ]);
+  assertRegistryDependencyClosure(ordered, inventory);
 
-const outputPath =
-  process.env.PACKAGE_RELEASE_OUTPUT &&
-  path.resolve(root, process.env.PACKAGE_RELEASE_OUTPUT);
-
-if (outputPath) {
-  fs.writeFileSync(
-    outputPath,
-    `${JSON.stringify({ dryRun, releases }, null, 2)}\n`,
+  fs.rmSync(outputDir, { force: true, recursive: true });
+  const artifactsDir = path.join(outputDir, 'artifacts');
+  fs.mkdirSync(artifactsDir, { recursive: true });
+  const packages = ordered.map((request) =>
+    preparePackage({ artifactsDir, inventory, request, root }),
   );
+  const sourceSha = run('git', ['rev-parse', 'HEAD'], {
+    capture: true,
+    cwd: root,
+  });
+  const plan = {
+    createdAt: new Date().toISOString(),
+    packages,
+    schemaVersion: 1,
+    sourceSha,
+  };
+  writeJson(path.join(outputDir, 'release-plan.json'), plan);
+  writeJson(path.join(outputDir, 'release-status.json'), {
+    mode: 'dry-run',
+    packages: packages.map(({ name, registryStatus, version }) => ({
+      name,
+      status: registryStatus,
+      version,
+    })),
+    sourceSha,
+  });
+  assertCleanWorkingTree(root);
+  return plan;
 }
 
-console.log('\nRelease summary:');
-for (const release of releases) {
-  console.log(`- ${release.name}@${release.version} (${release.path})`);
+export function publishReleasePlan({ planPath, root }) {
+  const plan = readJson(planPath);
+  assertMasterPublication(root, plan.sourceSha);
+  const outputDir = path.dirname(planPath);
+  const statuses = plan.packages.map((release) => ({
+    ...release,
+    status: 'pending',
+  }));
+  const writeStatus = () =>
+    writeJson(path.join(outputDir, 'release-status.json'), {
+      mode: 'publish',
+      packages: statuses,
+      sourceSha: plan.sourceSha,
+    });
+  writeStatus();
+
+  for (const [index, release] of plan.packages.entries()) {
+    const packageSpec = `${release.name}@${release.version}`;
+    const existing = npmView(packageSpec);
+    if (existing) {
+      const registryDigest = packRegistryVersion(packageSpec);
+      if (registryDigest === null) {
+        fail(`${packageSpec} exists but its tarball is unavailable`);
+      }
+      registryAction(release.contentDigest, registryDigest);
+      statuses[index] = { ...release, status: 'already-published' };
+    } else {
+      const tarballPath = path.join(outputDir, 'artifacts', release.tarball);
+      if (archiveIntegrity(tarballPath) !== release.integrity) {
+        fail(`${release.tarball} integrity does not match the release plan`);
+      }
+      run('npm', [
+        'publish',
+        tarballPath,
+        '--access',
+        'public',
+        '--provenance',
+        '--ignore-scripts',
+      ]);
+      waitForRegistryContent(packageSpec, release.contentDigest);
+      statuses[index] = { ...release, status: 'published' };
+    }
+    writeStatus();
+  }
+
+  return statuses;
+}
+
+function optionValue(args, option) {
+  const index = args.indexOf(option);
+  return index === -1 ? null : (args[index + 1] ?? null);
+}
+
+function runCli() {
+  const args = process.argv.slice(2);
+  const root = process.cwd();
+  const packagesJson = optionValue(args, '--packages-json');
+  const outputDirArg = optionValue(args, '--output-dir');
+  const publishPlanArg = optionValue(args, '--publish-plan');
+
+  if (publishPlanArg) {
+    const statuses = publishReleasePlan({
+      planPath: path.resolve(root, publishPlanArg),
+      root,
+    });
+    console.log('\nPublication complete:');
+    for (const release of statuses) {
+      console.log(`- ${release.name}@${release.version}: ${release.status}`);
+    }
+    return;
+  }
+
+  if (!packagesJson) {
+    fail(
+      "Usage: node scripts/publish-packages-from-json.mjs --packages-json '<json>' --output-dir <dir> | --publish-plan <plan.json>",
+    );
+  }
+  const outputDir = path.resolve(root, outputDirArg ?? '.package-release');
+  const plan = prepareRelease({
+    outputDir,
+    packagesJson,
+    root,
+  });
+  console.log('\nDry-run release plan:');
+  for (const release of plan.packages) {
+    console.log(
+      `- ${release.name}@${release.version}: ${release.registryStatus} (${release.integrity})`,
+    );
+  }
+}
+
+const isDirectInvocation =
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href;
+
+if (isDirectInvocation) {
+  try {
+    runCli();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
 }


### PR DESCRIPTION
## Summary

- make public-package policy fail closed for ambiguous manifests, source-only exports, private workspace runtime dependencies, missing repository/publish metadata, and unsupported SPDX identifiers
- repair current public package manifests/build outputs, preserve package-specific MIT/AGPL licensing, and include complete license text in immutable tarballs
- replace live version bumps with exact versions already merged through a PR, dependency-first release plans, registry-closure checks, tarball/import inspection, and collision-safe resumability
- split publication into an unprivileged preflight artifact job and an OIDC-only publish job bound to an unchanged `master` SHA; the workflow never commits or pushes to trunk
- replace unsafe generic `tsc-alias` rewriting with a package-internal alias/relative ESM resolver that preserves bare dependencies such as `react`
- add focused release-policy/build-rewrite tests and CI guards

Refs #74, #140, #1343, #1450.

## Optimization Target

Guarantee that an npm version can only be published from a validated immutable tarball built from the current clean `master`, while making a dependency-ordered multi-package release safely resumable after partial registry failure.

## Alternatives Considered

- Live version bumps plus a workflow commit to `master`: rejected because it bypasses PR review and can leave source/version state split after partial publication.
- One privileged build-and-publish job: rejected because registry credentials would be available before validation and rebuilt artifacts could differ from dry-run evidence.
- npm packing directly from workspaces: rejected because Bun owns workspace protocol resolution here. Bun creates the tarball; npm 11.5.1+ only dry-runs/uploads the exact artifact with OIDC provenance.
- Generic `tsc-alias --resolve-full-paths`: rejected after CI proved it can rewrite a bare package import to a same-named local output file (`react` to `./react.js`). The replacement only rewrites resolvable relative or explicitly package-internal aliases.

## Why This Fits This Repo

The implementation follows the Bun/Turborepo workspace, short-lived branch to `master` trunk policy, current `packages/*` boundaries, and the repository rule that broad validation belongs in PR CI. It explicitly excludes `ee/`, private workspaces, and symlinked package paths.

## Safety properties

- only direct OSS `packages/*` directories can be selected; `ee/` and symlinked directories are excluded
- package preparation requires a completely clean worktree, including nonignored untracked files, before and after builds
- publication requires the release-plan SHA to equal both checkout HEAD and the current remote `master`
- every selected package is built, Bun-packed, license-injected, inspected, import-checked, and passed through `npm publish --dry-run`
- real publication uploads only the preflighted tarball after its SHA-512 matches the plan
- partial failures are resumable only when registry content matches the planned package content
- no package was published by this PR

## Merge and publication order

This PR is ready for review, but do not publish from its current pre-overlap tree. Rebase after these already-open, green PRs land:

1. #1581 for the public install artifact and final `@genfeedai/create` manifest. Preserve this PRs exact `{path, version}` release contract instead of #1581s old live-bump example.
2. #1582 for workflow consolidation. Drop the `packages/core/package.json` metadata conflict because that package is deleted, and preserve the moved workflow exports/dependencies before using the versions in this PR.
3. #1586 for the exact full root AGPL text. This release code intentionally rejects the current abbreviated root notice before any AGPL tarball can be prepared.

After those rebases, rerun the focused package preflight and let PR CI prove the broad workspace build.

## External npm owner actions

No credentials were available or used. Before a real release, an npm owner must:

- configure `genfeedai/genfeed.ai` and `.github/workflows/publish-packages.yml` as trusted publishers for existing `@genfeedai/*` names
- bootstrap currently unregistered names (`api-types`, `auth-client`, `harness`, `pricing`, `queue-contracts`) once from their preflighted tarballs, then configure trusted publishing

The exact workflow and recovery procedure is documented in `RELEASING.md`.

## Testing

Verification evidence actually run:

- `bun install --frozen-lockfile --ignore-scripts`
- `node scripts/check-public-package-manifests.mjs` — 23/23 package directories
- `bunx vitest run --config scripts/package-release/vitest.config.ts` — 15/15 tests
- `actionlint .github/workflows/publish-packages.yml`
- Node syntax, Bash syntax, ShellCheck, `git diff --check`
- staged Gitleaks and Secretlint — no findings
- clean-tree dependency-first release plan for `enums@2.3.3` then `constants@2.2.10`: both builds and npm dry-runs passed, ordering was correct, each tarball contained exactly one LICENSE, and neither contained macOS metadata
- clean-tree `auth-client@0.1.0` pack/dry-run: bare `react` remained external, internal relative imports gained `.js`, LICENSE was present, and macOS metadata was absent
- focused UI regression spec after the CI-discovered resolver collision: 1 file, 8/8 tests passed
- independent Ultracode QA: conditional approval with only the merge/publication sequencing above

Measurement evidence (required only for performance, cost, or bundle-size claims): not an optimization task; no performance, cost, or bundle-size claim is made.

Broad workspace lint, typecheck, tests, and builds are delegated to PR CI per repository policy.
