### PR TITLE
fix(workflows): disable schedules missing required defaults

### DIFF
--- a/apps/app/src/features/workflows/components/WorkflowRunPanel.test.tsx
+++ b/apps/app/src/features/workflows/components/WorkflowRunPanel.test.tsx
@@ -1,0 +1,85 @@
+import '@testing-library/jest-dom/vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ChangeEvent, InputHTMLAttributes, ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { WorkflowRunPanel } from './WorkflowRunPanel';
+
+vi.mock('@ui/primitives/button', () => ({
+  Button: ({
+    children,
+    label,
+    type,
+  }: {
+    children?: ReactNode;
+    label?: ReactNode;
+    type?: 'button' | 'submit' | 'reset';
+  }) => <button type={type ?? 'button'}>{children ?? label}</button>,
+}));
+
+vi.mock('@ui/primitives/checkbox', () => ({
+  Checkbox: ({
+    id,
+    isChecked,
+    label,
+    onChange,
+  }: {
+    id?: string;
+    isChecked?: boolean;
+    label?: ReactNode;
+    onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
+  }) => {
+    const checkbox = (
+      <input checked={isChecked} id={id} type="checkbox" onChange={onChange} />
+    );
+
+    return label ? (
+      <label>
+        {checkbox}
+        {label}
+      </label>
+    ) : (
+      checkbox
+    );
+  },
+}));
+
+vi.mock('@ui/primitives/input', () => ({
+  Input: (props: InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+}));
+
+describe('WorkflowRunPanel', () => {
+  it('associates one visible label with a boolean input and submits its value', async () => {
+    const onRun = vi.fn();
+
+    render(
+      <WorkflowRunPanel
+        inputVariables={[
+          {
+            key: 'includeWatermark',
+            label: 'Include watermark',
+            type: 'boolean',
+          },
+        ]}
+        isRunning={false}
+        onClose={vi.fn()}
+        onRun={onRun}
+      />,
+    );
+
+    const checkbox = screen.getByRole('checkbox', {
+      name: 'Include watermark',
+    });
+    expect(checkbox).toHaveAttribute('id', 'workflow-run-includeWatermark');
+    expect(screen.getAllByText('Include watermark')).toHaveLength(1);
+
+    fireEvent.click(checkbox);
+    fireEvent.click(screen.getByRole('button', { name: 'Run' }));
+
+    await waitFor(() =>
+      expect(onRun).toHaveBeenCalledWith(
+        { includeWatermark: true },
+        { saveDefaults: false },
+      ),
+    );
+  });
+});

--- a/apps/app/src/features/workflows/components/WorkflowRunPanel.tsx
+++ b/apps/app/src/features/workflows/components/WorkflowRunPanel.tsx
@@ -232,15 +232,15 @@ export function WorkflowRunPanel({
                 )}
 
                 {variable.type === 'boolean' ? (
-                  <label className="flex items-center gap-2 border border-border px-3 py-2 text-sm text-foreground">
+                  <div className="flex items-center gap-2 border border-border px-3 py-2 text-sm text-foreground">
                     <Checkbox
+                      id={`workflow-run-${variable.key}`}
                       isChecked={value === true}
                       onChange={(event) =>
                         setFieldValue(variable.key, event.target.checked)
                       }
                     />
-                    <span>{variable.label}</span>
-                  </label>
+                  </div>
                 ) : variable.type === 'select' && selectOptions.length > 0 ? (
                   <Select
                     value={typeof value === 'string' ? value : ''}

--- a/apps/server/api/src/collections/workflows/services/workflow-scheduler.service.spec.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-scheduler.service.spec.ts
@@ -263,6 +263,7 @@ describe('WorkflowSchedulerService — scheduled fire execution', () => {
       where: {
         id: 'wf-1',
         isDeleted: false,
+        isScheduleEnabled: true,
         status: WorkflowStatus.ACTIVE,
       },
     });
@@ -279,7 +280,7 @@ describe('WorkflowSchedulerService — scheduled fire execution', () => {
     );
   });
 
-  it('skips scheduled node execution when required input defaults are missing', async () => {
+  it('disables and unschedules workflows when required input defaults are missing', async () => {
     const prisma = createMockPrisma();
     prisma.workflow.findFirst.mockResolvedValue({
       id: 'wf-1',
@@ -299,14 +300,22 @@ describe('WorkflowSchedulerService — scheduled fire execution', () => {
       executeManualWorkflow: vi.fn().mockResolvedValue({}),
       executeManualWorkflowDocument: vi.fn().mockResolvedValue({}),
     };
-    const { logger, service } = createService({
+    const { logger, queueService, service } = createService({
       prisma,
       workflowExecutorService,
     });
 
     await service.executeScheduledWorkflow('wf-1');
 
-    expect(prisma.workflow.update).not.toHaveBeenCalled();
+    expect(prisma.workflow.update).toHaveBeenCalledWith({
+      data: { isScheduleEnabled: false },
+      where: {
+        id: 'wf-1',
+        isDeleted: false,
+        organizationId: 'org-1',
+      },
+    });
+    expect(queueService.removeWorkflowScheduler).toHaveBeenCalledWith('wf-1');
     expect(
       workflowExecutorService.executeManualWorkflowDocument,
     ).not.toHaveBeenCalled();

--- a/apps/server/api/src/collections/workflows/services/workflow-scheduler.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-scheduler.service.ts
@@ -184,6 +184,7 @@ export class WorkflowSchedulerService implements OnModuleInit {
         where: {
           id: workflowId,
           isDeleted: false,
+          isScheduleEnabled: true,
           // Canonical workflow status is the lowercase enum value ('active');
           // the column is a drifted String (see schema). Must match what
           // createWorkflow / the executor persist, or scheduled rows never load.
@@ -222,8 +223,18 @@ export class WorkflowSchedulerService implements OnModuleInit {
       );
 
       if (missingRequiredInputs.length > 0) {
+        await this.prisma.workflow.update({
+          data: { isScheduleEnabled: false },
+          where: {
+            id: workflowId,
+            isDeleted: false,
+            organizationId: wOrgId,
+          },
+        });
+        await this.unscheduleWorkflow(workflowId);
+
         this.logger.warn(
-          `Scheduled workflow ${workflowId} skipped because required input defaults are missing: ${missingRequiredInputs.join(', ')}`,
+          `Scheduled workflow ${workflowId} disabled because required input defaults are missing: ${missingRequiredInputs.join(', ')}`,
           'WorkflowSchedulerService',
         );
         return;


### PR DESCRIPTION
## Summary

- associate boolean workflow inputs with their single visible label
- persistently disable and unschedule workflows whose required inputs have no defaults
- make persisted schedule disablement authoritative for stray queued fires
- add focused UI and scheduler regression coverage

Closes #1489

## Verification

Passed locally:
- touched-file Biome check
- design-system and app UI boundary checks
- touched-file control guard and bespoke-card guard
- multi-tenancy static guard
- repository Secretlint runner on touched files
- `git diff --check` and staged secret/path scans
- pre-commit Secretlint, Biome, control guard, and bespoke-card guard
- merge-base verified exactly against `origin/master`

Guard infrastructure issue:
- the repo-wide nested-card checker crashed before scanning because `ts.ScriptTarget` was undefined; the touched UI files contain no card usage, and the focused bespoke-card guard passed

## Skipped locally

Per workstation policy, tests, typecheck, build, coverage, and E2E were not run on this MacBook Pro. PR CI is the authoritative handoff for the new component test, updated API spec, and affected TypeScript surfaces.

## Residual risk

CI still needs to execute the new UI/API tests and typecheck the Prisma update filter. Runtime risk is bounded to schedule disablement when required defaults are absent; the cron expression is preserved so users can re-enable after supplying defaults.