### PR TITLE
fix(stripe): isolate lifecycle email failures

### DIFF
--- a/apps/server/api/src/endpoints/webhooks/stripe/handlers/stripe-subscription-webhook.handler.spec.ts
+++ b/apps/server/api/src/endpoints/webhooks/stripe/handlers/stripe-subscription-webhook.handler.spec.ts
@@ -244,6 +244,38 @@ describe('StripeSubscriptionWebhookHandler', () => {
       ).not.toHaveBeenCalled();
     });
 
+    it('keeps deletion successful when lifecycle recording fails', async () => {
+      subscriptionsService.findOne.mockResolvedValue(dbSubscription);
+      subscriptionsService.patch.mockResolvedValue(dbSubscription);
+      usersService.findOne.mockResolvedValue({ id: 'user_1' });
+      lifecycleEmailService.recordSubscriptionLapsed.mockRejectedValueOnce(
+        new Error('lifecycle unavailable'),
+      );
+
+      await handler.handleSubscriptionDeleted(stripeSubscription(), 'test');
+
+      expect(loggerService.warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'lifecycle email subscription-lapsed recording skipped',
+        ),
+        {
+          error: 'lifecycle unavailable',
+          subscriptionId: 'sub_stripe_1',
+        },
+      );
+      expect(loggerService.log).toHaveBeenCalledWith(
+        expect.stringContaining('subscription deleted successfully'),
+        {
+          organizationId: 'org_1',
+          stripeSubscriptionId: 'sub_stripe_1',
+        },
+      );
+      expect(loggerService.error).not.toHaveBeenCalledWith(
+        expect.stringContaining('failed to handle subscription deleted'),
+        expect.anything(),
+      );
+    });
+
     it('warns when the subscription is unknown', async () => {
       subscriptionsService.findOne.mockResolvedValue(null);
 

--- a/apps/server/api/src/endpoints/webhooks/stripe/handlers/stripe-subscription-webhook.handler.ts
+++ b/apps/server/api/src/endpoints/webhooks/stripe/handlers/stripe-subscription-webhook.handler.ts
@@ -268,11 +268,21 @@ export class StripeSubscriptionWebhookHandler {
         await this.supportService.invalidateUserCaches(userId);
       }
 
-      await this.lifecycleEmailService.recordSubscriptionLapsed({
-        organizationId: String(existingSubscription.organization),
-        subscriptionId: subscription.id,
-        userId: String(existingSubscription.user),
-      });
+      try {
+        await this.lifecycleEmailService.recordSubscriptionLapsed({
+          organizationId: String(existingSubscription.organization),
+          subscriptionId: subscription.id,
+          userId: String(existingSubscription.user),
+        });
+      } catch (error: unknown) {
+        this.loggerService.warn(
+          `${url} lifecycle email subscription-lapsed recording skipped`,
+          {
+            error: error instanceof Error ? error.message : error,
+            subscriptionId: subscription.id,
+          },
+        );
+      }
 
       this.loggerService.log(`${url} subscription deleted successfully`, {
         organizationId: existingSubscription.organization,

--- a/apps/server/api/src/services/integrations/stripe/controllers/user-stripe.controller.spec.ts
+++ b/apps/server/api/src/services/integrations/stripe/controllers/user-stripe.controller.spec.ts
@@ -63,6 +63,11 @@ describe('UserStripeController', () => {
     getOrganizationCreditsBalance: ReturnType<typeof vi.fn>;
   };
   let organizationsService: { findOne: ReturnType<typeof vi.fn> };
+  let loggerService: {
+    error: ReturnType<typeof vi.fn>;
+    log: ReturnType<typeof vi.fn>;
+    warn: ReturnType<typeof vi.fn>;
+  };
   let lifecycleEmailService: {
     recordCheckoutStarted: ReturnType<typeof vi.fn>;
   };
@@ -125,6 +130,11 @@ describe('UserStripeController', () => {
     lifecycleEmailService = {
       recordCheckoutStarted: vi.fn().mockResolvedValue(undefined),
     };
+    loggerService = {
+      error: vi.fn(),
+      log: vi.fn(),
+      warn: vi.fn(),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [UserStripeController],
@@ -137,10 +147,7 @@ describe('UserStripeController', () => {
         },
         { provide: CreditsUtilsService, useValue: creditsUtilsService },
         { provide: OrganizationsService, useValue: organizationsService },
-        {
-          provide: LoggerService,
-          useValue: { error: vi.fn(), log: vi.fn(), warn: vi.fn() },
-        },
+        { provide: LoggerService, useValue: loggerService },
         { provide: LifecycleEmailService, useValue: lifecycleEmailService },
       ],
     })
@@ -181,6 +188,33 @@ describe('UserStripeController', () => {
         source: 'user-checkout',
         userId: dbUserId,
       });
+    });
+
+    it('returns the created session when lifecycle recording fails', async () => {
+      lifecycleEmailService.recordCheckoutStarted.mockRejectedValueOnce(
+        new Error('lifecycle unavailable'),
+      );
+
+      const result = await controller.createCheckoutSession(
+        mockUser,
+        dto,
+        mockRequest,
+      );
+
+      expect(result).toEqual({
+        id: 'cs_user_1',
+        url: 'https://checkout.stripe.com/pay',
+      });
+      expect(loggerService.warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'lifecycle email checkout-started recording skipped',
+        ),
+        {
+          checkoutSessionId: 'cs_user_1',
+          error: 'lifecycle unavailable',
+        },
+      );
+      expect(loggerService.error).not.toHaveBeenCalled();
     });
 
     it('should create stripe customer if user has no stripeCustomerId', async () => {

--- a/apps/server/api/src/services/integrations/stripe/controllers/user-stripe.controller.ts
+++ b/apps/server/api/src/services/integrations/stripe/controllers/user-stripe.controller.ts
@@ -146,12 +146,22 @@ export class UserStripeController {
         userId: dbUser.id.toString(),
       });
 
-      await this.lifecycleEmailService.recordCheckoutStarted({
-        checkoutSessionId: session.id,
-        checkoutUrl: session.url,
-        source: 'user-checkout',
-        userId: dbUser.id.toString(),
-      });
+      try {
+        await this.lifecycleEmailService.recordCheckoutStarted({
+          checkoutSessionId: session.id,
+          checkoutUrl: session.url,
+          source: 'user-checkout',
+          userId: dbUser.id.toString(),
+        });
+      } catch (error: unknown) {
+        this.loggerService.warn(
+          `${url} lifecycle email checkout-started recording skipped`,
+          {
+            checkoutSessionId: session.id,
+            error: error instanceof Error ? error.message : error,
+          },
+        );
+      }
 
       return serializeSingle(request, StripeUrlSerializer, session);
     } catch (error: unknown) {


### PR DESCRIPTION
## Summary

- isolate subscription-lapsed lifecycle recording from successful Stripe subscription deletion
- isolate checkout-started lifecycle recording from an already-created user checkout session
- add focused regression coverage for both failure paths and structured warning telemetry

Closes #1487

## Verification

- `bunx biome check --write` on all four touched files — clean
- touched-file Secretlint — clean
- `git diff --check` and `git diff --cached --check` — clean
- lint-staged Secretlint, Biome, and control guard — clean
- merge-base verified exactly against `origin/master` (`96af3dd9fb68980a61c6978b2eead64b4bae2a74`)

## Skipped locally

Per workstation policy, focused tests, typecheck, build, coverage, and E2E were not run on this MacBook Pro. PR CI is the validation handoff for the two updated API specs and broader API checks.

## Residual risk

The behavior change is limited to treating lifecycle-email persistence as a non-blocking side effect after Stripe state/session creation. CI still needs to execute the focused specs and typecheck the affected API surface.