### PR TITLE
refactor(release): move ESM dist rewrite to publish time — packages build clean everywhere

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1118,6 +1118,7 @@
         "ts-jsonapi": "2.1.3",
       },
       "devDependencies": {
+        "tsc-alias": "1.9.0",
         "typescript": "6.0.2",
       },
     },
@@ -1229,6 +1230,7 @@
         "jsdom": "29.1.1",
         "react": "19.2.7",
         "react-dom": "19.2.7",
+        "tsc-alias": "1.9.0",
         "typescript": "6.0.2",
         "vitest": "4.1.10",
       },
@@ -5091,7 +5093,7 @@
 
     "globalthis": ["globalthis@1.0.4", "", { "dependencies": { "define-properties": "^1.2.1", "gopd": "^1.0.1" } }, "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ=="],
 
-    "globby": ["globby@14.1.0", "", { "dependencies": { "@sindresorhus/merge-streams": "^2.1.0", "fast-glob": "^3.3.3", "ignore": "^7.0.3", "path-type": "^6.0.0", "slash": "^5.1.0", "unicorn-magic": "^0.3.0" } }, "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA=="],
+    "globby": ["globby@11.1.0", "", { "dependencies": { "array-union": "^2.1.0", "dir-glob": "^3.0.1", "fast-glob": "^3.2.9", "ignore": "^5.2.0", "merge2": "^1.4.1", "slash": "^3.0.0" } }, "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g=="],
 
     "google-auth-library": ["google-auth-library@10.9.0", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg=="],
 
@@ -5969,6 +5971,8 @@
 
     "mute-stream": ["mute-stream@2.0.0", "", {}, "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA=="],
 
+    "mylas": ["mylas@2.1.14", "", {}, "sha512-BzQguy9W9NJgoVn2mRWzbFrFWWztGCcng2QI9+41frfk+Athwgx3qhqhvStz7ExeUUu7Kzw427sNzHpEZNINog=="],
+
     "mysql2": ["mysql2@3.15.3", "", { "dependencies": { "aws-ssl-profiles": "^1.1.1", "denque": "^2.1.0", "generate-function": "^2.3.1", "iconv-lite": "^0.7.0", "long": "^5.2.1", "lru.min": "^1.0.0", "named-placeholders": "^1.1.3", "seq-queue": "^0.0.5", "sqlstring": "^2.3.2" } }, "sha512-FBrGau0IXmuqg4haEZRBfHNWB5mUARw6hNwPDXXGg0XzVJ50mr/9hb267lvpVMnhZ1FON3qNd4Xfcez1rbFwSg=="],
 
     "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
@@ -6297,6 +6301,8 @@
 
     "playwright-core": ["playwright-core@1.61.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg=="],
 
+    "plimit-lit": ["plimit-lit@1.6.1", "", { "dependencies": { "queue-lit": "^1.5.1" } }, "sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA=="],
+
     "plist": ["plist@3.1.0", "", { "dependencies": { "@xmldom/xmldom": "^0.8.8", "base64-js": "^1.5.1", "xmlbuilder": "^15.1.1" } }, "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ=="],
 
     "pluralize": ["pluralize@8.0.0", "", {}, "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="],
@@ -6436,6 +6442,8 @@
     "querystringify": ["querystringify@2.2.0", "", {}, "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="],
 
     "queue": ["queue@6.0.2", "", { "dependencies": { "inherits": "~2.0.3" } }, "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA=="],
+
+    "queue-lit": ["queue-lit@1.5.2", "", {}, "sha512-tLc36IOPeMAubu8BkW8YDBV+WyIgKlYU7zUNs0J5Vk9skSZ4JfGlPOqplP0aHdfv7HL0B2Pg6nwiq60Qc6M2Hw=="],
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
@@ -7210,6 +7218,8 @@
     "ts-morph": ["ts-morph@17.0.1", "", { "dependencies": { "@ts-morph/common": "~0.18.0", "code-block-writer": "^11.0.3" } }, "sha512-10PkHyXmrtsTvZSL+cqtJLTgFXkU43Gd0JCc0Rw6GchWbqKe0Rwgt1v3ouobTZwQzF1mGhDeAlWYBMGRV7y+3g=="],
 
     "ts-toolbelt": ["ts-toolbelt@9.6.0", "", {}, "sha512-nsZd8ZeNUzukXPlJmTBwUAuABDe/9qtVDelJeT/qW0ow3ZS3BsQJtNkan1802aM9Uf68/Y8ljw86Hu0h5IUW3w=="],
+
+    "tsc-alias": ["tsc-alias@1.9.0", "", { "dependencies": { "chokidar": "^3.5.3", "commander": "^9.0.0", "get-tsconfig": "^4.10.0", "globby": "^11.0.4", "mylas": "^2.1.9", "normalize-path": "^3.0.0", "plimit-lit": "^1.2.6" }, "bin": { "tsc-alias": "dist/bin/index.js" } }, "sha512-IZrCInovKxVCwXyKhcdr/HaxSYugKT0w4zyktOE/4115Nzo6gbp/NhkaEeyOG0/H7QoTeXtv+3UHffBYta9oWw=="],
 
     "tsconfig-paths": ["tsconfig-paths@4.2.0", "", { "dependencies": { "json5": "^2.2.2", "minimist": "^1.2.6", "strip-bom": "^3.0.0" } }, "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg=="],
 
@@ -8451,8 +8461,6 @@
 
     "@web/test-runner-core/cli-cursor": ["cli-cursor@3.1.0", "", { "dependencies": { "restore-cursor": "^3.1.0" } }, "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw=="],
 
-    "@web/test-runner-core/globby": ["globby@11.1.0", "", { "dependencies": { "array-union": "^2.1.0", "dir-glob": "^3.0.1", "fast-glob": "^3.2.9", "ignore": "^5.2.0", "merge2": "^1.4.1", "slash": "^3.0.0" } }, "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g=="],
-
     "@web/test-runner-core/log-update": ["log-update@4.0.0", "", { "dependencies": { "ansi-escapes": "^4.3.0", "cli-cursor": "^3.1.0", "slice-ansi": "^4.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg=="],
 
     "@web/test-runner-core/nanoid": ["nanoid@3.3.15", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA=="],
@@ -8801,13 +8809,7 @@
 
     "global-agent/serialize-error": ["serialize-error@7.0.1", "", { "dependencies": { "type-fest": "^0.13.1" } }, "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw=="],
 
-    "globby/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
-
-    "globby/path-type": ["path-type@6.0.0", "", {}, "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ=="],
-
-    "globby/slash": ["slash@5.1.0", "", {}, "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg=="],
-
-    "globby/unicorn-magic": ["unicorn-magic@0.3.0", "", {}, "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA=="],
+    "globby/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "googleapis/google-auth-library": ["google-auth-library@10.6.2", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw=="],
 
@@ -9242,6 +9244,10 @@
     "tr46/punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "ts-loader/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "tsc-alias/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
+
+    "tsc-alias/commander": ["commander@9.5.0", "", {}, "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ=="],
 
     "tsconfig-paths-webpack-plugin/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -10099,8 +10105,6 @@
 
     "@plasmohq/parcel-resolver-post/tsup/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 
-    "@plasmohq/parcel-resolver-post/tsup/globby": ["globby@11.1.0", "", { "dependencies": { "array-union": "^2.1.0", "dir-glob": "^3.0.1", "fast-glob": "^3.2.9", "ignore": "^5.2.0", "merge2": "^1.4.1", "slash": "^3.0.0" } }, "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g=="],
-
     "@plasmohq/parcel-resolver-post/tsup/postcss-load-config": ["postcss-load-config@4.0.2", "", { "dependencies": { "lilconfig": "^3.0.0", "yaml": "^2.3.4" }, "peerDependencies": { "postcss": ">=8.0.9", "ts-node": ">=9.0.0" }, "optionalPeers": ["postcss", "ts-node"] }, "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ=="],
 
     "@plasmohq/parcel-resolver-post/tsup/rollup": ["rollup@3.30.0", "", { "optionalDependencies": { "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-kQvGasUgN+AlWGliFn2POSajRQEsULVYFGTvOZmK06d7vCD+YhZztt70kGk3qaeAXeWYL5eO7zx+rAubBc55eA=="],
@@ -10815,6 +10819,8 @@
 
     "@vscode/vsce/secretlint/@secretlint/profiler": ["@secretlint/profiler@10.2.2", "", {}, "sha512-qm9rWfkh/o8OvzMIfY8a5bCmgIniSpltbVlUVl983zDG1bUuQNd1/5lUEeWx5o/WJ99bXxS7yNI4/KIXfHexig=="],
 
+    "@vscode/vsce/secretlint/globby": ["globby@14.1.0", "", { "dependencies": { "@sindresorhus/merge-streams": "^2.1.0", "fast-glob": "^3.3.3", "ignore": "^7.0.3", "path-type": "^6.0.0", "slash": "^5.1.0", "unicorn-magic": "^0.3.0" } }, "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA=="],
+
     "@vscode/vsce/secretlint/read-pkg": ["read-pkg@9.0.1", "", { "dependencies": { "@types/normalize-package-data": "^2.4.3", "normalize-package-data": "^6.0.0", "parse-json": "^8.0.0", "type-fest": "^4.6.0", "unicorn-magic": "^0.1.0" } }, "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA=="],
 
     "@web/dev-server-core/@types/ws/@types/node": ["@types/node@26.0.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw=="],
@@ -10838,8 +10844,6 @@
     "@web/test-runner-core/@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "@web/test-runner-core/cli-cursor/restore-cursor": ["restore-cursor@3.1.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA=="],
-
-    "@web/test-runner-core/globby/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "@web/test-runner-core/log-update/slice-ansi": ["slice-ansi@4.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "astral-regex": "^2.0.0", "is-fullwidth-code-point": "^3.0.0" } }, "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ=="],
 
@@ -11516,6 +11520,12 @@
     "temp/rimraf/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
     "ts-loader/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "tsc-alias/chokidar/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "tsc-alias/chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "tsc-alias/chokidar/readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
     "tsconfig-paths-webpack-plugin/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
@@ -12241,8 +12251,6 @@
 
     "@plasmohq/parcel-resolver-post/tsup/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
 
-    "@plasmohq/parcel-resolver-post/tsup/globby/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
-
     "@plasmohq/parcel-resolver-post/tsup/rollup/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "@plasmohq/parcel-resolver-post/tsup/source-map/whatwg-url": ["whatwg-url@7.1.0", "", { "dependencies": { "lodash.sortby": "^4.7.0", "tr46": "^1.0.1", "webidl-conversions": "^4.0.2" } }, "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg=="],
@@ -12639,6 +12647,14 @@
 
     "@vscode/vsce/secretlint/@secretlint/formatter/terminal-link": ["terminal-link@4.0.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "supports-hyperlinks": "^3.2.0" } }, "sha512-lk+vH+MccxNqgVqSnkMVKx4VLJfnLjDBGzH16JVZjKE2DoxP57s6/vt6JmXV5I3jBcfGrxNrYtC+mPtU7WJztA=="],
 
+    "@vscode/vsce/secretlint/globby/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+
+    "@vscode/vsce/secretlint/globby/path-type": ["path-type@6.0.0", "", {}, "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ=="],
+
+    "@vscode/vsce/secretlint/globby/slash": ["slash@5.1.0", "", {}, "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg=="],
+
+    "@vscode/vsce/secretlint/globby/unicorn-magic": ["unicorn-magic@0.3.0", "", {}, "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA=="],
+
     "@vscode/vsce/secretlint/read-pkg/normalize-package-data": ["normalize-package-data@6.0.2", "", { "dependencies": { "hosted-git-info": "^7.0.0", "semver": "^7.3.5", "validate-npm-package-license": "^3.0.4" } }, "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g=="],
 
     "@vscode/vsce/secretlint/read-pkg/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
@@ -12872,6 +12888,8 @@
     "svgo/css-select/domutils/dom-serializer": ["dom-serializer@1.4.1", "", { "dependencies": { "domelementtype": "^2.0.1", "domhandler": "^4.2.0", "entities": "^2.0.0" } }, "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag=="],
 
     "temp/rimraf/glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "tsc-alias/chokidar/readdirp/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
     "vaul/@radix-ui/react-dialog/@radix-ui/react-dismissable-layer/@radix-ui/react-use-callback-ref": ["@radix-ui/react-use-callback-ref@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg=="],
 

--- a/docker/Dockerfile.selfhosted
+++ b/docker/Dockerfile.selfhosted
@@ -152,12 +152,6 @@ COPY scripts/ scripts/
 COPY packages/ packages/
 COPY apps/server/ apps/server/
 
-# Shared package `build` scripts run `node ../../scripts/fix-esm-relative-imports.mjs`
-# (added in #1588) to rewrite ESM relative imports in their dist output. The builder
-# must have that script on disk before the package build batch below, or
-# `@genfeedai/enums build` fails with "Cannot find module .../scripts/...".
-COPY scripts/fix-esm-relative-imports.mjs scripts/fix-esm-relative-imports.mjs
-
 # Build the shared packages that downstream project references resolve through
 # package exports before the parallel batch. A clean Docker context has no host
 # dist output, so this follows docker/Dockerfile.server's dependency order and

--- a/docker/Dockerfile.selfhosted
+++ b/docker/Dockerfile.selfhosted
@@ -141,14 +141,6 @@ RUN --mount=type=cache,id=bun-cache,target=/root/.bun/install/cache \
 # Copy source
 COPY tsconfig.json tsconfig.server.decorators.json webpack.base.config.js ./
 COPY configs/ configs/
-# Root build scripts must be present before the package builds below: every
-# ESM package's `build` runs `node ../../scripts/fix-esm-relative-imports.mjs`
-# (added in #1588 to harden public npm distribution), which resolves to
-# /app/scripts/fix-esm-relative-imports.mjs. Without this COPY the first package
-# build (@genfeedai/enums) aborts with `Cannot find module` and the image never
-# builds — the self-hosted release E2E (#1450) can't even reach boot. The dir
-# stays in the builder only; the runtime stage never copies it.
-COPY scripts/ scripts/
 COPY packages/ packages/
 COPY apps/server/ apps/server/
 

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -127,12 +127,6 @@ FROM base AS builder
 # --- Layer 1: Root configs + shared packages (cached when only services change) ---
 COPY tsconfig.json tsconfig.server.decorators.json webpack.base.config.js ./
 COPY configs/ configs/
-# Root build scripts must be present before the package builds below: every ESM
-# package's `build` runs `node ../../scripts/fix-esm-relative-imports.mjs` (added
-# in #1588), which resolves to /app/scripts/fix-esm-relative-imports.mjs. Without
-# this COPY the first package build (@genfeedai/enums) aborts with `Cannot find
-# module` and the image never builds. The dir stays in the builder only.
-COPY scripts/ scripts/
 COPY packages/ packages/
 COPY ee/packages/billing/ ee/packages/billing/
 

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -140,12 +140,6 @@ COPY ee/packages/billing/ ee/packages/billing/
 COPY apps/server/nest-cli.json apps/server/nest-cli.json
 COPY apps/server/tsconfig.json apps/server/tsconfig.json
 
-# Shared package `build` scripts run `node ../../scripts/fix-esm-relative-imports.mjs`
-# (added in #1588) to rewrite ESM relative imports in their dist output. Copy it
-# before the shared-package build batch or `@genfeedai/enums build` fails with
-# "Cannot find module .../scripts/fix-esm-relative-imports.mjs".
-COPY scripts/fix-esm-relative-imports.mjs scripts/fix-esm-relative-imports.mjs
-
 # Build shared workspace packages in dependency order (must run before service builds)
 # This layer is cached when only apps/server/* source changes
 # Some workspace packages export dist paths, so build those before packages that

--- a/packages/api-types/package.json
+++ b/packages/api-types/package.json
@@ -37,7 +37,7 @@
     "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "scripts": {
-    "build": "tsc --build && mkdir -p dist/generated && cp src/generated/api.d.ts dist/generated/api.d.ts && node ../../scripts/fix-esm-relative-imports.mjs --project tsconfig.json dist",
+    "build": "tsc --build && mkdir -p dist/generated && cp src/generated/api.d.ts dist/generated/api.d.ts",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "dev": "tsc --watch",
     "generate": "bun run scripts/generate.ts --skip-on-error",

--- a/packages/auth-client/package.json
+++ b/packages/auth-client/package.json
@@ -47,7 +47,7 @@
     "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "scripts": {
-    "build": "tsc --build && node ../../scripts/fix-esm-relative-imports.mjs --project tsconfig.json dist && test -f dist/index.js",
+    "build": "tsc --build && test -f dist/index.js",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "deps:update": "bunx npm-check-updates -u && bun install",
     "test": "vitest run --config vitest.config.ts",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -52,7 +52,7 @@
     "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "scripts": {
-    "build": "tsc --build && node ../../scripts/fix-esm-relative-imports.mjs --project tsconfig.json dist && test -f dist/index.js",
+    "build": "tsc --build && test -f dist/index.js",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "deps:update": "bunx npm-check-updates -u && bun install",
     "test": "vitest run --config vitest.config.ts",

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -35,7 +35,7 @@
     "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "scripts": {
-    "build": "tsc --build && node ../../scripts/fix-esm-relative-imports.mjs --project tsconfig.json dist",
+    "build": "tsc --build",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "dev": "tsc --watch",
     "prepack": "npm run build",

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -42,7 +42,7 @@
     "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json && node ../../scripts/fix-esm-relative-imports.mjs --project tsconfig.json dist",
+    "build": "tsc -p tsconfig.json",
     "check": "tsc --noEmit -p tsconfig.json",
     "test": "vitest run"
   },

--- a/packages/enums/package.json
+++ b/packages/enums/package.json
@@ -26,7 +26,7 @@
     "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "scripts": {
-    "build": "tsc --build && node ../../scripts/fix-esm-relative-imports.mjs --project tsconfig.json dist",
+    "build": "tsc --build",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "dev": "tsc --watch",
     "prepack": "npm run build",

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -57,7 +57,7 @@
     "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "scripts": {
-    "build": "tsc --build && node ../../scripts/fix-esm-relative-imports.mjs --project tsconfig.json dist",
+    "build": "tsc --build",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "deps:update": "bunx npm-check-updates -u && bun install",
     "dev": "tsc --watch",

--- a/packages/interfaces/package.json
+++ b/packages/interfaces/package.json
@@ -43,7 +43,7 @@
     "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "scripts": {
-    "build": "tsc --build && node ../../scripts/fix-esm-relative-imports.mjs --project tsconfig.json dist",
+    "build": "tsc --build",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "deps:update": "bunx npm-check-updates -u && bun install",
     "dev": "tsc --watch",

--- a/packages/pricing/package.json
+++ b/packages/pricing/package.json
@@ -36,7 +36,7 @@
   },
   "type": "module",
   "scripts": {
-    "build": "bun run clean && tsc --build && node ../../scripts/fix-esm-relative-imports.mjs --project tsconfig.json dist",
+    "build": "bun run clean && tsc --build",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "dev": "tsc --watch",
     "test": "bun test src",

--- a/packages/queue-contracts/package.json
+++ b/packages/queue-contracts/package.json
@@ -34,7 +34,7 @@
     "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "scripts": {
-    "build": "tsc --build && node ../../scripts/fix-esm-relative-imports.mjs --project tsconfig.json dist",
+    "build": "tsc --build",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "dev": "tsc --watch",
     "test": "vitest run --config vitest.config.ts",

--- a/packages/serializers/package.json
+++ b/packages/serializers/package.json
@@ -7,6 +7,7 @@
   },
   "description": "Genfeed.ai canonical JSON:API serializers",
   "devDependencies": {
+    "tsc-alias": "1.9.0",
     "typescript": "6.0.2"
   },
   "exports": {
@@ -38,7 +39,7 @@
     "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "scripts": {
-    "build": "tsc --build && test -f dist/index.js",
+    "build": "tsc --build && tsc-alias -p tsconfig.json && test -f dist/index.js",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "deps:update": "bunx npm-check-updates -u --reject typescript && bun install",
     "dev": "tsc --watch",

--- a/packages/serializers/package.json
+++ b/packages/serializers/package.json
@@ -38,7 +38,7 @@
     "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "scripts": {
-    "build": "tsc --build && node ../../scripts/fix-esm-relative-imports.mjs --project tsconfig.json dist && test -f dist/index.js",
+    "build": "tsc --build && test -f dist/index.js",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "deps:update": "bunx npm-check-updates -u --reject typescript && bun install",
     "dev": "tsc --watch",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -26,7 +26,7 @@
     "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "scripts": {
-    "build": "tsc --build && node ../../scripts/fix-esm-relative-imports.mjs --project tsconfig.json dist && test -f dist/index.js",
+    "build": "tsc --build && test -f dist/index.js",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "dev": "tsc --watch",
     "generate:mcp-tools": "bun run scripts/generate-mcp-tools.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -56,6 +56,7 @@
     "jsdom": "29.1.1",
     "react": "19.2.7",
     "react-dom": "19.2.7",
+    "tsc-alias": "1.9.0",
     "typescript": "6.0.2",
     "vitest": "4.1.10"
   },
@@ -124,7 +125,7 @@
     "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "scripts": {
-    "build": "tsc --build",
+    "build": "tsc --build && tsc-alias -p tsconfig.json",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "test": "../../scripts/sh/sanitize-node-color-env.sh vitest run --config vitest.config.ts",
     "test:watch": "vitest watch --config vitest.config.ts"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -124,7 +124,7 @@
     "url": "git+https://github.com/genfeedai/genfeed.ai.git"
   },
   "scripts": {
-    "build": "tsc --build && node ../../scripts/fix-esm-relative-imports.mjs --project tsconfig.json dist",
+    "build": "tsc --build",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "test": "../../scripts/sh/sanitize-node-color-env.sh vitest run --config vitest.config.ts",
     "test:watch": "vitest watch --config vitest.config.ts"

--- a/scripts/package-release/publish-packages-from-json.test.ts
+++ b/scripts/package-release/publish-packages-from-json.test.ts
@@ -1,5 +1,11 @@
 import { execFileSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { describe, expect, it } from 'vitest';
@@ -7,6 +13,7 @@ import {
   assertCleanWorkingTree,
   normalizeReleaseRequests,
   registryAction,
+  rewriteDistForNodeResolution,
   sortReleaseRequests,
   validatePackedPackage,
 } from '../publish-packages-from-json.mjs';
@@ -231,6 +238,57 @@ describe('publish package release planning', () => {
     expect(() => registryAction('sha256-expected', 'sha256-different')).toThrow(
       'does not match the plan',
     );
+  });
+
+  it('rewrites built dist for strict Node resolution at publish time', () => {
+    const packageDir = mkdtempSync(path.join(tmpdir(), 'publish-rewrite-'));
+    try {
+      mkdirSync(path.join(packageDir, 'dist'));
+      writeFileSync(
+        path.join(packageDir, 'tsconfig.json'),
+        JSON.stringify({
+          compilerOptions: {
+            baseUrl: '.',
+            outDir: 'dist',
+            paths: { '@fixture/*': ['src/*'] },
+            rootDir: 'src',
+          },
+        }),
+      );
+      writeFileSync(
+        path.join(packageDir, 'dist', 'index.js'),
+        "import { util } from './util';\nimport { aliased } from '@fixture/aliased';\nexport { aliased, util };\n",
+      );
+      writeFileSync(
+        path.join(packageDir, 'dist', 'util.js'),
+        'export const util = 1;\n',
+      );
+      writeFileSync(
+        path.join(packageDir, 'dist', 'aliased.js'),
+        'export const aliased = 2;\n',
+      );
+
+      const result = rewriteDistForNodeResolution(packageDir);
+
+      expect(result?.changedFiles).toBe(1);
+      const rewritten = readFileSync(
+        path.join(packageDir, 'dist', 'index.js'),
+        'utf8',
+      );
+      expect(rewritten).toContain("from './util.js'");
+      expect(rewritten).toContain("from './aliased.js'");
+    } finally {
+      rmSync(packageDir, { force: true, recursive: true });
+    }
+  });
+
+  it('skips the publish-time rewrite when a package builds no dist', () => {
+    const packageDir = mkdtempSync(path.join(tmpdir(), 'publish-no-dist-'));
+    try {
+      expect(rewriteDistForNodeResolution(packageDir)).toBeNull();
+    } finally {
+      rmSync(packageDir, { force: true, recursive: true });
+    }
   });
 });
 

--- a/scripts/publish-packages-from-json.mjs
+++ b/scripts/publish-packages-from-json.mjs
@@ -6,6 +6,7 @@ import { builtinModules } from 'node:module';
 import os from 'node:os';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { fixEsmRelativeImports } from './fix-esm-relative-imports.mjs';
 
 const RUNTIME_DEPENDENCY_FIELDS = [
   'dependencies',
@@ -639,6 +640,24 @@ function injectLicenseIntoTarball({ licensePath, tarballPath }) {
   }
 }
 
+// Published tarballs must resolve under strict Node ESM, but workspace
+// packages compile with moduleResolution "bundler": extensionless relative
+// imports and internal tsconfig path aliases that plain `node` cannot load.
+// Rewrite the freshly built output here — publish time is the ONLY place a
+// Node-strict dist is needed (every in-repo consumer is a bundler or Bun) —
+// rather than in each package's `build` script, which forced every build
+// environment (Docker included) to carry the repo-root rewrite script.
+// validatePackedImports() fails the release if this rewrite ever regresses.
+export function rewriteDistForNodeResolution(packageDir) {
+  const distDir = path.join(packageDir, 'dist');
+  if (!fs.existsSync(distDir)) return null;
+  const projectPath = path.join(packageDir, 'tsconfig.json');
+  return fixEsmRelativeImports(
+    [distDir],
+    fs.existsSync(projectPath) ? { projectPath } : {},
+  );
+}
+
 function preparePackage({ artifactsDir, inventory, request, root }) {
   if (request.pkg.scripts?.clean) {
     run('bun', ['run', 'clean'], { cwd: request.packageDir });
@@ -654,6 +673,7 @@ function preparePackage({ artifactsDir, inventory, request, root }) {
     }
   }
   run('bun', ['run', 'build'], { cwd: request.packageDir });
+  rewriteDistForNodeResolution(request.packageDir);
 
   const fileName = tarballName(request);
   const tarballPath = path.join(artifactsDir, fileName);


### PR DESCRIPTION
## Stacked on #1612 — merge that first (this PR then rebases to two commits)

Answers the audit question: **do package builds still need `fix-esm-relative-imports.mjs`? No** — with one precise exception restored to its pre-#1588 tool.

## Audit findings

The rewrite does two jobs; they have different consumers:

1. **Extension rewriting** (`./util` → `./util.js`) — needed ONLY by npm-published tarballs under strict Node ESM. Every in-repo consumer is a bundler or Bun:
   - Nest services: webpack aliases `@genfeedai/<name>` straight to *source* (`webpack.base.config.js`) and bundles it
   - Next apps: bundler resolution; prod runtime: `bun --filter … start:prod`
   - Pre-#1588 images ran for years on extensionless dist
2. **Internal `tsconfig paths` alias rewriting** (`@ui/core/colors` → `./core/colors.js`) — needed at **build time** by exactly two packages whose dist is consumed in-repo: `ui` and `serializers` (vitest + desktop suites resolve `@genfeedai/ui` through `dist/index.js`). Pre-#1588 these two — and only these two — handled it with `bunx tsc-alias` (unpinned, fetched from the network mid-build).

#1588 collapsed both jobs into one repo-root script and blanket-wired it into **13 package `build` scripts** — coupling every build environment to a repo-root file, which broke both Docker image builds (#1612). For `create` and `tools` it was a provable no-op (NodeNext compiles already enforce extensionful imports).

## Change

- **`publish-packages-from-json.mjs`**: new exported `rewriteDistForNodeResolution()` runs between `bun run build` and `bun pm pack` — published tarballs keep Node-strict specifiers + alias resolution, exactly as before.
- **Fail-closed guard already exists**: `validatePackedImports()` rejects any packed tarball with a non-resolvable relative import — a regression here fails the *release preflight*, never a user install.
- **13 package `build` scripts**: fix-esm call stripped.
- **`ui` + `serializers`**: build-time alias resolution restored via **`tsc-alias` pinned at 1.9.0 as a colocated devDependency** — resolves from node_modules in every environment (Docker included), deterministic instead of the old unpinned `bunx` network fetch.
- **Both Dockerfiles**: the `COPY scripts/…` lines from #1612 reverted — package builds no longer reference any repo-root script. Root cause removed, not patched around.
- **Tests**: `rewriteDistForNodeResolution` covered (extensionless-import rewrite, `paths`-alias rewrite, no-dist skip).

## Review history on this branch

First push stripped the rewrite from all 13 packages uniformly; PR CI correctly caught the ui-dist alias regression (workflow-ui + desktop suites: `Failed to resolve import "@ui/core/colors" from "../ui/dist/index.js"`). Second commit restores alias handling for the two packages that need it, per the pre-#1588 baseline.

## Not in scope (deliberate)

The true end-state — killing rewriting entirely via `module: nodenext` + extensionful imports in source — is a repo-wide import rewrite across 13+ packages. Wrong week for that churn with a release pending; after this PR the fix-esm script is a publish-pipeline implementation detail, so that migration becomes a later drop-in.

## Verification

- PR CI (Test Packages, Test Web/Desktop/Mobile — the suites that caught round 1) + full check matrix.
- Both image build-verifies dispatched on this branch post-fix: prod server + self-hosted (serializers now runs tsc-alias inside the image builders).
- The docker-publish `publish-install-artifact` create smoke stays Node-legal by construction (NodeNext).