### PR TITLE
refactor(agent): extract memory + goals tool handler from executor

### DIFF
--- a/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.module.ts
+++ b/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.module.ts
@@ -35,6 +35,7 @@ import { AgentOrchestratorController } from '@api/services/agent-orchestrator/ag
 import { AgentOrchestratorService } from '@api/services/agent-orchestrator/agent-orchestrator.service';
 import { AgentStreamPublisherModule } from '@api/services/agent-orchestrator/agent-stream-publisher.module';
 import { AgentToolsController } from '@api/services/agent-orchestrator/agent-tools.controller';
+import { AgentMemoryGoalsToolHandler } from '@api/services/agent-orchestrator/tools/agent-memory-goals-tool-handler.service';
 import { AgentRouteRewriteService } from '@api/services/agent-orchestrator/tools/agent-route-rewrite.service';
 import { AgentToolExecutorService } from '@api/services/agent-orchestrator/tools/agent-tool-executor.service';
 import { AgentSpawnModule } from '@api/services/agent-spawn/agent-spawn.module';
@@ -96,6 +97,7 @@ import { forwardRef, Module } from '@nestjs/common';
   ],
   providers: [
     AgentCompletionCardBuilderService,
+    AgentMemoryGoalsToolHandler,
     AgentOrchestratorService,
     AgentRouteRewriteService,
     AgentToolExecutorService,

--- a/apps/server/api/src/services/agent-orchestrator/tools/agent-memory-goals-tool-handler.service.spec.ts
+++ b/apps/server/api/src/services/agent-orchestrator/tools/agent-memory-goals-tool-handler.service.spec.ts
@@ -1,0 +1,294 @@
+import type { AgentGoalsService } from '@api/collections/agent-goals/services/agent-goals.service';
+import type { AgentMemoryCaptureService } from '@api/collections/agent-memories/services/agent-memory-capture.service';
+import { AgentMemoryGoalsToolHandler } from '@api/services/agent-orchestrator/tools/agent-memory-goals-tool-handler.service';
+import type { ToolExecutionContext } from '@api/services/agent-orchestrator/tools/agent-tool-executor.service';
+
+const ctx: ToolExecutionContext = {
+  organizationId: '67a123456789012345678901',
+  userId: '67a123456789012345678902',
+};
+
+describe('AgentMemoryGoalsToolHandler', () => {
+  let agentMemoryCaptureService: {
+    capture: ReturnType<typeof vi.fn>;
+  };
+  let agentGoalsService: {
+    create: ReturnType<typeof vi.fn>;
+    refreshProgress: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+  };
+  let handlerWithServices: AgentMemoryGoalsToolHandler;
+  let handlerWithoutServices: AgentMemoryGoalsToolHandler;
+
+  beforeEach(() => {
+    agentMemoryCaptureService = {
+      capture: vi.fn().mockResolvedValue({
+        memory: {
+          id: 'memory-1',
+          content: 'Write concise newsletters with a strong hook.',
+          contentType: 'newsletter',
+          kind: 'preference',
+          scope: 'user',
+          summary: 'Concise newsletter hook preference',
+        },
+        wroteBrandInsight: false,
+        wroteContextMemory: true,
+      }),
+    };
+    agentGoalsService = {
+      create: vi.fn().mockResolvedValue({
+        currentValue: 250,
+        id: 'goal-1',
+        label: 'Grow views',
+        metric: 'views',
+        progressPercent: 25,
+        targetValue: 1000,
+      }),
+      refreshProgress: vi.fn().mockResolvedValue({
+        currentValue: 250,
+        id: 'goal-1',
+        label: 'Grow views',
+        metric: 'views',
+        progressPercent: 25,
+        targetValue: 1000,
+      }),
+      update: vi.fn().mockResolvedValue({
+        currentValue: 400,
+        id: 'goal-1',
+        label: 'Grow views',
+        metric: 'views',
+        progressPercent: 40,
+        targetValue: 1000,
+      }),
+    };
+
+    handlerWithServices = new AgentMemoryGoalsToolHandler(
+      agentMemoryCaptureService as unknown as AgentMemoryCaptureService,
+      agentGoalsService as unknown as AgentGoalsService,
+    );
+    handlerWithoutServices = new AgentMemoryGoalsToolHandler(
+      undefined as unknown as AgentMemoryCaptureService,
+      undefined as unknown as AgentGoalsService,
+    );
+  });
+
+  describe('captureMemory', () => {
+    it('captures memory and reports routed destinations', async () => {
+      const result = await handlerWithServices.captureMemory(
+        {
+          brandId: '67a123456789012345678903',
+          content: 'Use short, curiosity-driven newsletter openings.',
+          contentType: 'newsletter',
+          kind: 'winner',
+          saveToContextMemory: true,
+          scope: 'brand',
+          summary: 'Short curiosity-driven newsletter openings',
+          tags: ['newsletter', 'hook'],
+        },
+        ctx,
+      );
+
+      expect(agentMemoryCaptureService.capture).toHaveBeenCalled();
+      expect(result).toEqual(
+        expect.objectContaining({
+          creditsUsed: 0,
+          data: expect.objectContaining({
+            contentType: 'newsletter',
+            destinations: ['agent memory', 'content memory'],
+            id: 'memory-1',
+            kind: 'preference',
+            scope: 'user',
+          }),
+          success: true,
+        }),
+      );
+    });
+
+    it('fails when content is missing', async () => {
+      const result = await handlerWithServices.captureMemory({}, ctx);
+
+      expect(result).toEqual({
+        creditsUsed: 0,
+        error: 'Memory capture requires content.',
+        success: false,
+      });
+      expect(agentMemoryCaptureService.capture).not.toHaveBeenCalled();
+    });
+
+    it('fails when the memory capture service is unavailable', async () => {
+      const result = await handlerWithoutServices.captureMemory(
+        { content: 'Use short, curiosity-driven newsletter openings.' },
+        ctx,
+      );
+
+      expect(result).toEqual({
+        creditsUsed: 0,
+        error: 'Memory capture is not available in this environment.',
+        success: false,
+      });
+    });
+  });
+
+  describe('createGoal', () => {
+    it('creates a goal via the agent goals service', async () => {
+      const result = await handlerWithServices.createGoal(
+        {
+          label: 'Grow views',
+          metric: 'views',
+          targetValue: 1000,
+        },
+        ctx,
+      );
+
+      expect(agentGoalsService.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          label: 'Grow views',
+          metric: 'views',
+          targetValue: 1000,
+        }),
+        ctx.organizationId,
+        ctx.userId,
+      );
+      expect(result).toEqual(
+        expect.objectContaining({
+          creditsUsed: 0,
+          data: expect.objectContaining({
+            goalId: 'goal-1',
+            progressPercent: 25,
+          }),
+          success: true,
+        }),
+      );
+    });
+
+    it('fails when label, metric, or targetValue are invalid', async () => {
+      const result = await handlerWithServices.createGoal(
+        { label: 'Grow views' },
+        ctx,
+      );
+
+      expect(result).toEqual({
+        creditsUsed: 0,
+        error: 'create_goal requires label, metric, and numeric targetValue.',
+        success: false,
+      });
+      expect(agentGoalsService.create).not.toHaveBeenCalled();
+    });
+
+    it('fails when the agent goals service is unavailable', async () => {
+      const result = await handlerWithoutServices.createGoal(
+        { label: 'Grow views', metric: 'views', targetValue: 1000 },
+        ctx,
+      );
+
+      expect(result).toEqual({
+        creditsUsed: 0,
+        error: 'Agent goals are not available in this environment.',
+        success: false,
+      });
+    });
+  });
+
+  describe('checkGoalProgress', () => {
+    it('refreshes and returns goal progress', async () => {
+      const result = await handlerWithServices.checkGoalProgress(
+        { goalId: '67a123456789012345678903' },
+        ctx,
+      );
+
+      expect(agentGoalsService.refreshProgress).toHaveBeenCalledWith(
+        '67a123456789012345678903',
+        ctx.organizationId,
+      );
+      expect(result).toEqual(
+        expect.objectContaining({
+          creditsUsed: 0,
+          data: expect.objectContaining({
+            goalId: 'goal-1',
+            progressPercent: 25,
+          }),
+          success: true,
+        }),
+      );
+    });
+
+    it('rejects an invalid goalId', async () => {
+      const result = await handlerWithServices.checkGoalProgress(
+        { goalId: 'not-an-object-id' },
+        ctx,
+      );
+
+      expect(result).toEqual({
+        creditsUsed: 0,
+        error: 'check_goal_progress requires a valid goalId.',
+        success: false,
+      });
+      expect(agentGoalsService.refreshProgress).not.toHaveBeenCalled();
+    });
+
+    it('fails when the agent goals service is unavailable', async () => {
+      const result = await handlerWithoutServices.checkGoalProgress(
+        { goalId: '67a123456789012345678903' },
+        ctx,
+      );
+
+      expect(result).toEqual({
+        creditsUsed: 0,
+        error: 'Agent goals are not available in this environment.',
+        success: false,
+      });
+    });
+  });
+
+  describe('updateGoal', () => {
+    it('updates a goal via the agent goals service', async () => {
+      const result = await handlerWithServices.updateGoal(
+        { goalId: '67a123456789012345678903', targetValue: 1000 },
+        ctx,
+      );
+
+      expect(agentGoalsService.update).toHaveBeenCalledWith(
+        '67a123456789012345678903',
+        expect.objectContaining({ targetValue: 1000 }),
+        ctx.organizationId,
+      );
+      expect(result).toEqual(
+        expect.objectContaining({
+          creditsUsed: 0,
+          data: expect.objectContaining({
+            goalId: 'goal-1',
+            progressPercent: 40,
+          }),
+          success: true,
+        }),
+      );
+    });
+
+    it('rejects an invalid goalId', async () => {
+      const result = await handlerWithServices.updateGoal(
+        { goalId: 'not-an-object-id', targetValue: 1000 },
+        ctx,
+      );
+
+      expect(result).toEqual({
+        creditsUsed: 0,
+        error: 'update_goal requires a valid goalId.',
+        success: false,
+      });
+      expect(agentGoalsService.update).not.toHaveBeenCalled();
+    });
+
+    it('fails when the agent goals service is unavailable', async () => {
+      const result = await handlerWithoutServices.updateGoal(
+        { goalId: '67a123456789012345678903', targetValue: 1000 },
+        ctx,
+      );
+
+      expect(result).toEqual({
+        creditsUsed: 0,
+        error: 'Agent goals are not available in this environment.',
+        success: false,
+      });
+    });
+  });
+});

--- a/apps/server/api/src/services/agent-orchestrator/tools/agent-memory-goals-tool-handler.service.ts
+++ b/apps/server/api/src/services/agent-orchestrator/tools/agent-memory-goals-tool-handler.service.ts
@@ -1,0 +1,332 @@
+import { CreateAgentGoalDto } from '@api/collections/agent-goals/dto/create-agent-goal.dto';
+import { UpdateAgentGoalDto } from '@api/collections/agent-goals/dto/update-agent-goal.dto';
+import { AgentGoalsService } from '@api/collections/agent-goals/services/agent-goals.service';
+import type {
+  AgentMemoryContentType,
+  AgentMemoryKind,
+  AgentMemoryScope,
+} from '@api/collections/agent-memories/schemas/agent-memory.schema';
+import { AgentMemoryCaptureService } from '@api/collections/agent-memories/services/agent-memory-capture.service';
+import { EntityIdUtil } from '@api/helpers/utils/entity-id/entity-id.util';
+import type { ToolExecutionContext } from '@api/services/agent-orchestrator/tools/agent-tool-executor.service';
+import type { AgentToolResult } from '@genfeedai/interfaces';
+import { Injectable, Optional } from '@nestjs/common';
+
+@Injectable()
+export class AgentMemoryGoalsToolHandler {
+  constructor(
+    @Optional()
+    private readonly agentMemoryCaptureService: AgentMemoryCaptureService,
+    @Optional()
+    private readonly agentGoalsService: AgentGoalsService,
+  ) {}
+
+  async captureMemory(
+    params: Record<string, unknown>,
+    ctx: ToolExecutionContext,
+  ): Promise<AgentToolResult> {
+    if (!this.agentMemoryCaptureService) {
+      return {
+        creditsUsed: 0,
+        error: 'Memory capture is not available in this environment.',
+        success: false,
+      };
+    }
+
+    const content = String(params.content || '').trim();
+    if (!content) {
+      return {
+        creditsUsed: 0,
+        error: 'Memory capture requires content.',
+        success: false,
+      };
+    }
+
+    const brandId =
+      typeof params.brandId === 'string' ? params.brandId : undefined;
+    const campaignId =
+      typeof params.campaignId === 'string' ? params.campaignId : undefined;
+    const summary =
+      typeof params.summary === 'string' ? params.summary.trim() : undefined;
+    const capture = await this.agentMemoryCaptureService.capture(
+      ctx.userId,
+      ctx.organizationId,
+      {
+        brandId,
+        campaignId,
+        confidence:
+          typeof params.confidence === 'number' ? params.confidence : undefined,
+        content,
+        contentType: this.normalizeAgentMemoryContentType(params.contentType),
+        importance:
+          typeof params.importance === 'number' ? params.importance : undefined,
+        kind: this.normalizeAgentMemoryKind(params.kind),
+        performanceSnapshot:
+          params.performanceSnapshot &&
+          typeof params.performanceSnapshot === 'object'
+            ? (params.performanceSnapshot as Record<string, unknown>)
+            : undefined,
+        platform:
+          typeof params.platform === 'string' ? params.platform : undefined,
+        saveToContextMemory: params.saveToContextMemory === true,
+        scope: this.normalizeAgentMemoryScope(params.scope),
+        sourceContentId:
+          typeof params.sourceContentId === 'string'
+            ? params.sourceContentId
+            : undefined,
+        sourceMessageId:
+          typeof params.sourceMessageId === 'string'
+            ? params.sourceMessageId
+            : undefined,
+        sourceType:
+          typeof params.sourceType === 'string'
+            ? params.sourceType
+            : 'agent-save',
+        sourceUrl:
+          typeof params.sourceUrl === 'string' ? params.sourceUrl : undefined,
+        summary,
+        tags: Array.isArray(params.tags)
+          ? params.tags.filter((tag): tag is string => typeof tag === 'string')
+          : undefined,
+      },
+    );
+
+    const memory = capture.memory;
+    const destinations = ['agent memory'];
+    if (capture.wroteContextMemory) {
+      destinations.push('content memory');
+    }
+    if (capture.wroteBrandInsight) {
+      destinations.push('brand insights');
+    }
+
+    return {
+      creditsUsed: 0,
+      data: {
+        contentType: memory.contentType,
+        destinations,
+        id: String(memory.id),
+        kind: memory.kind,
+        scope: memory.scope,
+        summary: memory.summary || summary || content.slice(0, 180),
+      },
+      success: true,
+    };
+  }
+
+  async createGoal(
+    params: Record<string, unknown>,
+    ctx: ToolExecutionContext,
+  ): Promise<AgentToolResult> {
+    if (!this.agentGoalsService) {
+      return {
+        creditsUsed: 0,
+        error: 'Agent goals are not available in this environment.',
+        success: false,
+      };
+    }
+
+    const label = String(params.label || '').trim();
+    const metric = String(params.metric || '').trim();
+    const targetValue = Number(params.targetValue);
+
+    if (!label || !metric || !Number.isFinite(targetValue)) {
+      return {
+        creditsUsed: 0,
+        error: 'create_goal requires label, metric, and numeric targetValue.',
+        success: false,
+      };
+    }
+
+    const dto: CreateAgentGoalDto = {
+      brand: typeof params.brandId === 'string' ? params.brandId : undefined,
+      description:
+        typeof params.description === 'string'
+          ? params.description.trim()
+          : undefined,
+      endDate:
+        typeof params.endDate === 'string'
+          ? new Date(params.endDate)
+          : undefined,
+      isActive:
+        typeof params.isActive === 'boolean' ? params.isActive : undefined,
+      label,
+      metric: metric as CreateAgentGoalDto['metric'],
+      startDate:
+        typeof params.startDate === 'string'
+          ? new Date(params.startDate)
+          : undefined,
+      targetValue,
+    };
+
+    const goal = await this.agentGoalsService.create(
+      dto,
+      ctx.organizationId,
+      ctx.userId,
+    );
+
+    return {
+      creditsUsed: 0,
+      data: {
+        currentValue: goal.currentValue,
+        goalId: String(goal.id),
+        label: goal.label,
+        metric: goal.metric,
+        progressPercent: goal.progressPercent,
+        targetValue: goal.targetValue,
+      },
+      success: true,
+    };
+  }
+
+  async checkGoalProgress(
+    params: Record<string, unknown>,
+    ctx: ToolExecutionContext,
+  ): Promise<AgentToolResult> {
+    if (!this.agentGoalsService) {
+      return {
+        creditsUsed: 0,
+        error: 'Agent goals are not available in this environment.',
+        success: false,
+      };
+    }
+
+    const goalId = String(params.goalId || '').trim();
+    if (!EntityIdUtil.isValid(goalId)) {
+      return {
+        creditsUsed: 0,
+        error: 'check_goal_progress requires a valid goalId.',
+        success: false,
+      };
+    }
+
+    const goal = await this.agentGoalsService.refreshProgress(
+      goalId,
+      ctx.organizationId,
+    );
+
+    return {
+      creditsUsed: 0,
+      data: {
+        currentValue: goal.currentValue,
+        goalId: String(goal.id),
+        label: goal.label,
+        metric: goal.metric,
+        progressPercent: goal.progressPercent,
+        targetValue: goal.targetValue,
+      },
+      success: true,
+    };
+  }
+
+  async updateGoal(
+    params: Record<string, unknown>,
+    ctx: ToolExecutionContext,
+  ): Promise<AgentToolResult> {
+    if (!this.agentGoalsService) {
+      return {
+        creditsUsed: 0,
+        error: 'Agent goals are not available in this environment.',
+        success: false,
+      };
+    }
+
+    const goalId = String(params.goalId || '').trim();
+    if (!EntityIdUtil.isValid(goalId)) {
+      return {
+        creditsUsed: 0,
+        error: 'update_goal requires a valid goalId.',
+        success: false,
+      };
+    }
+
+    const dto: UpdateAgentGoalDto = {
+      description:
+        typeof params.description === 'string'
+          ? params.description.trim()
+          : undefined,
+      endDate:
+        typeof params.endDate === 'string'
+          ? new Date(params.endDate)
+          : undefined,
+      isActive:
+        typeof params.isActive === 'boolean' ? params.isActive : undefined,
+      label: typeof params.label === 'string' ? params.label.trim() : undefined,
+      metric:
+        typeof params.metric === 'string'
+          ? (params.metric as UpdateAgentGoalDto['metric'])
+          : undefined,
+      startDate:
+        typeof params.startDate === 'string'
+          ? new Date(params.startDate)
+          : undefined,
+      targetValue:
+        typeof params.targetValue === 'number' ? params.targetValue : undefined,
+    };
+
+    const goal = await this.agentGoalsService.update(
+      goalId,
+      dto,
+      ctx.organizationId,
+    );
+
+    return {
+      creditsUsed: 0,
+      data: {
+        currentValue: goal.currentValue,
+        goalId: String(goal.id),
+        label: goal.label,
+        metric: goal.metric,
+        progressPercent: goal.progressPercent,
+        targetValue: goal.targetValue,
+      },
+      success: true,
+    };
+  }
+
+  private normalizeAgentMemoryContentType(
+    value: unknown,
+  ): AgentMemoryContentType | undefined {
+    switch (value) {
+      case 'article':
+      case 'generic':
+      case 'newsletter':
+      case 'post':
+      case 'thread':
+      case 'tweet':
+        return value;
+      default:
+        return undefined;
+    }
+  }
+
+  private normalizeAgentMemoryKind(
+    value: unknown,
+  ): AgentMemoryKind | undefined {
+    switch (value) {
+      case 'instruction':
+      case 'negative_example':
+      case 'pattern':
+      case 'positive_example':
+      case 'preference':
+      case 'reference':
+      case 'winner':
+        return value;
+      default:
+        return undefined;
+    }
+  }
+
+  private normalizeAgentMemoryScope(
+    value: unknown,
+  ): AgentMemoryScope | undefined {
+    switch (value) {
+      case 'brand':
+      case 'campaign':
+      case 'user':
+        return value;
+      default:
+        return undefined;
+    }
+  }
+}

--- a/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.spec.ts
+++ b/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.spec.ts
@@ -7,6 +7,7 @@ vi.mock(
 
 import 'reflect-metadata';
 import { AiActionType } from '@api/endpoints/ai-actions/dto/ai-action.dto';
+import { AgentMemoryGoalsToolHandler } from '@api/services/agent-orchestrator/tools/agent-memory-goals-tool-handler.service';
 import { AgentRouteRewriteService } from '@api/services/agent-orchestrator/tools/agent-route-rewrite.service';
 import { AgentToolExecutorService } from '@api/services/agent-orchestrator/tools/agent-tool-executor.service';
 import { PostStatus } from '@genfeedai/enums';
@@ -608,6 +609,11 @@ describe('AgentToolExecutorService', () => {
       }),
     };
 
+    const memoryGoalsHandler = new AgentMemoryGoalsToolHandler(
+      agentMemoryCaptureService as never,
+      agentGoalsService as never,
+    );
+
     const service = new AgentToolExecutorService(
       loggerService,
       configService as never,
@@ -615,6 +621,7 @@ describe('AgentToolExecutorService', () => {
       postsService as never,
       brandsService as never,
       routeRewriteService,
+      memoryGoalsHandler,
       botsService as never,
       botsLivestreamService as never,
       campaignsService as never,
@@ -633,7 +640,6 @@ describe('AgentToolExecutorService', () => {
       credentialsService as never,
       organizationsService as never,
       organizationSettingsService as never,
-      agentMemoryCaptureService as never,
       usersService as never,
       streamPublisher as never,
       undefined as never, // agentSpawnService
@@ -641,7 +647,6 @@ describe('AgentToolExecutorService', () => {
       voicesService as never,
       contentQualityScorerService as never,
       seoScorerService as never,
-      agentGoalsService as never,
       ingredientsService as never,
       {} as never, // votesService
       adsResearchService as never,
@@ -3096,6 +3101,7 @@ describe('AgentToolExecutorService', () => {
         brandsService as never,
         organizationsService as never,
       ),
+      new AgentMemoryGoalsToolHandler(undefined as never, undefined as never),
       {} as never,
       {} as never,
       {} as never,
@@ -3114,7 +3120,6 @@ describe('AgentToolExecutorService', () => {
       credentialsService as never,
       organizationsService as never,
       { findOne: vi.fn().mockResolvedValue({}) } as never,
-      { findOne: vi.fn().mockResolvedValue({}) } as never,
       usersService as never,
       undefined as never, // streamPublisher
       undefined as never, // agentSpawnService
@@ -3122,7 +3127,6 @@ describe('AgentToolExecutorService', () => {
       { findAll: vi.fn().mockResolvedValue({ docs: [] }) } as never,
       undefined as never, // contentQualityScorerService (intentionally absent)
       undefined as never, // seoScorerService
-      undefined as never, // agentGoalsService
       undefined as never, // ingredientsService
       undefined as never, // votesService
       undefined as never, // adsResearchService

--- a/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts
+++ b/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts
@@ -1,13 +1,4 @@
 import { randomUUID } from 'node:crypto';
-import { CreateAgentGoalDto } from '@api/collections/agent-goals/dto/create-agent-goal.dto';
-import { UpdateAgentGoalDto } from '@api/collections/agent-goals/dto/update-agent-goal.dto';
-import { AgentGoalsService } from '@api/collections/agent-goals/services/agent-goals.service';
-import type {
-  AgentMemoryContentType,
-  AgentMemoryKind,
-  AgentMemoryScope,
-} from '@api/collections/agent-memories/schemas/agent-memory.schema';
-import { AgentMemoryCaptureService } from '@api/collections/agent-memories/services/agent-memory-capture.service';
 import { BrandInterviewService } from '@api/collections/brands/brand-interview/services/brand-interview.service';
 import { resolveEffectiveBrandAgentConfig } from '@api/collections/brands/utils/brand-agent-config-resolution.util';
 import { ContentGeneratorService } from '@api/collections/content-intelligence/services/content-generator.service';
@@ -41,10 +32,10 @@ import {
 } from '@api/endpoints/ai-actions/dto/ai-action.dto';
 import { AnalyticsService } from '@api/endpoints/analytics/analytics.service';
 import { runEffectPromise } from '@api/helpers/utils/effect/effect.util';
-import { EntityIdUtil } from '@api/helpers/utils/entity-id/entity-id.util';
 import { MarketplaceApiClient } from '@api/marketplace-integration/marketplace-api-client';
 import { MarketplaceInstallService } from '@api/marketplace-integration/marketplace-install.service';
 import { AgentStreamPublisherService } from '@api/services/agent-orchestrator/agent-stream-publisher.service';
+import { AgentMemoryGoalsToolHandler } from '@api/services/agent-orchestrator/tools/agent-memory-goals-tool-handler.service';
 import { AgentRouteRewriteService } from '@api/services/agent-orchestrator/tools/agent-route-rewrite.service';
 import { AgentSpawnService } from '@api/services/agent-spawn/agent-spawn.service';
 import { BatchGenerationService } from '@api/services/batch-generation/batch-generation.service';
@@ -351,6 +342,7 @@ export class AgentToolExecutorService {
     @Inject('AGENT_BRANDS_SERVICE')
     private readonly brandsService: AgentBrandsServiceLike,
     private readonly routeRewriteService: AgentRouteRewriteService,
+    private readonly memoryGoalsHandler: AgentMemoryGoalsToolHandler,
     @Optional()
     @Inject('AGENT_BOTS_SERVICE')
     private readonly botsService: AgentBotsServiceLike | undefined,
@@ -387,8 +379,6 @@ export class AgentToolExecutorService {
     @Optional()
     private readonly organizationSettingsService: OrganizationSettingsService,
     @Optional()
-    private readonly agentMemoryCaptureService: AgentMemoryCaptureService,
-    @Optional()
     private readonly usersService: UsersService,
     @Optional()
     private readonly streamPublisher: AgentStreamPublisherService,
@@ -402,8 +392,6 @@ export class AgentToolExecutorService {
     private readonly contentQualityScorerService: ContentQualityScorerService,
     @Optional()
     private readonly seoScorerService: SeoScorerService,
-    @Optional()
-    private readonly agentGoalsService: AgentGoalsService,
     @Optional()
     private readonly ingredientsService: IngredientsService,
     @Optional()
@@ -1054,16 +1042,16 @@ export class AgentToolExecutorService {
         return this.replicateTopIngredient(params, ctx);
 
       case AgentToolName.CAPTURE_MEMORY:
-        return this.captureMemory(params, ctx);
+        return this.memoryGoalsHandler.captureMemory(params, ctx);
 
       case AgentToolName.CREATE_GOAL:
-        return this.createGoal(params, ctx);
+        return this.memoryGoalsHandler.createGoal(params, ctx);
 
       case AgentToolName.CHECK_GOAL_PROGRESS:
-        return this.checkGoalProgress(params, ctx);
+        return this.memoryGoalsHandler.checkGoalProgress(params, ctx);
 
       case AgentToolName.UPDATE_GOAL:
-        return this.updateGoal(params, ctx);
+        return this.memoryGoalsHandler.updateGoal(params, ctx);
 
       // Brand context interview tools
       case AgentToolName.START_BRAND_INTERVIEW:
@@ -1231,99 +1219,6 @@ export class AgentToolExecutorService {
     return Math.max(1, Math.min(200, Math.floor(explicitLimit)));
   }
 
-  private async captureMemory(
-    params: Record<string, unknown>,
-    ctx: ToolExecutionContext,
-  ): Promise<AgentToolResult> {
-    if (!this.agentMemoryCaptureService) {
-      return {
-        creditsUsed: 0,
-        error: 'Memory capture is not available in this environment.',
-        success: false,
-      };
-    }
-
-    const content = String(params.content || '').trim();
-    if (!content) {
-      return {
-        creditsUsed: 0,
-        error: 'Memory capture requires content.',
-        success: false,
-      };
-    }
-
-    const brandId =
-      typeof params.brandId === 'string' ? params.brandId : undefined;
-    const campaignId =
-      typeof params.campaignId === 'string' ? params.campaignId : undefined;
-    const summary =
-      typeof params.summary === 'string' ? params.summary.trim() : undefined;
-    const capture = await this.agentMemoryCaptureService.capture(
-      ctx.userId,
-      ctx.organizationId,
-      {
-        brandId,
-        campaignId,
-        confidence:
-          typeof params.confidence === 'number' ? params.confidence : undefined,
-        content,
-        contentType: this.normalizeAgentMemoryContentType(params.contentType),
-        importance:
-          typeof params.importance === 'number' ? params.importance : undefined,
-        kind: this.normalizeAgentMemoryKind(params.kind),
-        performanceSnapshot:
-          params.performanceSnapshot &&
-          typeof params.performanceSnapshot === 'object'
-            ? (params.performanceSnapshot as Record<string, unknown>)
-            : undefined,
-        platform:
-          typeof params.platform === 'string' ? params.platform : undefined,
-        saveToContextMemory: params.saveToContextMemory === true,
-        scope: this.normalizeAgentMemoryScope(params.scope),
-        sourceContentId:
-          typeof params.sourceContentId === 'string'
-            ? params.sourceContentId
-            : undefined,
-        sourceMessageId:
-          typeof params.sourceMessageId === 'string'
-            ? params.sourceMessageId
-            : undefined,
-        sourceType:
-          typeof params.sourceType === 'string'
-            ? params.sourceType
-            : 'agent-save',
-        sourceUrl:
-          typeof params.sourceUrl === 'string' ? params.sourceUrl : undefined,
-        summary,
-        tags: Array.isArray(params.tags)
-          ? params.tags.filter((tag): tag is string => typeof tag === 'string')
-          : undefined,
-      },
-    );
-
-    const memory = capture.memory;
-    const destinations = ['agent memory'];
-    if (capture.wroteContextMemory) {
-      destinations.push('content memory');
-    }
-    if (capture.wroteBrandInsight) {
-      destinations.push('brand insights');
-    }
-
-    return {
-      creditsUsed: 0,
-      data: {
-        contentType: memory.contentType,
-        destinations,
-        id: String(memory.id),
-        kind: memory.kind,
-        scope: memory.scope,
-        summary: memory.summary || summary || content.slice(0, 180),
-      },
-      success: true,
-    };
-  }
-
   private async createBrand(
     params: Record<string, unknown>,
     ctx: ToolExecutionContext,
@@ -1382,176 +1277,6 @@ export class AgentToolExecutorService {
         name,
       },
       nextActions: onboardingStatus.nextActions,
-      success: true,
-    };
-  }
-
-  private async createGoal(
-    params: Record<string, unknown>,
-    ctx: ToolExecutionContext,
-  ): Promise<AgentToolResult> {
-    if (!this.agentGoalsService) {
-      return {
-        creditsUsed: 0,
-        error: 'Agent goals are not available in this environment.',
-        success: false,
-      };
-    }
-
-    const label = String(params.label || '').trim();
-    const metric = String(params.metric || '').trim();
-    const targetValue = Number(params.targetValue);
-
-    if (!label || !metric || !Number.isFinite(targetValue)) {
-      return {
-        creditsUsed: 0,
-        error: 'create_goal requires label, metric, and numeric targetValue.',
-        success: false,
-      };
-    }
-
-    const dto: CreateAgentGoalDto = {
-      brand: typeof params.brandId === 'string' ? params.brandId : undefined,
-      description:
-        typeof params.description === 'string'
-          ? params.description.trim()
-          : undefined,
-      endDate:
-        typeof params.endDate === 'string'
-          ? new Date(params.endDate)
-          : undefined,
-      isActive:
-        typeof params.isActive === 'boolean' ? params.isActive : undefined,
-      label,
-      metric: metric as CreateAgentGoalDto['metric'],
-      startDate:
-        typeof params.startDate === 'string'
-          ? new Date(params.startDate)
-          : undefined,
-      targetValue,
-    };
-
-    const goal = await this.agentGoalsService.create(
-      dto,
-      ctx.organizationId,
-      ctx.userId,
-    );
-
-    return {
-      creditsUsed: 0,
-      data: {
-        currentValue: goal.currentValue,
-        goalId: String(goal.id),
-        label: goal.label,
-        metric: goal.metric,
-        progressPercent: goal.progressPercent,
-        targetValue: goal.targetValue,
-      },
-      success: true,
-    };
-  }
-
-  private async checkGoalProgress(
-    params: Record<string, unknown>,
-    ctx: ToolExecutionContext,
-  ): Promise<AgentToolResult> {
-    if (!this.agentGoalsService) {
-      return {
-        creditsUsed: 0,
-        error: 'Agent goals are not available in this environment.',
-        success: false,
-      };
-    }
-
-    const goalId = String(params.goalId || '').trim();
-    if (!EntityIdUtil.isValid(goalId)) {
-      return {
-        creditsUsed: 0,
-        error: 'check_goal_progress requires a valid goalId.',
-        success: false,
-      };
-    }
-
-    const goal = await this.agentGoalsService.refreshProgress(
-      goalId,
-      ctx.organizationId,
-    );
-
-    return {
-      creditsUsed: 0,
-      data: {
-        currentValue: goal.currentValue,
-        goalId: String(goal.id),
-        label: goal.label,
-        metric: goal.metric,
-        progressPercent: goal.progressPercent,
-        targetValue: goal.targetValue,
-      },
-      success: true,
-    };
-  }
-
-  private async updateGoal(
-    params: Record<string, unknown>,
-    ctx: ToolExecutionContext,
-  ): Promise<AgentToolResult> {
-    if (!this.agentGoalsService) {
-      return {
-        creditsUsed: 0,
-        error: 'Agent goals are not available in this environment.',
-        success: false,
-      };
-    }
-
-    const goalId = String(params.goalId || '').trim();
-    if (!EntityIdUtil.isValid(goalId)) {
-      return {
-        creditsUsed: 0,
-        error: 'update_goal requires a valid goalId.',
-        success: false,
-      };
-    }
-
-    const dto: UpdateAgentGoalDto = {
-      description:
-        typeof params.description === 'string'
-          ? params.description.trim()
-          : undefined,
-      endDate:
-        typeof params.endDate === 'string'
-          ? new Date(params.endDate)
-          : undefined,
-      isActive:
-        typeof params.isActive === 'boolean' ? params.isActive : undefined,
-      label: typeof params.label === 'string' ? params.label.trim() : undefined,
-      metric:
-        typeof params.metric === 'string'
-          ? (params.metric as UpdateAgentGoalDto['metric'])
-          : undefined,
-      startDate:
-        typeof params.startDate === 'string'
-          ? new Date(params.startDate)
-          : undefined,
-      targetValue:
-        typeof params.targetValue === 'number' ? params.targetValue : undefined,
-    };
-
-    const goal = await this.agentGoalsService.update(
-      goalId,
-      dto,
-      ctx.organizationId,
-    );
-
-    return {
-      creditsUsed: 0,
-      data: {
-        currentValue: goal.currentValue,
-        goalId: String(goal.id),
-        label: goal.label,
-        metric: goal.metric,
-        progressPercent: goal.progressPercent,
-        targetValue: goal.targetValue,
-      },
       success: true,
     };
   }
@@ -9055,52 +8780,6 @@ export class AgentToolExecutorService {
         error: `Replicate ingredient failed: ${errorMessage}`,
         success: false,
       };
-    }
-  }
-
-  private normalizeAgentMemoryContentType(
-    value: unknown,
-  ): AgentMemoryContentType | undefined {
-    switch (value) {
-      case 'article':
-      case 'generic':
-      case 'newsletter':
-      case 'post':
-      case 'thread':
-      case 'tweet':
-        return value;
-      default:
-        return undefined;
-    }
-  }
-
-  private normalizeAgentMemoryKind(
-    value: unknown,
-  ): AgentMemoryKind | undefined {
-    switch (value) {
-      case 'instruction':
-      case 'negative_example':
-      case 'pattern':
-      case 'positive_example':
-      case 'preference':
-      case 'reference':
-      case 'winner':
-        return value;
-      default:
-        return undefined;
-    }
-  }
-
-  private normalizeAgentMemoryScope(
-    value: unknown,
-  ): AgentMemoryScope | undefined {
-    switch (value) {
-      case 'brand':
-      case 'campaign':
-      case 'user':
-        return value;
-      default:
-        return undefined;
     }
   }
 


### PR DESCRIPTION
## Summary

- Extracts the memory-capture and goal-management tool handlers out of `AgentToolExecutorService` into a new `AgentMemoryGoalsToolHandler` (`apps/server/api/src/services/agent-orchestrator/tools/agent-memory-goals-tool-handler.service.ts`), following the `AgentCompletionCardBuilderService` (#1583) extraction pattern.
- Moved verbatim: `captureMemory`, `createGoal`, `checkGoalProgress`, `updateGoal` (made public; were `private async` on the executor), plus the private helpers `normalizeAgentMemoryContentType`, `normalizeAgentMemoryKind`, `normalizeAgentMemoryScope` (kept private, used only by `captureMemory`).
- The executor now injects `AgentMemoryGoalsToolHandler` as a required constructor dependency and delegates the `CAPTURE_MEMORY` / `CREATE_GOAL` / `CHECK_GOAL_PROGRESS` / `UPDATE_GOAL` dispatch cases to it.
- Removes the executor's two now-dead `@Optional()` dependencies (`agentMemoryCaptureService`, `agentGoalsService`) — no longer referenced anywhere in the executor.
- `createBrand` and its `checkOnboardingStatus`/`normalizeHandle` helpers are a different tool family and were intentionally left untouched.
- Executor size: 9307 -> 8986 lines.

## Behavior preserved

Pure move — no refactoring of logic, guard clauses, or error strings. All guard clauses, error strings, and result payload shapes are unchanged from the original private methods.

## Verification

- Local tests/typecheck/build intentionally not run per repo policy (MacBook verification constraint) — PR CI is the verification source of truth.
- Both `AgentToolExecutorService` construction sites in `agent-tool-executor.service.spec.ts` were updated to construct/pass `AgentMemoryGoalsToolHandler` instead of the two removed services directly.
- New spec file `agent-memory-goals-tool-handler.service.spec.ts` covers all four public methods' present/absent/success/failure paths, asserting exact error strings and result shapes.

Part of #519.