### PR TITLE
fix(agent): wire BrandCreateCard.onCreate and floating AgentPanel onOAuthConnect

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/~/agent/AgentWorkspaceLayoutClient.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/agent/AgentWorkspaceLayoutClient.tsx
@@ -1,27 +1,20 @@
 'use client';
 
-import { useBrand } from '@contexts/user/brand-context/brand-context';
 import {
   AgentApiService,
   useAgentChatStore,
   useAgentChatStream,
 } from '@genfeedai/agent';
 import { APP_ROUTES } from '@genfeedai/constants';
+import { useAgentOAuthConnect } from '@genfeedai/hooks/agent/use-agent-oauth-connect';
 import { useAuthIdentity } from '@genfeedai/hooks/auth/use-auth-identity/use-auth-identity';
 import {
   getPlaywrightAuthState,
   resolveAuthToken,
 } from '@helpers/auth/auth.helper';
 import { useOrgUrl } from '@hooks/navigation/use-org-url';
-import { logger } from '@services/core/logger.service';
-import { ServicesService } from '@services/external/services.service';
 import { UsersService } from '@services/organization/users.service';
-import {
-  useParams,
-  usePathname,
-  useRouter,
-  useSearchParams,
-} from 'next/navigation';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import {
   type PropsWithChildren,
   Suspense,
@@ -42,13 +35,11 @@ function AgentWorkspaceLayoutClientContent({ children }: PropsWithChildren) {
     () => normalizeProtectedPathname(rawPathname),
     [rawPathname],
   );
-  const params = useParams<{ id?: string; threadId?: string }>();
   const { replace } = useRouter();
   const { orgHref } = useOrgUrl();
   const searchParams = useSearchParams();
   const { getToken, isLoaded } = useAuthIdentity();
   const playwrightAuth = getPlaywrightAuthState();
-  const { selectedBrand } = useBrand();
   const activeThreadId = useAgentChatStore((s) => s.activeThreadId);
   const completedRef = useRef(false);
   const lastBootstrapKeyRef = useRef<string | null>(null);
@@ -64,12 +55,6 @@ function AgentWorkspaceLayoutClientContent({ children }: PropsWithChildren) {
   const isUnthreadedRoute = isOnboardingEntryRoute || isStandardNewRoute;
   const prefillPrompt = searchParams.get('prompt')?.trim() || '';
   const effectiveIsLoaded = isLoaded || playwrightAuth?.isLoaded === true;
-  const threadId =
-    typeof params.threadId === 'string' && params.threadId.length > 0
-      ? params.threadId
-      : typeof params.id === 'string' && params.id.length > 0
-        ? params.id
-        : undefined;
 
   const agentApiService = useMemo(
     () =>
@@ -102,37 +87,7 @@ function AgentWorkspaceLayoutClientContent({ children }: PropsWithChildren) {
     onOnboardingCompleted: completeOnboardingFlow,
   });
 
-  const handleOAuthConnect = useCallback(
-    async (platform: string) => {
-      try {
-        const token = await resolveAuthToken(getToken);
-        if (!token) {
-          return;
-        }
-
-        // Brand is optional for agent OAuth; uses active brand if available.
-        const service = new ServicesService(platform, token);
-        const credential = await service.postConnect({
-          ...(selectedBrand ? { brand: selectedBrand.id } : {}),
-        });
-        const returnTo = isOnboarding
-          ? threadId
-            ? orgHref(`${APP_ROUTES.AGENT.ONBOARDING}/${threadId}`)
-            : orgHref(APP_ROUTES.AGENT.ONBOARDING)
-          : threadId
-            ? orgHref(`${APP_ROUTES.AGENT.ROOT}/${threadId}`)
-            : orgHref(APP_ROUTES.AGENT.NEW);
-        const separator = credential.url.includes('?') ? '&' : '?';
-        window.open(
-          `${credential.url}${separator}return_to=${encodeURIComponent(returnTo)}`,
-          '_self',
-        );
-      } catch (error) {
-        logger.error('OAuth connect failed', error);
-      }
-    },
-    [getToken, isOnboarding, orgHref, selectedBrand, threadId],
-  );
+  const handleOAuthConnect = useAgentOAuthConnect({ isOnboarding });
 
   // Bootstrap the prefilled prompt only on unthreaded entry routes.
   useEffect(() => {

--- a/apps/app/app/(protected)/[orgSlug]/~/agent/AgentWorkspacePageShell.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/agent/AgentWorkspacePageShell.tsx
@@ -3,6 +3,7 @@
 import { AgentFullPage } from '@genfeedai/agent';
 import { isEEEnabled } from '@genfeedai/config/license';
 import { APP_ROUTES } from '@genfeedai/constants';
+import { useAgentBrandCreate } from '@genfeedai/hooks/agent/use-agent-brand-create';
 import { useAuthIdentity } from '@genfeedai/hooks/auth/use-auth-identity/use-auth-identity';
 import { resolveAuthToken } from '@helpers/auth/auth.helper';
 import { useOrgUrl } from '@hooks/navigation/use-org-url';
@@ -28,6 +29,7 @@ export function AgentWorkspacePageShell({
     completeOnboardingFlow,
     isOnboarding,
   } = useAgentWorkspace();
+  const handleBrandCreate = useAgentBrandCreate();
 
   const handleCreateFollowUpTasks = useCallback(
     async (taskId: string) => {
@@ -65,6 +67,7 @@ export function AgentWorkspacePageShell({
           );
         }}
         onOAuthConnect={handleOAuthConnect}
+        onBrandCreate={handleBrandCreate}
         onOnboardingCompleted={completeOnboardingFlow}
         onSelectCreditPack={(pack) => {
           push(

--- a/apps/app/packages/components/app-protected-layout.tsx
+++ b/apps/app/packages/components/app-protected-layout.tsx
@@ -160,6 +160,7 @@ function AppLayoutWithDynamicMenu({
     setConversationActions,
     handleNavigate,
     handleNavigateToBilling,
+    handleOAuthConnect,
     handleOpenCommandPalette,
     isLowCreditsBannerEnabled,
     isDesktopShell,
@@ -263,6 +264,7 @@ function AppLayoutWithDynamicMenu({
         authReady={isAuthReadyForAgentPanel}
         isActive={isAgentOpen}
         onNavigateToBilling={handleNavigateToBilling}
+        onOAuthConnect={handleOAuthConnect}
       />
     );
 

--- a/apps/app/packages/components/useAppProtectedLayout.ts
+++ b/apps/app/packages/components/useAppProtectedLayout.ts
@@ -28,6 +28,7 @@ import {
   APP_ROUTES,
   COMPOSE_ROUTES,
 } from '@genfeedai/constants';
+import { useAgentOAuthConnect } from '@genfeedai/hooks/agent/use-agent-oauth-connect';
 import type { AppContext } from '@genfeedai/interfaces';
 import type { MenuItemConfig } from '@genfeedai/interfaces/ui/menu-config.interface';
 import { resolveAuthToken } from '@helpers/auth/auth.helper';
@@ -352,6 +353,13 @@ export function useAppProtectedLayout(
   // Sync route context into the agent store
   useAgentPageContext(role);
 
+  // Shared with the dedicated /agent workspace page so the floating agent
+  // panel's oauth_connect_card actually connects (previously it received no
+  // handler and was a no-op outside /agent).
+  const handleOAuthConnect = useAgentOAuthConnect({
+    isOnboarding: isFocusedOnboardingRoute,
+  });
+
   const handleNavigateToBilling = useCallback(() => {
     push(orgHref(isEEEnabled() ? '/settings/billing' : '/settings/credits'));
   }, [push, orgHref]);
@@ -596,6 +604,7 @@ export function useAppProtectedLayout(
     // handlers
     handleNavigate,
     handleNavigateToBilling,
+    handleOAuthConnect,
     handleOpenCommandPalette,
     // banners
     isLowCreditsBannerEnabled,

--- a/packages/agent/src/components/AgentChatContainer.tsx
+++ b/packages/agent/src/components/AgentChatContainer.tsx
@@ -33,6 +33,10 @@ interface AgentChatContainerProps {
   onCopy?: (content: string) => void | Promise<void>;
   onRegenerate?: (message: AgentChatMessageType) => void | Promise<void>;
   onOAuthConnect?: (platform: string) => void;
+  onBrandCreate?: (payload: {
+    name: string;
+    description: string;
+  }) => void | Promise<void>;
   onCreateFollowUpTasks?: (taskId: string) => Promise<{ createdCount: number }>;
   onSelectCreditPack?: (pack: {
     label: string;
@@ -62,6 +66,7 @@ export function AgentChatContainer({
   onCopy,
   onRegenerate,
   onOAuthConnect,
+  onBrandCreate,
   onCreateFollowUpTasks,
   onSelectCreditPack,
   onSelectIngredient,
@@ -280,6 +285,7 @@ export function AgentChatContainer({
                   onRetry={handleRetry}
                   onRegenerate={onRegenerate}
                   onOAuthConnect={onOAuthConnect}
+                  onBrandCreate={onBrandCreate}
                   onSelectCreditPack={onSelectCreditPack}
                   onSelectIngredient={handleIngredientSelect}
                   onUiAction={handleUiAction}

--- a/packages/agent/src/components/AgentChatMessage.tsx
+++ b/packages/agent/src/components/AgentChatMessage.tsx
@@ -22,6 +22,10 @@ interface AgentChatMessageProps {
   onRetry?: (message: AgentChatMessageType) => void | Promise<void>;
   onRegenerate?: (message: AgentChatMessageType) => void | Promise<void>;
   onOAuthConnect?: (platform: string) => void;
+  onBrandCreate?: (payload: {
+    name: string;
+    description: string;
+  }) => void | Promise<void>;
   onSelectCreditPack?: (pack: {
     label: string;
     price: string;
@@ -73,6 +77,7 @@ export function AgentChatMessage({
   onRetry,
   onRegenerate,
   onOAuthConnect,
+  onBrandCreate,
   onSelectCreditPack,
   onSelectIngredient,
   onUiAction,
@@ -320,6 +325,7 @@ export function AgentChatMessage({
             apiService={apiService}
             onCopy={onCopy}
             onOAuthConnect={onOAuthConnect}
+            onBrandCreate={onBrandCreate}
             onRetry={onRetry ? () => onRetry(message) : undefined}
             onSelectCreditPack={onSelectCreditPack}
             onSelectIngredient={onSelectIngredient}
@@ -335,6 +341,7 @@ export function AgentChatMessage({
               apiService={apiService}
               onCopy={onCopy}
               onOAuthConnect={onOAuthConnect}
+              onBrandCreate={onBrandCreate}
               onRetry={onRetry ? () => onRetry(message) : undefined}
               onSelectCreditPack={onSelectCreditPack}
               onSelectIngredient={onSelectIngredient}

--- a/packages/agent/src/components/AgentChatTimeline.tsx
+++ b/packages/agent/src/components/AgentChatTimeline.tsx
@@ -26,6 +26,10 @@ type AgentChatTimelineProps = {
   onRetry: (message: AgentChatMessageType) => Promise<void>;
   onRegenerate?: (message: AgentChatMessageType) => void | Promise<void>;
   onOAuthConnect?: (platform: string) => void;
+  onBrandCreate?: (payload: {
+    name: string;
+    description: string;
+  }) => void | Promise<void>;
   onSelectCreditPack?: (pack: {
     label: string;
     price: string;
@@ -51,6 +55,7 @@ export function AgentChatTimeline({
   onRetry,
   onRegenerate,
   onOAuthConnect,
+  onBrandCreate,
   onSelectCreditPack,
   onSelectIngredient,
   onUiAction,
@@ -74,6 +79,7 @@ export function AgentChatTimeline({
                 onRetry={onRetry}
                 onRegenerate={onRegenerate}
                 onOAuthConnect={onOAuthConnect}
+                onBrandCreate={onBrandCreate}
                 onSelectCreditPack={onSelectCreditPack}
                 onSelectIngredient={onSelectIngredient}
                 onUiAction={onUiAction}
@@ -96,6 +102,7 @@ export function AgentChatTimeline({
             apiService={apiService}
             onCopy={onCopy}
             onOAuthConnect={onOAuthConnect}
+            onBrandCreate={onBrandCreate}
             onSelectCreditPack={onSelectCreditPack}
             onSelectIngredient={onSelectIngredient}
             onUiAction={onUiAction}

--- a/packages/agent/src/components/AgentFullPage.tsx
+++ b/packages/agent/src/components/AgentFullPage.tsx
@@ -24,6 +24,10 @@ interface AgentFullPageProps {
   onOnboardingCompleted?: () => void | Promise<void>;
   onCreateFollowUpTasks?: (taskId: string) => Promise<{ createdCount: number }>;
   onOAuthConnect?: (platform: string) => void;
+  onBrandCreate?: (payload: {
+    name: string;
+    description: string;
+  }) => void | Promise<void>;
   onOpenRunThread?: (threadId: string) => void;
   onSelectCreditPack?: (pack: {
     label: string;
@@ -44,6 +48,7 @@ export function AgentFullPage({
   onOnboardingCompleted,
   onCreateFollowUpTasks,
   onOAuthConnect,
+  onBrandCreate,
   onOpenRunThread,
   onSelectCreditPack,
   userRole,
@@ -134,6 +139,7 @@ export function AgentFullPage({
               onCreateFollowUpTasks={onCreateFollowUpTasks}
               onOnboardingCompleted={onOnboardingCompleted}
               onOAuthConnect={onOAuthConnect}
+              onBrandCreate={onBrandCreate}
               onSelectCreditPack={onSelectCreditPack}
               onboardingMode={onboardingMode}
               isWideLayout={!hasThreadOutputs}

--- a/packages/agent/src/components/BrandCreateCard.spec.tsx
+++ b/packages/agent/src/components/BrandCreateCard.spec.tsx
@@ -1,0 +1,70 @@
+import { BrandCreateCard } from '@genfeedai/agent/components/BrandCreateCard';
+import type { AgentUiAction } from '@genfeedai/agent/models/agent-chat.model';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+function makeAction(overrides: Partial<AgentUiAction> = {}): AgentUiAction {
+  return {
+    brandDescription: 'A tasty brand',
+    brandName: 'Acme',
+    id: 'brand-create-1',
+    title: 'Create Brand',
+    type: 'brand_create_card',
+    ...overrides,
+  } as AgentUiAction;
+}
+
+describe('BrandCreateCard', () => {
+  it('invokes onCreate with the form values and shows the created state on success', async () => {
+    const onCreate = vi.fn().mockResolvedValue(undefined);
+    render(<BrandCreateCard action={makeAction()} onCreate={onCreate} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /create brand/i }));
+    });
+
+    expect(onCreate).toHaveBeenCalledWith({
+      description: 'A tasty brand',
+      name: 'Acme',
+    });
+    await waitFor(() =>
+      expect(screen.getByText(/Brand .*Acme.* created/i)).toBeInTheDocument(),
+    );
+  });
+
+  it('surfaces an error and keeps the form editable when onCreate rejects', async () => {
+    const onCreate = vi.fn().mockRejectedValue(new Error('server down'));
+    render(<BrandCreateCard action={makeAction()} onCreate={onCreate} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /create brand/i }));
+    });
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        /could not create brand/i,
+      ),
+    );
+    // Form remains available for retry.
+    expect(screen.getByPlaceholderText('Enter brand name...')).toBeVisible();
+  });
+
+  it('disables the create action when the name is empty', () => {
+    render(
+      <BrandCreateCard
+        action={makeAction({ brandName: '' })}
+        onCreate={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByRole('button', { name: /create brand/i }),
+    ).toBeDisabled();
+  });
+});

--- a/packages/agent/src/components/BrandCreateCard.tsx
+++ b/packages/agent/src/components/BrandCreateCard.tsx
@@ -8,7 +8,10 @@ import { HiCheck, HiSparkles } from 'react-icons/hi2';
 
 interface BrandCreateCardProps {
   action: AgentUiAction;
-  onCreate?: (payload: { name: string; description: string }) => void;
+  onCreate?: (payload: {
+    name: string;
+    description: string;
+  }) => void | Promise<void>;
 }
 
 export function BrandCreateCard({
@@ -18,14 +21,26 @@ export function BrandCreateCard({
   const [name, setName] = useState(action.brandName ?? '');
   const [description, setDescription] = useState(action.brandDescription ?? '');
   const [isCreated, setIsCreated] = useState(false);
+  const [isCreating, setIsCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
-  const handleCreate = useCallback(() => {
-    if (!name.trim()) {
+  const handleCreate = useCallback(async () => {
+    if (!name.trim() || isCreating) {
       return;
     }
-    onCreate?.({ description, name });
-    setIsCreated(true);
-  }, [name, description, onCreate]);
+
+    setError(null);
+    setIsCreating(true);
+    try {
+      await onCreate?.({ description, name });
+      setIsCreated(true);
+    } catch {
+      // Keep the form editable so the user can retry after a failed create.
+      setError('Could not create brand. Please try again.');
+    } finally {
+      setIsCreating(false);
+    }
+  }, [name, description, isCreating, onCreate]);
 
   if (isCreated) {
     return (
@@ -90,15 +105,22 @@ export function BrandCreateCard({
         />
       </div>
 
+      {error && (
+        <p className="mb-3 text-xs text-red-600 dark:text-red-400" role="alert">
+          {error}
+        </p>
+      )}
+
       {/* Create button */}
       <Button
         variant={ButtonVariant.DEFAULT}
         onClick={handleCreate}
-        isDisabled={!name.trim()}
+        isDisabled={!name.trim() || isCreating}
+        isLoading={isCreating}
         icon={<HiSparkles className="size-4" />}
         className="w-full justify-center"
       >
-        Create Brand
+        {isCreating ? 'Creating…' : 'Create Brand'}
       </Button>
     </div>
   );

--- a/packages/agent/src/components/UiActionRenderer.spec.tsx
+++ b/packages/agent/src/components/UiActionRenderer.spec.tsx
@@ -1,0 +1,31 @@
+import { UiActionRenderer } from '@genfeedai/agent/components/UiActionRenderer';
+import type { AgentUiAction } from '@genfeedai/agent/models/agent-chat.model';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+const brandCreateProps = vi.fn();
+
+// Capture the props BrandCreateCard receives so we can assert the onCreate
+// handler is threaded all the way to the card (previously a dead wire).
+vi.mock('@genfeedai/agent/components/BrandCreateCard', () => ({
+  BrandCreateCard: (props: { onCreate?: unknown }) => {
+    brandCreateProps(props);
+    return <div data-testid="brand-create-card" />;
+  },
+}));
+
+describe('UiActionRenderer', () => {
+  it('forwards onBrandCreate to BrandCreateCard.onCreate for brand_create_card', () => {
+    const onBrandCreate = vi.fn();
+    const action = {
+      id: 'brand-create-1',
+      type: 'brand_create_card',
+    } as AgentUiAction;
+
+    render(<UiActionRenderer action={action} onBrandCreate={onBrandCreate} />);
+
+    expect(screen.getByTestId('brand-create-card')).toBeInTheDocument();
+    expect(brandCreateProps).toHaveBeenCalledTimes(1);
+    expect(brandCreateProps.mock.calls[0][0].onCreate).toBe(onBrandCreate);
+  });
+});

--- a/packages/agent/src/components/UiActionRenderer.tsx
+++ b/packages/agent/src/components/UiActionRenderer.tsx
@@ -50,6 +50,7 @@ export function UiActionRenderer({
   apiService,
   onCopy,
   onOAuthConnect,
+  onBrandCreate,
   onSelectCreditPack,
   onSelectIngredient,
   onRetry,
@@ -59,6 +60,10 @@ export function UiActionRenderer({
   apiService?: AgentApiService;
   onCopy?: (content: string) => void | Promise<void>;
   onOAuthConnect?: (platform: string) => void;
+  onBrandCreate?: (payload: {
+    name: string;
+    description: string;
+  }) => void | Promise<void>;
   onSelectCreditPack?: (pack: {
     label: string;
     price: string;
@@ -140,7 +145,7 @@ export function UiActionRenderer({
     case 'studio_handoff_card':
       return <StudioHandoffCard action={action} />;
     case 'brand_create_card':
-      return <BrandCreateCard action={action} />;
+      return <BrandCreateCard action={action} onCreate={onBrandCreate} />;
     case 'workflow_execute_card':
       return apiService ? (
         <WorkflowExecuteCard action={action} apiService={apiService} />

--- a/packages/hooks/agent/use-agent-brand-create/index.ts
+++ b/packages/hooks/agent/use-agent-brand-create/index.ts
@@ -1,0 +1,4 @@
+export {
+  type AgentBrandCreatePayload,
+  useAgentBrandCreate,
+} from '@hooks/agent/use-agent-brand-create/use-agent-brand-create';

--- a/packages/hooks/agent/use-agent-brand-create/use-agent-brand-create.test.ts
+++ b/packages/hooks/agent/use-agent-brand-create/use-agent-brand-create.test.ts
@@ -1,0 +1,79 @@
+import { useAgentBrandCreate } from '@hooks/agent/use-agent-brand-create/use-agent-brand-create';
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockPost = vi.fn();
+const mockRefreshBrands = vi.fn();
+const mockGetInstance = vi.fn(() => ({ post: mockPost }));
+
+vi.mock('@services/social/brands.service', () => ({
+  BrandsService: {
+    getInstance: (token: string) => mockGetInstance(token),
+  },
+}));
+
+// Identity constructor so we can assert on the payload passed to `post`.
+vi.mock('@models/organization/brand.model', () => ({
+  Brand: class {
+    constructor(data: Record<string, unknown>) {
+      Object.assign(this, data);
+    }
+  },
+}));
+
+vi.mock('@contexts/user/brand-context/brand-context', () => ({
+  useBrand: () => ({
+    organizationId: 'org-1',
+    refreshBrands: mockRefreshBrands,
+  }),
+}));
+
+vi.mock('@hooks/auth/use-authed-service/use-authed-service', () => ({
+  useAuthedService: (factory: (token: string) => unknown) => async () =>
+    factory('test-token'),
+}));
+
+describe('useAgentBrandCreate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPost.mockResolvedValue({ id: 'brand-1' });
+    mockRefreshBrands.mockResolvedValue(undefined);
+  });
+
+  it('creates a brand with the trimmed label/description and active org', async () => {
+    const { result } = renderHook(() => useAgentBrandCreate());
+
+    await act(async () => {
+      await result.current({ name: '  Acme  ', description: '  A brand  ' });
+    });
+
+    expect(mockGetInstance).toHaveBeenCalledWith('test-token');
+    expect(mockPost).toHaveBeenCalledTimes(1);
+    expect(mockPost.mock.calls[0][0]).toMatchObject({
+      description: 'A brand',
+      isDeleted: false,
+      isSelected: false,
+      label: 'Acme',
+      organizationId: 'org-1',
+    });
+    expect(mockRefreshBrands).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects and does not post when the name is blank', async () => {
+    const { result } = renderHook(() => useAgentBrandCreate());
+
+    await expect(
+      result.current({ name: '   ', description: 'x' }),
+    ).rejects.toThrow('Brand name is required.');
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it('propagates create failures to the caller', async () => {
+    mockPost.mockRejectedValueOnce(new Error('boom'));
+    const { result } = renderHook(() => useAgentBrandCreate());
+
+    await expect(
+      result.current({ name: 'Acme', description: '' }),
+    ).rejects.toThrow('boom');
+  });
+});

--- a/packages/hooks/agent/use-agent-brand-create/use-agent-brand-create.ts
+++ b/packages/hooks/agent/use-agent-brand-create/use-agent-brand-create.ts
@@ -1,0 +1,55 @@
+'use client';
+
+import { useBrand } from '@contexts/user/brand-context/brand-context';
+import type { IBrand } from '@genfeedai/interfaces';
+import { useAuthedService } from '@hooks/auth/use-authed-service/use-authed-service';
+import { Brand } from '@models/organization/brand.model';
+import { BrandsService } from '@services/social/brands.service';
+import { useCallback } from 'react';
+
+export interface AgentBrandCreatePayload {
+  name: string;
+  description: string;
+}
+
+/**
+ * Shared handler for the agent `brand_create_card`. Persists a brand
+ * server-side through {@link BrandsService} (mirroring the brand modal's
+ * `service.post(new Brand(...))` create path) and refreshes the brand context
+ * so the new brand is immediately selectable.
+ *
+ * Previously the card only flipped a local `isCreated` flag with no handler
+ * wired, so "Create Brand" in chat never created anything. The returned
+ * callback rejects on failure so the card can surface the error.
+ */
+export function useAgentBrandCreate(): (
+  payload: AgentBrandCreatePayload,
+) => Promise<void> {
+  const getBrandsService = useAuthedService((token: string) =>
+    BrandsService.getInstance(token),
+  );
+  const { organizationId, refreshBrands } = useBrand();
+
+  return useCallback(
+    async ({ name, description }: AgentBrandCreatePayload) => {
+      const trimmedName = name.trim();
+      if (!trimmedName) {
+        throw new Error('Brand name is required.');
+      }
+
+      const service = await getBrandsService();
+      await service.post(
+        new Brand({
+          description: description.trim(),
+          isDeleted: false,
+          isSelected: false,
+          label: trimmedName,
+          ...(organizationId ? { organizationId } : {}),
+        } as Partial<IBrand>),
+      );
+
+      await refreshBrands().catch(() => undefined);
+    },
+    [getBrandsService, organizationId, refreshBrands],
+  );
+}

--- a/packages/hooks/agent/use-agent-oauth-connect/index.ts
+++ b/packages/hooks/agent/use-agent-oauth-connect/index.ts
@@ -1,0 +1,1 @@
+export { useAgentOAuthConnect } from '@hooks/agent/use-agent-oauth-connect/use-agent-oauth-connect';

--- a/packages/hooks/agent/use-agent-oauth-connect/use-agent-oauth-connect.test.ts
+++ b/packages/hooks/agent/use-agent-oauth-connect/use-agent-oauth-connect.test.ts
@@ -1,0 +1,104 @@
+import { useAgentOAuthConnect } from '@hooks/agent/use-agent-oauth-connect/use-agent-oauth-connect';
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockPostConnect = vi.fn();
+const mockResolveAuthToken = vi.fn();
+const mockUseParams = vi.fn();
+let selectedBrand: { id: string } | undefined;
+
+vi.mock('@services/external/services.service', () => ({
+  ServicesService: class {
+    constructor(
+      public platform: string,
+      public token: string,
+    ) {}
+    postConnect(body: unknown) {
+      return mockPostConnect(this.platform, this.token, body);
+    }
+  },
+}));
+
+vi.mock('@services/core/logger.service', () => ({
+  logger: { error: vi.fn() },
+}));
+
+vi.mock('@contexts/user/brand-context/brand-context', () => ({
+  useBrand: () => ({ selectedBrand }),
+}));
+
+vi.mock('@helpers/auth/auth.helper', () => ({
+  resolveAuthToken: (...args: unknown[]) => mockResolveAuthToken(...args),
+}));
+
+vi.mock('@hooks/auth/use-auth-identity/use-auth-identity', () => ({
+  useAuthIdentity: () => ({ getToken: vi.fn() }),
+}));
+
+vi.mock('@hooks/navigation/use-org-url/use-org-url', () => ({
+  useOrgUrl: () => ({ orgHref: (path: string) => `/o${path}` }),
+}));
+
+vi.mock('next/navigation', () => ({
+  useParams: () => mockUseParams(),
+}));
+
+describe('useAgentOAuthConnect', () => {
+  const openSpy = vi
+    .spyOn(window, 'open')
+    .mockImplementation(() => null as unknown as Window);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    selectedBrand = undefined;
+    mockUseParams.mockReturnValue({});
+    mockResolveAuthToken.mockResolvedValue('token-abc');
+    mockPostConnect.mockResolvedValue({ url: 'https://provider.test/oauth' });
+  });
+
+  it('connects and redirects with a standard-agent return_to', async () => {
+    const { result } = renderHook(() => useAgentOAuthConnect());
+
+    await act(async () => {
+      await result.current('twitter');
+    });
+
+    expect(mockPostConnect).toHaveBeenCalledWith('twitter', 'token-abc', {});
+    expect(openSpy).toHaveBeenCalledWith(
+      `https://provider.test/oauth?return_to=${encodeURIComponent('/o/agent/new')}`,
+      '_self',
+    );
+  });
+
+  it('includes the active brand and threads the return_to when available', async () => {
+    selectedBrand = { id: 'brand-9' };
+    mockUseParams.mockReturnValue({ threadId: 'thread-5' });
+    const { result } = renderHook(() =>
+      useAgentOAuthConnect({ isOnboarding: true }),
+    );
+
+    await act(async () => {
+      await result.current('linkedin');
+    });
+
+    expect(mockPostConnect).toHaveBeenCalledWith('linkedin', 'token-abc', {
+      brand: 'brand-9',
+    });
+    expect(openSpy).toHaveBeenCalledWith(
+      `https://provider.test/oauth?return_to=${encodeURIComponent('/o/agent/onboarding/thread-5')}`,
+      '_self',
+    );
+  });
+
+  it('does nothing when no auth token is available', async () => {
+    mockResolveAuthToken.mockResolvedValue(null);
+    const { result } = renderHook(() => useAgentOAuthConnect());
+
+    await act(async () => {
+      await result.current('twitter');
+    });
+
+    expect(mockPostConnect).not.toHaveBeenCalled();
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/hooks/agent/use-agent-oauth-connect/use-agent-oauth-connect.ts
+++ b/packages/hooks/agent/use-agent-oauth-connect/use-agent-oauth-connect.ts
@@ -1,0 +1,83 @@
+'use client';
+
+import { useBrand } from '@contexts/user/brand-context/brand-context';
+import { APP_ROUTES } from '@genfeedai/constants';
+import { resolveAuthToken } from '@helpers/auth/auth.helper';
+import { useAuthIdentity } from '@hooks/auth/use-auth-identity/use-auth-identity';
+import { useOrgUrl } from '@hooks/navigation/use-org-url/use-org-url';
+import { logger } from '@services/core/logger.service';
+import { ServicesService } from '@services/external/services.service';
+import { useParams } from 'next/navigation';
+import { useCallback } from 'react';
+
+export interface UseAgentOAuthConnectOptions {
+  /**
+   * Whether the caller is on the agent onboarding surface. Callers pass their
+   * own route-normalized value — the raw pathname carries the `/[orgSlug]/~`
+   * prefix and can't be matched against `APP_ROUTES.AGENT.ONBOARDING` here.
+   * Controls whether `return_to` points back to the onboarding or standard
+   * agent route. Defaults to `false`.
+   */
+  isOnboarding?: boolean;
+}
+
+/**
+ * Shared handler for the agent `oauth_connect_card`. Kicks off a platform OAuth
+ * connect via {@link ServicesService} and redirects the tab to the provider's
+ * auth URL, appending a `return_to` that brings the user back to the agent
+ * surface they came from.
+ *
+ * Backs BOTH the dedicated `/agent` workspace page and the globally-mounted
+ * floating agent panel from one implementation — previously the panel received
+ * no handler, so the card was a no-op everywhere except `/agent`.
+ */
+export function useAgentOAuthConnect(
+  options: UseAgentOAuthConnectOptions = {},
+): (platform: string) => Promise<void> {
+  const { isOnboarding = false } = options;
+  const params = useParams<{ id?: string; threadId?: string }>();
+  const { orgHref } = useOrgUrl();
+  const { getToken } = useAuthIdentity();
+  const { selectedBrand } = useBrand();
+
+  // Route params are prefix-independent, so the active thread id resolves the
+  // same way from the workspace page and the floating panel.
+  const threadId =
+    typeof params.threadId === 'string' && params.threadId.length > 0
+      ? params.threadId
+      : typeof params.id === 'string' && params.id.length > 0
+        ? params.id
+        : undefined;
+
+  return useCallback(
+    async (platform: string) => {
+      try {
+        const token = await resolveAuthToken(getToken);
+        if (!token) {
+          return;
+        }
+
+        // Brand is optional for agent OAuth; uses active brand if available.
+        const service = new ServicesService(platform, token);
+        const credential = await service.postConnect({
+          ...(selectedBrand ? { brand: selectedBrand.id } : {}),
+        });
+        const returnTo = isOnboarding
+          ? threadId
+            ? orgHref(`${APP_ROUTES.AGENT.ONBOARDING}/${threadId}`)
+            : orgHref(APP_ROUTES.AGENT.ONBOARDING)
+          : threadId
+            ? orgHref(`${APP_ROUTES.AGENT.ROOT}/${threadId}`)
+            : orgHref(APP_ROUTES.AGENT.NEW);
+        const separator = credential.url.includes('?') ? '&' : '?';
+        window.open(
+          `${credential.url}${separator}return_to=${encodeURIComponent(returnTo)}`,
+          '_self',
+        );
+      } catch (error) {
+        logger.error('OAuth connect failed', error);
+      }
+    },
+    [getToken, isOnboarding, orgHref, selectedBrand, threadId],
+  );
+}

--- a/packages/pages/agent/agent-page-content.tsx
+++ b/packages/pages/agent/agent-page-content.tsx
@@ -3,6 +3,7 @@
 import { AgentApiService, AgentFullPage } from '@genfeedai/agent';
 import { isEEEnabled } from '@genfeedai/config/license';
 import { resolveAuthToken } from '@helpers/auth/auth.helper';
+import { useAgentBrandCreate } from '@hooks/agent/use-agent-brand-create';
 import { useAuthIdentity } from '@hooks/auth/use-auth-identity/use-auth-identity';
 import { useUserRole } from '@hooks/auth/use-user-role';
 import { useOrgUrl } from '@hooks/navigation/use-org-url';
@@ -26,6 +27,7 @@ export default function AgentPageContent({
   const { getToken } = useAuthIdentity();
   const userRole = useUserRole();
   const { orgHref } = useOrgUrl();
+  const handleBrandCreate = useAgentBrandCreate();
   const agentApiService = useMemo(
     () =>
       new AgentApiService({
@@ -61,6 +63,7 @@ export default function AgentPageContent({
         onboardingMode={onboardingMode}
         onOnboardingCompleted={onOnboardingCompleted}
         onOAuthConnect={onOAuthConnect}
+        onBrandCreate={handleBrandCreate}
         onSelectCreditPack={handleSelectCreditPack}
         onNavigateToBilling={handleNavigateToBilling}
         threadId={threadId}


### PR DESCRIPTION
## What & why

Fixes two dead wires in the agent chat cards where user actions silently no-op'd. Closes #1642.

### 1. `BrandCreateCard.onCreate` was never wired
`UiActionRenderer` rendered `<BrandCreateCard action={action} />` with no `onCreate`, so **Create Brand** in chat only flipped a local `isCreated` flag — nothing was persisted. The only `onCreate` ever passed was a test stub.

- New shared hook **`useAgentBrandCreate`** (`packages/hooks/agent/`) persists a brand via `BrandsService.post(new Brand(...))` + `refreshBrands()`, mirroring the brand modal's create path.
- `onBrandCreate` is threaded through the same chain as `onOAuthConnect`: `AgentFullPage → AgentChatContainer → AgentChatTimeline → AgentChatMessage → UiActionRenderer → BrandCreateCard`, wired from `AgentWorkspacePageShell` and the admin agent page content (`packages/pages/agent`).
- `BrandCreateCard` now reflects async **success / failure** (loading label, error + retry, created confirmation).

### 2. Floating agent panel never received `onOAuthConnect`
`app-protected-layout.tsx` declared `onOAuthConnect` on `AgentPanelProps` but the `<LazyAgentPanel>` render site never passed it, so `oauth_connect_card` was inert everywhere except `/agent` (which wires the handler locally).

- Extracted the working handler from `AgentWorkspaceLayoutClient` into a shared **`useAgentOAuthConnect`** hook (route-normalized `isOnboarding` passed in; thread id self-derived from route params).
- `AgentWorkspaceLayoutClient` and `useAppProtectedLayout` both consume the shared hook; the floating `LazyAgentPanel` now receives `onOAuthConnect` (consistent with the already-passed `onNavigateToBilling`).

## Tests
Colocated tests added:
- `useAgentOAuthConnect` — connect + `return_to` for standard/onboarding routes, brand pass-through, no-token short-circuit.
- `useAgentBrandCreate` — trimmed payload + org + refresh, blank-name rejection, failure propagation.
- `BrandCreateCard` — success/created state, error + retry, disabled-when-empty.
- `UiActionRenderer` — asserts `onBrandCreate` reaches `BrandCreateCard.onCreate` (guards the fixed wire).

## Verification
Per repo policy, local test/typecheck/build suites were **not** run on this machine — verification is via PR CI. Pre-commit gates (secretlint, UI control-guard, biome, no-bespoke-card) passed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
