### PR TITLE
chore: harmonize PR issue linking

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 ## Related issue
 
-<!-- Use `Fixes #123` or `Refs #123`. -->
+<!-- Use `Closes #123` only when this PR fully resolves the issue. Use `Refs #123` otherwise. A closing keyword takes effect when the PR merges into the repository's default branch. -->
 
 ## Scope and boundaries
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,7 +143,7 @@ request, list exactly what you ran and any checks left to CI.
 ## Pull-request expectations
 
 - Keep the patch single-purpose and split unrelated work.
-- Link the issue with `Fixes #123` or `Refs #123`.
+- Link the issue with `Closes #123` only when this PR fully resolves it; use `Refs #123` otherwise. A closing keyword takes effect when the PR merges into the default branch.
 - Explain user-visible behavior and repository-boundary effects.
 - Include focused verification commands and results.
 - Call out generated files, migrations, configuration changes, and external


### PR DESCRIPTION
## Summary

- add the shared Related issue contract to the repository PR template
- use `Closes #123` only for fully resolved issues and `Refs #123` otherwise
- document that the closing keyword takes effect when the PR merges into the default branch

## Verification

- `git diff --check`
- documentation-only GitHub PR-template change

## Impact

Fully resolving PRs can consistently close their linked issue on merge. The GitHub Project Item closed workflow remains responsible for moving the closed issue to Done.