### PR TITLE
feat(desktop): add safe asset protocol

### DIFF
--- a/apps/desktop/app/src/main.ts
+++ b/apps/desktop/app/src/main.ts
@@ -30,6 +30,10 @@ import {
 import { autoUpdater } from 'electron-updater';
 import { DesktopAppShellService } from './main/app-shell.service';
 import {
+  DesktopAssetProtocolService,
+  registerDesktopAssetScheme,
+} from './main/asset-protocol.service';
+import {
   buildDesktopFailureScreenUrl,
   buildDesktopLoadingScreenUrl,
   getDesktopBootBackground,
@@ -58,6 +62,8 @@ import { DesktopWorkspaceService } from './main/workspace.service';
 const configService = new DesktopConfigService();
 const environment = configService.getEnvironment();
 const mainDir = path.dirname(fileURLToPath(import.meta.url));
+
+registerDesktopAssetScheme();
 
 let mainWindow: BrowserWindow | null = null;
 let bootstrapCache: IDesktopBootstrap | null = null;
@@ -957,6 +963,7 @@ app.whenReady().then(async () => {
   syncService = new DesktopSyncService(prismaClient);
   await syncService.init();
   filesService = new DesktopFilesService(workspaceService, prismaClient);
+  new DesktopAssetProtocolService(filesService).register();
   terminalService = new DesktopTerminalService(workspaceService);
   generationService = new DesktopGenerationService(
     {

--- a/apps/desktop/app/src/main/asset-mime.util.ts
+++ b/apps/desktop/app/src/main/asset-mime.util.ts
@@ -1,0 +1,107 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const MIME_BY_EXTENSION: Record<string, string> = {
+  '.avif': 'image/avif',
+  '.gif': 'image/gif',
+  '.jpeg': 'image/jpeg',
+  '.jpg': 'image/jpeg',
+  '.mp3': 'audio/mpeg',
+  '.mp4': 'video/mp4',
+  '.pdf': 'application/pdf',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml',
+  '.wav': 'audio/wav',
+  '.webp': 'image/webp',
+};
+
+const ASSET_EXTENSION_BY_MIME: Record<string, string> = {
+  'image/avif': '.avif',
+  'image/gif': '.gif',
+  'image/jpeg': '.jpg',
+  'image/png': '.png',
+  'image/svg+xml': '.svg',
+  'image/webp': '.webp',
+};
+
+const startsWithBytes = (bytes: Buffer, signature: number[]): boolean =>
+  signature.every((value, index) => bytes[index] === value);
+
+const hasIsoBaseMediaBrand = (bytes: Buffer, brands: string[]): boolean =>
+  bytes.length >= 12 &&
+  bytes.toString('ascii', 4, 8) === 'ftyp' &&
+  brands.includes(bytes.toString('ascii', 8, 12));
+
+const isMimeSignatureValid = (bytes: Buffer, mimeType: string): boolean => {
+  switch (mimeType) {
+    case 'application/octet-stream':
+      return true;
+    case 'application/pdf':
+      return bytes.toString('ascii', 0, 5) === '%PDF-';
+    case 'audio/mpeg':
+      return (
+        bytes.toString('ascii', 0, 3) === 'ID3' ||
+        (bytes[0] === 0xff && (bytes[1] & 0xe0) === 0xe0)
+      );
+    case 'audio/wav':
+      return (
+        bytes.toString('ascii', 0, 4) === 'RIFF' &&
+        bytes.toString('ascii', 8, 12) === 'WAVE'
+      );
+    case 'image/avif':
+      return hasIsoBaseMediaBrand(bytes, ['avif', 'avis']);
+    case 'image/gif':
+      return ['GIF87a', 'GIF89a'].includes(bytes.toString('ascii', 0, 6));
+    case 'image/jpeg':
+      return startsWithBytes(bytes, [0xff, 0xd8, 0xff]);
+    case 'image/png':
+      return startsWithBytes(
+        bytes,
+        [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a],
+      );
+    case 'image/svg+xml': {
+      const source = bytes.toString('utf8').trimStart().toLowerCase();
+      return (
+        (source.startsWith('<svg') || source.startsWith('<?xml')) &&
+        !source.includes('<script') &&
+        !source.includes('<foreignobject') &&
+        !/\son[a-z]+\s*=/.test(source)
+      );
+    }
+    case 'image/webp':
+      return (
+        bytes.toString('ascii', 0, 4) === 'RIFF' &&
+        bytes.toString('ascii', 8, 12) === 'WEBP'
+      );
+    case 'video/mp4':
+      return bytes.length >= 12 && bytes.toString('ascii', 4, 8) === 'ftyp';
+    default:
+      return false;
+  }
+};
+
+export const inferDesktopAssetMimeType = (filePath: string): string =>
+  MIME_BY_EXTENSION[path.extname(filePath).toLowerCase()] ??
+  'application/octet-stream';
+
+export const extensionForDesktopAssetMimeType = (mimeType: string): string =>
+  ASSET_EXTENSION_BY_MIME[mimeType.toLowerCase()] ?? '.bin';
+
+export const validateDesktopAssetMimeType = async (
+  filePath: string,
+  mimeType: string,
+): Promise<boolean> => {
+  if (inferDesktopAssetMimeType(filePath) !== mimeType) {
+    return false;
+  }
+
+  const file = await fs.open(filePath, 'r');
+
+  try {
+    const bytes = Buffer.alloc(4096);
+    const { bytesRead } = await file.read(bytes, 0, bytes.length, 0);
+    return isMimeSignatureValid(bytes.subarray(0, bytesRead), mimeType);
+  } finally {
+    await file.close();
+  }
+};

--- a/apps/desktop/app/src/main/asset-protocol.service.test.ts
+++ b/apps/desktop/app/src/main/asset-protocol.service.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  electronMockState,
+  resetElectronMockState,
+} from './test-support/electron.mock';
+
+describe('DesktopAssetProtocolService', () => {
+  it('registers the privileged asset scheme and streams registered files', async () => {
+    resetElectronMockState();
+    const { DesktopAssetProtocolService, registerDesktopAssetScheme } =
+      await import('./asset-protocol.service');
+    const filesService = {
+      resolveLocalAssetFile: async () => ({
+        absolutePath: '/workspace/.genfeed/assets/example.png',
+        mimeType: 'image/png',
+      }),
+    };
+
+    registerDesktopAssetScheme();
+    new DesktopAssetProtocolService(filesService as never).register();
+
+    expect(electronMockState.protocol.privilegedSchemes).toEqual([
+      'genfeed-asset',
+    ]);
+    const handler = electronMockState.protocol.handlers.get('genfeed-asset');
+    expect(handler).toBeDefined();
+
+    const response = await handler?.(
+      new Request('genfeed-asset://local/asset-1'),
+    );
+    expect(response?.status).toBe(200);
+    expect(response?.headers.get('Content-Type')).toBe('image/png');
+    expect(response?.headers.get('X-Content-Type-Options')).toBe('nosniff');
+    expect(electronMockState.net.fetchRequests).toEqual([
+      'file:///workspace/.genfeed/assets/example.png',
+    ]);
+  });
+
+  it('does not resolve malformed or unknown asset URLs', async () => {
+    resetElectronMockState();
+    const { DesktopAssetProtocolService } = await import(
+      './asset-protocol.service'
+    );
+    let resolutionCount = 0;
+    const filesService = {
+      resolveLocalAssetFile: async () => {
+        resolutionCount += 1;
+        throw new Error('Unknown asset');
+      },
+    };
+    new DesktopAssetProtocolService(filesService as never).register();
+    const handler = electronMockState.protocol.handlers.get('genfeed-asset');
+
+    const traversalResponse = await handler?.(
+      new Request('genfeed-asset://local/%2E%2E%2Fprivate.png'),
+    );
+    const unknownResponse = await handler?.(
+      new Request('genfeed-asset://local/unknown-asset'),
+    );
+
+    expect(traversalResponse?.status).toBe(404);
+    expect(unknownResponse?.status).toBe(404);
+    expect(resolutionCount).toBe(1);
+    expect(electronMockState.net.fetchRequests).toEqual([]);
+  });
+});

--- a/apps/desktop/app/src/main/asset-protocol.service.ts
+++ b/apps/desktop/app/src/main/asset-protocol.service.ts
@@ -1,0 +1,72 @@
+import { pathToFileURL } from 'node:url';
+import {
+  DESKTOP_ASSET_PROTOCOL_SCHEME,
+  parseDesktopAssetUrl,
+} from '@genfeedai/desktop-contracts';
+import { net, protocol } from 'electron';
+import type { DesktopFilesService } from './files.service';
+
+const NOT_FOUND_RESPONSE = (): Response =>
+  new Response('Asset not found.', {
+    headers: {
+      'Cache-Control': 'no-store',
+      'Content-Type': 'text/plain; charset=utf-8',
+      'X-Content-Type-Options': 'nosniff',
+    },
+    status: 404,
+  });
+
+export function registerDesktopAssetScheme(): void {
+  protocol.registerSchemesAsPrivileged([
+    {
+      privileges: {
+        corsEnabled: true,
+        secure: true,
+        standard: true,
+        stream: true,
+        supportFetchAPI: true,
+      },
+      scheme: DESKTOP_ASSET_PROTOCOL_SCHEME,
+    },
+  ]);
+}
+
+export class DesktopAssetProtocolService {
+  constructor(private readonly filesService: DesktopFilesService) {}
+
+  register(): void {
+    protocol.handle(DESKTOP_ASSET_PROTOCOL_SCHEME, async (request) => {
+      const assetId = parseDesktopAssetUrl(request.url);
+
+      if (!assetId) {
+        return NOT_FOUND_RESPONSE();
+      }
+
+      try {
+        const asset = await this.filesService.resolveLocalAssetFile(assetId);
+        const range = request.headers.get('range');
+        const fileResponse = await net.fetch(
+          pathToFileURL(asset.absolutePath).toString(),
+          range ? { headers: { Range: range } } : undefined,
+        );
+
+        if (!fileResponse.ok) {
+          return NOT_FOUND_RESPONSE();
+        }
+
+        const headers = new Headers(fileResponse.headers);
+        headers.set('Cache-Control', 'private, max-age=60');
+        headers.set('Content-Type', asset.mimeType);
+        headers.set('X-Content-Type-Options', 'nosniff');
+
+        return new Response(fileResponse.body, {
+          headers,
+          status: fileResponse.status,
+          statusText: fileResponse.statusText,
+        });
+      } catch {
+        return NOT_FOUND_RESPONSE();
+      }
+    });
+  }
+}

--- a/apps/desktop/app/src/main/files.service.test.ts
+++ b/apps/desktop/app/src/main/files.service.test.ts
@@ -8,6 +8,10 @@ import {
 } from './test-support/electron.mock';
 import type { DesktopWorkspaceService } from './workspace.service';
 
+const PNG_BYTES = new Uint8Array([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+]);
+
 const createPrismaMock = () => {
   const assets = new Map<string, Record<string, unknown>>();
 
@@ -65,7 +69,7 @@ describe('DesktopFilesService', () => {
     );
 
     const asset = await service.writeGeneratedAsset({
-      bytes: new Uint8Array([1, 2, 3]),
+      bytes: PNG_BYTES,
       jobId: 'job-1',
       mimeType: 'image/png',
       model: 'black-forest-labs/flux-schnell',
@@ -81,19 +85,22 @@ describe('DesktopFilesService', () => {
       uploadPolicy: 'never',
       workspaceId: 'ws-1',
     });
-    expect(asset.localPath).toContain(
+    expect(asset.localPath).toBeUndefined();
+    const storedAsset = prisma.assets.get(asset.id);
+    const storedLocalPath = String(storedAsset?.localPath);
+    expect(storedLocalPath).toContain(
       path.join(
         '.genfeed',
         'assets',
         'replicate-black-forest-labs-flux-schnell-job-1.png',
       ),
     );
-    await expect(fs.readFile(asset.localPath ?? '')).resolves.toEqual(
-      Buffer.from([1, 2, 3]),
+    await expect(fs.readFile(storedLocalPath)).resolves.toEqual(
+      Buffer.from(PNG_BYTES),
     );
     await expect(service.listAssets('ws-1')).resolves.toHaveLength(1);
-    await expect(service.getAssetUrl(asset.id)).resolves.toContain(
-      encodeURIComponent(asset.originalFileName),
+    await expect(service.getAssetUrl(asset.id)).resolves.toBe(
+      `genfeed-asset://local/${asset.id}`,
     );
   });
 
@@ -110,18 +117,26 @@ describe('DesktopFilesService', () => {
       prisma as never,
     );
     const sourcePath = path.join(tmpDir, 'source.png');
-    await fs.writeFile(sourcePath, Buffer.from([1, 2, 3]));
+    await fs.writeFile(sourcePath, Buffer.from(PNG_BYTES));
 
     const [firstImport] = await service.importAssets('ws-1', [sourcePath]);
     const [secondImport] = await service.importAssets('ws-1', [sourcePath]);
 
-    expect(firstImport.localPath).not.toBe(secondImport.localPath);
+    expect(firstImport.localPath).toBeUndefined();
+    expect(secondImport.localPath).toBeUndefined();
     expect(secondImport.displayName).toBe('source-1.png');
-    await expect(fs.readFile(firstImport.localPath ?? '')).resolves.toEqual(
-      Buffer.from([1, 2, 3]),
+    const firstStoredPath = String(
+      prisma.assets.get(firstImport.id)?.localPath,
     );
-    await expect(fs.readFile(secondImport.localPath ?? '')).resolves.toEqual(
-      Buffer.from([1, 2, 3]),
+    const secondStoredPath = String(
+      prisma.assets.get(secondImport.id)?.localPath,
+    );
+    expect(firstStoredPath).not.toBe(secondStoredPath);
+    await expect(fs.readFile(firstStoredPath)).resolves.toEqual(
+      Buffer.from(PNG_BYTES),
+    );
+    await expect(fs.readFile(secondStoredPath)).resolves.toEqual(
+      Buffer.from(PNG_BYTES),
     );
   });
 
@@ -139,7 +154,7 @@ describe('DesktopFilesService', () => {
     );
 
     const asset = await service.writeGeneratedAsset({
-      bytes: new Uint8Array([4, 5, 6]),
+      bytes: PNG_BYTES,
       jobId: 'job-2',
       mimeType: 'image/png',
       model: 'flux',
@@ -149,6 +164,91 @@ describe('DesktopFilesService', () => {
 
     await service.revealAsset(asset.id);
 
-    expect(electronMockState.shell.revealedPaths).toEqual([asset.localPath]);
+    expect(electronMockState.shell.revealedPaths).toEqual([
+      prisma.assets.get(asset.id)?.localPath,
+    ]);
+  });
+
+  it('rejects registered asset paths outside the workspace asset directory', async () => {
+    const { DesktopFilesService } = await import('./files.service');
+    const prisma = createPrismaMock();
+    const workspaceService = {
+      getWorkspace: () => ({ path: tmpDir }),
+    };
+    const service = new DesktopFilesService(
+      workspaceService as DesktopWorkspaceService,
+      prisma as never,
+    );
+    const outsidePath = path.join(tmpDir, 'outside.png');
+    await fs.writeFile(outsidePath, Buffer.from(PNG_BYTES));
+    prisma.assets.set('escaping-asset', {
+      id: 'escaping-asset',
+      localPath: outsidePath,
+      mimeType: 'image/png',
+      workspaceId: 'ws-1',
+    });
+
+    await expect(service.getAssetUrl('escaping-asset')).rejects.toThrow(
+      'Path escapes workspace root',
+    );
+  });
+
+  it('rejects an asset directory symlink that escapes the workspace', async () => {
+    const { DesktopFilesService } = await import('./files.service');
+    const prisma = createPrismaMock();
+    const workspaceService = {
+      getWorkspace: () => ({ path: tmpDir }),
+    };
+    const service = new DesktopFilesService(
+      workspaceService as DesktopWorkspaceService,
+      prisma as never,
+    );
+    const outsideDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'genfeed-files-outside-'),
+    );
+    const outsidePath = path.join(outsideDir, 'outside.png');
+    await fs.writeFile(outsidePath, Buffer.from(PNG_BYTES));
+    await fs.mkdir(path.join(tmpDir, '.genfeed'), { recursive: true });
+    await fs.symlink(outsideDir, path.join(tmpDir, '.genfeed', 'assets'));
+    prisma.assets.set('symlink-asset', {
+      id: 'symlink-asset',
+      localPath: path.join(tmpDir, '.genfeed', 'assets', 'outside.png'),
+      mimeType: 'image/png',
+      workspaceId: 'ws-1',
+    });
+
+    try {
+      await expect(service.getAssetUrl('symlink-asset')).rejects.toThrow(
+        'Path escapes workspace root',
+      );
+    } finally {
+      await fs.rm(outsideDir, { force: true, recursive: true });
+    }
+  });
+
+  it('rejects assets whose bytes disagree with the registered MIME type', async () => {
+    const { DesktopFilesService } = await import('./files.service');
+    const prisma = createPrismaMock();
+    const workspaceService = {
+      getWorkspace: () => ({ path: tmpDir }),
+    };
+    const service = new DesktopFilesService(
+      workspaceService as DesktopWorkspaceService,
+      prisma as never,
+    );
+    const asset = await service.writeGeneratedAsset({
+      bytes: PNG_BYTES,
+      jobId: 'mime-mismatch',
+      mimeType: 'image/png',
+      model: 'flux',
+      provider: 'fal',
+      workspaceId: 'ws-1',
+    });
+    const storedAsset = prisma.assets.get(asset.id);
+    await fs.writeFile(String(storedAsset?.localPath), '<html>unsafe</html>');
+
+    await expect(service.getAssetUrl(asset.id)).rejects.toThrow(
+      'Local asset file type is invalid.',
+    );
   });
 });

--- a/apps/desktop/app/src/main/files.service.ts
+++ b/apps/desktop/app/src/main/files.service.ts
@@ -1,47 +1,28 @@
 import { createHash, randomUUID } from 'node:crypto';
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { pathToFileURL } from 'node:url';
 import type {
   DesktopAssetKind,
   DesktopAssetUploadPolicy,
   IDesktopAsset,
 } from '@genfeedai/desktop-contracts';
-import { buildWorkspaceAssetsDir } from '@genfeedai/desktop-core';
+import { buildDesktopAssetUrl } from '@genfeedai/desktop-contracts';
+import {
+  buildWorkspaceAssetsDir,
+  resolvePathInsideRoot,
+} from '@genfeedai/desktop-core';
 import type { PrismaClient } from '@genfeedai/desktop-prisma';
 import { dialog, shell } from 'electron';
+import {
+  extensionForDesktopAssetMimeType,
+  inferDesktopAssetMimeType,
+  validateDesktopAssetMimeType,
+} from './asset-mime.util';
 import { toDesktopAsset } from './desktop-asset.util';
 import { toIso } from './time.util';
 import type { DesktopWorkspaceService } from './workspace.service';
 
 const LOCAL_ORGANIZATION_ID = 'local-org';
-
-const MIME_BY_EXTENSION: Record<string, string> = {
-  '.avif': 'image/avif',
-  '.gif': 'image/gif',
-  '.jpeg': 'image/jpeg',
-  '.jpg': 'image/jpeg',
-  '.mp3': 'audio/mpeg',
-  '.mp4': 'video/mp4',
-  '.pdf': 'application/pdf',
-  '.png': 'image/png',
-  '.svg': 'image/svg+xml',
-  '.wav': 'audio/wav',
-  '.webp': 'image/webp',
-};
-
-const ASSET_EXTENSION_BY_MIME: Record<string, string> = {
-  'image/avif': '.avif',
-  'image/gif': '.gif',
-  'image/jpeg': '.jpg',
-  'image/png': '.png',
-  'image/svg+xml': '.svg',
-  'image/webp': '.webp',
-};
-
-const inferMimeType = (filePath: string): string =>
-  MIME_BY_EXTENSION[path.extname(filePath).toLowerCase()] ??
-  'application/octet-stream';
 
 const inferAssetKind = (mimeType: string): DesktopAssetKind => {
   if (mimeType.startsWith('image/')) return 'image';
@@ -49,9 +30,6 @@ const inferAssetKind = (mimeType: string): DesktopAssetKind => {
   if (mimeType.startsWith('audio/')) return 'audio';
   return 'document';
 };
-
-const extensionForMimeType = (mimeType: string): string =>
-  ASSET_EXTENSION_BY_MIME[mimeType.toLowerCase()] ?? '.bin';
 
 const sanitizeFilenamePart = (value: string): string =>
   value
@@ -67,6 +45,16 @@ const pathExists = async (targetPath: string): Promise<boolean> => {
   } catch {
     return false;
   }
+};
+
+const toRendererAsset = (asset: IDesktopAsset): IDesktopAsset => {
+  const { localPath: _localPath, ...rendererAsset } = asset;
+  return rendererAsset;
+};
+
+export type ResolvedDesktopAssetFile = {
+  absolutePath: string;
+  mimeType: string;
 };
 
 export interface GeneratedAssetWriteOptions {
@@ -146,7 +134,7 @@ export class DesktopFilesService {
         await this.registerAsset({
           displayName: targetFileName,
           localPath: targetPath,
-          mimeType: inferMimeType(targetPath),
+          mimeType: inferDesktopAssetMimeType(targetPath),
           origin: 'local-import',
           originalFileName: fileName,
           uploadPolicy: 'never',
@@ -197,17 +185,50 @@ export class DesktopFilesService {
   }
 
   async getAssetUrl(assetId: string): Promise<string> {
+    await this.resolveLocalAssetFile(assetId);
+    return buildDesktopAssetUrl(assetId);
+  }
+
+  async resolveLocalAssetFile(
+    assetId: string,
+  ): Promise<ResolvedDesktopAssetFile> {
     const asset = await this.prisma.desktopAsset.findUnique({
       where: {
         id: assetId,
       },
     });
 
-    if (!asset?.localPath) {
+    if (!asset?.localPath || !asset.workspaceId) {
       throw new Error('Local asset file is not available.');
     }
 
-    return pathToFileURL(asset.localPath).toString();
+    const workspace = this.workspaceService.getWorkspace(asset.workspaceId);
+    const assetsRoot = buildWorkspaceAssetsDir(workspace.path);
+    const absolutePath = resolvePathInsideRoot(assetsRoot, asset.localPath);
+    const [realWorkspaceRoot, realAssetsRoot, realAssetPath] =
+      await Promise.all([
+        fs.realpath(workspace.path),
+        fs.realpath(assetsRoot),
+        fs.realpath(absolutePath),
+      ]);
+    resolvePathInsideRoot(realWorkspaceRoot, realAssetsRoot);
+    resolvePathInsideRoot(realAssetsRoot, realAssetPath);
+
+    const stats = await fs.stat(realAssetPath);
+    if (
+      !stats.isFile() ||
+      !(await validateDesktopAssetMimeType(realAssetPath, asset.mimeType))
+    ) {
+      throw new Error('Local asset file type is invalid.');
+    }
+
+    return {
+      absolutePath: realAssetPath,
+      mimeType:
+        asset.mimeType === 'image/svg+xml'
+          ? 'application/octet-stream'
+          : asset.mimeType,
+    };
   }
 
   async listAssets(workspaceId?: string): Promise<IDesktopAsset[]> {
@@ -222,7 +243,7 @@ export class DesktopFilesService {
         : undefined,
     });
 
-    return rows.map(toDesktopAsset);
+    return rows.map((row) => toRendererAsset(toDesktopAsset(row)));
   }
 
   async writeGeneratedAsset(
@@ -232,7 +253,7 @@ export class DesktopFilesService {
     const targetDirectory = buildWorkspaceAssetsDir(workspace.path);
     await fs.mkdir(targetDirectory, { recursive: true });
 
-    const extension = extensionForMimeType(options.mimeType);
+    const extension = extensionForDesktopAssetMimeType(options.mimeType);
     const filename = `${sanitizeFilenamePart(options.provider)}-${sanitizeFilenamePart(options.model)}-${options.jobId}${extension}`;
     const targetPath = path.join(targetDirectory, filename);
     await fs.writeFile(targetPath, Buffer.from(options.bytes));
@@ -307,6 +328,6 @@ export class DesktopFilesService {
       },
     });
 
-    return toDesktopAsset(row);
+    return toRendererAsset(toDesktopAsset(row));
   }
 }

--- a/apps/desktop/app/src/main/test-support/electron.mock.ts
+++ b/apps/desktop/app/src/main/test-support/electron.mock.ts
@@ -28,7 +28,18 @@ export const electronMockState = {
   },
   protocol: {
     handledSchemes: [] as string[],
+    handlers: new Map<
+      string,
+      (request: Request) => Promise<Response> | Response
+    >(),
     privilegedSchemes: [] as string[],
+  },
+  net: {
+    fetchRequests: [] as string[],
+    response: new Response(new Uint8Array([1, 2, 3]), {
+      headers: { 'Content-Type': 'application/octet-stream' },
+      status: 200,
+    }),
   },
   safeStorage: {
     decryptString: (buffer: Buffer) => buffer.toString('utf8'),
@@ -64,7 +75,13 @@ export const resetElectronMockState = (): void => {
   };
   electronMockState.menu.applicationMenu = null;
   electronMockState.protocol.handledSchemes = [];
+  electronMockState.protocol.handlers.clear();
   electronMockState.protocol.privilegedSchemes = [];
+  electronMockState.net.fetchRequests = [];
+  electronMockState.net.response = new Response(new Uint8Array([1, 2, 3]), {
+    headers: { 'Content-Type': 'application/octet-stream' },
+    status: 200,
+  });
   electronMockState.shell.externalUrls = [];
   electronMockState.shell.revealedPaths = [];
   electronMockState.shortcuts.registered = [];
@@ -132,13 +149,23 @@ mock.module('electron', () => ({
   },
   safeStorage: electronMockState.safeStorage,
   protocol: {
-    handle: (scheme: string) => {
+    handle: (
+      scheme: string,
+      handler: (request: Request) => Promise<Response> | Response,
+    ) => {
       electronMockState.protocol.handledSchemes.push(scheme);
+      electronMockState.protocol.handlers.set(scheme, handler);
     },
     registerSchemesAsPrivileged: (schemes: Array<{ scheme: string }>) => {
       electronMockState.protocol.privilegedSchemes.push(
         ...schemes.map(({ scheme }) => scheme),
       );
+    },
+  },
+  net: {
+    fetch: async (targetUrl: string) => {
+      electronMockState.net.fetchRequests.push(targetUrl);
+      return electronMockState.net.response;
     },
   },
   shell: {

--- a/apps/desktop/app/src/renderer/asset-url.util.test.ts
+++ b/apps/desktop/app/src/renderer/asset-url.util.test.ts
@@ -1,0 +1,51 @@
+import type { IDesktopAsset } from '@genfeedai/desktop-contracts';
+import { describe, expect, it } from 'vitest';
+import { hasLocalAssetCopy, resolveDesktopAssetUrl } from './asset-url.util';
+
+const buildAsset = (residency: IDesktopAsset['residency']): IDesktopAsset => ({
+  createdAt: '2026-07-13T00:00:00.000Z',
+  displayName: 'Example',
+  id: 'asset-1',
+  kind: 'image',
+  mimeType: 'image/png',
+  organizationId: 'local-org',
+  origin: 'local-import',
+  originalFileName: 'example.png',
+  residency,
+  sha256: 'abc123',
+  sizeBytes: 3,
+  updatedAt: '2026-07-13T00:00:00.000Z',
+  uploadPolicy: 'never',
+  workspaceId: 'workspace-1',
+});
+
+describe('desktop asset URL resolution', () => {
+  it('uses the opaque protocol for assets with a local copy', () => {
+    const asset = buildAsset('local-only');
+
+    expect(hasLocalAssetCopy(asset)).toBe(true);
+    expect(resolveDesktopAssetUrl(asset)).toBe('genfeed-asset://local/asset-1');
+  });
+
+  it('uses a signed cloud URL when no local copy exists', () => {
+    const asset = buildAsset('cloud-only');
+
+    expect(hasLocalAssetCopy(asset)).toBe(false);
+    expect(
+      resolveDesktopAssetUrl(
+        asset,
+        'https://cdn.genfeed.ai/signed/example.png?token=secret',
+      ),
+    ).toBe('https://cdn.genfeed.ai/signed/example.png?token=secret');
+  });
+
+  it('does not expose file URLs as cloud fallbacks', () => {
+    expect(resolveDesktopAssetUrl(buildAsset('missing-local'))).toBeNull();
+    expect(
+      resolveDesktopAssetUrl(
+        buildAsset('cloud-only'),
+        'file:///tmp/private.png',
+      ),
+    ).toBeNull();
+  });
+});

--- a/apps/desktop/app/src/renderer/asset-url.util.ts
+++ b/apps/desktop/app/src/renderer/asset-url.util.ts
@@ -1,0 +1,32 @@
+import type { IDesktopAsset } from '@genfeedai/desktop-contracts';
+import { buildDesktopAssetUrl } from '@genfeedai/desktop-contracts';
+
+const LOCAL_ASSET_RESIDENCIES = new Set<IDesktopAsset['residency']>([
+  'local-only',
+  'synced',
+  'upload-pending',
+]);
+
+const isHttpUrl = (value: string): boolean => {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'https:' || url.protocol === 'http:';
+  } catch {
+    return false;
+  }
+};
+
+export function hasLocalAssetCopy(asset: IDesktopAsset): boolean {
+  return LOCAL_ASSET_RESIDENCIES.has(asset.residency);
+}
+
+export function resolveDesktopAssetUrl(
+  asset: IDesktopAsset,
+  signedCloudUrl?: string,
+): string | null {
+  if (hasLocalAssetCopy(asset)) {
+    return buildDesktopAssetUrl(asset.id);
+  }
+
+  return signedCloudUrl && isHttpUrl(signedCloudUrl) ? signedCloudUrl : null;
+}

--- a/apps/desktop/app/src/renderer/styles.css
+++ b/apps/desktop/app/src/renderer/styles.css
@@ -1516,6 +1516,29 @@ textarea {
   gap: 10px;
 }
 
+.asset-preview {
+  align-items: center;
+  aspect-ratio: 16 / 9;
+  background: var(--tertiary);
+  border-radius: var(--radius-lg);
+  display: flex;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.asset-preview-image {
+  height: 100%;
+  object-fit: contain;
+  width: 100%;
+}
+
+.asset-preview-unavailable {
+  color: var(--muted);
+  font-size: 12px;
+  padding: 12px;
+  text-align: center;
+}
+
 .ingredient-header {
   align-items: center;
   display: flex;

--- a/apps/desktop/app/src/renderer/views/LibraryAssetGrid.tsx
+++ b/apps/desktop/app/src/renderer/views/LibraryAssetGrid.tsx
@@ -3,6 +3,8 @@ import { ButtonVariant } from '@genfeedai/enums';
 import { Button } from '@ui/primitives/button';
 import type { ReactElement } from 'react';
 import { HiOutlineFolderOpen } from 'react-icons/hi2';
+import { hasLocalAssetCopy } from '../asset-url.util';
+import { LibraryAssetPreview } from './LibraryAssetPreview';
 
 type LibraryAssetGridProps = {
   assets: IDesktopAsset[];
@@ -19,6 +21,7 @@ export function LibraryAssetGrid({
     <div className="ingredient-grid">
       {assets.map((asset) => (
         <div className="ingredient-card panel-card" key={asset.id}>
+          <LibraryAssetPreview asset={asset} />
           <div className="ingredient-header">
             <strong className="ingredient-title">{asset.displayName}</strong>
             <span className="platform-badge">{asset.residency}</span>
@@ -30,7 +33,7 @@ export function LibraryAssetGrid({
             <span className="vote-count">
               {Math.round(asset.sizeBytes / 1024)} KB
             </span>
-            {asset.localPath && (
+            {hasLocalAssetCopy(asset) && (
               <Button
                 ariaLabel={`Show ${asset.displayName} in Finder`}
                 className="asset-card-action"

--- a/apps/desktop/app/src/renderer/views/LibraryAssetPreview.test.tsx
+++ b/apps/desktop/app/src/renderer/views/LibraryAssetPreview.test.tsx
@@ -1,0 +1,48 @@
+import type { IDesktopAsset } from '@genfeedai/desktop-contracts';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { LibraryAssetPreview } from './LibraryAssetPreview';
+
+const asset: IDesktopAsset = {
+  createdAt: '2026-07-13T00:00:00.000Z',
+  displayName: 'Example asset',
+  id: 'asset-1',
+  kind: 'image',
+  mimeType: 'image/png',
+  organizationId: 'local-org',
+  origin: 'local-import',
+  originalFileName: 'example.png',
+  residency: 'local-only',
+  sha256: 'abc123',
+  sizeBytes: 3,
+  updatedAt: '2026-07-13T00:00:00.000Z',
+  uploadPolicy: 'never',
+  workspaceId: 'workspace-1',
+};
+
+describe('LibraryAssetPreview', () => {
+  it('renders local images through the safe asset protocol', () => {
+    render(<LibraryAssetPreview asset={asset} />);
+
+    expect(screen.getByRole('img', { name: 'Example asset' })).toHaveAttribute(
+      'src',
+      'genfeed-asset://local/asset-1',
+    );
+  });
+
+  it('renders a clear missing-local state', () => {
+    render(
+      <LibraryAssetPreview asset={{ ...asset, residency: 'missing-local' }} />,
+    );
+
+    expect(screen.getByRole('status')).toHaveTextContent('Local file missing');
+  });
+
+  it('switches to the missing-local state when a registered file is gone', () => {
+    render(<LibraryAssetPreview asset={asset} />);
+
+    fireEvent.error(screen.getByRole('img', { name: 'Example asset' }));
+
+    expect(screen.getByRole('status')).toHaveTextContent('Local file missing');
+  });
+});

--- a/apps/desktop/app/src/renderer/views/LibraryAssetPreview.tsx
+++ b/apps/desktop/app/src/renderer/views/LibraryAssetPreview.tsx
@@ -1,0 +1,45 @@
+import type { IDesktopAsset } from '@genfeedai/desktop-contracts';
+import { useState } from 'react';
+import { hasLocalAssetCopy, resolveDesktopAssetUrl } from '../asset-url.util';
+
+type LibraryAssetPreviewProps = {
+  asset: IDesktopAsset;
+  signedCloudUrl?: string;
+};
+
+export function LibraryAssetPreview({
+  asset,
+  signedCloudUrl,
+}: LibraryAssetPreviewProps) {
+  const [failedPreviewUrl, setFailedPreviewUrl] = useState<string | null>(null);
+  const previewUrl = resolveDesktopAssetUrl(asset, signedCloudUrl);
+  const hasLoadError = previewUrl !== null && failedPreviewUrl === previewUrl;
+
+  if (!previewUrl || hasLoadError || asset.kind !== 'image') {
+    const message =
+      asset.residency === 'missing-local' ||
+      (hasLoadError && hasLocalAssetCopy(asset))
+        ? 'Local file missing'
+        : asset.residency === 'cloud-only'
+          ? 'Cloud preview unavailable offline'
+          : 'Preview unavailable';
+
+    return (
+      <div className="asset-preview asset-preview-unavailable" role="status">
+        {message}
+      </div>
+    );
+  }
+
+  return (
+    <div className="asset-preview">
+      <img
+        alt={asset.displayName}
+        className="asset-preview-image"
+        loading="lazy"
+        onError={() => setFailedPreviewUrl(previewUrl)}
+        src={previewUrl}
+      />
+    </div>
+  );
+}

--- a/apps/desktop/app/src/shared/desktop-contracts.test.ts
+++ b/apps/desktop/app/src/shared/desktop-contracts.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'bun:test';
-import { DESKTOP_IPC_CHANNELS } from '@genfeedai/desktop-contracts';
+import {
+  buildDesktopAssetUrl,
+  DESKTOP_IPC_CHANNELS,
+  parseDesktopAssetUrl,
+} from '@genfeedai/desktop-contracts';
 import {
   buildWorkspaceAssetsDir,
   buildWorkspaceDraftsPath,
@@ -43,6 +47,27 @@ describe('desktop shared packages', () => {
   it('builds the workspace assets directory in a shared utility', () => {
     expect(buildWorkspaceAssetsDir('/tmp/workspace')).toBe(
       '/tmp/workspace/.genfeed/assets',
+    );
+  });
+
+  it('round-trips opaque desktop asset protocol URLs', () => {
+    const assetUrl = buildDesktopAssetUrl('asset_123-abc');
+
+    expect(assetUrl).toBe('genfeed-asset://local/asset_123-abc');
+    expect(parseDesktopAssetUrl(assetUrl)).toBe('asset_123-abc');
+  });
+
+  it('rejects malformed desktop asset protocol URLs', () => {
+    expect(parseDesktopAssetUrl('file:///tmp/private.png')).toBeNull();
+    expect(
+      parseDesktopAssetUrl('genfeed-asset://local/%2E%2E%2Fprivate.png'),
+    ).toBeNull();
+    expect(parseDesktopAssetUrl('genfeed-asset://remote/asset-1')).toBeNull();
+    expect(
+      parseDesktopAssetUrl('genfeed-asset://user@local/asset-1'),
+    ).toBeNull();
+    expect(() => buildDesktopAssetUrl('../private.png')).toThrow(
+      'Invalid desktop asset id.',
     );
   });
 

--- a/packages/desktop-contracts/src/index.ts
+++ b/packages/desktop-contracts/src/index.ts
@@ -1,5 +1,43 @@
 /* ─── Desktop IPC Channel Names ─── */
 
+export const DESKTOP_ASSET_PROTOCOL_HOST = 'local';
+export const DESKTOP_ASSET_PROTOCOL_SCHEME = 'genfeed-asset';
+
+const DESKTOP_ASSET_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
+
+export function buildDesktopAssetUrl(assetId: string): string {
+  if (!DESKTOP_ASSET_ID_PATTERN.test(assetId)) {
+    throw new Error('Invalid desktop asset id.');
+  }
+
+  return `${DESKTOP_ASSET_PROTOCOL_SCHEME}://${DESKTOP_ASSET_PROTOCOL_HOST}/${encodeURIComponent(assetId)}`;
+}
+
+export function parseDesktopAssetUrl(rawUrl: string): string | null {
+  try {
+    const url = new URL(rawUrl);
+    const assetId = decodeURIComponent(url.pathname.slice(1));
+
+    if (
+      url.protocol !== `${DESKTOP_ASSET_PROTOCOL_SCHEME}:` ||
+      url.hostname !== DESKTOP_ASSET_PROTOCOL_HOST ||
+      url.username.length > 0 ||
+      url.password.length > 0 ||
+      url.port.length > 0 ||
+      url.search.length > 0 ||
+      url.hash.length > 0 ||
+      url.pathname.slice(1).includes('/') ||
+      !DESKTOP_ASSET_ID_PATTERN.test(assetId)
+    ) {
+      return null;
+    }
+
+    return assetId;
+  } catch {
+    return null;
+  }
+}
+
 export const DESKTOP_IPC_CHANNELS = {
   appBootstrap: 'desktop:app:bootstrap',
   appEnableOfflineMode: 'desktop:app:enableOfflineMode',


### PR DESCRIPTION
## Summary

- register a privileged `genfeed-asset://local/<assetId>` Electron protocol before app readiness and stream registered files through the main process
- resolve asset IDs through the desktop asset registry with workspace and symlink containment, file signature/MIME validation, range forwarding, and `nosniff` responses
- stop returning raw local paths or `file://` URLs to the renderer
- render local image previews in the desktop library and show explicit missing-local/cloud-unavailable states
- add a renderer URL helper that prefers the local protocol and accepts only HTTP(S) signed cloud fallbacks

## Verification

Passed locally:
- `bun run --cwd apps/desktop/app lint`
- `bun run check:ui-guards`
- `bun run design:lint` (0 errors; 9 existing unused-token warnings)
- touched-file Secretlint
- `git diff --check origin/master..HEAD`
- pre-commit Secretlint, Biome, raw-control, and bespoke-card guards

Not run locally per workstation policy:
- desktop tests
- typecheck
- build / Electron smoke test

PR CI is the handoff for those broader checks. The remaining risk is runtime verification of the custom protocol in packaged Electron, which CI/smoke coverage must confirm.

Closes #320