### PR TITLE
feat(onboarding): make the agent workspace the default first-run surface

### DIFF
--- a/apps/app/app/(onboarding)/onboarding/post-signup/page.behavior.test.tsx
+++ b/apps/app/app/(onboarding)/onboarding/post-signup/page.behavior.test.tsx
@@ -13,6 +13,7 @@ const {
   currentUserState,
   getTokenMock,
   getMyOrganizationsMock,
+  isCloudMock,
   isEEEnabledMock,
   isSelfHostedMock,
   managedCreateCheckoutSessionMock,
@@ -33,6 +34,7 @@ const {
   },
   getTokenMock: vi.fn(),
   getMyOrganizationsMock: vi.fn(),
+  isCloudMock: vi.fn(),
   isEEEnabledMock: vi.fn(),
   isSelfHostedMock: vi.fn(),
   managedCreateCheckoutSessionMock: vi.fn(),
@@ -156,6 +158,7 @@ vi.mock('@genfeedai/config/license', () => ({
 }));
 
 vi.mock('@genfeedai/config/deployment', () => ({
+  isCloudDeployment: () => isCloudMock(),
   isSelfHostedDeployment: () => isSelfHostedMock(),
 }));
 
@@ -185,6 +188,7 @@ describe('PostSignupPage behavior', () => {
     managedCreateCheckoutSessionMock.mockReset();
     getTokenMock.mockReset();
     getMyOrganizationsMock.mockReset();
+    isCloudMock.mockReset();
     isEEEnabledMock.mockReset();
     isSelfHostedMock.mockReset();
     resolveAuthTokenMock.mockReset();
@@ -198,6 +202,7 @@ describe('PostSignupPage behavior', () => {
       onboardingStepsCompleted: [],
     };
     currentUserState.isLoading = false;
+    isCloudMock.mockReturnValue(false);
     isEEEnabledMock.mockReturnValue(false);
     isSelfHostedMock.mockReturnValue(true);
     resolveAuthTokenMock.mockResolvedValue('api-token');
@@ -369,5 +374,69 @@ describe('PostSignupPage behavior', () => {
     expect(locationState.href).toBe(
       'https://checkout.stripe.test/managed-session',
     );
+  });
+
+  it('routes new cloud signups to the org-scoped agent onboarding surface', async () => {
+    isCloudMock.mockReturnValue(true);
+    isSelfHostedMock.mockReturnValue(false);
+    getMyOrganizationsMock.mockResolvedValue([
+      {
+        brand: null,
+        id: 'org-1',
+        isActive: true,
+        isOwner: true,
+        label: 'Acme',
+        slug: 'acme',
+      },
+    ]);
+
+    render(<PostSignupPage />);
+
+    await waitFor(() => {
+      expect(locationState.href).toBe('/acme/~/agent/onboarding');
+    });
+    expect(createCheckoutSessionMock).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the wizard when no cloud org slug can be resolved', async () => {
+    isCloudMock.mockReturnValue(true);
+    isSelfHostedMock.mockReturnValue(false);
+    getMyOrganizationsMock.mockResolvedValue([]);
+
+    render(<PostSignupPage />);
+
+    await waitFor(() => {
+      expect(locationState.href).toBe('/onboarding/brand');
+    });
+  });
+
+  it('keeps plan checkout returns on the wizard even on cloud (preserves #1421)', async () => {
+    isCloudMock.mockReturnValue(true);
+    isEEEnabledMock.mockReturnValue(true);
+    isSelfHostedMock.mockReturnValue(false);
+    getMyOrganizationsMock.mockResolvedValue([
+      {
+        brand: null,
+        id: 'org-1',
+        isActive: true,
+        isOwner: true,
+        label: 'Acme',
+        slug: 'acme',
+      },
+    ]);
+    searchParamsState.value = new URLSearchParams('plan=price_123');
+
+    render(<PostSignupPage />);
+
+    await waitFor(() => {
+      expect(createCheckoutSessionMock).toHaveBeenCalledWith({
+        cancelUrl: 'http://localhost/onboarding/providers',
+        quantity: null,
+        stripePriceId: 'price_123',
+        successUrl:
+          'http://localhost/onboarding/brand?checkout=completed&checkoutKind=plan',
+      });
+    });
+    expect(locationState.href).toBe('https://checkout.stripe.test/session');
   });
 });

--- a/apps/app/app/(onboarding)/onboarding/post-signup/use-post-signup-routing.hook.ts
+++ b/apps/app/app/(onboarding)/onboarding/post-signup/use-post-signup-routing.hook.ts
@@ -7,9 +7,17 @@ import {
   parseSelectedCredits,
 } from '@app/(onboarding)/onboarding/post-signup/post-signup-routing.util';
 import { useCurrentUser } from '@contexts/user/user-context/user-context';
-import { isSelfHostedDeployment } from '@genfeedai/config/deployment';
+import {
+  isCloudDeployment,
+  isSelfHostedDeployment,
+} from '@genfeedai/config/deployment';
 import { isEEEnabled } from '@genfeedai/config/license';
-import { getResumeStep, ONBOARDING_STEPS } from '@genfeedai/constants';
+import {
+  APP_ROUTES,
+  createOrganizationAppRoute,
+  getResumeStep,
+  ONBOARDING_STEPS,
+} from '@genfeedai/constants';
 import { resolveAuthToken } from '@helpers/auth/auth.helper';
 import { useAuthIdentity } from '@hooks/auth/use-auth-identity/use-auth-identity';
 import { useAuthUser } from '@hooks/auth/use-auth-user/use-auth-user';
@@ -52,7 +60,10 @@ export function usePostSignupRouting(): PostSignupRoutingState {
   const proactiveLeadId = authUser?.publicMetadata?.proactiveLeadId;
   const checkoutEmail = currentUser?.email || authPrimaryEmail || '';
 
-  const resolveOnboardingHref = useCallback(async (): Promise<string> => {
+  // Base href for post-checkout returns. Kept byte-identical to the #1421
+  // handoff (wizard resume step) so the Stripe success/cancel round-trip is
+  // unchanged — the revenue path is exactly where #1421 regressed.
+  const resolveCheckoutReturnHref = useCallback(async (): Promise<string> => {
     if (proactiveLeadId) {
       return '/onboarding/proactive';
     }
@@ -96,6 +107,63 @@ export function usePostSignupRouting(): PostSignupRoutingState {
 
     return onboardingHref;
   }, [currentUser, getToken, proactiveLeadId]);
+
+  // Resolve the active organization slug so we can build the org-scoped agent
+  // onboarding route. Falls back to null so callers can degrade to the wizard.
+  const resolveActiveOrgSlug = useCallback(async (): Promise<string | null> => {
+    const token = await resolveAuthToken(getToken);
+    if (!token) {
+      return null;
+    }
+
+    const organizations = await OrganizationsService.getInstance(token)
+      .getMyOrganizations()
+      .catch((error) => {
+        logger.error(
+          'Failed to resolve organizations for agent onboarding routing',
+          error,
+        );
+        return [];
+      });
+
+    const activeOrganization =
+      organizations.find((organization) => organization.isActive) ??
+      organizations[0];
+
+    return activeOrganization?.slug ?? null;
+  }, [getToken]);
+
+  // Default first-run destination. Agent-first onboarding is the cloud SaaS
+  // default; self-hosted/desktop keep the form wizard because the agent
+  // onboarding surface needs the managed orchestrator to run.
+  const resolveOnboardingHref = useCallback(async (): Promise<string> => {
+    if (proactiveLeadId) {
+      return '/onboarding/proactive';
+    }
+
+    const completedSteps = currentUser?.onboardingStepsCompleted ?? [];
+    const hasCompletedAllOnboardingSteps =
+      currentUser?.isOnboardingCompleted === true ||
+      ONBOARDING_STEPS.every((step) => completedSteps.includes(step));
+
+    if (hasCompletedAllOnboardingSteps) {
+      return '/';
+    }
+
+    const wizardHref = buildOnboardingResumeHref(
+      getResumeStep(completedSteps),
+      localStorage.getItem(ONBOARDING_STORAGE_KEYS.brandDomain),
+    );
+
+    if (!isCloudDeployment()) {
+      return wizardHref;
+    }
+
+    const orgSlug = await resolveActiveOrgSlug();
+    return orgSlug
+      ? createOrganizationAppRoute(orgSlug, APP_ROUTES.AGENT.ONBOARDING)
+      : wizardHref;
+  }, [currentUser, proactiveLeadId, resolveActiveOrgSlug]);
 
   useEffect(() => {
     if (isLoading || !currentUser || !hasAuthUser || calledRef.current) {
@@ -201,7 +269,7 @@ export function usePostSignupRouting(): PostSignupRoutingState {
         }
 
         try {
-          const onboardingHref = await resolveOnboardingHref();
+          const onboardingHref = await resolveCheckoutReturnHref();
           const successPath = appendCheckoutReturnParams(
             onboardingHref,
             'plan-checkout',
@@ -308,7 +376,7 @@ export function usePostSignupRouting(): PostSignupRoutingState {
         }
 
         try {
-          const onboardingHref = await resolveOnboardingHref();
+          const onboardingHref = await resolveCheckoutReturnHref();
           const successPath = appendCheckoutReturnParams(
             onboardingHref,
             'credits-checkout',
@@ -385,6 +453,7 @@ export function usePostSignupRouting(): PostSignupRoutingState {
     requestedBrandNameParam,
     requestedCreditsParam,
     requestedPlanParam,
+    resolveCheckoutReturnHref,
     resolveOnboardingHref,
   ]);
 

--- a/apps/app/app/(protected)/[orgSlug]/org-landing-content.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/org-landing-content.test.tsx
@@ -129,6 +129,29 @@ describe('OrgLandingContent', () => {
     });
   });
 
+  it('routes incomplete cloud users to the agent onboarding surface', async () => {
+    vi.stubEnv('NEXT_PUBLIC_GENFEED_CLOUD', 'true');
+    mocks.currentUserState.currentUser = {
+      id: 'user_1',
+      isOnboardingCompleted: false,
+      onboardingStepsCompleted: [],
+    };
+    mocks.brandState.brands = [
+      {
+        id: 'brand_1',
+        label: 'Default Organization',
+        slug: 'default',
+        totalCredentials: 0,
+      },
+    ];
+
+    render(<OrgLandingContent />);
+
+    await waitFor(() => {
+      expect(mocks.replace).toHaveBeenCalledWith('/acme/~/agent/onboarding');
+    });
+  });
+
   it('renders the project picker when multiple projects exist', () => {
     mocks.brandState.brands = [
       {

--- a/apps/app/app/(protected)/[orgSlug]/org-landing-content.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/org-landing-content.tsx
@@ -2,9 +2,11 @@
 
 import { useBrand } from '@contexts/user/brand-context/brand-context';
 import { useCurrentUser } from '@contexts/user/user-context/user-context';
+import { isCloudDeployment } from '@genfeedai/config/deployment';
 import {
   APP_ROUTES,
   createBrandAppRoute,
+  createOrganizationAppRoute,
   getResumeStep,
   ONBOARDING_STEPS,
 } from '@genfeedai/constants';
@@ -98,7 +100,11 @@ export default function OrgLandingContent() {
       ONBOARDING_STEPS.every((step) => completedSteps.includes(step));
 
     if (!hasCompletedOnboarding) {
-      replace(`/onboarding/${getResumeStep(completedSteps)}`);
+      replace(
+        isCloudDeployment() && orgSlug
+          ? createOrganizationAppRoute(orgSlug, APP_ROUTES.AGENT.ONBOARDING)
+          : `/onboarding/${getResumeStep(completedSteps)}`,
+      );
       return;
     }
 

--- a/apps/app/app/(protected)/[orgSlug]/~/agent/onboarding/page.spec.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/agent/onboarding/page.spec.tsx
@@ -1,7 +1,14 @@
+import type { ReactNode } from 'react';
 import { vi } from 'vitest';
 
 vi.mock('@genfeedai/agent', () => ({
   AgentFullPage: () => null,
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
 }));
 
 vi.mock('@genfeedai/auth-client/react', () => ({
@@ -28,13 +35,13 @@ vi.mock('../agent-workspace-context', () => ({
 }));
 
 import { runPageModuleTests } from '@shared/pages/pageTestUtils';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import ChatOnboardingPage, * as PageModule from './page';
 
 runPageModuleTests('app/(protected)/agent/onboarding/page', PageModule);
 
 describe('ChatOnboardingPage', () => {
-  it('renders only the workspace shell container and no inline page content', () => {
+  it('renders the workspace shell container', () => {
     const { container } = render(<ChatOnboardingPage />);
     expect(container.firstChild).toHaveClass(
       'flex',
@@ -42,6 +49,13 @@ describe('ChatOnboardingPage', () => {
       'flex-1',
       'flex-col',
     );
-    expect(container.firstChild).toBeEmptyDOMElement();
+  });
+
+  it('offers a classic-wizard fallback link', () => {
+    render(<ChatOnboardingPage />);
+    const fallbackLink = screen.getByRole('link', {
+      name: /prefer a form\? use the classic setup/i,
+    });
+    expect(fallbackLink).toHaveAttribute('href', '/onboarding');
   });
 });

--- a/apps/app/app/(protected)/[orgSlug]/~/agent/onboarding/page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/agent/onboarding/page.tsx
@@ -1,7 +1,21 @@
 'use client';
 
+import { APP_ROUTES } from '@genfeedai/constants';
+import Link from 'next/link';
 import { AgentWorkspacePageShell } from '../AgentWorkspacePageShell';
 
 export default function ChatOnboardingPage() {
-  return <AgentWorkspacePageShell />;
+  return (
+    <div className="relative flex min-h-[calc(100vh-4rem)] flex-1 flex-col">
+      <div className="pointer-events-none absolute right-4 top-3 z-10 flex justify-end">
+        <Link
+          href={APP_ROUTES.ONBOARDING.ROOT}
+          className="pointer-events-auto rounded-full bg-background/70 px-3 py-1 text-xs text-muted-foreground shadow-border backdrop-blur transition hover:text-foreground"
+        >
+          Prefer a form? Use the classic setup
+        </Link>
+      </div>
+      <AgentWorkspacePageShell />
+    </div>
+  );
 }

--- a/apps/app/app/(protected)/root-resolver-client.test.tsx
+++ b/apps/app/app/(protected)/root-resolver-client.test.tsx
@@ -141,4 +141,23 @@ describe('ProtectedRootResolver', () => {
       expect(mocks.replace).toHaveBeenCalledWith('/onboarding');
     });
   });
+
+  it('routes incomplete cloud users to the agent onboarding surface', async () => {
+    vi.stubEnv('NEXT_PUBLIC_GENFEED_CLOUD', 'true');
+    mocks.currentUserState.currentUser = {
+      id: 'user_1',
+      isOnboardingCompleted: false,
+      onboardingStepsCompleted: ['brand'],
+    };
+    mocks.brandState.selectedBrand = {
+      organization: { slug: 'acme' },
+      slug: 'default',
+    };
+
+    render(<ProtectedRootResolver />);
+
+    await waitFor(() => {
+      expect(mocks.replace).toHaveBeenCalledWith('/acme/~/agent/onboarding');
+    });
+  });
 });

--- a/apps/app/app/(protected)/root-resolver-client.tsx
+++ b/apps/app/app/(protected)/root-resolver-client.tsx
@@ -2,8 +2,11 @@
 
 import { useBrand } from '@contexts/user/brand-context/brand-context';
 import { useCurrentUser } from '@contexts/user/user-context/user-context';
+import { isCloudDeployment } from '@genfeedai/config/deployment';
 import {
+  APP_ROUTES,
   createBrandAppRoute,
+  createOrganizationAppRoute,
   getResumeStep,
   ONBOARDING_STEPS,
 } from '@genfeedai/constants';
@@ -56,9 +59,18 @@ export default function ProtectedRootResolver() {
       ONBOARDING_STEPS.every((step) => completedSteps.includes(step));
 
     if (!hasCompletedOnboarding) {
-      const resumeStep = getResumeStep(completedSteps);
       setStatusMessage('Opening onboarding...');
-      replace(`/onboarding/${resumeStep}`);
+      const agentOrgSlug =
+        getBrandOrganizationSlug(selectedBrand) ||
+        getBrandOrganizationSlug(brands[0]);
+      replace(
+        isCloudDeployment() && agentOrgSlug
+          ? createOrganizationAppRoute(
+              agentOrgSlug,
+              APP_ROUTES.AGENT.ONBOARDING,
+            )
+          : `/onboarding/${getResumeStep(completedSteps)}`,
+      );
       return;
     }
 

--- a/apps/app/proxy.test.ts
+++ b/apps/app/proxy.test.ts
@@ -263,6 +263,87 @@ describe('proxy', () => {
     );
   });
 
+  describe('agent-first onboarding (cloud)', () => {
+    const mockIncompleteUser = () =>
+      fetchMock.mockImplementation(async (input: string | URL) => {
+        const url = String(input);
+
+        if (url.endsWith('/auth/token')) {
+          return new Response(JSON.stringify({ token: BEARER_TOKEN }), {
+            status: 200,
+          });
+        }
+
+        if (url.endsWith('/auth/bootstrap')) {
+          return new Response(
+            JSON.stringify({
+              access: { brandId: 'brand_1', isOnboardingCompleted: false },
+              brands: [{ id: 'brand_1', slug: 'default' }],
+              currentUser: {
+                id: 'user_1',
+                isOnboardingCompleted: false,
+                onboardingStepsCompleted: [],
+              },
+            }),
+            { status: 200 },
+          );
+        }
+
+        if (url.endsWith('/organizations/mine')) {
+          return new Response(
+            JSON.stringify([{ isActive: true, slug: 'acme' }]),
+            { status: 200 },
+          );
+        }
+
+        return new Response('not found', { status: 404 });
+      });
+
+    it('redirects an incomplete cloud user on a protected route to the agent onboarding surface', async () => {
+      vi.stubEnv('NEXT_PUBLIC_GENFEED_CLOUD', 'true');
+      mockIncompleteUser();
+
+      const { default: proxy } = await import('./proxy');
+      const response = await proxy(
+        makeSignedInRequest('/acme/default/workspace/overview'),
+        {} as never,
+      );
+
+      expect(response.status).toBe(307);
+      expect(response.headers.get('location')).toBe(
+        'http://localhost:3000/acme/~/agent/onboarding',
+      );
+    });
+
+    it('lets an incomplete cloud user stay on the agent onboarding surface (no redirect loop)', async () => {
+      vi.stubEnv('NEXT_PUBLIC_GENFEED_CLOUD', 'true');
+      mockIncompleteUser();
+
+      const { default: proxy } = await import('./proxy');
+      const response = await proxy(
+        makeSignedInRequest('/acme/~/agent/onboarding'),
+        {} as never,
+      );
+
+      expect(response.headers.get('location')).toBeNull();
+    });
+
+    it('keeps self-hosted incomplete users on the classic wizard', async () => {
+      mockIncompleteUser();
+
+      const { default: proxy } = await import('./proxy');
+      const response = await proxy(
+        makeSignedInRequest('/acme/default/workspace/overview'),
+        {} as never,
+      );
+
+      expect(response.status).toBe(307);
+      expect(response.headers.get('location')).toBe(
+        'http://localhost:3000/onboarding',
+      );
+    });
+  });
+
   it('keeps completed users on workspace routing even when their only brand is seeded', async () => {
     fetchMock.mockImplementation(async (input: string | URL) => {
       const url = String(input);

--- a/apps/app/proxy.ts
+++ b/apps/app/proxy.ts
@@ -464,6 +464,34 @@ async function shouldRedirectSignedInUserToOnboarding(
   return !ONBOARDING_STEPS.every((step) => completedSteps.includes(step));
 }
 
+// Matches the org-scoped agent onboarding surface and its threaded children,
+// e.g. `/acme/~/agent/onboarding` and `/acme/~/agent/onboarding/<threadId>`.
+const AGENT_ONBOARDING_PATH_RE = /^\/[^/]+\/~\/agent\/onboarding(?:\/|$)/;
+
+function isAgentOnboardingPath(pathname: string): boolean {
+  return AGENT_ONBOARDING_PATH_RE.test(pathname);
+}
+
+// Resolve the org-scoped agent onboarding destination for an incomplete user.
+// Agent-first onboarding is the cloud default; callers fall back to the wizard
+// (`ONBOARDING_PATH`) when the workspace slug can't be resolved.
+async function resolveAgentOnboardingRedirect(
+  token: string,
+  cacheKey?: string | null,
+  req?: NextRequest,
+): Promise<{ cookieValue: string | null; path: string } | null> {
+  const resolution = await resolveActiveWorkspaceSlugs(token, cacheKey, req);
+  if (!resolution) {
+    return null;
+  }
+
+  const { cookieValue, slugs } = resolution;
+  return {
+    cookieValue,
+    path: `/${slugs.orgSlug}/~/agent/onboarding`,
+  };
+}
+
 type CanonicalResolution = {
   cookieValue: string | null;
   path: string;
@@ -610,6 +638,21 @@ async function redirectSignedInUserToDefaultRoute(
   cacheKey?: string | null,
 ): Promise<NextResponse | null> {
   if (await shouldRedirectSignedInUserToOnboarding(token)) {
+    if (isCloudDeployment()) {
+      const agentOnboarding = await resolveAgentOnboardingRedirect(
+        token,
+        cacheKey,
+        req,
+      );
+      if (agentOnboarding) {
+        const response = redirectDroppingSearch(req, agentOnboarding.path);
+        if (agentOnboarding.cookieValue) {
+          setSlugCookie(response, agentOnboarding.cookieValue);
+        }
+        return response;
+      }
+    }
+
     return redirectDroppingSearch(req, ONBOARDING_PATH);
   }
 
@@ -793,6 +836,30 @@ export async function proxy(req: NextRequest) {
     }
 
     if (await shouldRedirectSignedInUserToOnboarding(token)) {
+      // Self-hosted/desktop keep the form wizard; only cloud gets agent-first.
+      if (!isCloudDeployment()) {
+        return redirectPreservingSearch(req, ONBOARDING_PATH);
+      }
+
+      // The agent onboarding surface is itself a protected route — let it
+      // render instead of bouncing the user back to the wizard (redirect loop).
+      if (isAgentOnboardingPath(pathname)) {
+        return NextResponse.next();
+      }
+
+      const agentOnboarding = await resolveAgentOnboardingRedirect(
+        token,
+        sessionCookie,
+        req,
+      );
+      if (agentOnboarding) {
+        const response = redirectPreservingSearch(req, agentOnboarding.path);
+        if (agentOnboarding.cookieValue) {
+          setSlugCookie(response, agentOnboarding.cookieValue);
+        }
+        return response;
+      }
+
       return redirectPreservingSearch(req, ONBOARDING_PATH);
     }
 


### PR DESCRIPTION
## What & why

Makes the **agent workspace** the first page a new **cloud** Genfeed user sees after signup, replacing the 3-step form wizard (`brand → providers → summary`) as the default. The classic wizard remains reachable as an explicit fallback.

Closes #1639. Builds on #1421 (post-signup handoff). Relates to #1009 (agent app surface).

## Behaviour

| Deployment | New signup lands on |
|---|---|
| Cloud SaaS | `/{orgSlug}/~/agent/onboarding` (agent surface) |
| Self-hosted / desktop | `/onboarding/{step}` (wizard, unchanged) |

Deep links + resume also land on the agent surface on cloud — the routing is applied in the post-signup hook **and all three gate layers** (proxy, root resolver, org-landing).

## How

- **Post-signup routing hook** (`use-post-signup-routing.hook.ts`): the plain onboarding + manual-fallback destination resolves to the org-scoped agent surface on cloud (via `getMyOrganizations` → active org slug → `createOrganizationAppRoute`). Self-hosted/desktop keep the wizard.
- **Proxy** (`proxy.ts`): incomplete cloud users on any protected route are redirected to the agent surface; the agent onboarding path (`isAgentOnboardingPath`) is **exempted from the gate** so it renders instead of bouncing back to the wizard — this breaks the redirect loop, since the surface is itself a `(protected)` route. Both the login-entry redirect and the main protected redirect are updated, with the workspace slug cookie set on redirect.
- **Client gates** (`root-resolver-client.tsx`, `org-landing-content.tsx`): same cloud-gated routing.
- **Fallback link**: "Prefer a form? Use the classic setup" → `/onboarding` on the agent onboarding page.

## Completion signal — no new backend

Reuses the existing wiring: the agent flow's `completeOnboardingFlow` already `PATCH /users/me { isOnboardingCompleted: true }`, which cascades server-side (`users.controller.ts`) to set `onboardingStepsCompleted: ['brand','providers','summary']`. That satisfies every gate predicate, so completing onboarding via the agent flow behaves exactly like completing the wizard.

## Checkout handoff preserved (the #1421 regression zone)

The Stripe plan/credits handoff is kept **byte-identical**. The internal checkout-return base is split out as `resolveCheckoutReturnHref` (still the wizard success path); only the non-checkout destination moves to the agent surface. A regression test asserts the plan-checkout `successUrl` stays `/onboarding/brand?checkout=completed&checkoutKind=plan` **even on cloud**.

## Design decisions

- **Cloud-gated** behind `isCloudDeployment()` — bounds blast radius to the cloud SaaS audience and keeps self-hosted/desktop on the battle-tested wizard (the agent onboarding surface needs the managed orchestrator/LLM; the wizard does not).
- **Prerequisite:** the `agent` feature flag must be enabled in cloud (the agent layout is behind `FeatureGate flagKey="agent"`). It is on the shipped cloud surface today.

## Tests (colocated)

- `post-signup/page.behavior.test.tsx`: cloud → agent surface; fallback to wizard when no org slug; checkout base stays on wizard on cloud; existing self-hosted + checkout cases preserved.
- `proxy.test.ts`: incomplete cloud user → agent surface; **no-redirect-loop** when already on the surface; self-hosted → wizard.
- `root-resolver-client.test.tsx`, `org-landing-content.test.tsx`: cloud → agent surface.
- `agent/onboarding/page.spec.tsx`: renders shell + wizard fallback link.

## Verification

Per repo policy, local test/typecheck/build suites were not run — verified via unit-test coverage above + PR CI. Pre-commit gates (secretlint, raw-HTML/control-guard, Biome) passed.

## Review notes

- The fallback link is positioned top-right of the onboarding content (`absolute right-4 top-3`); worth a visual check in the preview that it doesn't collide with the agent header on narrow viewports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)