### PR TITLE
fix(e2e): make the authed Better Auth job hermetic — no prod dependency, no repo secrets

### DIFF
--- a/.agents/memory/context/e2e-architecture.md
+++ b/.agents/memory/context/e2e-architecture.md
@@ -49,7 +49,7 @@ Top-level env: `TURBO_TOKEN` (secret) + `TURBO_TEAM` (var) enable Turborepo remo
 | `e2e-frontend` | Frontend E2E (Shard N/12) | ubuntu / 45m | **yes** (via gate) | matrix 12 shards, `fail-fast:false`, `bun run test:e2e:sharded -- --reporter=blob` |
 | `e2e-merge-reports` | Merge E2E Reports | ubuntu / 10m | no (`if: always()`) | `playwright merge-reports` → single HTML report |
 | `e2e-gate` | E2E Gate (all shards) | ubuntu / 5m | **yes — the aggregator** | bash check of `e2e-route-coverage` + `e2e-frontend` + `e2e-api` results (fails on any required job failure OR cancellation) |
-| `e2e-frontend-authed` | Frontend Authenticated E2E | ubuntu / 40m | no (`continue-on-error`, gated by `E2E_AUTHED_ENABLED` var) | `bun run test:e2e:authed` |
+| `e2e-frontend-authed` | Frontend Authed E2E (real Better Auth) | ubuntu / 40m | **yes on nightly cron** (`continue-on-error` on all other events; gated by `E2E_AUTHED_ENABLED` var) | hermetic full stack: Postgres+Redis containers, `prisma migrate deploy`, real API on :3010, `bun run test:e2e:authed` |
 
 `e2e-gate` is the single job that represents the required suite's pass/fail (it `needs:` route-coverage +
 frontend + API). It exits 1 if route coverage failed, API E2E failed, or any shard failed/was cancelled. Re-running only the
@@ -140,9 +140,14 @@ Primary config highlights:
   No real backend calls; `requiredEnvVars` is intentionally empty.
 - **global-teardown.ts** — deletes `apps/app/.next/dev/cache` (Turbopack persistent cache, observed at
   ~15 GB → `ENOSPC`). Best-effort; never fails the suite. Respects `PLAYWRIGHT_WEB_APP_PATH`.
-- **auth.setup.ts** (`better-auth-setup` project) — writes Better Auth storage state from
-  `E2E_BETTER_AUTH_SESSION_TOKEN` for the `app-authed` project.
-  Hard-fails if the token is missing when the authed project is enabled.
+- **auth.setup.ts** (`better-auth-setup` project) — hermetic by default: mints a fresh
+  session against the job-local API (`sign-up/email` → session cookie → `/auth/token`
+  JWT → `PATCH /users/me {isOnboardingCompleted:true}`), then writes Better Auth storage
+  state for the `app-authed` project. No repo secrets, no production dependency —
+  `BETTER_AUTH_SECRET` is a synthetic workflow literal. A pre-minted token can still be
+  supplied via `E2E_BETTER_AUTH_SESSION_TOKEN` for local runs (`E2E_AUTHED_LOCAL=1`).
+  The authed smoke derives org/brand slugs from the real provisioned workspace
+  (`/` → canonical redirect), not hardcoded `test-org/brand-1`.
 
 ### Mock-auth fixtures (`playwright/e2e/fixtures/`)
 Most specs use **3-layer auth bypass** (no real Better Auth session needed):

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -315,9 +315,13 @@ jobs:
         working-directory: packages/prisma
 
       - name: Start API (hermetic backend on :3010)
+        # Boot the compiled webpack bundle directly (same invocation
+        # build-verify.yml's boot gate uses). The api package's start:prod
+        # preloads tsconfig-paths/register, which is not a declared dependency
+        # anywhere in the workspace — path aliases are compiled into the bundle.
         run: |
           set -euo pipefail
-          (bun run --cwd apps/server/api start:prod > "$RUNNER_TEMP/api.log" 2>&1 &)
+          (node apps/server/dist/apps/api/main.js > "$RUNNER_TEMP/api.log" 2>&1 &)
           for attempt in $(seq 1 60); do
             if curl -fsS http://localhost:3010/v1/health >/dev/null 2>&1; then
               echo "API healthy after ~$((attempt * 2))s"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -297,8 +297,8 @@ jobs:
           install-command: "bun install"
           cache-playwright: "true"
 
-      - name: Build API + app (real Better Auth client, bypass OFF)
-        run: bunx turbo run build --filter=@genfeedai/api --filter=@genfeedai/app
+      - name: Build app (real Better Auth client, bypass OFF)
+        run: bunx turbo run build --filter=@genfeedai/app
         env:
           # CRUCIAL: build with the bypass flag OFF so the app uses the real
           # Better Auth browser session path. NEXT_PUBLIC_* is inlined at build
@@ -307,6 +307,13 @@ jobs:
           NEXT_PUBLIC_BETTER_AUTH_ENABLED: "true"
           # Point the app (client + proxy.ts) at the job-local API.
           NEXT_PUBLIC_API_ENDPOINT: http://localhost:3010/v1
+
+      - name: Build API (compiled bundle)
+        # The api package emits to apps/server/dist, OUTSIDE apps/server/api,
+        # so turbo's package-relative `dist/**` outputs never capture it and a
+        # cache-hit replay restores nothing. Force a real build — same reason
+        # as build-verify.yml's boot gate.
+        run: bunx turbo run build --filter=@genfeedai/api --force
 
       # Provision the schema on the ephemeral Postgres service container —
       # same pattern as e2e-api above.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -247,22 +247,46 @@ jobs:
           fi
           echo "All required E2E checks passed."
 
-  # Real-Better Auth authenticated smoke (Playwright `app-authed` project). Exercises
-  # the GENUINE authMiddleware path via a real Better Auth test-instance session — no
-  # proxy.ts bypass — so it must be built with a REAL Better Auth client (bypass flag
-  # OFF) and given the real test-instance secrets. Gated behind the E2E_AUTHED_ENABLED
-  # repo variable. It has been green for 7+ consecutive runs (all nightlies), so it is
-  # now GATING on the nightly cron — a real regression turns the nightly red and trips
-  # nightly-failure-report below, instead of rotting unseen behind continue-on-error
-  # (it sat red for 5+ June nightlies that way). On the deploy path it stays
-  # non-gating so a flake can never cancel a production release while this path keeps
-  # hardening: continue-on-error is true for every event EXCEPT the scheduled nightly.
+  # Hermetic real-Better Auth authenticated smoke (Playwright `app-authed`
+  # project). Exercises the GENUINE authMiddleware path — no proxy.ts bypass —
+  # against a fully job-local stack: Postgres + Redis service containers,
+  # migrated schema, and the real compiled API on :3010. auth.setup.ts mints a
+  # fresh session per run (sign-up → onboarding completion), so the job needs
+  # NO repo secrets and never touches production (#1448 — the previous design
+  # validated sessions against api.genfeed.ai with a static prod token).
+  # Gated behind the E2E_AUTHED_ENABLED repo variable. GATING on the nightly
+  # cron — a real regression turns the nightly red and trips
+  # nightly-failure-report below, instead of rotting unseen behind
+  # continue-on-error (it sat red for 5+ June nightlies that way). On the
+  # deploy path it stays non-gating so a flake can never cancel a production
+  # release: continue-on-error is true for every event EXCEPT the scheduled
+  # nightly.
   e2e-frontend-authed:
     name: Frontend Authed E2E (real Better Auth)
     if: ${{ vars.E2E_AUTHED_ENABLED == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 40
     continue-on-error: ${{ github.event_name != 'schedule' }}
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_DB: test
+          POSTGRES_USER: genfeed
+          POSTGRES_PASSWORD: genfeed_local
+        ports:
+          - 5432:5432
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+    env:
+      DATABASE_URL: postgresql://genfeed:genfeed_local@localhost:5432/test
+      REDIS_URL: redis://localhost:6379
+      # Synthetic signing secret — the whole auth stack is job-local, so this
+      # is deliberately a literal, not a credential.
+      BETTER_AUTH_SECRET: e2e-hermetic-better-auth-secret
+      E2E_API_ENDPOINT: http://localhost:3010/v1
     steps:
       - uses: actions/checkout@v5
 
@@ -273,66 +297,70 @@ jobs:
           install-command: "bun install"
           cache-playwright: "true"
 
-      - name: Check authed E2E secrets
-        id: authed_secrets
-        env:
-          BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
-          E2E_BETTER_AUTH_SESSION_TOKEN: ${{ secrets.E2E_BETTER_AUTH_SESSION_TOKEN }}
-        run: |
-          set -euo pipefail
-          missing=()
-          if [ -z "${BETTER_AUTH_SECRET:-}" ]; then
-            missing+=("BETTER_AUTH_SECRET")
-          fi
-          if [ -z "${E2E_BETTER_AUTH_SESSION_TOKEN:-}" ]; then
-            missing+=("E2E_BETTER_AUTH_SESSION_TOKEN")
-          fi
-
-          if [ "${#missing[@]}" -gt 0 ]; then
-            echo "ready=false" >> "$GITHUB_OUTPUT"
-            echo "::error::Authed E2E is enabled but missing required GitHub Actions secret(s): ${missing[*]}"
-            {
-              echo "## Authed E2E Blocked"
-              echo ""
-              echo "Missing GitHub Actions secret(s): ${missing[*]}."
-            } >> "$GITHUB_STEP_SUMMARY"
-            exit 1
-          fi
-
-          echo "ready=true" >> "$GITHUB_OUTPUT"
-
-      - name: Build app (real Better Auth client, bypass OFF)
-        if: steps.authed_secrets.outputs.ready == 'true'
-        run: bunx turbo run build --filter=@genfeedai/app
+      - name: Build API + app (real Better Auth client, bypass OFF)
+        run: bunx turbo run build --filter=@genfeedai/api --filter=@genfeedai/app
         env:
           # CRUCIAL: build with the bypass flag OFF so the app uses the real
           # Better Auth browser session path. NEXT_PUBLIC_* is inlined at build
           # time, so this MUST be set here — not just at runtime.
           NEXT_PUBLIC_PLAYWRIGHT_TEST: "false"
-          BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
-          NEXT_PUBLIC_BETTER_AUTH_ENABLED: ${{ secrets.NEXT_PUBLIC_BETTER_AUTH_ENABLED || 'true' }}
-          # Correct var name (app reads NEXT_PUBLIC_API_ENDPOINT, not _API_URL).
-          NEXT_PUBLIC_API_ENDPOINT: https://api.genfeed.ai/v1
+          NEXT_PUBLIC_BETTER_AUTH_ENABLED: "true"
+          # Point the app (client + proxy.ts) at the job-local API.
+          NEXT_PUBLIC_API_ENDPOINT: http://localhost:3010/v1
+
+      # Provision the schema on the ephemeral Postgres service container —
+      # same pattern as e2e-api above.
+      - name: Apply Prisma migrations to test DB
+        run: bun x prisma migrate deploy
+        working-directory: packages/prisma
+
+      - name: Start API (hermetic backend on :3010)
+        run: |
+          set -euo pipefail
+          (bun run --cwd apps/server/api start:prod > "$RUNNER_TEMP/api.log" 2>&1 &)
+          for attempt in $(seq 1 60); do
+            if curl -fsS http://localhost:3010/v1/health >/dev/null 2>&1; then
+              echo "API healthy after ~$((attempt * 2))s"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::API did not become healthy within 120s"
+          tail -n 200 "$RUNNER_TEMP/api.log"
+          exit 1
+        env:
+          NODE_ENV: test
+          PORT: "3010"
+          # Mock external provider keys — the spec's network guard blocks any
+          # real external call regardless.
+          REPLICATE_API_TOKEN: test-mock-key
+          STRIPE_SECRET_KEY: test-mock-key
 
       - name: Run authed E2E (Better Auth setup + app-authed)
-        if: steps.authed_secrets.outputs.ready == 'true'
         run: bun run test:e2e:authed
         env:
           CI: true
           APP_BASE_URL: http://localhost:3000
           NEXT_PUBLIC_PLAYWRIGHT_TEST: "false"
+          NEXT_PUBLIC_BETTER_AUTH_ENABLED: "true"
+          NEXT_PUBLIC_API_ENDPOINT: http://localhost:3010/v1
           # Unlocks the better-auth-setup + app-authed projects in
           # playwright.config.ts, which gate on process.env.E2E_AUTHED_ENABLED.
           # The job-level `if` checks the GitHub repo var; this plumbs the value
           # into the runner process so --project=app-authed actually resolves.
           E2E_AUTHED_ENABLED: "1"
-          BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET }}
-          NEXT_PUBLIC_BETTER_AUTH_ENABLED: ${{ secrets.NEXT_PUBLIC_BETTER_AUTH_ENABLED || 'true' }}
-          E2E_BETTER_AUTH_SESSION_TOKEN: ${{ secrets.E2E_BETTER_AUTH_SESSION_TOKEN }}
+
+      - name: Upload API log (on failure)
+        uses: actions/upload-artifact@v7
+        if: failure()
+        with:
+          name: api-log-authed
+          path: ${{ runner.temp }}/api.log
+          retention-days: 7
 
       - name: Upload authed Playwright report
         uses: actions/upload-artifact@v7
-        if: always() && steps.authed_secrets.outputs.ready == 'true'
+        if: always()
         with:
           name: playwright-report-authed
           path: playwright/artifacts/report/
@@ -340,7 +368,7 @@ jobs:
 
       - name: Upload authed traces (on failure)
         uses: actions/upload-artifact@v7
-        if: failure() && steps.authed_secrets.outputs.ready == 'true'
+        if: failure()
         with:
           name: playwright-traces-authed
           path: playwright/artifacts/results/

--- a/playwright/e2e/auth.setup.ts
+++ b/playwright/e2e/auth.setup.ts
@@ -5,10 +5,11 @@ import { test as setup } from '@playwright/test';
 /**
  * Better Auth authenticated-storage bootstrap.
  *
- * The default Playwright suite uses mocked auth fixtures. The opt-in
- * `app-authed` project can exercise the real proxy/authMiddleware path when a
- * runner supplies a valid Better Auth session token through
- * `E2E_BETTER_AUTH_SESSION_TOKEN`.
+ * Hermetic by default: mints a fresh session against the job-local API
+ * (sign-up → session cookie → onboarding completion), so CI needs no
+ * long-lived credentials and never touches production (#1448). A pre-minted
+ * token can still be supplied via `E2E_BETTER_AUTH_SESSION_TOKEN` for local
+ * runs against an already-authenticated dev stack (`E2E_AUTHED_LOCAL=1`).
  */
 
 const AUTH_DIR = path.join(
@@ -19,6 +20,153 @@ const AUTH_DIR = path.join(
 );
 const USER_AUTH_FILE = path.join(AUTH_DIR, 'user.json');
 const ADMIN_AUTH_FILE = path.join(AUTH_DIR, 'admin.json');
+
+const SESSION_COOKIE_NAMES = [
+  'better-auth.session_token',
+  '__Secure-better-auth.session_token',
+] as const;
+
+interface ISessionCredentials {
+  email: string;
+  name: string;
+  password: string;
+}
+
+function getApiBaseUrl(): string {
+  return (
+    process.env.E2E_API_ENDPOINT ||
+    process.env.NEXT_PUBLIC_API_ENDPOINT ||
+    'http://localhost:3010/v1'
+  ).replace(/\/+$/, '');
+}
+
+function getSessionCredentials(): ISessionCredentials {
+  return {
+    email: process.env.E2E_BETTER_AUTH_EMAIL || 'e2e-bot@genfeed.test',
+    name: 'E2E Bot',
+    // Job-local ephemeral database — this is not a real credential.
+    password: process.env.E2E_BETTER_AUTH_PASSWORD || 'e2e-bot-password-1',
+  };
+}
+
+function readSetCookieHeaders(response: Response): string[] {
+  const headers = response.headers as Headers & {
+    getSetCookie?: () => string[];
+  };
+  if (typeof headers.getSetCookie === 'function') {
+    return headers.getSetCookie();
+  }
+  const single = headers.get('set-cookie');
+  return single ? [single] : [];
+}
+
+function extractSessionToken(setCookies: string[]): string | null {
+  for (const cookie of setCookies) {
+    for (const name of SESSION_COOKIE_NAMES) {
+      const prefix = `${name}=`;
+      if (cookie.startsWith(prefix)) {
+        const value = cookie.slice(prefix.length).split(';')[0].trim();
+        if (value) {
+          return value;
+        }
+      }
+    }
+  }
+  return null;
+}
+
+async function readErrorBody(response: Response): Promise<string> {
+  try {
+    return (await response.text()).slice(0, 500);
+  } catch {
+    return '<unreadable body>';
+  }
+}
+
+/**
+ * Sign the E2E user up against the local API; fall back to sign-in when the
+ * user already exists (idempotent re-runs against a warm local database).
+ * Returns the raw `better-auth.session_token` cookie value.
+ */
+async function mintSessionToken(apiBaseUrl: string): Promise<string> {
+  const credentials = getSessionCredentials();
+
+  const signUpResponse = await fetch(`${apiBaseUrl}/auth/sign-up/email`, {
+    body: JSON.stringify(credentials),
+    headers: { 'content-type': 'application/json' },
+    method: 'POST',
+  });
+
+  let sessionResponse = signUpResponse;
+  if (!signUpResponse.ok) {
+    const body = await readErrorBody(signUpResponse);
+    if (!/already exists|USER_ALREADY_EXISTS/i.test(body)) {
+      throw new Error(
+        `Better Auth sign-up failed (${signUpResponse.status}): ${body}`,
+      );
+    }
+    sessionResponse = await fetch(`${apiBaseUrl}/auth/sign-in/email`, {
+      body: JSON.stringify({
+        email: credentials.email,
+        password: credentials.password,
+      }),
+      headers: { 'content-type': 'application/json' },
+      method: 'POST',
+    });
+    if (!sessionResponse.ok) {
+      throw new Error(
+        `Better Auth sign-in failed (${sessionResponse.status}): ${await readErrorBody(sessionResponse)}`,
+      );
+    }
+  }
+
+  const sessionToken = extractSessionToken(
+    readSetCookieHeaders(sessionResponse),
+  );
+  if (!sessionToken) {
+    throw new Error(
+      'Better Auth sign-up/sign-in succeeded but returned no session cookie.',
+    );
+  }
+  return sessionToken;
+}
+
+/**
+ * Mark onboarding complete for the freshly minted user so proxy.ts routes the
+ * authed smoke to the provisioned workspace instead of `/onboarding`. Uses the
+ * same cookie → JWT exchange proxy.ts itself performs.
+ */
+async function completeOnboarding(
+  apiBaseUrl: string,
+  sessionToken: string,
+): Promise<void> {
+  const tokenResponse = await fetch(`${apiBaseUrl}/auth/token`, {
+    headers: { cookie: `better-auth.session_token=${sessionToken}` },
+  });
+  if (!tokenResponse.ok) {
+    throw new Error(
+      `Better Auth token exchange failed (${tokenResponse.status}): ${await readErrorBody(tokenResponse)}`,
+    );
+  }
+  const { token } = (await tokenResponse.json()) as { token?: string };
+  if (!token) {
+    throw new Error('Better Auth token exchange returned no JWT.');
+  }
+
+  const patchResponse = await fetch(`${apiBaseUrl}/users/me`, {
+    body: JSON.stringify({ isOnboardingCompleted: true }),
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'content-type': 'application/json',
+    },
+    method: 'PATCH',
+  });
+  if (!patchResponse.ok) {
+    throw new Error(
+      `Onboarding completion failed (${patchResponse.status}): ${await readErrorBody(patchResponse)}`,
+    );
+  }
+}
 
 function buildStorageState(token: string) {
   const appBaseUrl =
@@ -46,11 +194,13 @@ function buildStorageState(token: string) {
 }
 
 setup('prepare Better Auth storage state', async () => {
-  const sessionToken = process.env.E2E_BETTER_AUTH_SESSION_TOKEN?.trim();
+  const presetToken = process.env.E2E_BETTER_AUTH_SESSION_TOKEN?.trim();
+  let sessionToken = presetToken;
+
   if (!sessionToken) {
-    throw new Error(
-      'E2E_BETTER_AUTH_SESSION_TOKEN is required when the app-authed Playwright project is enabled.',
-    );
+    const apiBaseUrl = getApiBaseUrl();
+    sessionToken = await mintSessionToken(apiBaseUrl);
+    await completeOnboarding(apiBaseUrl, sessionToken);
   }
 
   mkdirSync(AUTH_DIR, { recursive: true });

--- a/playwright/e2e/tests/smoke/all-app-pages.authed.spec.ts
+++ b/playwright/e2e/tests/smoke/all-app-pages.authed.spec.ts
@@ -1,156 +1,17 @@
-import { createServer, type Server, type ServerResponse } from 'node:http';
 import { expect, type Page, type Response, test } from '@playwright/test';
+import { setupStrictNetworkGuard } from '../../utils/network-guard';
 
 /**
  * Real-Better Auth authenticated route smoke.
  *
- * Unlike all-app-pages.spec.ts (fully-mocked auth via fake cookies + Better Auth FAPI
- * mock + the __playwright_test bypass), this spec runs under a REAL Better Auth
- * session supplied by the `app-authed` project's storageState (written by
- * playwright/e2e/auth.setup.ts). It exercises the genuine proxy.ts / authMiddleware path,
- * while backend DATA is still served by a local mock API on :3010.
- *
- * The mock API binds dual-stack (::) so the app's SSR fetch to `localhost:3010`
- * (which resolves to IPv6 ::1 first) reaches it.
+ * Unlike all-app-pages.spec.ts (fully-mocked auth via fake cookies + Better Auth
+ * FAPI mock + the __playwright_test bypass), this spec runs under a REAL Better
+ * Auth session minted by playwright/e2e/auth.setup.ts against the job-local API
+ * (sign-up + onboarding completion). It exercises the genuine proxy.ts /
+ * authMiddleware path end-to-end: session cookie → /auth/token → /auth/bootstrap
+ * → canonical workspace redirect — all against the hermetic local stack
+ * (Postgres + Redis + real compiled API on :3010). No production dependency.
  */
-
-function jsonResponse(response: ServerResponse, body: unknown) {
-  response.writeHead(200, { 'content-type': 'application/json' });
-  response.end(JSON.stringify(body));
-}
-
-function collection(type: string) {
-  return { data: [], meta: { page: 1, pageSize: 0, totalCount: 0 }, type };
-}
-
-function bootstrapPayload() {
-  return {
-    access: {
-      brandId: 'brand-1',
-      creditsBalance: 500,
-      hasEverHadCredits: true,
-      isOnboardingCompleted: true,
-      isSuperAdmin: true,
-      organizationId: 'mock-org-id-e2e-test',
-      subscriptionStatus: 'active',
-      subscriptionTier: 'pro',
-      userId: 'mock-user-id-e2e-test',
-    },
-    brands: [
-      {
-        credentials: [],
-        id: 'brand-1',
-        label: 'Brand 1',
-        name: 'Brand 1',
-        organization: {
-          id: 'mock-org-id-e2e-test',
-          label: 'Test Organization',
-          name: 'Test Organization',
-          slug: 'test-org',
-        },
-        slug: 'brand-1',
-      },
-    ],
-    currentUser: {
-      authProviderId: 'mock-user-id-e2e-test',
-      email: 'test@genfeed.ai',
-      firstName: 'Test',
-      id: 'mock-user-id-e2e-test',
-      isOnboardingCompleted: true,
-      lastName: 'User',
-    },
-    darkroomCapabilities: { isByokEnabled: false, isDarkroomAvailable: false },
-    settings: {
-      defaultAvatarIngredientId: null,
-      defaultVoiceId: null,
-      id: 'org-settings-1',
-      isAdvancedMode: false,
-      isDarkroomNsfwVisible: false,
-    },
-    streak: null,
-  };
-}
-
-function installReadinessPayload() {
-  return {
-    access: {
-      byokConfiguredProviders: ['openai'],
-      byokEnabled: true,
-      runtimeMode: 'byok',
-      selectedMode: 'server',
-      serverDefaultsReady: true,
-    },
-    authMode: 'better_auth',
-    billingMode: 'oss_local',
-    localTools: {
-      anyDetected: true,
-      claude: true,
-      codex: true,
-      detected: ['Claude Code'],
-    },
-    providers: {
-      anyConfigured: true,
-      configured: ['OpenAI'],
-      imageGenerationReady: true,
-      openai: true,
-      textGenerationReady: true,
-    },
-    ui: {
-      showBilling: false,
-      showCloudUpgradeCta: true,
-      showCredits: false,
-      showPricing: false,
-    },
-    workspace: {
-      brandId: 'brand-1',
-      hasBrand: true,
-      hasOrganization: true,
-      organizationId: 'mock-org-id-e2e-test',
-    },
-  };
-}
-
-function startMockApiServer(): Promise<Server | null> {
-  const server = createServer((request, response) => {
-    const url = request.url ?? '/';
-    if (url.startsWith('/v1/health'))
-      return jsonResponse(response, { status: 'ok' });
-    if (url.startsWith('/v1/auth/bootstrap'))
-      return jsonResponse(response, bootstrapPayload());
-    if (url.startsWith('/v1/onboarding/install-readiness'))
-      return jsonResponse(response, installReadinessPayload());
-    if (url.startsWith('/v1/users/me/brands'))
-      return jsonResponse(response, bootstrapPayload().brands);
-    if (url.startsWith('/v1/users/me/organizations'))
-      return jsonResponse(response, [
-        {
-          brand: { id: 'brand-1', label: 'Brand 1', slug: 'brand-1' },
-          id: 'mock-org-id-e2e-test',
-          isActive: true,
-          label: 'Test Organization',
-          slug: 'test-org',
-        },
-      ]);
-    if (url.startsWith('/v1/users/me'))
-      return jsonResponse(response, bootstrapPayload().currentUser);
-    if (url.includes('/settings'))
-      return jsonResponse(response, {
-        data: { attributes: bootstrapPayload().settings },
-      });
-    if (url.includes('/credits'))
-      return jsonResponse(response, { balance: 500, modelCosts: {} });
-    return jsonResponse(response, collection('mock'));
-  });
-
-  return new Promise((resolve, reject) => {
-    server.once('error', (error: NodeJS.ErrnoException) => {
-      if (error.code === 'EADDRINUSE') return resolve(null);
-      reject(error);
-    });
-    // Dual-stack bind so SSR fetch to localhost:3010 (::1) reaches the mock.
-    server.listen(3010, '::', () => resolve(server));
-  });
-}
 
 async function assertRouteLoads(page: Page, route: string): Promise<void> {
   const response: Response | null = await page.goto(route, {
@@ -180,40 +41,46 @@ async function assertRouteLoads(page: Page, route: string): Promise<void> {
   ).toBeGreaterThan(0);
 }
 
-// Auth-dependent routes that 500'd / bounced to /login under the broken bypass
-// and must now render with a real session. Limited to routes with a direct
-// page.tsx — index-less segments (overview/library/compose) redirect to a
-// data-dependent child and are non-deterministic for a smoke.
-const PROTECTED_ROUTES = [
-  '/',
-  '/settings',
-  '/test-org',
-  '/test-org/brand-1/workflows',
-  '/test-org/brand-1/posts',
-  '/test-org/brand-1/tasks',
-  '/test-org/brand-1/editor',
-  '/test-org/brand-1/workspace',
-];
+/**
+ * Auth-dependent routes that 500'd / bounced to /login under the broken bypass
+ * and must now render with a real session. Limited to routes with a direct
+ * page.tsx — index-less segments (overview/library/compose) redirect to a
+ * data-dependent child and are non-deterministic for a smoke. Slugs come from
+ * the workspace the API provisioned for the freshly signed-up user.
+ */
+function buildProtectedRoutes(orgSlug: string, brandSlug: string): string[] {
+  return [
+    '/settings',
+    `/${orgSlug}`,
+    `/${orgSlug}/${brandSlug}/workflows`,
+    `/${orgSlug}/${brandSlug}/posts`,
+    `/${orgSlug}/${brandSlug}/tasks`,
+    `/${orgSlug}/${brandSlug}/editor`,
+    `/${orgSlug}/${brandSlug}/workspace`,
+  ];
+}
 
 test.describe('Authenticated route smoke (real Better Auth session)', () => {
   test.setTimeout(600_000);
 
-  let mockApiServer: Server | null = null;
-
-  test.beforeAll(async () => {
-    mockApiServer = await startMockApiServer();
-  });
-
-  test.afterAll(async () => {
-    await new Promise<void>((resolve) => {
-      if (!mockApiServer) return resolve();
-      mockApiServer.close(() => resolve());
-    });
-  });
-
   test('protected routes render under a real session', async ({ page }) => {
+    const networkGuard = await setupStrictNetworkGuard(page, { strict: true });
+
+    // `/` routes a signed-in, onboarded user to the canonical workspace path
+    // (/{orgSlug}/{brandSlug}/workspace/overview) via proxy.ts — the first real
+    // proof the session is honored, and the source of the provisioned slugs.
+    await assertRouteLoads(page, '/');
+    const workspaceMatch = new URL(page.url()).pathname.match(
+      /^\/([a-zA-Z0-9-]+)\/([a-zA-Z0-9-]+)\//,
+    );
+    expect(
+      workspaceMatch,
+      `/ did not land on a /{org}/{brand}/… workspace path (got ${page.url()})`,
+    ).not.toBeNull();
+    const [, orgSlug, brandSlug] = workspaceMatch as RegExpMatchArray;
+
     const failures: string[] = [];
-    for (const route of PROTECTED_ROUTES) {
+    for (const route of buildProtectedRoutes(orgSlug, brandSlug)) {
       await test.step(route, async () => {
         try {
           await assertRouteLoads(page, route);
@@ -225,5 +92,7 @@ test.describe('Authenticated route smoke (real Better Auth session)', () => {
       });
     }
     expect(failures, failures.join('\n\n')).toEqual([]);
+
+    networkGuard.assertNoBlockedRequests();
   });
 });


### PR DESCRIPTION
## Summary

The nightly-gating `e2e-frontend-authed` job validated real Better Auth sessions against **production** `api.genfeed.ai` using a static `E2E_BETTER_AUTH_SESSION_TOKEN` repo secret that was never provisioned (and would expire every 7 days if it had been — Better Auth default session TTL, no per-user override exists). This is the still-red half of #1448 after #1579 correctly made the job fail closed.

This PR removes the production dependency entirely instead of provisioning prod credentials:

- **`.github/workflows/e2e.yml`** — `e2e-frontend-authed` now runs a fully job-local stack: Postgres 17 + Redis 7 service containers, `prisma migrate deploy`, the real compiled API booted on :3010 with a **synthetic** `BETTER_AUTH_SECRET` literal, and the app built against `http://localhost:3010/v1` (bypass flag OFF, real Better Auth client). The secrets-check step is deleted — the job needs **zero repo secrets**. Nightly-cron gating and deploy-path `continue-on-error` semantics are unchanged (#1579's alarm design preserved). API log uploaded on failure.
- **`playwright/e2e/auth.setup.ts`** — mints a fresh session per run: `POST /v1/auth/sign-up/email` (sign-in fallback for warm local DBs) → session cookie → `GET /v1/auth/token` JWT → `PATCH /v1/users/me {isOnboardingCompleted:true}` (the idempotent completion cascade), then writes the storage state. Sign-up auto-provisions org/settings/brand/member/credits via `UserProvisioningListener`, so the E2E user gets a real workspace for free. `E2E_BETTER_AUTH_SESSION_TOKEN` remains supported as a local-dev override (`E2E_AUTHED_LOCAL=1`).
- **`playwright/e2e/tests/smoke/all-app-pages.authed.spec.ts`** — drops the in-spec :3010 mock server (the real API serves bootstrap + data), derives org/brand slugs from the actually provisioned workspace via the canonical `/` redirect instead of hardcoded `test-org/brand-1`, and adds `setupStrictNetworkGuard({strict:true})` so no external call can escape the job.
- **`.agents/memory/context/e2e-architecture.md`** — updated to match.

### Root-cause context (#1448)

- 07-10 core-gate failure (six unbucketed `/test-org/brand-1/agent*` routes) was already fixed on master by #1579 — the 07-11 nightly ran all shards green.
- 07-11 authed failure is the missing-secrets fail-closed path this PR eliminates. Audit found the prior design was split-brain: session validated against prod, data from a local mock, no network guard — and its "7+ green runs" were skipped-step no-ops.

## Verification

- Branch E2E dispatched: https://github.com/genfeedai/genfeed.ai/actions/runs/29155107755 — the authed job runs its full hermetic path on `workflow_dispatch` (only `continue-on-error` differs from the nightly), so its individual job conclusion is the proof.
- `node scripts/e2e-route-coverage.mjs` — 96.0% dedicated / threshold 80% (spec rewrite causes no coverage regression).
- `actionlint .github/workflows/e2e.yml` — clean.
- Biome + secretlint + UI control-guard pre-commit hooks passed.

Closes #1448 once the nightly is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)