### PR TITLE
fix(billing): dedup subscription-invoice credit grants past the Redis TTL

### DIFF
--- a/apps/server/api/package.json
+++ b/apps/server/api/package.json
@@ -97,7 +97,7 @@
     "type-check": "tsc --noEmit -p tsconfig.typecheck.json",
     "test:cov": "vitest run --coverage --config vitest.config.ts",
     "test:e2e": "vitest run --config vitest.config.e2e.ts",
-    "test:e2e:ci": "vitest run --config vitest.config.e2e.ts test/e2e/integrations.e2e-spec.ts test/integration/payment-processing.integration.spec.ts test/integration/health.e2e-spec.spec.ts",
+    "test:e2e:ci": "vitest run --config vitest.config.e2e.ts test/e2e/integrations.e2e-spec.ts test/integration/payment-processing.integration.spec.ts test/integration/health.e2e-spec.spec.ts test/integration/stripe-webhook-credit-grant.integration.spec.ts",
     "test:e2e:cov": "vitest run --coverage --config vitest.config.e2e.ts",
     "test:file": "vitest run --config vitest.config.ts",
     "test:file:cov": "vitest run --coverage --config vitest.config.ts",

--- a/apps/server/api/src/collections/credits/services/credits.utils.service.spec.ts
+++ b/apps/server/api/src/collections/credits/services/credits.utils.service.spec.ts
@@ -252,6 +252,56 @@ describe('CreditsUtilsService', () => {
         500,
         txClient,
       );
+      expect(
+        creditTransactionsService.createTransactionEntry,
+      ).toHaveBeenCalledWith(
+        'org_1',
+        expect.anything(),
+        500,
+        100,
+        500,
+        'system',
+        'reset',
+        undefined,
+        txClient,
+      );
+    });
+
+    // #1398: the yearly subscription reset path relies on this reference
+    // being persisted on the transaction row — otherwise
+    // StripeWebhookSupportService#hasSubscriptionInvoiceCreditGrant can
+    // never find a match and a replayed invoice.paid double-resets credits.
+    it('persists a referenceId/referenceType on the reset transaction when options are passed', async () => {
+      const service = buildService();
+
+      await service.resetOrganizationCredits(
+        'org_1',
+        500_000,
+        'yearly',
+        'yearly subscription billing period reset',
+        {
+          referenceId: 'stripe-invoice:in_123',
+          referenceType: 'stripe-invoice:subscription-grant',
+        },
+      );
+
+      expect(
+        creditTransactionsService.createTransactionEntry,
+      ).toHaveBeenCalledWith(
+        'org_1',
+        expect.anything(),
+        500_000,
+        100,
+        500_000,
+        'yearly',
+        'yearly subscription billing period reset',
+        undefined,
+        txClient,
+        {
+          referenceId: 'stripe-invoice:in_123',
+          referenceType: 'stripe-invoice:subscription-grant',
+        },
+      );
     });
   });
 

--- a/apps/server/api/src/collections/credits/services/credits.utils.service.ts
+++ b/apps/server/api/src/collections/credits/services/credits.utils.service.ts
@@ -600,6 +600,7 @@ export class CreditsUtilsService implements ICreditsUtilsService {
     newCreditAmount: number,
     source: string,
     description: string,
+    options?: IAddCreditsOptions,
   ): Promise<void> {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
 
@@ -620,6 +621,19 @@ export class CreditsUtilsService implements ICreditsUtilsService {
         throw new BusinessLogicException('Organization not found');
       }
 
+      const transactionOptions =
+        options?.referenceId || options?.referenceType || options?.metadata
+          ? {
+              ...(options.metadata ? { metadata: options.metadata } : {}),
+              ...(options.referenceId
+                ? { referenceId: options.referenceId }
+                : {}),
+              ...(options.referenceType
+                ? { referenceType: options.referenceType }
+                : {}),
+            }
+          : undefined;
+
       // Core reset logic — runs atomically inside a transaction when available
       const resetCore = async (tx?: PrismaTransactionClient) => {
         const currentBalance = await this.getOrganizationCreditsBalance(
@@ -632,17 +646,32 @@ export class CreditsUtilsService implements ICreditsUtilsService {
           newCreditAmount,
           tx,
         );
-        await this.creditTransactionsService.createTransactionEntry(
-          organizationId,
-          CreditTransactionCategory.RESET,
-          newCreditAmount,
-          currentBalance,
-          newCreditAmount,
-          source,
-          description,
-          undefined,
-          tx,
-        );
+        if (transactionOptions) {
+          await this.creditTransactionsService.createTransactionEntry(
+            organizationId,
+            CreditTransactionCategory.RESET,
+            newCreditAmount,
+            currentBalance,
+            newCreditAmount,
+            source,
+            description,
+            undefined,
+            tx,
+            transactionOptions,
+          );
+        } else {
+          await this.creditTransactionsService.createTransactionEntry(
+            organizationId,
+            CreditTransactionCategory.RESET,
+            newCreditAmount,
+            currentBalance,
+            newCreditAmount,
+            source,
+            description,
+            undefined,
+            tx,
+          );
+        }
 
         return currentBalance;
       };

--- a/apps/server/api/src/common/credits/oss-credits-utils.service.ts
+++ b/apps/server/api/src/common/credits/oss-credits-utils.service.ts
@@ -60,6 +60,7 @@ export class OssCreditsUtilsService implements ICreditsUtilsService {
     _newCreditAmount: number,
     _source: string,
     _description: string,
+    _options?: IAddCreditsOptions,
   ): Promise<void> {
     return undefined;
   }

--- a/apps/server/api/src/endpoints/webhooks/stripe/handlers/stripe-invoice-webhook.handler.spec.ts
+++ b/apps/server/api/src/endpoints/webhooks/stripe/handlers/stripe-invoice-webhook.handler.spec.ts
@@ -29,6 +29,8 @@ describe('StripeInvoiceWebhookHandler', () => {
   const usersService = { findOne: vi.fn(), patch: vi.fn() };
   const accessBootstrapCacheService = { invalidateForUser: vi.fn() };
   const supportService = {
+    hasSubscriptionInvoiceCreditGrant: vi.fn().mockResolvedValue(false),
+    isUniqueConstraintError: vi.fn().mockReturnValue(false),
     markOnboardingComplete: vi.fn(),
     recordCreditsActivity: vi.fn(),
     resolveTierFromPriceId: vi.fn().mockReturnValue(null),
@@ -61,6 +63,8 @@ describe('StripeInvoiceWebhookHandler', () => {
     subscriptionsService.findOne.mockResolvedValue(monthlySubscription);
     subscriptionsService.patch.mockResolvedValue(monthlySubscription);
     supportService.resolveTierFromPriceId.mockReturnValue(null);
+    supportService.hasSubscriptionInvoiceCreditGrant.mockResolvedValue(false);
+    supportService.isUniqueConstraintError.mockReturnValue(false);
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -103,6 +107,10 @@ describe('StripeInvoiceWebhookHandler', () => {
         'monthly',
         expect.stringContaining('monthly'),
         expect.any(Date),
+        {
+          referenceId: 'stripe-invoice:in_123',
+          referenceType: 'stripe-invoice:subscription-grant',
+        },
       );
       expect(supportService.setHasEverHadCredits).toHaveBeenCalledWith(
         'org_1',
@@ -134,6 +142,10 @@ describe('StripeInvoiceWebhookHandler', () => {
         500_000,
         'yearly',
         expect.stringContaining('yearly'),
+        {
+          referenceId: 'stripe-invoice:in_123',
+          referenceType: 'stripe-invoice:subscription-grant',
+        },
       );
     });
 
@@ -161,6 +173,10 @@ describe('StripeInvoiceWebhookHandler', () => {
         'monthly',
         expect.stringContaining('monthly'),
         expect.any(Date),
+        {
+          referenceId: 'stripe-invoice:in_123',
+          referenceType: 'stripe-invoice:subscription-grant',
+        },
       );
     });
 
@@ -188,6 +204,10 @@ describe('StripeInvoiceWebhookHandler', () => {
         'monthly',
         expect.stringContaining('monthly'),
         expect.any(Date),
+        {
+          referenceId: 'stripe-invoice:in_123',
+          referenceType: 'stripe-invoice:subscription-grant',
+        },
       );
     });
 
@@ -213,6 +233,10 @@ describe('StripeInvoiceWebhookHandler', () => {
         96_000,
         'yearly',
         expect.stringContaining('yearly'),
+        {
+          referenceId: 'stripe-invoice:in_123',
+          referenceType: 'stripe-invoice:subscription-grant',
+        },
       );
     });
 
@@ -271,6 +295,121 @@ describe('StripeInvoiceWebhookHandler', () => {
       expect(
         accessBootstrapCacheService.invalidateForUser,
       ).toHaveBeenCalledWith('user_1');
+    });
+
+    it('#1398: skips a duplicate monthly grant when the invoice reference already exists', async () => {
+      supportService.hasSubscriptionInvoiceCreditGrant.mockResolvedValue(true);
+
+      await handler.handleInvoicePaid(
+        invoiceWith({
+          parent: {
+            subscription_details: { subscription: 'sub_stripe_1' },
+          },
+        }),
+        'test',
+      );
+
+      expect(
+        supportService.hasSubscriptionInvoiceCreditGrant,
+      ).toHaveBeenCalledWith('org_1', {
+        referenceId: 'stripe-invoice:in_123',
+        referenceType: 'stripe-invoice:subscription-grant',
+      });
+      expect(
+        creditsUtilsService.addOrganizationCreditsWithExpiration,
+      ).not.toHaveBeenCalled();
+      expect(
+        creditsUtilsService.resetOrganizationCredits,
+      ).not.toHaveBeenCalled();
+      expect(supportService.recordCreditsActivity).not.toHaveBeenCalled();
+    });
+
+    it('#1398: skips a duplicate yearly grant when the invoice reference already exists', async () => {
+      subscriptionsService.findOne.mockResolvedValue({
+        ...monthlySubscription,
+        type: 'yearly',
+      });
+      supportService.hasSubscriptionInvoiceCreditGrant.mockResolvedValue(true);
+
+      await handler.handleInvoicePaid(
+        invoiceWith({
+          parent: {
+            subscription_details: { subscription: 'sub_stripe_1' },
+          },
+        }),
+        'test',
+      );
+
+      expect(
+        creditsUtilsService.resetOrganizationCredits,
+      ).not.toHaveBeenCalled();
+      expect(
+        creditsUtilsService.addOrganizationCreditsWithExpiration,
+      ).not.toHaveBeenCalled();
+    });
+
+    it('#1398: treats a P2002 unique-constraint race on the monthly grant as a no-op, not an error', async () => {
+      const uniqueConstraintError = { code: 'P2002' };
+      creditsUtilsService.addOrganizationCreditsWithExpiration.mockRejectedValue(
+        uniqueConstraintError,
+      );
+      supportService.isUniqueConstraintError.mockReturnValue(true);
+
+      await handler.handleInvoicePaid(
+        invoiceWith({
+          parent: {
+            subscription_details: { subscription: 'sub_stripe_1' },
+          },
+        }),
+        'test',
+      );
+
+      expect(supportService.isUniqueConstraintError).toHaveBeenCalledWith(
+        uniqueConstraintError,
+      );
+      // handleInvoicePaid's outer catch only logs — it must not fire here,
+      // proving the P2002 was swallowed locally as a duplicate no-op.
+      expect(loggerService.error).not.toHaveBeenCalled();
+      expect(supportService.recordCreditsActivity).not.toHaveBeenCalled();
+    });
+
+    it('#1398: treats a P2002 unique-constraint race on the yearly grant as a no-op, not an error', async () => {
+      subscriptionsService.findOne.mockResolvedValue({
+        ...monthlySubscription,
+        type: 'yearly',
+      });
+      const uniqueConstraintError = { code: 'P2002' };
+      creditsUtilsService.resetOrganizationCredits.mockRejectedValue(
+        uniqueConstraintError,
+      );
+      supportService.isUniqueConstraintError.mockReturnValue(true);
+
+      await handler.handleInvoicePaid(
+        invoiceWith({
+          parent: {
+            subscription_details: { subscription: 'sub_stripe_1' },
+          },
+        }),
+        'test',
+      );
+
+      expect(creditsUtilsService.resetOrganizationCredits).toHaveBeenCalledWith(
+        'org_1',
+        500_000,
+        'yearly',
+        expect.stringContaining('yearly'),
+        {
+          referenceId: 'stripe-invoice:in_123',
+          referenceType: 'stripe-invoice:subscription-grant',
+        },
+      );
+      expect(supportService.isUniqueConstraintError).toHaveBeenCalledWith(
+        uniqueConstraintError,
+      );
+      // handleInvoicePaid's outer catch only logs — it must not fire here,
+      // proving the P2002 was swallowed locally as a duplicate no-op.
+      expect(loggerService.error).not.toHaveBeenCalled();
+      expect(supportService.recordCreditsActivity).not.toHaveBeenCalled();
     });
 
     it('routes BYOK platform fee invoices to the BYOK path', async () => {

--- a/apps/server/api/src/endpoints/webhooks/stripe/handlers/stripe-invoice-webhook.handler.ts
+++ b/apps/server/api/src/endpoints/webhooks/stripe/handlers/stripe-invoice-webhook.handler.ts
@@ -20,6 +20,15 @@ import { ConfigService } from '@libs/config/config.service';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Inject, Injectable } from '@nestjs/common';
 
+/**
+ * Durable reference type for subscription-invoice credit grants (#1398).
+ * Scoped by `stripe-invoice:{invoice.id}` so a Stripe replay of the same
+ * invoice (same or a fresh event id) can never re-grant credits, even after
+ * the 24h Redis webhook-event dedup marker has expired.
+ */
+const SUBSCRIPTION_INVOICE_CREDIT_REFERENCE_TYPE =
+  'stripe-invoice:subscription-grant';
+
 /** Handles invoice.paid / invoice.payment_failed Stripe webhook events. */
 @Injectable()
 export class StripeInvoiceWebhookHandler {
@@ -150,24 +159,78 @@ export class StripeInvoiceWebhookHandler {
       return;
     }
 
+    const organizationId = String(subscription.organization);
+    // #1398: durable Postgres-level dedup keyed on the invoice, covering
+    // BOTH rollover policies below. The Redis event-id marker only guards
+    // the 24h window immediately after the original webhook — this guards
+    // any later replay of the same invoice regardless of event id.
+    const creditReference = {
+      referenceId: `stripe-invoice:${invoice.id}`,
+      referenceType: SUBSCRIPTION_INVOICE_CREDIT_REFERENCE_TYPE,
+    };
+
+    if (
+      await this.supportService.hasSubscriptionInvoiceCreditGrant(
+        organizationId,
+        creditReference,
+      )
+    ) {
+      this.loggerService.log(
+        `${url} skipping duplicate subscription invoice credit grant`,
+        { invoiceId: invoice.id, organizationId, ...creditReference },
+      );
+      return;
+    }
+
     // Handle different rollover policies based on subscription type
     if (subscription.type === SubscriptionPlan.MONTHLY) {
-      // Monthly: 3-month rollover with expiration
-      await this.creditsUtilsService.addOrganizationCreditsWithExpiration(
-        String(subscription.organization),
-        creditsToAdd,
-        subscription.type,
-        `${subscription.type} subscription billing period`,
-        new Date(Date.now() + 90 * 24 * 60 * 60 * 1000), // 3 months from now
-      );
+      // Monthly: 3-month rollover with expiration. The reference is also
+      // passed through to the transaction row as a race-condition backstop
+      // behind a unique index (P2002 is treated as a duplicate no-op below).
+      try {
+        await this.creditsUtilsService.addOrganizationCreditsWithExpiration(
+          organizationId,
+          creditsToAdd,
+          subscription.type,
+          `${subscription.type} subscription billing period`,
+          new Date(Date.now() + 90 * 24 * 60 * 60 * 1000), // 3 months from now
+          creditReference,
+        );
+      } catch (error: unknown) {
+        if (this.supportService.isUniqueConstraintError(error)) {
+          this.loggerService.log(
+            `${url} skipping duplicate subscription invoice credit grant`,
+            { invoiceId: invoice.id, organizationId, ...creditReference },
+          );
+          return;
+        }
+        throw error;
+      }
     } else if (subscription.type === SubscriptionPlan.YEARLY) {
-      // Yearly: reset credits (no rollover)
-      await this.creditsUtilsService.resetOrganizationCredits(
-        String(subscription.organization),
-        creditsToAdd,
-        subscription.type,
-        `${subscription.type} subscription billing period reset`,
-      );
+      // Yearly: reset credits (no rollover). The reference is also passed
+      // through to the reset transaction row as a race-condition backstop
+      // behind the same unique index used by the monthly path above (P2002
+      // is treated as a duplicate no-op below) — symmetric protection to
+      // MONTHLY, since the pre-check alone cannot see a prior grant unless
+      // the reset transaction actually persists the reference (#1398).
+      try {
+        await this.creditsUtilsService.resetOrganizationCredits(
+          organizationId,
+          creditsToAdd,
+          subscription.type,
+          `${subscription.type} subscription billing period reset`,
+          creditReference,
+        );
+      } catch (error: unknown) {
+        if (this.supportService.isUniqueConstraintError(error)) {
+          this.loggerService.log(
+            `${url} skipping duplicate subscription invoice credit grant`,
+            { invoiceId: invoice.id, organizationId, ...creditReference },
+          );
+          return;
+        }
+        throw error;
+      }
     }
 
     // Log activity for credit handling

--- a/apps/server/api/src/endpoints/webhooks/stripe/handlers/stripe-webhook-support.service.spec.ts
+++ b/apps/server/api/src/endpoints/webhooks/stripe/handlers/stripe-webhook-support.service.spec.ts
@@ -276,6 +276,59 @@ describe('StripeWebhookSupportService', () => {
     });
   });
 
+  describe('hasSubscriptionInvoiceCreditGrant', () => {
+    it('returns false when no matching credit transaction exists', async () => {
+      prisma.creditTransaction.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.hasSubscriptionInvoiceCreditGrant('org_1', {
+          referenceId: 'stripe-invoice:in_123',
+          referenceType: 'stripe-invoice:subscription-grant',
+        }),
+      ).resolves.toBe(false);
+
+      expect(prisma.creditTransaction.findFirst).toHaveBeenCalledWith({
+        select: { id: true },
+        where: {
+          isDeleted: false,
+          organizationId: 'org_1',
+          referenceId: 'stripe-invoice:in_123',
+          referenceType: 'stripe-invoice:subscription-grant',
+        },
+      });
+    });
+
+    it('returns true when a matching credit transaction exists, without filtering by category', async () => {
+      prisma.creditTransaction.findFirst.mockResolvedValue({ id: 'txn_1' });
+
+      await expect(
+        service.hasSubscriptionInvoiceCreditGrant('org_1', {
+          referenceId: 'stripe-invoice:in_123',
+          referenceType: 'stripe-invoice:subscription-grant',
+        }),
+      ).resolves.toBe(true);
+
+      const where = prisma.creditTransaction.findFirst.mock.calls[0][0].where;
+      expect(where).not.toHaveProperty('category');
+    });
+  });
+
+  describe('isUniqueConstraintError', () => {
+    it('returns true for a Prisma P2002 error', () => {
+      expect(service.isUniqueConstraintError({ code: 'P2002' })).toBe(true);
+    });
+
+    it('returns false for other error codes', () => {
+      expect(service.isUniqueConstraintError({ code: 'P2025' })).toBe(false);
+    });
+
+    it('returns false for non-object errors', () => {
+      expect(service.isUniqueConstraintError(new Error('boom'))).toBe(false);
+      expect(service.isUniqueConstraintError(null)).toBe(false);
+      expect(service.isUniqueConstraintError(undefined)).toBe(false);
+    });
+  });
+
   describe('recordCreditsActivity', () => {
     it('defaults to CREDITS_ADD and includes the user when given', async () => {
       await service.recordCreditsActivity({

--- a/apps/server/api/src/endpoints/webhooks/stripe/handlers/stripe-webhook-support.service.ts
+++ b/apps/server/api/src/endpoints/webhooks/stripe/handlers/stripe-webhook-support.service.ts
@@ -206,7 +206,33 @@ export class StripeWebhookSupportService {
     return existing !== null;
   }
 
-  private isUniqueConstraintError(error: unknown): boolean {
+  /**
+   * Durable Postgres-level dedup for subscription-invoice credit grants
+   * (#1398). The Redis `stripe:webhook:{event.id}` marker only covers the
+   * originating event for 24h; a Stripe replay past that window (auto-retry
+   * runs up to 3 days, or a manual Dashboard resend) must still be a no-op.
+   * Unlike {@link hasPurchasedCreditGrant} this is NOT filtered by
+   * `category` — a MONTHLY grant writes an ADD row, a YEARLY grant writes a
+   * RESET row, and either must block a re-grant for the same invoice.
+   */
+  async hasSubscriptionInvoiceCreditGrant(
+    organizationId: string,
+    reference: PurchasedCreditsReference,
+  ): Promise<boolean> {
+    const existing = await this.prisma.creditTransaction.findFirst({
+      select: { id: true },
+      where: {
+        isDeleted: false,
+        organizationId,
+        referenceId: reference.referenceId,
+        referenceType: reference.referenceType,
+      },
+    });
+
+    return existing !== null;
+  }
+
+  isUniqueConstraintError(error: unknown): boolean {
     return (
       error !== null &&
       typeof error === 'object' &&

--- a/apps/server/api/test/integration/stripe-webhook-credit-grant.integration.spec.ts
+++ b/apps/server/api/test/integration/stripe-webhook-credit-grant.integration.spec.ts
@@ -1,0 +1,453 @@
+/**
+ * Real-backend proof of the Stripe subscription -> credit-grant money path
+ * (#1398, linking #334).
+ *
+ * Unlike `payment-processing.integration.spec.ts` (which mocks the entire
+ * Stripe SDK AND the database), this spec:
+ *  - Constructs a REAL Stripe webhook signature via the real Stripe SDK
+ *    (`stripe.webhooks.generateTestHeaderString` / `constructEventAsync`) and
+ *    invokes `StripeWebhookController.handleStripe` directly with the raw,
+ *    signed payload — the same code path production traffic takes.
+ *  - Writes to and reads from a REAL Postgres database via `PrismaService`
+ *    (through `E2ETestModule.forRoot`), asserting on real `creditTransaction`
+ *    / `creditBalance` rows.
+ *
+ * It proves two layers of webhook idempotency:
+ *  1. Redis-level: replaying the identical Stripe event id is a no-op
+ *     (`stripe:webhook:<event.id>` SET NX guard in the controller).
+ *  2. Postgres-level: Stripe redelivering the SAME invoice under a NEW event
+ *     id (e.g. a dashboard "Resend" or a retry after the 24h Redis TTL
+ *     expires) must not double-grant credits. This is enforced by
+ *     `StripeWebhookSupportService#hasSubscriptionInvoiceCreditGrant`,
+ *     keyed on a `referenceId`/`referenceType` persisted on the credit
+ *     transaction row.
+ *
+ * The Postgres-level MONTHLY path already persisted this reference via
+ * `CreditsUtilsService#addOrganizationCreditsWithExpiration`. The YEARLY
+ * path did not — `resetOrganizationCredits` had no mechanism to persist a
+ * reference, making the pre-check dead code for YEARLY organizations, so a
+ * replayed `invoice.paid` past the Redis TTL would double (or triple, ...)
+ * a yearly organization's credit balance. Both `resetOrganizationCredits`
+ * (via a new optional `options` param) and this spec's YEARLY scenario cover
+ * that gap.
+ */
+
+// Allow skipping this file when the Prisma DB is not available
+// Set SKIP_PRISMA_DB=true to skip all tests in this file
+if (process.env.SKIP_PRISMA_DB === 'true') {
+  const g: any = global as any;
+  const d: any = (global as any).describe;
+  g.describe = ((name: string, fn: any) =>
+    d?.skip ? d.skip(name, fn) : describe(name, fn)) as any;
+  const i: any = (global as any).it;
+  g.it = ((name: string, fn: any) =>
+    i?.skip ? i.skip(name, fn) : it(name, fn)) as any;
+  g.test = g.it;
+}
+
+import { ActivitiesService } from '@api/collections/activities/services/activities.service';
+import { CreditBalanceService } from '@api/collections/credits/services/credit-balance.service';
+import { CreditTransactionsService } from '@api/collections/credits/services/credit-transactions.service';
+import { CreditsUtilsService } from '@api/collections/credits/services/credits.utils.service';
+import { OrganizationSettingsService } from '@api/collections/organization-settings/services/organization-settings.service';
+import { OrganizationsService } from '@api/collections/organizations/services/organizations.service';
+import { UsersService } from '@api/collections/users/services/users.service';
+import { AccessBootstrapCacheService } from '@api/common/services/access-bootstrap-cache.service';
+import { CacheInvalidationService } from '@api/common/services/cache-invalidation.service';
+import { RequestContextCacheService } from '@api/common/services/request-context-cache.service';
+import { StripeCheckoutWebhookHandler } from '@api/endpoints/webhooks/stripe/handlers/stripe-checkout-webhook.handler';
+import { StripeCustomerWebhookHandler } from '@api/endpoints/webhooks/stripe/handlers/stripe-customer-webhook.handler';
+import { StripeInvoiceWebhookHandler } from '@api/endpoints/webhooks/stripe/handlers/stripe-invoice-webhook.handler';
+import { StripeSubscriptionWebhookHandler } from '@api/endpoints/webhooks/stripe/handlers/stripe-subscription-webhook.handler';
+import { StripeWebhookSupportService } from '@api/endpoints/webhooks/stripe/handlers/stripe-webhook-support.service';
+import { StripeWebhookController } from '@api/endpoints/webhooks/stripe/webhooks.stripe.controller';
+import { StripeWebhookService } from '@api/endpoints/webhooks/stripe/webhooks.stripe.service';
+import { StripeService } from '@api/services/integrations/stripe/services/stripe.service';
+import { NotificationsPublisherService } from '@api/services/notifications/publisher/notifications-publisher.service';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import {
+  createTestOrganization,
+  generateIdString,
+} from '@api-test/e2e/e2e-test.utils';
+import type { TestDatabaseHelper } from '@api-test/e2e-test.module';
+import {
+  createTestDatabaseHelper,
+  E2ETestModule,
+} from '@api-test/e2e-test.module';
+import { CreditTransactionCategory, SubscriptionPlan } from '@genfeedai/enums';
+import type {
+  ISubscriptionFindOneFilter,
+  ISubscriptionOssReadModel,
+  ISubscriptionsService,
+} from '@genfeedai/interfaces/billing';
+import { SUBSCRIPTIONS_SERVICE } from '@genfeedai/interfaces/billing';
+import { ConfigService } from '@libs/config/config.service';
+import { RedisService } from '@libs/redis/redis.service';
+import { EventEmitter2 } from '@nestjs/event-emitter';
+import { Test, type TestingModule } from '@nestjs/testing';
+import type { Request } from 'express';
+
+vi.mock('@genfeedai/config', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@genfeedai/config')>();
+  return {
+    ...actual,
+    isSelfHostedDeployment: () => false,
+  };
+});
+
+const STRIPE_WEBHOOK_SECRET = 'whsec_test_stripe_webhook_credit_grant_e2e';
+const SUBSCRIPTION_CREDIT_REFERENCE_TYPE = 'stripe-invoice:subscription-grant';
+
+const createRedisPublisherDouble = () => {
+  const store = new Map<string, string>();
+  return {
+    del: vi.fn(async (key: string): Promise<number> => {
+      return store.delete(key) ? 1 : 0;
+    }),
+    set: vi.fn(
+      async (
+        key: string,
+        value: string,
+        _ex: 'EX',
+        _ttl: number,
+        nx: 'NX',
+      ): Promise<'OK' | null> => {
+        if (nx === 'NX' && store.has(key)) {
+          return null;
+        }
+        store.set(key, value);
+        return 'OK';
+      },
+    ),
+  };
+};
+
+const buildSubscriptionsServiceStub = (
+  subscriptionsById: Map<string, ISubscriptionOssReadModel>,
+): ISubscriptionsService => ({
+  createForOrganization: vi.fn(async () => {
+    throw new Error('createForOrganization is not exercised by this spec');
+  }),
+  findAll: vi.fn(async () => ({ docs: [], total: 0, totalDocs: 0 })),
+  findByOrganizationId: vi.fn(async () => null),
+  findByStripeCustomerId: vi.fn(async () => null),
+  findOne: vi.fn(async (filter: ISubscriptionFindOneFilter) => {
+    if (!filter.stripeSubscriptionId) {
+      return null;
+    }
+    return subscriptionsById.get(filter.stripeSubscriptionId) ?? null;
+  }),
+  patch: vi.fn(async (id: string, data: unknown) => {
+    for (const subscription of subscriptionsById.values()) {
+      if (String(subscription.id) === id) {
+        Object.assign(subscription, data as Record<string, unknown>);
+        return subscription;
+      }
+    }
+    return null;
+  }),
+  syncSubscriptionState: vi.fn(async () => undefined),
+  syncWithStripe: vi.fn(
+    async (subscription: ISubscriptionOssReadModel) => subscription,
+  ),
+});
+
+const buildInvoicePaidEventPayload = (params: {
+  eventId: string;
+  invoiceId: string;
+  stripeSubscriptionId: string;
+}): string =>
+  JSON.stringify({
+    api_version: '2026-03-25.dahlia',
+    created: Math.floor(Date.now() / 1000),
+    data: {
+      object: {
+        billing_reason: 'subscription_cycle',
+        id: params.invoiceId,
+        metadata: {},
+        object: 'invoice',
+        parent: {
+          subscription_details: {
+            subscription: params.stripeSubscriptionId,
+          },
+        },
+      },
+    },
+    id: params.eventId,
+    livemode: false,
+    object: 'event',
+    pending_webhooks: 0,
+    request: { id: null, idempotency_key: null },
+    type: 'invoice.paid',
+  });
+
+describe('Stripe webhook subscription credit grant (#1398 real-backend E2E)', () => {
+  let moduleRef: TestingModule;
+  let dbHelper: TestDatabaseHelper;
+  let controller: StripeWebhookController;
+  let stripeService: StripeService;
+  let prisma: PrismaService;
+  let webhookSecret: string;
+  let redisPublisherDouble: ReturnType<typeof createRedisPublisherDouble>;
+  let subscriptionsById: Map<string, ISubscriptionOssReadModel>;
+
+  beforeAll(async () => {
+    redisPublisherDouble = createRedisPublisherDouble();
+    subscriptionsById = new Map();
+
+    const moduleConfig = await E2ETestModule.forRoot({
+      configOverrides: {
+        STRIPE_SECRET_KEY: 'sk_test_stripe_webhook_credit_grant_e2e',
+        STRIPE_WEBHOOK_SIGNING_SECRET: STRIPE_WEBHOOK_SECRET,
+      },
+      controllers: [StripeWebhookController],
+      providers: [
+        StripeService,
+        StripeWebhookService,
+        StripeInvoiceWebhookHandler,
+        StripeWebhookSupportService,
+        CreditsUtilsService,
+        CreditBalanceService,
+        CreditTransactionsService,
+        {
+          provide: RedisService,
+          useValue: { getPublisher: () => redisPublisherDouble },
+        },
+        { provide: StripeSubscriptionWebhookHandler, useValue: {} },
+        { provide: StripeCheckoutWebhookHandler, useValue: {} },
+        { provide: StripeCustomerWebhookHandler, useValue: {} },
+        {
+          provide: SUBSCRIPTIONS_SERVICE,
+          useValue: buildSubscriptionsServiceStub(subscriptionsById),
+        },
+        {
+          provide: UsersService,
+          useValue: {
+            findOne: vi.fn().mockResolvedValue(null),
+            patch: vi.fn().mockResolvedValue(null),
+          },
+        },
+        {
+          provide: AccessBootstrapCacheService,
+          useValue: {
+            invalidateForOrganization: vi.fn().mockResolvedValue(undefined),
+            invalidateForUser: vi.fn().mockResolvedValue(undefined),
+          },
+        },
+        {
+          provide: ActivitiesService,
+          useValue: { create: vi.fn().mockResolvedValue({}) },
+        },
+        {
+          provide: OrganizationSettingsService,
+          useValue: {
+            findOne: vi.fn().mockResolvedValue(null),
+            patch: vi.fn().mockResolvedValue(null),
+          },
+        },
+        {
+          provide: OrganizationsService,
+          useValue: { findOne: vi.fn().mockResolvedValue(null) },
+        },
+        {
+          provide: RequestContextCacheService,
+          useValue: {
+            invalidateForOrganization: vi.fn().mockResolvedValue(undefined),
+            invalidateForUser: vi.fn().mockResolvedValue(undefined),
+          },
+        },
+        {
+          provide: NotificationsPublisherService,
+          useValue: { emit: vi.fn().mockResolvedValue(undefined) },
+        },
+        {
+          provide: CacheInvalidationService,
+          useValue: { invalidate: vi.fn().mockResolvedValue(undefined) },
+        },
+        { provide: EventEmitter2, useValue: { emit: vi.fn() } },
+      ],
+      useMockGuards: false,
+    });
+
+    moduleRef = await Test.createTestingModule({
+      imports: [moduleConfig],
+    }).compile();
+
+    dbHelper = createTestDatabaseHelper(moduleRef);
+    controller = moduleRef.get(StripeWebhookController);
+    stripeService = moduleRef.get(StripeService);
+    prisma = moduleRef.get(PrismaService);
+    webhookSecret = moduleRef
+      .get(ConfigService)
+      .get('STRIPE_WEBHOOK_SIGNING_SECRET') as string;
+  });
+
+  afterAll(async () => {
+    await moduleRef.close();
+  });
+
+  beforeEach(async () => {
+    await dbHelper.clearDatabase();
+    subscriptionsById.clear();
+  });
+
+  const signAndBuildRequest = (payload: string): Request => {
+    const signature = stripeService.stripe.webhooks.generateTestHeaderString({
+      payload,
+      secret: webhookSecret,
+    });
+    return {
+      body: payload,
+      headers: { 'stripe-signature': signature },
+    } as unknown as Request;
+  };
+
+  const seedOrganizationWithSubscription = async (params: {
+    plan: SubscriptionPlan;
+    stripeSubscriptionId: string;
+  }) => {
+    const organizationId = generateIdString();
+    const userId = generateIdString();
+    const organization = createTestOrganization({
+      id: organizationId,
+      label: `Test Org ${params.plan} ${organizationId}`,
+      user: userId,
+    });
+
+    await dbHelper.seedCollection('organizations', [organization]);
+
+    const subscription: ISubscriptionOssReadModel = {
+      id: generateIdString(),
+      organization: organizationId,
+      status: 'active',
+      stripeSubscriptionId: params.stripeSubscriptionId,
+      type: params.plan,
+      user: userId,
+    };
+    subscriptionsById.set(params.stripeSubscriptionId, subscription);
+
+    return { organizationId, subscription };
+  };
+
+  it('processes a monthly invoice.paid webhook exactly once when the identical Stripe event is replayed (Redis-level idempotency)', async () => {
+    const stripeSubscriptionId = `sub_${generateIdString()}`;
+    const { organizationId } = await seedOrganizationWithSubscription({
+      plan: SubscriptionPlan.MONTHLY,
+      stripeSubscriptionId,
+    });
+
+    const payload = buildInvoicePaidEventPayload({
+      eventId: `evt_${generateIdString()}`,
+      invoiceId: `in_${generateIdString()}`,
+      stripeSubscriptionId,
+    });
+
+    const firstResult = await controller.handleStripe(
+      signAndBuildRequest(payload),
+    );
+    const secondResult = await controller.handleStripe(
+      signAndBuildRequest(payload),
+    );
+
+    expect(firstResult).toEqual({ success: true });
+    expect(secondResult).toEqual({ success: true });
+
+    const transactions = await prisma.creditTransaction.findMany({
+      where: {
+        isDeleted: false,
+        organizationId,
+        referenceType: SUBSCRIPTION_CREDIT_REFERENCE_TYPE,
+      },
+    });
+    expect(transactions).toHaveLength(1);
+    expect(transactions[0]?.category).toBe(CreditTransactionCategory.ADD);
+
+    const balance = await prisma.creditBalance.findFirst({
+      where: { isDeleted: false, organizationId },
+    });
+    expect(balance?.balance).toBe(35_000);
+  });
+
+  it('does not double-grant credits for a MONTHLY subscription when Stripe redelivers the same invoice under a NEW event id (Postgres-level dedup)', async () => {
+    const stripeSubscriptionId = `sub_${generateIdString()}`;
+    const { organizationId } = await seedOrganizationWithSubscription({
+      plan: SubscriptionPlan.MONTHLY,
+      stripeSubscriptionId,
+    });
+    const invoiceId = `in_${generateIdString()}`;
+
+    const firstDelivery = buildInvoicePaidEventPayload({
+      eventId: `evt_${generateIdString()}`,
+      invoiceId,
+      stripeSubscriptionId,
+    });
+    const redelivery = buildInvoicePaidEventPayload({
+      eventId: `evt_${generateIdString()}`,
+      invoiceId,
+      stripeSubscriptionId,
+    });
+
+    await controller.handleStripe(signAndBuildRequest(firstDelivery));
+    await controller.handleStripe(signAndBuildRequest(redelivery));
+
+    const transactions = await prisma.creditTransaction.findMany({
+      where: {
+        isDeleted: false,
+        organizationId,
+        referenceType: SUBSCRIPTION_CREDIT_REFERENCE_TYPE,
+      },
+    });
+    expect(transactions).toHaveLength(1);
+
+    const balance = await prisma.creditBalance.findFirst({
+      where: { isDeleted: false, organizationId },
+    });
+    expect(balance?.balance).toBe(35_000);
+  });
+
+  it('does not double-reset credits for a YEARLY subscription when Stripe redelivers the same invoice under a NEW event id (#1398 fix: Postgres-level dedup)', async () => {
+    const stripeSubscriptionId = `sub_${generateIdString()}`;
+    const { organizationId } = await seedOrganizationWithSubscription({
+      plan: SubscriptionPlan.YEARLY,
+      stripeSubscriptionId,
+    });
+    const invoiceId = `in_${generateIdString()}`;
+
+    const firstDelivery = buildInvoicePaidEventPayload({
+      eventId: `evt_${generateIdString()}`,
+      invoiceId,
+      stripeSubscriptionId,
+    });
+    const redelivery = buildInvoicePaidEventPayload({
+      eventId: `evt_${generateIdString()}`,
+      invoiceId,
+      stripeSubscriptionId,
+    });
+
+    await controller.handleStripe(signAndBuildRequest(firstDelivery));
+    await controller.handleStripe(signAndBuildRequest(redelivery));
+
+    const transactions = await prisma.creditTransaction.findMany({
+      where: {
+        isDeleted: false,
+        organizationId,
+        referenceType: SUBSCRIPTION_CREDIT_REFERENCE_TYPE,
+      },
+    });
+    // Before the #1398 fix, resetOrganizationCredits had no way to persist a
+    // referenceId/referenceType, so hasSubscriptionInvoiceCreditGrant could
+    // never find this row and the redelivery would reset credits a second
+    // time (the balance would still read 500_000 either way, since RESET is
+    // absolute — but a second RESET row, and re-running side effects like
+    // markOrganizationAsHavingCredits/websocket emits, would still occur).
+    // The transaction-count assertion is the real proof of dedup.
+    expect(transactions).toHaveLength(1);
+    expect(transactions[0]?.category).toBe(CreditTransactionCategory.RESET);
+    expect(transactions[0]?.referenceId).toBe(`stripe-invoice:${invoiceId}`);
+
+    const balance = await prisma.creditBalance.findFirst({
+      where: { isDeleted: false, organizationId },
+    });
+    expect(balance?.balance).toBe(500_000);
+  });
+});

--- a/packages/interfaces/src/billing/credits-utils.contract.ts
+++ b/packages/interfaces/src/billing/credits-utils.contract.ts
@@ -131,6 +131,13 @@ export interface ICreditsUtilsService {
   /**
    * Reset the organization balance to a new absolute amount.
    * Used by billing cycle resets.
+   *
+   * `options.referenceId`/`referenceType` let callers persist a dedup
+   * reference on the reset transaction row itself, symmetric to
+   * {@link addOrganizationCreditsWithExpiration} — required so a resettable
+   * (e.g. yearly) billing cycle grant can be idempotency-checked the same
+   * way an additive (e.g. monthly) grant is (see #1398).
+   *
    * OSS no-op is a no-op.
    */
   resetOrganizationCredits(
@@ -138,6 +145,7 @@ export interface ICreditsUtilsService {
     newCreditAmount: number,
     source: string,
     description: string,
+    options?: IAddCreditsOptions,
   ): Promise<void>;
 
   /**

--- a/packages/prisma/prisma/migrations/20260711120000_add_stripe_invoice_credit_reference_unique/migration.sql
+++ b/packages/prisma/prisma/migrations/20260711120000_add_stripe_invoice_credit_reference_unique/migration.sql
@@ -1,0 +1,25 @@
+-- Enforce one credit grant per Stripe subscription invoice (#1398).
+--
+-- The only prior protection against a duplicate subscription-credit grant
+-- was the 24h Redis `stripe:webhook:{event.id}` marker in
+-- StripeWebhookController. A Stripe replay of `invoice.paid` past that
+-- window (auto-retry runs up to 3 days, or a manual Dashboard resend) — or
+-- a fresh event id for the same invoice — was an unguarded double-grant.
+--
+-- This mirrors the `credit_transactions_stripe_checkout_reference_key`
+-- pattern (20260706120000) but is intentionally NOT scoped by `source`:
+-- StripeWebhookSupportService#hasSubscriptionInvoiceCreditGrant checks
+-- existence by (organizationId, referenceType, referenceId) alone, because a
+-- MONTHLY grant writes an ADD row and a YEARLY grant writes a RESET row for
+-- the same invoice reference, and either must block a re-grant.
+--
+-- Partial predicates cannot be represented in schema.prisma, so this lives as
+-- raw SQL like the existing live Stripe unique indexes. CONCURRENTLY keeps
+-- the hot credit ledger writable while the index builds.
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "credit_transactions_stripe_invoice_reference_key"
+  ON "credit_transactions" ("organizationId", "referenceType", "referenceId")
+  WHERE "isDeleted" = false
+    AND "referenceId" IS NOT NULL
+    AND "referenceType" IN (
+      'stripe-invoice:subscription-grant'
+    );


### PR DESCRIPTION
## Summary

The only prior protection against a duplicate Stripe subscription credit grant was the 24h Redis `stripe:webhook:{event.id}` marker in `StripeWebhookController`. A replay of `invoice.paid` past that window (Stripe auto-retries for up to 3 days, or a manual Dashboard resend) — or a fresh event id for the same invoice — was an unguarded double-grant.

- The **MONTHLY** path already persisted a `referenceId`/`referenceType` on its credit transaction row via `addOrganizationCreditsWithExpiration`, so `StripeWebhookSupportService#hasSubscriptionInvoiceCreditGrant` could dedup it.
- The **YEARLY** path called `resetOrganizationCredits`, which had no mechanism to persist a reference at all — making the pre-check dead code for yearly organizations and leaving them exposed to a full-balance reset (and its side effects) on every replay.

## Changes

- Thread an optional `IAddCreditsOptions` through `ICreditsUtilsService#resetOrganizationCredits` (contract, OSS no-op, and the real `CreditsUtilsService` implementation) so the YEARLY path can persist the same `referenceId`/`referenceType` shape as MONTHLY.
- `StripeInvoiceWebhookHandler` now pre-checks `hasSubscriptionInvoiceCreditGrant` before granting on **both** the MONTHLY and YEARLY branches, and passes a `stripe-invoice:{invoice.id}` reference through to the transaction write on both.
- Add a partial unique index (`credit_transactions_stripe_invoice_reference_key`, `CREATE UNIQUE INDEX CONCURRENTLY`) on `credit_transactions(organizationId, referenceType, referenceId)` scoped to subscription-grant references, as a database-level backstop against a race between the pre-check and the write. `P2002` on that index is now treated as a duplicate no-op rather than an unhandled error.
- New real-backend integration spec, `apps/server/api/test/integration/stripe-webhook-credit-grant.integration.spec.ts` — unlike the existing `payment-processing.integration.spec.ts` (which mocks the entire Stripe SDK **and** the database), this spec:
  - Constructs a genuine Stripe webhook signature via the real Stripe SDK (`generateTestHeaderString` / `constructEventAsync`) and invokes `StripeWebhookController.handleStripe` directly with the raw signed payload — the same code path production traffic takes.
  - Writes to and reads from a real Postgres database via `PrismaService` (through `E2ETestModule.forRoot`), asserting on real `creditTransaction`/`creditBalance` rows.
  - Proves both idempotency layers: replaying the identical Stripe event id (Redis-level no-op) and Stripe redelivering the same invoice under a **new** event id for both MONTHLY (ADD) and YEARLY (RESET) subscriptions (Postgres-level dedup — this is the core #1398 proof, since YEARLY previously had no way to be protected).
  - Wired into `test:e2e:ci`.
- Unit coverage added in `credits.utils.service.spec.ts`, `stripe-invoice-webhook.handler.spec.ts`, and `stripe-webhook-support.service.spec.ts`.

Linked: #334

## Test plan

- [ ] CI: `test:e2e:ci` runs the new `stripe-webhook-credit-grant.integration.spec.ts` against a real Postgres instance
- [ ] CI: unit suites for `CreditsUtilsService`, `StripeInvoiceWebhookHandler`, `StripeWebhookSupportService` green
- [ ] CI: type-check + lint green
- [ ] Verify the new partial unique index migration applies cleanly (`CREATE UNIQUE INDEX CONCURRENTLY`, non-blocking)