### PR TITLE
fix(onboarding): keep preview response-only

### DIFF
--- a/apps/server/api/src/endpoints/onboarding/services/onboarding-preview.service.spec.ts
+++ b/apps/server/api/src/endpoints/onboarding/services/onboarding-preview.service.spec.ts
@@ -1,0 +1,144 @@
+import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticated-user.interface';
+import type { BrandDataMapper } from '@api/collections/brands/services/brand-data.mapper';
+import type { BrandsService } from '@api/collections/brands/services/brands.service';
+import type { CreditsUtilsService } from '@api/collections/credits/services/credits.utils.service';
+import { OnboardingContentType } from '@api/endpoints/onboarding/dto/generate-preview.dto';
+import { OnboardingPreviewService } from '@api/endpoints/onboarding/services/onboarding-preview.service';
+import type { ComfyUIService } from '@api/services/integrations/comfyui/comfyui.service';
+import { MODEL_KEYS } from '@genfeedai/constants';
+import { FileInputType } from '@genfeedai/enums';
+import type { LoggerService } from '@libs/logger/logger.service';
+import type { FilesClientService } from '@server/services/files-microservice/client/files-client.service';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('OnboardingPreviewService', () => {
+  let brandDataMapper: vi.Mocked<Pick<BrandDataMapper, 'buildPreviewPrompt'>>;
+  let brandsService: vi.Mocked<Pick<BrandsService, 'findOne' | 'patch'>>;
+  let comfyUIService: vi.Mocked<Pick<ComfyUIService, 'generateImage'>>;
+  let creditsUtilsService: vi.Mocked<
+    Pick<
+      CreditsUtilsService,
+      'checkOrganizationCreditsAvailable' | 'deductCreditsFromOrganization'
+    >
+  >;
+  let filesClientService: vi.Mocked<
+    Pick<FilesClientService, 'getPresignedUploadUrl' | 'uploadToS3'>
+  >;
+  let loggerService: vi.Mocked<Pick<LoggerService, 'error' | 'log' | 'warn'>>;
+  let service: OnboardingPreviewService;
+
+  const user: User = {
+    id: 'user-1',
+    publicMetadata: {
+      organization: 'org-1',
+      user: 'user-1',
+    },
+  };
+
+  beforeEach(() => {
+    brandDataMapper = {
+      buildPreviewPrompt: vi.fn().mockReturnValue('generated prompt'),
+    };
+    brandsService = {
+      findOne: vi.fn().mockResolvedValue({
+        description: 'Content operations platform',
+        id: 'brand-1',
+        label: 'Genfeed',
+        primaryColor: '#000000',
+        secondaryColor: '#ffffff',
+      } as never),
+      patch: vi.fn(),
+    };
+    comfyUIService = {
+      generateImage: vi.fn().mockResolvedValue({
+        filename: 'preview.png',
+        imageBuffer: Buffer.from('preview'),
+      }),
+    };
+    creditsUtilsService = {
+      checkOrganizationCreditsAvailable: vi.fn().mockResolvedValue(true),
+      deductCreditsFromOrganization: vi.fn().mockResolvedValue(undefined),
+    };
+    filesClientService = {
+      getPresignedUploadUrl: vi.fn().mockResolvedValue({
+        publicUrl: 'https://cdn.genfeed.ai/onboarding/preview.png',
+        s3Key: 'onboarding/org-1/preview.png',
+        uploadUrl: 'https://uploads.genfeed.ai/onboarding/preview.png',
+      }),
+      uploadToS3: vi.fn().mockResolvedValue({
+        publicUrl: 'https://cdn.genfeed.ai/onboarding/preview.png',
+      }),
+    };
+    loggerService = {
+      error: vi.fn(),
+      log: vi.fn(),
+      warn: vi.fn(),
+    };
+
+    service = new OnboardingPreviewService(
+      loggerService as unknown as LoggerService,
+      brandsService as unknown as BrandsService,
+      comfyUIService as unknown as ComfyUIService,
+      creditsUtilsService as unknown as CreditsUtilsService,
+      filesClientService as unknown as FilesClientService,
+      brandDataMapper as unknown as BrandDataMapper,
+    );
+  });
+
+  it('returns the uploaded preview after charging without patching the brand', async () => {
+    const result = await service.generateOnboardingPreview(
+      {
+        brandId: 'brand-1',
+        contentType: OnboardingContentType.SOCIAL,
+      },
+      user,
+    );
+
+    expect(brandsService.findOne).toHaveBeenCalledWith(
+      {
+        _id: 'brand-1',
+        isDeleted: false,
+        organization: 'org-1',
+      },
+      'none',
+    );
+    expect(brandDataMapper.buildPreviewPrompt).toHaveBeenCalledWith(
+      OnboardingContentType.SOCIAL,
+      'Genfeed',
+      'Content operations platform',
+      '#000000',
+      '#ffffff',
+    );
+    expect(comfyUIService.generateImage).toHaveBeenCalledWith(
+      MODEL_KEYS.GENFEED_AI_Z_IMAGE_TURBO,
+      {
+        height: 1024,
+        prompt: 'generated prompt',
+        steps: 4,
+        width: 1024,
+      },
+    );
+    expect(filesClientService.getPresignedUploadUrl).toHaveBeenCalledWith(
+      expect.stringMatching(/^org-1\/onboarding-preview-\d+$/),
+      'onboarding',
+      'image/png',
+    );
+    expect(filesClientService.uploadToS3).toHaveBeenCalledWith(
+      expect.stringMatching(/^org-1\/onboarding-preview-\d+$/),
+      'onboarding',
+      {
+        contentType: 'image/png',
+        data: expect.any(Buffer),
+        type: FileInputType.BUFFER,
+      },
+    );
+    expect(
+      creditsUtilsService.deductCreditsFromOrganization,
+    ).toHaveBeenCalledWith('org-1', 'user-1', 5, 'Onboarding preview image');
+    expect(brandsService.patch).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      imageUrl: 'https://cdn.genfeed.ai/onboarding/preview.png',
+      prompt: 'generated prompt',
+    });
+  });
+});

--- a/apps/server/api/src/endpoints/onboarding/services/onboarding-preview.service.ts
+++ b/apps/server/api/src/endpoints/onboarding/services/onboarding-preview.service.ts
@@ -21,7 +21,7 @@ const ONBOARDING_PREVIEW_CREDIT_COST = 5;
  *
  * Owns the onboarding preview-generation pipeline: brand fetch → credit
  * check → prompt build → ComfyUI generation → S3 upload → credit deduction
- * → brand patch.
+ * → response.
  */
 @Injectable()
 export class OnboardingPreviewService {
@@ -147,19 +147,14 @@ export class OnboardingPreviewService {
           type: FileInputType.BUFFER,
         });
 
-        // 6. Deduct credits
+        // Preview assets are response-only; keep the credit deduction as the
+        // final awaited side effect so no later persistence write can fail.
         await this.creditsUtilsService.deductCreditsFromOrganization(
           organizationId,
           userId,
           ONBOARDING_PREVIEW_CREDIT_COST,
           'Onboarding preview image',
         );
-
-        // 7. Save preview URL to brand
-        await this.brandsService.patch(brand.id, {
-          // @ts-expect-error onboardingPreviewUrl is valid
-          onboardingPreviewUrl: publicUrl,
-        });
 
         this.loggerService.log(`${caller} completed`, {
           brandId: dto.brandId,


### PR DESCRIPTION
## Summary

- remove the invalid `Brand.onboardingPreviewUrl` persistence step from onboarding preview generation
- keep credit deduction as the final awaited side effect so the generated preview can return without a post-charge Prisma failure
- add a focused service regression spec covering brand lookup, prompt generation, upload, charging, response data, and the absence of a brand patch

## Verification

- `bunx biome check apps/server/api/src/endpoints/onboarding/services/onboarding-preview.service.ts apps/server/api/src/endpoints/onboarding/services/onboarding-preview.service.spec.ts`
- `bun scripts/run-secretlint.ts --no-glob <touched files>`
- `bun scripts/ui/control-guard.ts <touched files>`
- `git diff --check origin/master...HEAD`
- staged secret/path scan and pre-commit lint-staged hooks

## Skipped locally

Tests, typecheck, build, coverage, and E2E were not run on the local MacBook per workstation policy. PR CI is the validation handoff for the new service spec and affected TypeScript surface.

## Residual risk

CI still needs to execute the new mocked success-path spec and type-check the service-test dependency shapes. The preview URL remains intentionally response-only because no schema, serializer, DTO, or client consumer owns a persisted brand field.

Closes #1545