### PR TITLE
fix(docker): copy fix-esm-relative-imports.mjs into image builders (unbreaks both image builds)

### DIFF
--- a/docker/Dockerfile.selfhosted
+++ b/docker/Dockerfile.selfhosted
@@ -144,6 +144,12 @@ COPY configs/ configs/
 COPY packages/ packages/
 COPY apps/server/ apps/server/
 
+# Shared package `build` scripts run `node ../../scripts/fix-esm-relative-imports.mjs`
+# (added in #1588) to rewrite ESM relative imports in their dist output. The builder
+# must have that script on disk before the package build batch below, or
+# `@genfeedai/enums build` fails with "Cannot find module .../scripts/...".
+COPY scripts/fix-esm-relative-imports.mjs scripts/fix-esm-relative-imports.mjs
+
 # Build the shared packages that downstream project references resolve through
 # package exports before the parallel batch. A clean Docker context has no host
 # dist output, so this follows docker/Dockerfile.server's dependency order and

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -134,6 +134,12 @@ COPY ee/packages/billing/ ee/packages/billing/
 COPY apps/server/nest-cli.json apps/server/nest-cli.json
 COPY apps/server/tsconfig.json apps/server/tsconfig.json
 
+# Shared package `build` scripts run `node ../../scripts/fix-esm-relative-imports.mjs`
+# (added in #1588) to rewrite ESM relative imports in their dist output. Copy it
+# before the shared-package build batch or `@genfeedai/enums build` fails with
+# "Cannot find module .../scripts/fix-esm-relative-imports.mjs".
+COPY scripts/fix-esm-relative-imports.mjs scripts/fix-esm-relative-imports.mjs
+
 # Build shared workspace packages in dependency order (must run before service builds)
 # This layer is cached when only apps/server/* source changes
 # Some workspace packages export dist paths, so build those before packages that


### PR DESCRIPTION
## P0 — master cannot build either image since #1588

[#1588](https://github.com/genfeedai/genfeed.ai/pull/1588) wired
`node ../../scripts/fix-esm-relative-imports.mjs` into the `build` script of ~14
shared packages (`enums`, `api-types`, `constants`, `interfaces`, `pricing`,
`client`, `helpers`, `serializers`, …), but neither image Dockerfile copies that
script into its builder stage. Both `COPY` tsconfig / configs / `packages/` /
`apps/server/` — but never `scripts/`. So the first shared-package build aborts:

```
@genfeedai/enums build: Error: Cannot find module '/usr/src/app/scripts/fix-esm-relative-imports.mjs'
```

### Blast radius (both images, since 2026-07-10)
- **Production ECS image** — `build-server-image.yml` has **4 consecutive failures** on master (`#1588` → `#1592` → `#1586` → `#1582`); last green was `#1587`, the commit immediately before `#1588`.
- **Community self-hosted image** — `build-verify-selfhosted.yml` fails at the identical step (dispatched run [29153254632](https://github.com/genfeedai/genfeed.ai/actions/runs/29153254632)).

This means **no production deploy and no self-hosted release can build a fresh image** off current master until this lands.

## Fix

Copy the one required script into both builder stages, before the shared-package
build batch. Surgical single-file `COPY` (not `COPY scripts/`) because:
- it matches the Dockerfiles' existing surgical-copy pattern,
- it keeps the build cache tight (busts only when that script changes),
- the server/app/nest build steps reference no other repo `scripts/*` — verified only `fix-esm-relative-imports.mjs` appears in built package `build` scripts.

`.dockerignore` is a denylist (node_modules/dist/.next/etc.); `scripts/` is in the build context, so the `COPY` resolves.

## Verification

CI on this PR builds both images. I dispatched `build-verify-selfhosted` and `full-suite` on master to confirm the failure pre-fix; the PR's own image builds are the post-fix proof. (Per repo policy I don't run image builds locally.)

## Follow-up (not in this PR)
`#1588`'s PR gate didn't run a full image build, so this shipped red. Worth making the prod/self-hosted image build a required PR check on `packages/**` + `docker/**` changes so a build-breaking package-script change can't merge again.