### PR TITLE
ci(e2e): add postgres/redis healthchecks to the E2E service containers

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -64,10 +64,22 @@ jobs:
           POSTGRES_PASSWORD: genfeed_local
         ports:
           - 5432:5432
+        # Gate job start on container readiness so the first DB touch can
+        # never race container startup (deferred CodeRabbit finding on #1615).
+        options: >-
+          --health-cmd "pg_isready -U genfeed -d test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
       redis:
         image: redis:7
         ports:
           - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
     env:
       NODE_ENV: test
       DATABASE_URL: postgresql://genfeed:genfeed_local@localhost:5432/test
@@ -276,10 +288,22 @@ jobs:
           POSTGRES_PASSWORD: genfeed_local
         ports:
           - 5432:5432
+        # Gate job start on container readiness so the first DB touch can
+        # never race container startup (deferred CodeRabbit finding on #1615).
+        options: >-
+          --health-cmd "pg_isready -U genfeed -d test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
       redis:
         image: redis:7
         ports:
           - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
     env:
       DATABASE_URL: postgresql://genfeed:genfeed_local@localhost:5432/test
       REDIS_URL: redis://localhost:6379


### PR DESCRIPTION
## Summary

Gate job start on container readiness (`pg_isready` / `redis-cli ping`) so the first DB or Redis touch can never race container startup. Applied to both `e2e-api` and the hermetic `e2e-frontend-authed` job — their services blocks are identical, so both get the same hardening.

Resolves the CodeRabbit finding deferred as non-blocking on #1615.

## Verification

- Branch E2E dispatched: https://github.com/genfeedai/genfeed.ai/actions/runs/29189210646 — exercises both service-container jobs (API E2E + authed) with the healthchecks live.
- `actionlint .github/workflows/e2e.yml` — clean.

Refs #1448

🤖 Generated with [Claude Code](https://claude.com/claude-code)