### PR TITLE
docs(release): fix packages/create publish example (exact version, not bump)

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -55,8 +55,9 @@ Do not change the visibility of the internal `genfeed.ai/server` package.
 
 After the release is green, publish `packages/create` through the package
 publishing workflow so npm users receive the installer tested by this contract.
-Use `[{"path":"packages/create","bump":"patch"}]` for `packages_json` and
-set `dry_run=false` only for the approved publish run.
+Use `[{"path":"packages/create","version":"0.2.0"}]` for `packages_json` — the
+exact version already merged to `master`, never a `bump` request (see the npm
+section below) — and set `dry_run=false` only for the approved publish run.
 
 Production backend deploys are handled separately through
 `.github/workflows/deploy-ecs.yml`, dispatched from `master` and gated by the


### PR DESCRIPTION
## What

`RELEASING.md` told maintainers to publish `packages/create` with
`[{"path":"packages/create","bump":"patch"}]`. That's wrong on two counts:

- The `Publish Packages` workflow (`publish-packages.yml`) accepts only an exact
  `version` per entry in `packages_json` — there is **no `bump` input**.
- The doc's own npm section (line ~161) already says *"Do not pass `bump`
  requests to the workflow."*

A maintainer following the create-publish step verbatim would pass an input the
workflow ignores/rejects.

## Change

One-line docs fix: use the exact-version form (`"version":"0.2.0"`, the version
already merged to `master`) and cross-reference the no-`bump` rule.

## Context

Found while root-causing why GitHub release **v0.5.0 has zero assets**. Root
cause of that incident is separate and operational (v0.5.0 predates the
`publish-install-artifact` asset job added in #1581, its publish run was
cancelled by red gates so no image shipped either, and the `genfeed.ai` GHCR
package is still private — blocking the anonymous-pull smoke). Per maintainer
decision, v0.5.0 will be superseded by the next release rather than re-cut; this
PR is just the doc defect surfaced along the way.

## Test

Docs only — no code paths touched.