### PR TITLE
fix(shell): re-hide org switcher outside SaaS (epic #740 last item)

### DIFF
--- a/apps/app/packages/components/AppProtectedLayoutSidebar.tsx
+++ b/apps/app/packages/components/AppProtectedLayoutSidebar.tsx
@@ -11,6 +11,7 @@ import { SETTINGS_LOGO_HREF } from '@app-config/settings-menu-items.config';
 import { STUDIO_LOGO_HREF } from '@app-config/studio-menu-items.config';
 import { WORKFLOWS_LOGO_HREF } from '@app-config/workflows-menu-items.config';
 import { useBrand } from '@contexts/user/brand-context/brand-context';
+import { isSaaS } from '@genfeedai/config/deployment';
 import { APP_ROUTES } from '@genfeedai/constants';
 import type { MenuItemConfig } from '@genfeedai/interfaces/ui/menu-config.interface';
 import type { MenuSharedProps } from '@genfeedai/props/navigation/menu.props';
@@ -108,9 +109,15 @@ export default function AppProtectedLayoutSidebar({
 }: Props) {
   const { href: buildHref, orgHref } = useOrgUrl();
   const { settings } = useBrand();
-  const orgSwitcherSlot = (
+  // Canonical switcher rule (ADR-DEPLOYMENT-MODES): the org switcher only
+  // renders in SaaS. Community and Desktop are single-tenant (one org), so an
+  // org switcher there can't switch anything. The brand switcher stays visible
+  // in every mode. Regressed after #743 shipped when the switcher moved into
+  // the sidebar (#1059) and dropped its cloud gate; re-applied here on the
+  // canonical isSaaS() rather than a raw env read.
+  const orgSwitcherSlot = isSaaS() ? (
     <OrganizationSwitcher subscriptionTier={settings?.subscriptionTier} />
-  );
+  ) : undefined;
   const collapseProps = {
     isCollapsed,
     onToggleCollapse,

--- a/apps/app/packages/components/app-protected-layout.test.tsx
+++ b/apps/app/packages/components/app-protected-layout.test.tsx
@@ -560,7 +560,11 @@ describe('AppProtectedLayout', () => {
     expect(
       screen.queryByTestId('sidebar-brand-switcher'),
     ).not.toBeInTheDocument();
-    expect(screen.getByTestId('organization-switcher')).toBeInTheDocument();
+    // Community mode (no cloud flag): the org switcher must not render — one
+    // org per instance, nothing to switch (ADR-DEPLOYMENT-MODES switcher rule).
+    expect(
+      screen.queryByTestId('organization-switcher'),
+    ).not.toBeInTheDocument();
     expect(appLayoutSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         bannerComponent: expect.anything(),
@@ -574,7 +578,7 @@ describe('AppProtectedLayout', () => {
         collapsedSidebarWidth: 0,
         currentApp: 'workspace',
         mobileSidebarWidth: 304,
-        orgSwitcherSlot: expect.anything(),
+        orgSwitcherSlot: undefined,
         renderTopSlot: expect.any(Function),
         secondaryItems: [
           { href: '/workspace/activity', label: 'Activity' },
@@ -593,6 +597,21 @@ describe('AppProtectedLayout', () => {
     expect(screen.queryByTestId('agent-thread-list')).not.toBeInTheDocument();
     expect(screen.getByTestId('agent-panel-rail')).toBeInTheDocument();
     expect(screen.getByTestId('agent-panel')).toBeInTheDocument();
+  });
+
+  it('renders the org switcher only in SaaS mode', () => {
+    process.env.NEXT_PUBLIC_GENFEED_CLOUD = 'true';
+
+    render(
+      <AppProtectedLayout>
+        <div>Protected content</div>
+      </AppProtectedLayout>,
+    );
+
+    expect(screen.getByTestId('organization-switcher')).toBeInTheDocument();
+    expect(appSidebarSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ orgSwitcherSlot: expect.anything() }),
+    );
   });
 
   it('renders the workspace quick actions in the sidebar top slot', () => {


### PR DESCRIPTION
## What

Restores the canonical switcher rule from **ADR-DEPLOYMENT-MODES**: the **org switcher renders only in SaaS**; the **brand switcher stays visible in every mode**. Community and Desktop are single-tenant (one org per instance), so an org switcher there can switch nothing.

## Why — a regression of #743

#743 (PR #869) originally fixed the "self-hosted shows a useless org switcher" bug by gating `<OrganizationSwitcher/>` on the cloud flag inside `MenuShared`. Two later refactors silently undid it:

- **#1059** ("move organization switcher into sidebar top, Vercel-style") relocated the switcher out of `MenuShared` into `AppProtectedLayoutSidebar` as an `orgSwitcherSlot`, dropping the `shouldRenderOrganizationSwitcher` cloud gate.
- **#1493** then hard-wired `showOrgSwitcher: true` across every sidebar surface.

Result: the org switcher reappeared in Community/Desktop — the exact bug #743 removed. The existing layout test had even baked the regression in (asserted the switcher visible in community mode).

Caught during a PRD-verification pass over epic #740: every child issue is closed/COMPLETED and its surface verified in code, **except** this regressed acceptance criterion of #743.

## Fix

- Gate `orgSwitcherSlot` on the canonical `isSaaS()` from `@genfeedai/config/deployment` (the #742 authority), at the single slot construction site (`AppProtectedLayoutSidebar.tsx`). Using `isSaaS()` — not a raw `NEXT_PUBLIC_GENFEED_CLOUD` read — keeps it compliant with the deployment-mode architecture guard (`scripts/architecture/check-deployment-mode-boundary.ts`), which now forbids raw mode-env reads outside `packages/config` and `next.config`.
- Correct the community-mode assertion in `app-protected-layout.test.tsx` (org switcher hidden) and add a SaaS-mode case (org switcher shown).

Desktop (cloud + desktop client) is also non-SaaS, so the switcher stays hidden there too — matching the ADR table (SaaS shown / Community hidden / Desktop hidden).

## Verification

- Colocated unit tests cover both branches (community hidden, SaaS shown). Behavior is gated purely by a build-time env flag, so this is the meaningful verification surface; PR CI runs the suite + the deployment-mode architecture guard.

Closes the last open item of epic #740.