### PR TITLE
fix(workflows): resolve brand ownership review feedback

### DIFF
--- a/apps/app/src/features/workflows/nodes/saas/BrandNode.test.tsx
+++ b/apps/app/src/features/workflows/nodes/saas/BrandNode.test.tsx
@@ -1,0 +1,153 @@
+import '@testing-library/jest-dom/vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { BrandNode } from './BrandNode';
+
+const mocks = vi.hoisted(() => ({
+  brands: [
+    { _id: 'brand-1', label: 'First Brand', logoUrl: null },
+    {
+      _id: 'brand-2',
+      label: 'Second Brand',
+      logoUrl: 'https://example.test/brand-2.png',
+    },
+  ],
+  updateNodeData: vi.fn(),
+}));
+
+vi.mock('@genfeedai/workflow-ui/stores', () => ({
+  selectUpdateNodeData: (state: {
+    updateNodeData: typeof mocks.updateNodeData;
+  }) => state.updateNodeData,
+  useWorkflowStore: (
+    selector: (state: {
+      updateNodeData: typeof mocks.updateNodeData;
+    }) => unknown,
+  ) => selector({ updateNodeData: mocks.updateNodeData }),
+}));
+
+vi.mock('next/image', () => ({
+  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => (
+    <picture>
+      <img alt={props.alt ?? ''} {...props} />
+    </picture>
+  ),
+}));
+
+vi.mock('@/features/workflows/stores/cloud-workflow-store', () => ({
+  useCloudWorkflowStore: (
+    selector: (state: {
+      brands: typeof mocks.brands;
+      isBrandsLoading: boolean;
+    }) => unknown,
+  ) => selector({ brands: mocks.brands, isBrandsLoading: false }),
+}));
+
+vi.mock('@/features/workflows/components/ui/badge', () => ({
+  NodeBadge: ({ children }: { children?: ReactNode }) => (
+    <span>{children}</span>
+  ),
+}));
+
+vi.mock('@/features/workflows/components/ui/card', () => ({
+  NodeCard: ({ children }: { children?: ReactNode }) => (
+    <section>{children}</section>
+  ),
+  NodeHeader: ({ title }: { title: string }) => <h2>{title}</h2>,
+}));
+
+vi.mock('@/features/workflows/components/ui/inputs', () => ({
+  NodeSelect: ({
+    children,
+    label,
+    onChange,
+    value,
+  }: React.SelectHTMLAttributes<HTMLSelectElement> & {
+    children?: ReactNode;
+    label?: string;
+  }) => (
+    <label>
+      {label}
+      <select value={value} onChange={onChange}>
+        <option value="">Choose a brand</option>
+        {children}
+      </select>
+    </label>
+  ),
+}));
+
+vi.mock('@/features/workflows/components/ui/status', () => ({
+  HelpText: ({ children }: { children?: ReactNode }) => <p>{children}</p>,
+}));
+
+function renderBrandNode(data: Record<string, unknown> = {}) {
+  return render(
+    <BrandNode
+      id="brand-node"
+      data={data}
+      selected={false}
+      type="brand"
+      zIndex={1}
+      isConnectable
+      dragging={false}
+      deletable
+      draggable
+      selectable
+      positionAbsoluteX={0}
+      positionAbsoluteY={0}
+    />,
+  );
+}
+
+describe('BrandNode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('clears resolved brand details when the selected brand changes or is removed', () => {
+    renderBrandNode({
+      brandId: 'brand-1',
+      resolvedColors: {
+        accent: '#333333',
+        primary: '#111111',
+        secondary: '#222222',
+      },
+      resolvedFonts: { body: 'Inter', heading: 'Geist' },
+      resolvedHandle: 'first-brand',
+      resolvedLabel: 'First Brand',
+      resolvedModels: { image: 'image-model', video: 'video-model' },
+      resolvedVoice: 'Direct and playful',
+    });
+
+    fireEvent.change(screen.getByLabelText('Select Brand'), {
+      target: { value: 'brand-2' },
+    });
+    expect(mocks.updateNodeData).toHaveBeenLastCalledWith('brand-node', {
+      brandId: 'brand-2',
+      resolvedBrandId: 'brand-2',
+      resolvedColors: null,
+      resolvedFonts: null,
+      resolvedHandle: null,
+      resolvedLabel: 'Second Brand',
+      resolvedLogoUrl: 'https://example.test/brand-2.png',
+      resolvedModels: null,
+      resolvedVoice: null,
+    });
+
+    fireEvent.change(screen.getByLabelText('Select Brand'), {
+      target: { value: '' },
+    });
+    expect(mocks.updateNodeData).toHaveBeenLastCalledWith('brand-node', {
+      brandId: null,
+      resolvedBrandId: null,
+      resolvedColors: null,
+      resolvedFonts: null,
+      resolvedHandle: null,
+      resolvedLabel: null,
+      resolvedLogoUrl: null,
+      resolvedModels: null,
+      resolvedVoice: null,
+    });
+  });
+});

--- a/apps/app/src/features/workflows/nodes/saas/BrandNode.tsx
+++ b/apps/app/src/features/workflows/nodes/saas/BrandNode.tsx
@@ -55,8 +55,13 @@ function BrandNodeComponent(props: NodeProps): React.JSX.Element {
       updateNodeData(id, {
         brandId,
         resolvedBrandId: brandId,
+        resolvedColors: null,
+        resolvedFonts: null,
+        resolvedHandle: null,
         resolvedLabel: selectedBrand?.label ?? null,
         resolvedLogoUrl: selectedBrand?.logoUrl ?? null,
+        resolvedModels: null,
+        resolvedVoice: null,
       });
     },
     [brands, id, updateNodeData],

--- a/apps/server/api/src/collections/brands/services/brands.service.relocate.spec.ts
+++ b/apps/server/api/src/collections/brands/services/brands.service.relocate.spec.ts
@@ -12,15 +12,15 @@ import {
   SECOND_ORDER_TARGETS,
 } from '@api/collections/brands/constants/brand-org-cascade.constants';
 import { BrandsService } from '@api/collections/brands/services/brands.service';
-import { CacheInvalidationService } from '@api/common/services/cache-invalidation.service';
-import { BrandScraperService } from '@api/services/brand-scraper/brand-scraper.service';
-import { CacheService } from '@api/services/cache/services/cache.service';
-import { LlmDispatcherService } from '@api/services/integrations/llm/llm-dispatcher.service';
-import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import type { CacheInvalidationService } from '@api/common/services/cache-invalidation.service';
+import type { BrandScraperService } from '@api/services/brand-scraper/brand-scraper.service';
+import type { CacheService } from '@api/services/cache/services/cache.service';
+import type { LlmDispatcherService } from '@api/services/integrations/llm/llm-dispatcher.service';
+import type { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { Prisma } from '@genfeedai/prisma';
-import { LoggerService } from '@libs/logger/logger.service';
+import type { LoggerService } from '@libs/logger/logger.service';
 import { ConflictException, ForbiddenException } from '@nestjs/common';
-import { FilesClientService } from '@server/services/files-microservice/client/files-client.service';
+import type { FilesClientService } from '@server/services/files-microservice/client/files-client.service';
 
 type Delegate = {
   count: ReturnType<typeof vi.fn>;
@@ -397,9 +397,11 @@ describe('BrandsService.relocateToOrganization', () => {
     );
 
     expect(getDelegate('workflow').create).not.toHaveBeenCalled();
+    // Workflow definition is re-homed through the first-order brand cascade
+    // (matched by brandId, not a precomputed id list — see the sibling test above).
     expect(getDelegate('workflow').updateMany).toHaveBeenCalledWith({
       data: { organizationId: DEST_ORG },
-      where: { id: { in: ['wf_owned'] }, organizationId: { not: DEST_ORG } },
+      where: { brandId: BRAND_ID, organizationId: { not: DEST_ORG } },
     });
     expect(result.summary).toEqual({
       ...EMPTY_RELOCATION_SUMMARY,

--- a/apps/server/api/src/collections/brands/services/brands.service.relocate.spec.ts
+++ b/apps/server/api/src/collections/brands/services/brands.service.relocate.spec.ts
@@ -353,8 +353,12 @@ describe('BrandsService.relocateToOrganization', () => {
       { isSuperAdmin: true, userId: USER_ID },
     );
 
-    // Workflow definition re-homed to the destination org.
+    // Workflow definition is re-homed once through the first-order brand cascade.
     expect(getDelegate('workflow').updateMany).toHaveBeenCalledWith({
+      data: { organizationId: DEST_ORG },
+      where: { brandId: BRAND_ID, organizationId: { not: DEST_ORG } },
+    });
+    expect(getDelegate('workflow').updateMany).not.toHaveBeenCalledWith({
       data: { organizationId: DEST_ORG },
       where: { id: { in: ['wf_sole'] }, organizationId: { not: DEST_ORG } },
     });

--- a/apps/server/api/src/collections/brands/services/brands.service.ts
+++ b/apps/server/api/src/collections/brands/services/brands.service.ts
@@ -2265,16 +2265,9 @@ Respond ONLY with the JSON array.`;
       },
     });
 
-    // Move brand-owned workflows (definition + org-keyed execution/batch history)
-    // into the destination org. The scalar workflow.brandId stays unchanged.
+    // Workflow definitions already moved through FIRST_ORDER_TARGETS. Move the
+    // org-keyed execution and batch history that follows those workflows.
     if (workflowsToMove.length > 0) {
-      await client.workflow.updateMany({
-        data: { organizationId: destOrgId },
-        where: {
-          id: { in: workflowsToMove },
-          organizationId: { not: destOrgId },
-        },
-      });
       await client.workflowExecution.updateMany({
         data: { organizationId: destOrgId },
         where: {

--- a/apps/server/api/src/collections/workflows/schemas/workflow.schema.ts
+++ b/apps/server/api/src/collections/workflows/schemas/workflow.schema.ts
@@ -91,7 +91,6 @@ export interface WorkflowDocument
   > {
   organization?: string;
   user?: string;
-  brand?: string | null;
   name?: string | null;
   trigger?: string;
   sourceAsset?: string | null;

--- a/apps/server/api/src/collections/workflows/services/workflows.service.spec.ts
+++ b/apps/server/api/src/collections/workflows/services/workflows.service.spec.ts
@@ -11,12 +11,17 @@ describe('WorkflowsService template creation', () => {
     log: vi.fn(),
     warn: vi.fn(),
   };
+  const brandFindFirst = vi.fn();
 
   let service: WorkflowsService;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    service = new WorkflowsService({} as never, logger as never);
+    brandFindFirst.mockResolvedValue({ id: 'brand-1' });
+    service = new WorkflowsService(
+      { brand: { findFirst: brandFindFirst } } as never,
+      logger as never,
+    );
     vi.spyOn(service, 'create').mockResolvedValue({
       _id: { toString: () => 'workflow-1' },
       id: 'workflow-1',
@@ -172,6 +177,28 @@ describe('WorkflowsService template creation', () => {
     expect(createInput.user).toBeUndefined();
   });
 
+  it('rejects workflow brands outside the authenticated organization', async () => {
+    brandFindFirst.mockResolvedValue(null);
+
+    await expect(
+      service.createWorkflow('user-1', 'org-1', {
+        brandId: 'foreign-brand',
+        edges: [],
+        nodes: [],
+      } as never),
+    ).rejects.toThrow('Brand is not available in this organization');
+
+    expect(brandFindFirst).toHaveBeenCalledWith({
+      select: { id: true },
+      where: {
+        id: 'foreign-brand',
+        isDeleted: false,
+        organizationId: 'org-1',
+      },
+    });
+    expect(service.create).not.toHaveBeenCalled();
+  });
+
   it('skips initial manual execution when required inputs do not have defaults', async () => {
     await service.createWorkflow('user-1', 'org-1', {
       edges: [],
@@ -225,12 +252,17 @@ describe('WorkflowsService system workflow guardrails', () => {
     log: vi.fn(),
     warn: vi.fn(),
   };
+  const brandFindFirst = vi.fn();
 
   let service: WorkflowsService;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    service = new WorkflowsService({} as never, logger as never);
+    brandFindFirst.mockResolvedValue({ id: 'brand-1' });
+    service = new WorkflowsService(
+      { brand: { findFirst: brandFindFirst } } as never,
+      logger as never,
+    );
   });
 
   it('rejects mutable access to protected system workflows', async () => {
@@ -420,6 +452,34 @@ describe('WorkflowsService system workflow guardrails', () => {
     expect(createInput.mongoId).toBeUndefined();
     expect(createInput.organization).toBeUndefined();
     expect(createInput.user).toBeUndefined();
+  });
+
+  it('rejects clone target brands outside the authenticated organization', async () => {
+    vi.spyOn(service, 'findVisibleOrThrow').mockResolvedValue({
+      brandId: 'source-brand',
+      edges: [],
+      id: 'workflow-1',
+      inputVariables: [],
+      label: 'Launch Workflow',
+      nodes: [],
+      steps: [],
+    } as never);
+    vi.spyOn(service, 'create').mockResolvedValue({} as never);
+    brandFindFirst.mockResolvedValue(null);
+
+    await expect(
+      service.cloneWorkflow('workflow-1', 'user-1', 'org-1', 'foreign-brand'),
+    ).rejects.toThrow('Brand is not available in this organization');
+
+    expect(brandFindFirst).toHaveBeenCalledWith({
+      select: { id: true },
+      where: {
+        id: 'foreign-brand',
+        isDeleted: false,
+        organizationId: 'org-1',
+      },
+    });
+    expect(service.create).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/server/api/src/collections/workflows/services/workflows.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflows.service.ts
@@ -29,7 +29,12 @@ import {
   WorkflowStepStatus,
 } from '@genfeedai/enums';
 import { LoggerService } from '@libs/logger/logger.service';
-import { ForbiddenException, Injectable, Optional } from '@nestjs/common';
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  Optional,
+} from '@nestjs/common';
 
 type WorkflowCreateExtras = CreateWorkflowDto & {
   brandId?: string | null;
@@ -114,6 +119,25 @@ export class WorkflowsService extends BaseService<
       .filter((id) => id.length > 0);
 
     return legacyIds[0] ?? fallbackBrandId;
+  }
+
+  private async assertWorkflowBrandAccess(
+    brandId: string | undefined,
+    organizationId: string,
+  ): Promise<void> {
+    if (!brandId) {
+      return;
+    }
+
+    const brand = await this.prisma.brand.findFirst({
+      select: { id: true },
+      where: { id: brandId, isDeleted: false, organizationId },
+    });
+    if (!brand) {
+      throw new BadRequestException(
+        'Brand is not available in this organization',
+      );
+    }
   }
 
   private normalizeWorkflowStepsForCreate(
@@ -279,6 +303,7 @@ export class WorkflowsService extends BaseService<
       (workflowData as WorkflowCreateExtras).brands,
       defaultBrandId,
     );
+    await this.assertWorkflowBrandAccess(brandId, organizationId);
 
     const workflow = await this.create(
       this.buildWorkflowCreatePayload({
@@ -478,6 +503,7 @@ export class WorkflowsService extends BaseService<
         workflowDoc.brandId,
         (workflowDoc as WorkflowCreateExtras).brands,
       );
+    await this.assertWorkflowBrandAccess(brandId, organizationId);
 
     const clonedWorkflow = await this.create(
       this.buildWorkflowCreatePayload({


### PR DESCRIPTION
## Summary

- reject create and clone requests that target a missing, deleted, or cross-organization brand
- clear every resolved brand output when a workflow brand selection changes
- move workflow definitions only once during brand relocation and remove the misleading legacy workflow schema field
- add focused regression coverage for brand selection, tenant scoping, and relocation writes

## Verification

Passed locally:
- touched-file Biome check
- touched-file Secretlint
- full UI guard suite
- multi-tenancy static guard
- git diff --check and staged diff/secret scans
- pre-commit Secretlint, Biome, control guard, and bespoke-card guard

Not run locally per workstation policy:
- tests
- typecheck
- build
- coverage
- E2E

These are delegated to PR CI. Residual risk is limited to CI execution of the new app and API regression specs plus the affected TypeScript surface.

Closes #1488