### PR TITLE
fix(publish): resolve queued-post relations via scalar FKs

### DIFF
--- a/apps/server/workers/src/crons/posts/cron.posts.service.spec.ts
+++ b/apps/server/workers/src/crons/posts/cron.posts.service.spec.ts
@@ -303,4 +303,86 @@ describe('CronPostsService', () => {
       }),
     );
   });
+
+  it('resolves credential via scalar FKs when relation aliases are undefined (regression #1622)', async () => {
+    // Shaped the way findDueScheduledPosts actually returns rows: scalar FKs
+    // are populated (Post model requires them), but the top-level relation
+    // aliases (credential/organization/brand/user) are NOT included by the
+    // findDueScheduledPosts query — only children.credential is included.
+    // Pre-fix, publishSinglePost read post.credential/post.organization/etc
+    // (the aliases) which are undefined here, so credentialsService.findOne
+    // would be called with `{ _id: undefined }` and resolve to null.
+    const post = {
+      brandId: 'brand-scalar-1',
+      children: [],
+      credentialId: 'cred-scalar-1',
+      id: 'post-1',
+      ingredients: [],
+      organizationId: 'org-scalar-1',
+      platform: CredentialPlatform.GHOST,
+      scheduledDate: new Date('2026-07-07T09:55:00.000Z'),
+      status: PostStatus.SCHEDULED,
+      userId: 'user-scalar-1',
+      // Intentionally no `credential`, `organization`, `brand`, or `user`
+      // alias fields set — mirrors the real findDueScheduledPosts payload.
+    };
+
+    postsService.findAll.mockResolvedValueOnce({
+      docs: [post],
+      total: 1,
+    } as never);
+
+    const ghostCredential = {
+      id: 'cred-scalar-1',
+      platform: CredentialPlatform.GHOST,
+    };
+    credentialsService.findOne.mockImplementation((query: { _id?: unknown }) =>
+      query?._id === 'cred-scalar-1'
+        ? Promise.resolve(ghostCredential)
+        : Promise.resolve(null),
+    );
+
+    quotaService.checkQuota.mockResolvedValue({
+      allowed: true,
+      currentCount: 0,
+      dailyLimit: 10,
+    });
+    publisherFactory.getPublisher.mockReturnValue({
+      publish: vi.fn().mockResolvedValue({
+        externalId: 'ghost-post-1',
+        externalShortcode: null,
+        platform: CredentialPlatform.GHOST,
+        status: PostStatus.PUBLIC,
+        success: true,
+        url: 'https://example.ghost.io/ghost-post-1',
+      }),
+      supportsThreads: false,
+    });
+
+    const result = await service.processQueuedPost({
+      enqueuedAt: '2026-07-07T09:55:00.000Z',
+      organizationId: 'org-scalar-1',
+      postId: 'post-1',
+      source: 'scheduled_sweep',
+    });
+
+    // The fix: credentialsService.findOne must be called with the scalar
+    // credentialId, not the undefined `credential` alias.
+    expect(credentialsService.findOne).toHaveBeenCalledWith({
+      _id: 'cred-scalar-1',
+    });
+
+    // Post must NOT be marked FAILED with "Credential not found" — it
+    // should proceed all the way through to a successful publish.
+    expect(postsService.patch).not.toHaveBeenCalledWith(
+      'post-1',
+      expect.objectContaining({ status: PostStatus.FAILED }),
+    );
+    expect(
+      publishEventWebhookService.emitLegacyPostFailed,
+    ).not.toHaveBeenCalled();
+    expect(result).toEqual(
+      expect.objectContaining({ success: true, externalId: 'ghost-post-1' }),
+    );
+  });
 });

--- a/apps/server/workers/src/crons/posts/cron.posts.service.ts
+++ b/apps/server/workers/src/crons/posts/cron.posts.service.ts
@@ -150,13 +150,15 @@ export class CronPostsService {
     if (result.success) {
       await this.activitiesService.create(
         new ActivityEntity({
-          brand: post.brand,
+          brand: this.readPostString(post, ['brandId', 'brand']) ?? null,
           entityId: post.id,
           entityModel: ActivityEntityModel.POST,
           key: ActivityKey.POST_PUBLISHED,
-          organization: post.organization,
+          organization:
+            this.readPostString(post, ['organizationId', 'organization']) ??
+            null,
           source: ActivitySource.POST,
-          user: post.user,
+          user: this.readPostString(post, ['userId', 'user']) ?? null,
           value: `Published to ${result.platform}: ${result.url}`,
         }),
       );
@@ -269,10 +271,21 @@ export class CronPostsService {
       status: PostStatus.PROCESSING,
     });
 
+    const postCredentialId = this.readPostString(post, [
+      'credentialId',
+      'credential',
+    ]);
+    const postOrganizationId = this.readPostString(post, [
+      'organizationId',
+      'organization',
+    ]);
+    const postBrandId = this.readPostString(post, ['brandId', 'brand']);
+    const postUserId = this.readPostString(post, ['userId', 'user']);
+
     try {
       // Get credential
       const credential = await this.credentialsService.findOne({
-        _id: post.credential,
+        _id: postCredentialId,
       });
 
       if (!credential) {
@@ -284,7 +297,7 @@ export class CronPostsService {
 
       // Get organization
       const organization = await this.organizationsService.findOne({
-        _id: post.organization,
+        _id: postOrganizationId,
       });
 
       if (!organization) {
@@ -339,10 +352,10 @@ export class CronPostsService {
 
       // Build publish context
       const context: PublishContext = {
-        brandId: post.brand.toString(),
+        brandId: postBrandId ?? '',
         credential,
         organization,
-        organizationId: post.organization.toString(),
+        organizationId: postOrganizationId ?? '',
         post,
         postId: post.id.toString(),
       };
@@ -360,7 +373,7 @@ export class CronPostsService {
               ? undefined
               : publishResult.error || 'Scheduled post publishing failed',
           inputValues: {
-            brandId: post.brand.toString(),
+            brandId: postBrandId ?? '',
             platform: credential.platform,
             postId: post.id.toString(),
             scheduledDate:
@@ -373,12 +386,12 @@ export class CronPostsService {
             credentialId: credential.id?.toString?.() ?? credential.id,
             hasThreadChildren: Boolean(post.children?.length),
           },
-          organizationId: post.organization.toString(),
+          organizationId: postOrganizationId ?? '',
           postIds: [post.id.toString()],
           schedule: '*/15 * * * *',
           source: 'CronPostsService.publishSinglePost',
           trigger: WorkflowExecutionTrigger.SCHEDULED,
-          userId: post.user.toString(),
+          userId: postUserId,
         },
         () => publisher.publish(context),
       );
@@ -670,15 +683,17 @@ export class CronPostsService {
       const ingredients = post.ingredients || [];
 
       const postData = {
-        brand: post.brand,
+        brand: this.readPostString(post, ['brandId', 'brand']) ?? '',
         category: (post.category as PostCategory) || PostCategory.VIDEO,
-        credential: post.credential,
+        credential:
+          this.readPostString(post, ['credentialId', 'credential']) ?? '',
         description: post.description,
         ingredients: ingredients,
         isRepeat: true,
         label: post.label,
         maxRepeats: post.maxRepeats,
-        organization: post.organization,
+        organization:
+          this.readPostString(post, ['organizationId', 'organization']) ?? '',
         platform: post.platform,
         repeatCount: nextRepeatCount, // Track repeat count on new post
         repeatDaysOfWeek: post.repeatDaysOfWeek,
@@ -688,7 +703,7 @@ export class CronPostsService {
         scheduledDate: nextDate,
         status: PostStatus.SCHEDULED,
         tags: post.tags,
-        user: post.user,
+        user: this.readPostString(post, ['userId', 'user']) ?? '',
       };
 
       const newPost = await this.postsService.create(postData);
@@ -743,20 +758,29 @@ export class CronPostsService {
           .map((ingredient) => String(ingredient));
 
         const childData = {
-          brand: originalParent.brand,
+          brand:
+            this.readPostString(originalParent, ['brandId', 'brand']) ?? '',
           category:
             (child.category as PostCategory | undefined) || PostCategory.TEXT,
-          credential: originalParent.credential,
+          credential:
+            this.readPostString(originalParent, [
+              'credentialId',
+              'credential',
+            ]) ?? '',
           description: child.description || '',
           ingredients: ingredientIds,
           label: child.label || '',
           order: child.order || 0,
-          organization: originalParent.organization,
+          organization:
+            this.readPostString(originalParent, [
+              'organizationId',
+              'organization',
+            ]) ?? '',
           parent: newParentId,
           platform: originalParent.platform as never,
           scheduledDate: newScheduledDate, // Use new parent's scheduled date
           status: PostStatus.SCHEDULED,
-          user: originalParent.user,
+          user: this.readPostString(originalParent, ['userId', 'user']) ?? '',
         };
 
         await this.postsService.create(childData);
@@ -837,13 +861,14 @@ export class CronPostsService {
   ): Promise<void> {
     await this.activitiesService.create(
       new ActivityEntity({
-        brand: post.brand,
+        brand: this.readPostString(post, ['brandId', 'brand']) ?? null,
         entityId: post.id,
         entityModel: ActivityEntityModel.POST,
         key: ActivityKey.POST_FAILED,
-        organization: post.organization,
+        organization:
+          this.readPostString(post, ['organizationId', 'organization']) ?? null,
         source: ActivitySource.POST,
-        user: post.user,
+        user: this.readPostString(post, ['userId', 'user']) ?? null,
         value: `Quota exceeded: ${quotaCheck.currentCount}/${quotaCheck.dailyLimit} posts for ${platform}`,
       }),
     );
@@ -891,13 +916,14 @@ export class CronPostsService {
   ): Promise<void> {
     await this.activitiesService.create(
       new ActivityEntity({
-        brand: post.brand,
+        brand: this.readPostString(post, ['brandId', 'brand']) ?? null,
         entityId: post.id,
         entityModel: ActivityEntityModel.POST,
         key: ActivityKey.POST_FAILED,
-        organization: post.organization,
+        organization:
+          this.readPostString(post, ['organizationId', 'organization']) ?? null,
         source: ActivitySource.POST,
-        user: post.user,
+        user: this.readPostString(post, ['userId', 'user']) ?? null,
         value: errorMessage,
       }),
     );


### PR DESCRIPTION
## Summary

- `publishSinglePost` and its side-effect helpers in `CronPostsService` read Mongo-era relation aliases (`post.credential`, `post.organization`, `post.brand`, `post.user`) that are **undefined at runtime**. `findDueScheduledPosts` only `include`s `children.credential` — never the top-level post's `credential`/`organization`/`brand`/`user` relations.
- Result in production: `credentialsService.findOne({ _id: post.credential })` resolves `{ _id: undefined }`, `BaseService.findOne`'s guard treats that as "not found," and **every queued post fails with "Credential not found."** Publishing is broken.
- Fix: convert every alias read to the scalar FK (`credentialId`, `organizationId`, `brandId`, `userId`) via the existing `readPostString(post, [scalarKey, aliasKey])` fallback helper, mirroring the pattern already used in `enqueuePostPublishJobs`.

## Sites converted (7 methods, cron.posts.service.ts)

- `publishPostWithSideEffects` — `ActivityEntity` construction (brand/organization/user, `?? null`)
- `publishSinglePost` — credential lookup (`_id`), organization lookup (`_id`), `PublishContext.brandId`/`.organizationId`, workflow `inputValues.brandId`, workflow `organizationId`/`userId`
- `scheduleNextRepeat` — `postData` (brand/credential/organization/user, `?? ''`)
- `cloneChildrenForRepeat` — `childData` (brand/credential/organization/user, `?? ''`)
- `logQuotaExceededActivity` — `ActivityEntity` construction (`?? null`)
- `logFailedActivity` — `ActivityEntity` construction (`?? null`)

No changes to the `findDueScheduledPosts` Prisma `include`, the queue, or `children.credential` handling (already correctly included).

## Test plan

- [x] Added a regression test (`cron.posts.service.spec.ts`) that drives `processQueuedPost` with a Post shaped exactly as `findDueScheduledPosts` returns it: scalar FKs set (`credentialId`, `organizationId`, `brandId`, `userId`), relation aliases left `undefined`.
- [x] `credentialsService.findOne` is mocked argument-conditionally — resolves a Ghost credential only for `{ _id: 'cred-scalar-1' }`, `null` otherwise.
- [x] Test asserts `credentialsService.findOne` was called with the scalar `credentialId` and that the post does **not** end up FAILED with "Credential not found" — it publishes successfully.
- [x] Reasoned through (not run locally, per repo policy — CI is the gate): **pre-fix** the code reads `post.credential` (undefined) so `findOne` is called with `{ _id: undefined }`, my mock resolves `null` for that, and every assertion (call args, non-FAILED status, non-called failure webhook, success result) fails. **Post-fix** `readPostString` resolves `credentialId` first, the mock resolves a real credential, and the flow proceeds through quota/publisher/publish to a successful result — all assertions pass.
- [x] `bunx biome check --write` run on both changed files; pre-commit hooks (biome, secretlint, control-guard) passed on commit.
- [ ] CI: type-check, lint, and test suite (not run locally per machine policy)

Closes #1622
Relates to #334