### PR TITLE
chore(dx): recommend genfeed.localhost dev host + auth/worktree memory rules

### DIFF
--- a/.agents/memory/MEMORY.md
+++ b/.agents/memory/MEMORY.md
@@ -8,7 +8,7 @@
 - [One API Epic](project_one_api_epic.md) — Epic #95: consolidate self-hosted + cloud into one NestJS API, 20 issues, 8 phases
 - [Fallow Health](project_fallow.md) — Fallow codebase health analysis (#83), weekly CI, score 72/100
 - [BullMQ Processor Placement](project_bullmq.md) — API no longer owns BullMQ processors; add new processors to workers or the owning runtime service
-- [Backend type-check pattern](project_backend_typecheck.md) — dedicated `tsconfig.typecheck.json` for all 11 backend service workspaces (never the runtime config); shared base, `useDefineForClassFields:false`, cross-app `$TURBO_ROOT$` inputs. #1145 closed by #1148 + #1221.
+- [Backend type-check pattern](project_backend_typecheck.md) — dedicated `tsconfig.typecheck.json` for all 12 backend service/server-tier workspaces (never the runtime config); shared base, `useDefineForClassFields:false`, cross-app `$TURBO_ROOT$` inputs. Includes `@genfeedai/server` from #1584.
 - [Migration Status](project_migration.md) — cloud + core → genfeed.ai migration complete, all pages/tests present
 - [Settings Routing](project_settings_routing.md) — canonical personal/org/brand settings URL shapes
 - [Desktop BYOK Generation](project_desktop_byok_generation.md) — desktop local/BYOK generation is local-first; cloud connect is optional
@@ -46,6 +46,8 @@
 - [NestJS value imports for DI](rules/nestjs_value_imports_for_di.md) — never `import type` classes used in decorator metadata (constructor DI, `@Body`/`@Query`/`@Param` DTOs); emitDecoratorMetadata erases them → DI injects undefined / validation silently skips; guarded by `check:di-value-imports` in CI
 - [server, not core](rules/server_not_core.md) — #1090 server-tier lib = `apps/server/server` / `@genfeedai/server`; the name "core" is retired (collides with `packages/core`); workflow UI target is `@genfeedai/workflows/ui`
 - [Pricing output meter](pricing_output_meter.md) — Credits/API rates are the monetization throttle; do not add hard product caps for brands or connected channels
+- [Better Auth additionalFields](rules/better_auth_additional_fields.md) — any `User` column a Better Auth hook sets (e.g. `handle`) MUST be declared in `user.additionalFields` or it's stripped and first-time signup fails with `Argument 'X' is missing` (#1576)
+- [Worktree env sync](rules/worktree_env_sync.md) — `.env*` is gitignored; new worktrees have no env. Use `git wt <path>` (after `bun run wt:setup`) or run `bun run wt:sync <path>` after `git worktree add`. NOT automatic for plain `git worktree add` (#1578)
 
 ## References
 
@@ -58,7 +60,7 @@
 ## Context (loaded via CLAUDE.md @import)
 
 - [System Patterns](context/system-patterns.md) — architecture patterns, serializers, multi-tenancy
-- [Project Structure](context/project-structure.md) — directory layout, 11 backend service workspaces, 7 frontend/client workspaces
+- [Project Structure](context/project-structure.md) — directory layout, 12 backend service/server-tier workspaces, 7 frontend/client workspaces
 - [Style Guide](context/project-style-guide.md) — TypeScript, git, formatting, naming conventions
 - [Skills Architecture](context/skills-architecture.md) — skills/ vs .agents/skills/ vs .claude/skills/
 - [Progress](context/progress.md) — migration status, active work areas

--- a/.agents/memory/context/project-overview.md
+++ b/.agents/memory/context/project-overview.md
@@ -1,6 +1,6 @@
 ---
 created: 2026-04-07T00:00:00Z
-last_updated: 2026-07-06T00:00:00Z
+last_updated: 2026-07-11T00:00:00Z
 version: 1.2
 author: Claude Code PM System
 ---
@@ -21,7 +21,7 @@ Genfeed.ai is an open-source AI operating system for content creation — a self
 
 ## Architecture Summary
 
-- **11 backend service workspaces** (NestJS): api, discord, files, images, mcp, notifications, slack, telegram, videos, voices, workers. `apps/server/clips/` is not currently a package workspace.
+- **12 backend service workspaces** (NestJS and server-tier packages): api, discord, files, images, mcp, notifications, server, slack, telegram, videos, voices, workers. `apps/server/clips/` is not currently a package workspace.
 - **7 frontend/client workspaces**: app (studio), docs, website, desktop, mobile, browser extension, IDE extension
 - **43 shared packages**: serializers, UI components, hooks, services, types, enums, workflow engine, integrations, Prisma, auth client, harness, etc.
 - **2 enterprise packages** (`ee/`): billing and harness

--- a/.agents/memory/context/project-structure.md
+++ b/.agents/memory/context/project-structure.md
@@ -1,6 +1,6 @@
 ---
 created: 2026-04-07T00:00:00Z
-last_updated: 2026-07-06T00:00:00Z
+last_updated: 2026-07-11T00:00:00Z
 version: 1.2
 author: Claude Code PM System
 ---
@@ -12,12 +12,13 @@ author: Claude Code PM System
 ```
 genfeed.ai/
 ├── apps/
-│   ├── server/              # 11 NestJS backend service workspaces
+│   ├── server/              # 12 backend service/server-tier workspaces
 │   │   ├── api/             # Main API (port 3010)
 │   │   ├── notifications/   # Notification service (3011)
 │   │   ├── files/           # File processing (3012)
 │   │   ├── workers/         # Background jobs (3013)
 │   │   ├── mcp/             # MCP server (3014)
+│   │   ├── server/          # Shared @genfeedai/server source-level package
 │   │   ├── clips/           # Not currently a package workspace; re-verify before treating as a service
 │   │   ├── discord/         # Discord integration (3016)
 │   │   ├── slack/           # Slack integration (3018)

--- a/.agents/memory/context/project-style-guide.md
+++ b/.agents/memory/context/project-style-guide.md
@@ -64,4 +64,3 @@ author: Claude Code PM System
 - Colocated test files: `*.test.ts` / `*.spec.ts`
 - TDD: write failing tests first, then implement
 - Run per-package: `bun run test --filter=@genfeedai/[name]`
-- Never run full test suite locally

--- a/.agents/memory/project_backend_typecheck.md
+++ b/.agents/memory/project_backend_typecheck.md
@@ -1,7 +1,7 @@
 # Backend type-check pattern (`apps/server/*`)
 
-last_verified: 2026-07-06
-Source: PR #1148 and PR #1221 (#1145). Verified against committed `package.json` scripts and `tsconfig.typecheck.json` files on `origin/master`.
+last_verified: 2026-07-11
+Source: PR #1148, PR #1221 (#1145), and the `@genfeedai/server` extraction in PR #1584. Verified against committed `package.json` scripts and `tsconfig.typecheck.json` files.
 
 ## Invariant
 
@@ -48,9 +48,9 @@ PR #1342 added `scripts/architecture/check-no-api-imports-in-workers.ts` and the
 `@genfeedai/queue-contracts`, `@genfeedai/libs`, or the planned `@genfeedai/server`
 surface instead of adding more API deep imports.
 
-## Status (2026-07-06)
+## Status (2026-07-11)
 
-Green coverage is present for all current backend service workspaces:
-`api, discord, files, images, mcp, notifications, slack, telegram, videos, voices, workers`
-(11/11). `apps/server/clips/` is not currently a package workspace and has no
+Dedicated type-check configuration is present for all current backend service/server-tier workspaces:
+`api, discord, files, images, mcp, notifications, server, slack, telegram, videos, voices, workers`
+(12/12). `apps/server/clips/` is not currently a package workspace and has no
 `tsconfig.typecheck.json`; re-verify before treating it as an active service.

--- a/.agents/memory/rules/better_auth_additional_fields.md
+++ b/.agents/memory/rules/better_auth_additional_fields.md
@@ -1,0 +1,43 @@
+# Better Auth: hook-set User columns MUST be declared in `user.additionalFields`
+
+**last_verified: 2026-07-11**
+
+Better Auth only persists user columns it knows about. Its `create.before` hook
+(and any field set inside it) is **stripped from the create payload unless the
+field is declared in `user.additionalFields`**. The column then falls back to
+its DB default — or, if it is `NOT NULL` with no default, the insert throws
+`Argument '<field>' is missing` at `db.user.create()` and **first-time signup
+fails**. Existing-user sign-in never calls `user.create`, so the bug is
+invisible until a brand-new account is created — which is why it can pass every
+local smoke test and still break production onboarding.
+
+## Rule
+
+Any `User` column that a Better Auth hook computes/sets (e.g. `handle`) MUST also
+be declared in `user.additionalFields`:
+
+```ts
+// apps/server/api/src/auth/better-auth/better-auth.factory.ts
+user: {
+  fields: { image: 'avatar' },
+  additionalFields: {
+    handle: { input: false, required: false, type: 'string' },
+  },
+},
+```
+
+- `input: false` — clients can't set it; only the hook can.
+- Declaring it makes Better Auth carry the hook's value through to the insert.
+
+## Where
+
+- Config: `apps/server/api/src/auth/better-auth/better-auth.factory.ts`
+  (`createBetterAuthInstance`, `user.additionalFields`).
+- Regression guard: `better-auth.factory.spec.ts` asserts the source contains
+  `additionalFields` with a `handle:` entry.
+
+## History
+
+Root-caused and fixed in **#1576** (handle stripped → `Argument 'handle' is
+missing` on new-user signup). Add the same declaration whenever a new
+hook-populated column is introduced.

--- a/.agents/memory/rules/worktree_env_sync.md
+++ b/.agents/memory/rules/worktree_env_sync.md
@@ -1,0 +1,31 @@
+# New worktrees need env files copied — use `git wt` or `bun run wt:sync`
+
+**last_verified: 2026-07-11**
+
+Env files (`.env*`) are gitignored, so a fresh `git worktree add` starts with
+**no env** and the app/API won't boot there. `.worktreeinclude` lists the globs
+to copy from the primary worktree; `scripts/sync-worktree-includes.sh` does the
+copy (idempotent — never clobbers an existing file in the target).
+
+## For agents (Claude, Codex) creating worktrees
+
+`git worktree add` has **no post-add hook**, so the sync is NOT automatic for a
+plain `git worktree add`. Do one of:
+
+- **`git wt <path> [branch]`** — wrapper alias that runs `git worktree add` then
+  syncs env in one step. Requires the one-time `bun run wt:setup` (installs the
+  `wt` git alias for the current user).
+- **`bun run wt:sync [target-dir]`** — run manually after any `git worktree add`
+  (or after a Codex/CI worktree is created). Copies the `.worktreeinclude`
+  globs into the target. Safe to re-run.
+
+Rule of thumb: **if you `git worktree add`, immediately `bun run wt:sync <path>`**
+(or use `git wt` instead of `git worktree add`). Do not hand-copy `.env*` files —
+that path is policy-blocked and error-prone.
+
+## Wiring
+
+- `.worktreeinclude` — glob list (repo root).
+- `scripts/sync-worktree-includes.sh` — the copier (target-dir arg optional).
+- `package.json` → `wt:sync` (copier) and `wt:setup` (installs `git wt` alias).
+- Shipped in **#1578**.

--- a/.agents/memory/system/CRITICAL-NEVER-DO.md
+++ b/.agents/memory/system/CRITICAL-NEVER-DO.md
@@ -19,11 +19,11 @@ All operations within the workspace root only. NEVER use `/tmp`, `/private/tmp`,
 
 ### NEVER DELETE Protected Root Files
 
-At repo root: `AGENTS.md`, `CLAUDE.md`, `CODEX.md`, `CONTRIBUTING.md`, `DESIGN.md`, `README.md`, and `RELEASING.md`. These are intentional root documentation surfaces -- NOT duplicates of `.agents/` files.
+At repo root: `AGENTS.md` and `CLAUDE.md`, `CONTRIBUTING.md`, `DESIGN.md`, `README.md`, and `RELEASING.md`. These are intentional root documentation surfaces -- NOT duplicates of `.agents/` files.
 
 ### NEVER Create Root-Level .md Files
 
-Only the current intentional root docs are allowed at root: `AGENTS.md`, `CLAUDE.md`, `CODEX.md`, `CONTRIBUTING.md`, `DESIGN.md`, `README.md`, and `RELEASING.md`. Everything else goes in `.agents/`.
+Only the current intentional root docs are allowed at root: `AGENTS.md` and `CLAUDE.md`, `CONTRIBUTING.md`, `DESIGN.md`, `README.md`, and `RELEASING.md`. Everything else goes in `.agents/`.
 
 ### Session Files: ONE FILE PER DAY
 
@@ -85,7 +85,3 @@ All imports at top of file, never `import('...')` inline in type definitions.
 ### NEVER Implement Backward Compatibility Workarounds
 
 Break things properly, then fix them at the source. No aliases, wrappers, or re-exports.
-
-### NEVER Run Full Test Suites Locally
-
-Scoped tests only: `bun test path/to/file.spec.ts` or `bun test src/collections/module/`. Full suite -> CI/CD.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,33 @@ bun run dev:docs
 The self-hosted distribution has a separate container-image path that does not
 require local Node.js or Bun. See [docs/self-hosting.md](docs/self-hosting.md).
 
+### Dev host
+
+Plain `localhost` works out of the box. The **recommended** dev host, though, is
+`genfeed.localhost`:
+
+- `*.localhost` resolves to loopback in every modern browser and OS
+  ([RFC 6761](https://www.rfc-editor.org/rfc/rfc6761)) — **no `/etc/hosts` entry
+  needed** (unlike the older `local.genfeed.ai`, which required one).
+- Browser cookies are keyed by host, not port, so a distinct host gives this
+  project its **own cookie jar**. The app (`:3000`) and API (`:3010`) still
+  share it (same host → auth cookies flow), but it never collides with the
+  session/JWT of another project you run on plain `localhost`.
+
+To use it, point the frontend and Better Auth at `genfeed.localhost` in
+`.env.local`:
+
+```env
+BETTER_AUTH_URL=http://genfeed.localhost:3010
+NEXT_PUBLIC_API_ENDPOINT=http://genfeed.localhost:3010/v1
+NEXT_PUBLIC_WS_ENDPOINT=ws://genfeed.localhost:3010
+```
+
+All three hosts (`genfeed.localhost`, `localhost`, `local.genfeed.ai`) are
+auto-trusted by Better Auth outside production/staging, so no
+`BETTER_AUTH_TRUSTED_ORIGINS` config is required for local dev
+(`apps/server/api/src/auth/better-auth/better-auth.config.ts`).
+
 ## Branch and pull-request workflow
 
 1. Fork the repository.

--- a/apps/server/api/src/auth/better-auth/better-auth.config.spec.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.config.spec.ts
@@ -29,8 +29,10 @@ describe('Better Auth config', () => {
   });
 
   describe('resolveTrustedOrigins', () => {
-    it('auto-trusts localhost AND local.genfeed.ai for local dev (no env needed)', () => {
+    it('auto-trusts genfeed.localhost, localhost AND local.genfeed.ai for local dev (no env needed)', () => {
       const origins = resolveTrustedOrigins(undefined, 'development');
+      expect(origins).toContain('http://genfeed.localhost:3000');
+      expect(origins).toContain('http://genfeed.localhost:3010');
       expect(origins).toContain('http://localhost:3000');
       expect(origins).toContain('http://local.genfeed.ai:3000');
     });

--- a/apps/server/api/src/auth/better-auth/better-auth.config.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.config.ts
@@ -38,16 +38,23 @@ export function parseTrustedOrigins(value: string | undefined): string[] {
 }
 
 /**
- * Frontends local dev serves from. Both `localhost` and `local.genfeed.ai`
- * (which resolves to 127.0.0.1 via /etc/hosts) are auto-trusted so a fresh
- * clone works on either hostname — app (3000), website (3002), API (3010) —
- * without anyone having to set `BETTER_AUTH_TRUSTED_ORIGINS` by hand.
+ * Frontends local dev serves from, auto-trusted so a fresh clone works with zero
+ * `BETTER_AUTH_TRUSTED_ORIGINS` config — app (3000), website (3002), API (3010).
+ *
+ * Recommended dev host is `genfeed.localhost`: `*.localhost` resolves to loopback
+ * in every modern browser/OS (RFC 6761) with NO `/etc/hosts` entry, and gives
+ * this project its own cookie jar so its session/JWT never collides with another
+ * project on plain `localhost`. `local.genfeed.ai` (needs an `/etc/hosts` entry)
+ * is kept for back-compat during migration; plain `localhost` also works.
  */
 const LOCAL_DEV_TRUSTED_ORIGINS = [
+  'http://genfeed.localhost:3000',
   'http://localhost:3000',
   'http://local.genfeed.ai:3000',
+  'http://genfeed.localhost:3002',
   'http://localhost:3002',
   'http://local.genfeed.ai:3002',
+  'http://genfeed.localhost:3010',
   'http://localhost:3010',
   'http://local.genfeed.ai:3010',
 ] as const;
@@ -56,9 +63,10 @@ const LOCAL_DEV_TRUSTED_ORIGINS = [
  * Resolve Better Auth's trusted origins. Always honours whatever
  * `BETTER_AUTH_TRUSTED_ORIGINS` lists; outside production/staging it also merges
  * the standard {@link LOCAL_DEV_TRUSTED_ORIGINS} so local dev needs zero env
- * config and never hits a spurious `INVALID_ORIGIN` when accessed via either
- * `localhost` or `local.genfeed.ai`. Real deployments (production/staging) get
- * exactly the configured list — localhost is never auto-trusted there.
+ * config and never hits a spurious `INVALID_ORIGIN` when accessed via
+ * `genfeed.localhost`, `localhost`, or `local.genfeed.ai`. Real deployments
+ * (production/staging) get exactly the configured list — loopback hosts are
+ * never auto-trusted there.
  */
 export function resolveTrustedOrigins(
   value: string | undefined,

--- a/packages/libs/config/cors.config.spec.ts
+++ b/packages/libs/config/cors.config.spec.ts
@@ -42,6 +42,12 @@ describe('CORS Configuration', () => {
         expect(localPattern.test('http://localhost:3011')).toBe(true); // Notifications
         expect(localPattern.test('http://localhost:3016')).toBe(true); // Discord
         expect(localPattern.test('http://local.genfeed.ai:3015')).toBe(true); // Clips
+        // genfeed.localhost dev host (loopback, no /etc/hosts, isolated cookies)
+        expect(localPattern.test('http://genfeed.localhost:3000')).toBe(true); // App
+        expect(localPattern.test('http://genfeed.localhost:3010')).toBe(true); // API
+        expect(localPattern.test('http://app.genfeed.localhost:3000')).toBe(
+          true,
+        ); // subdomain
         // Upper boundary
         expect(localPattern.test('http://localhost:3999')).toBe(true);
         // Out of range

--- a/packages/libs/config/cors.config.ts
+++ b/packages/libs/config/cors.config.ts
@@ -60,8 +60,11 @@ export function getGenfeedCorsOrigins(
 
   if (isDevelopment) {
     return [
-      // Local development domains (ports 3000-3999: web apps and local services)
-      /^http:\/\/(localhost|local\.genfeed\.ai):(3\d{3})$/,
+      // Local development domains (ports 3000-3999: web apps and local services).
+      // genfeed.localhost (and any *.genfeed.localhost subdomain) is the
+      // recommended dev host — it resolves to loopback with no /etc/hosts entry
+      // and isolates this project's cookie jar from other localhost projects.
+      /^http:\/\/(localhost|local\.genfeed\.ai|([a-z0-9-]+\.)*genfeed\.localhost):(3\d{3})$/,
       /^https:\/\/([a-z0-9-]+\.)*genfeed\.localhost$/,
 
       // Allow Chrome extensions in development


### PR DESCRIPTION
## What

**Dev host** — Auto-trust `genfeed.localhost` (`:3000`/`:3002`/`:3010`) in Better Auth's local-dev trusted origins, alongside the existing `localhost` and `local.genfeed.ai`.

`*.localhost` resolves to loopback in every modern browser/OS ([RFC 6761](https://www.rfc-editor.org/rfc/rfc6761)) with **no `/etc/hosts` entry**, and — because cookies are keyed by host, not port — gives the project its **own cookie jar**. App (`:3000`) and API (`:3010`) still share it, but it no longer collides with the session/JWT of another project running on plain `localhost`.

**Docs** — CONTRIBUTING.md now documents the recommended dev host + the three local-config vars to point at it.

**Memory rules** (durable, for future agents):
- `better_auth_additional_fields.md` — any `User` column a Better Auth hook sets (e.g. `handle`) **must** be declared in `user.additionalFields`, or the value is stripped and first-time signup throws `Argument 'X' is missing`. Root-caused in #1576.
- `worktree_env_sync.md` — new worktrees have no local env (those files are gitignored). Use `git wt <path>` (after `bun run wt:setup`) or `bun run wt:sync <path>` after `git worktree add`. Shipped in #1578; **not** automatic for a plain `git worktree add`.

## Why

Removes the last `/etc/hosts` dependency from local dev and stops cross-project cookie/JWT contamination on `localhost`. The two rules capture gotchas that each cost real debugging time this cycle.

## Test

- `better-auth.config.spec.ts` updated to assert `genfeed.localhost` origins are auto-trusted in dev and still never in production/staging.
- Docs + memory are non-code.

No per-developer local config changes in this PR — those stay local.
