### PR TITLE
chore(guard): ratchet agent orchestrator + executor file size

### DIFF
--- a/scripts/architecture/check-agent-decomposition-size.test.ts
+++ b/scripts/architecture/check-agent-decomposition-size.test.ts
@@ -1,0 +1,91 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { runCheckAgentDecompositionSize } from './check-agent-decomposition-size';
+
+const TREE = 'apps/server/api/src/services/agent-orchestrator';
+
+describe('check-agent-decomposition-size', () => {
+  let testDir = '';
+
+  beforeEach(() => {
+    testDir = mkdtempSync(path.join(tmpdir(), 'agent-decomposition-size-'));
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { force: true, recursive: true });
+  });
+
+  it('flags a ratcheted file that grew past its ceiling', () => {
+    writeFixture(`${TREE}/big.service.ts`, linesOf(11));
+
+    const result = runCheckAgentDecompositionSize({
+      ceilings: { [`${TREE}/big.service.ts`]: 10 },
+      rootDir: testDir,
+    });
+
+    expect(result.violations).toEqual([
+      expect.objectContaining({
+        ceiling: 10,
+        file: `${TREE}/big.service.ts`,
+        lines: 11,
+      }),
+    ]);
+  });
+
+  it('passes a ratcheted file at or below its ceiling', () => {
+    writeFixture(`${TREE}/big.service.ts`, linesOf(10));
+
+    const result = runCheckAgentDecompositionSize({
+      ceilings: { [`${TREE}/big.service.ts`]: 10 },
+      rootDir: testDir,
+    });
+
+    expect(result.violations).toEqual([]);
+    expect(result.scannedFileCount).toBe(1);
+  });
+
+  it('flags a new untracked file over the general ceiling', () => {
+    writeFixture(`${TREE}/new-handler.service.ts`, linesOf(6));
+
+    const result = runCheckAgentDecompositionSize({
+      ceilings: {},
+      generalCeiling: 5,
+      rootDir: testDir,
+    });
+
+    expect(result.violations).toEqual([
+      expect.objectContaining({
+        ceiling: 5,
+        file: `${TREE}/new-handler.service.ts`,
+        lines: 6,
+      }),
+    ]);
+  });
+
+  it('ignores spec and test files', () => {
+    writeFixture(`${TREE}/huge.service.spec.ts`, linesOf(500));
+    writeFixture(`${TREE}/huge.service.test.ts`, linesOf(500));
+
+    const result = runCheckAgentDecompositionSize({
+      ceilings: {},
+      generalCeiling: 10,
+      rootDir: testDir,
+    });
+
+    expect(result.violations).toEqual([]);
+    expect(result.scannedFileCount).toBe(0);
+  });
+
+  function writeFixture(relativePath: string, contents: string): void {
+    const absolutePath = path.join(testDir, relativePath);
+    mkdirSync(path.dirname(absolutePath), { recursive: true });
+    writeFileSync(absolutePath, contents);
+  }
+
+  // Produces content whose `wc -l` (newline count) equals `count`.
+  function linesOf(count: number): string {
+    return `${Array.from({ length: count }, (_, index) => `line ${index}`).join('\n')}\n`;
+  }
+});

--- a/scripts/architecture/check-agent-decomposition-size.ts
+++ b/scripts/architecture/check-agent-decomposition-size.ts
@@ -1,0 +1,151 @@
+/**
+ * Guardrail: the agent orchestrator + tool executor may only shrink (#519, #520).
+ *
+ * `agent-tool-executor.service.ts` and `agent-orchestrator.service.ts` are the
+ * two largest hand-written source files in the repo and are being decomposed,
+ * slice by slice, into per-domain handler/sub-services. This ratchet locks in
+ * the progress: each tracked file has a recorded ceiling and the build fails if
+ * the file grows past it. When a decomposition slice shrinks a file, lower its
+ * ceiling to the new line count IN THE SAME PR — the numbers may only ever go
+ * down. New source files under the agent-orchestrator tree are held to a
+ * general ceiling so extracted handlers stay small instead of recreating a new
+ * monolith.
+ *
+ * Line counts match `wc -l` (number of newline characters).
+ */
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { globSync } from 'glob';
+
+const AGENT_ORCHESTRATOR_TREE =
+  'apps/server/api/src/services/agent-orchestrator';
+
+/**
+ * Per-file ceilings for the known-oversized files. These are a downward-only
+ * ratchet: never raise a number; lower it whenever a slice removes lines.
+ */
+const RATCHET_CEILINGS: Record<string, number> = {
+  'apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.ts': 6113,
+  'apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts': 9307,
+  'apps/server/api/src/services/agent-orchestrator/tools/agent-tool-registry.ts': 1136,
+};
+
+/**
+ * Any other non-spec source file under the tree must stay under this ceiling so
+ * decomposition produces small, cohesive services rather than a new monolith.
+ */
+const GENERAL_CEILING = 1000;
+
+const DEFAULT_IGNORE_GLOBS = [
+  '**/node_modules/**',
+  '**/dist/**',
+  '**/.next/**',
+  '**/.turbo/**',
+  '**/coverage/**',
+  '**/generated/**',
+  '**/*.spec.ts',
+  '**/*.test.ts',
+];
+
+export type AgentDecompositionSizeViolation = {
+  ceiling: number;
+  file: string;
+  lines: number;
+  message: string;
+};
+
+export type AgentDecompositionSizeResult = {
+  scannedFileCount: number;
+  violations: AgentDecompositionSizeViolation[];
+};
+
+export type AgentDecompositionSizeOptions = {
+  ceilings?: Record<string, number>;
+  generalCeiling?: number;
+  ignoreGlobs?: string[];
+  rootDir?: string;
+  treeGlob?: string;
+};
+
+function countLines(contents: string): number {
+  const match = contents.match(/\n/g);
+  return match ? match.length : 0;
+}
+
+export function runCheckAgentDecompositionSize(
+  options: AgentDecompositionSizeOptions = {},
+): AgentDecompositionSizeResult {
+  const rootDir = options.rootDir ?? process.cwd();
+  const ceilings = options.ceilings ?? RATCHET_CEILINGS;
+  const generalCeiling = options.generalCeiling ?? GENERAL_CEILING;
+  const treeGlob = options.treeGlob ?? `${AGENT_ORCHESTRATOR_TREE}/**/*.ts`;
+  const ignoreGlobs = options.ignoreGlobs ?? DEFAULT_IGNORE_GLOBS;
+
+  const files = globSync(treeGlob, {
+    absolute: true,
+    cwd: rootDir,
+    ignore: ignoreGlobs,
+    nodir: true,
+  });
+
+  const violations: AgentDecompositionSizeViolation[] = [];
+
+  for (const absoluteFile of files) {
+    const relativeFile = path
+      .relative(rootDir, absoluteFile)
+      .replaceAll('\\', '/');
+    const lines = countLines(readFileSync(absoluteFile, 'utf8'));
+    const trackedCeiling = ceilings[relativeFile];
+
+    if (trackedCeiling !== undefined) {
+      if (lines > trackedCeiling) {
+        violations.push({
+          ceiling: trackedCeiling,
+          file: relativeFile,
+          lines,
+          message: `grew to ${lines} lines (ceiling ${trackedCeiling}). This file is being decomposed (#519/#520) and may only shrink — extract a slice, don't add to it.`,
+        });
+      }
+      continue;
+    }
+
+    if (lines > generalCeiling) {
+      violations.push({
+        ceiling: generalCeiling,
+        file: relativeFile,
+        lines,
+        message: `is ${lines} lines (ceiling ${generalCeiling}). Extracted agent services must stay small and single-purpose; split this file further.`,
+      });
+    }
+  }
+
+  return {
+    scannedFileCount: files.length,
+    violations,
+  };
+}
+
+function isMainModule(): boolean {
+  const entryPoint = process.argv[1];
+  return Boolean(entryPoint) && path.resolve(entryPoint) === __filename;
+}
+
+if (isMainModule()) {
+  const result = runCheckAgentDecompositionSize();
+
+  if (result.violations.length > 0) {
+    console.error('Agent decomposition size ratchet violations found:');
+    for (const violation of result.violations) {
+      console.error(`- ${violation.file} ${violation.message}`);
+    }
+    console.error(
+      '\nIf a slice legitimately shrank a file, lower its ceiling in scripts/architecture/check-agent-decomposition-size.ts to the new count.',
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `Agent decomposition size ratchet passed across ${result.scannedFileCount} source file(s).`,
+  );
+}

--- a/scripts/check-architecture.ts
+++ b/scripts/check-architecture.ts
@@ -61,6 +61,14 @@ const checks = [
     ],
     name: 'Product workflow boundary',
   },
+  {
+    command: [
+      'bun',
+      'run',
+      'scripts/architecture/check-agent-decomposition-size.ts',
+    ],
+    name: 'Agent decomposition size ratchet',
+  },
 ] as const;
 
 let failed = false;


### PR DESCRIPTION
## Summary

The two largest hand-written source files in the repo are being decomposed slice by slice into per-domain handler/sub-services (#519, #520):

- `agent-tool-executor.service.ts` — **9,307 lines**
- `agent-orchestrator.service.ts` — **6,113 lines**

This adds a **downward-only line-count ratchet** so they cannot grow again mid-effort, and so newly extracted handlers stay small instead of recreating a monolith.

## What it does

- New `scripts/architecture/check-agent-decomposition-size.ts` records a per-file ceiling for each tracked file and fails the build if the file grows past it. **Ceilings may only be lowered** — a slice that shrinks a file lowers its ceiling in the same PR.
- Any other non-spec source file under `apps/server/api/src/services/agent-orchestrator/` is held to a general **1000-line** ceiling.
- Wired into `check:architecture` (runs in the CI `guards` job).
- Colocated unit test covers regrowth, at-ceiling, general-ceiling, and spec-file exclusion.

Line counts match `wc -l` (newline count). Verified locally: `Agent decomposition size ratchet passed across 20 source file(s).`

## Behavior

No runtime code touched — this is a CI guard only. It establishes the baseline every subsequent decomposition slice ratchets down against.

Refs #519, #520.

🤖 Generated with [Claude Code](https://claude.com/claude-code)