### PR TITLE
fix(messages): make outbound social actions idempotent

### DIFF
--- a/apps/server/api/src/collections/social-inbox/services/social-inbox.service.spec.ts
+++ b/apps/server/api/src/collections/social-inbox/services/social-inbox.service.spec.ts
@@ -1,5 +1,5 @@
 import { SocialInboxService } from '@api/collections/social-inbox/services/social-inbox.service';
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, ConflictException } from '@nestjs/common';
 
 type StoreConversation = {
   id: string;
@@ -92,6 +92,7 @@ type PrismaMock = {
     findFirst: ReturnType<typeof vi.fn>;
     findMany: ReturnType<typeof vi.fn>;
     update: ReturnType<typeof vi.fn>;
+    updateMany: ReturnType<typeof vi.fn>;
   };
 };
 
@@ -264,6 +265,19 @@ function createContext(): TestContext {
           ),
         ),
       create: vi.fn().mockImplementation(({ data }) => {
+        if (
+          data.idempotencyKey &&
+          messages.some(
+            (item) =>
+              item.organizationId === data.organizationId &&
+              item.idempotencyKey === data.idempotencyKey,
+          )
+        ) {
+          throw Object.assign(new Error('Unique constraint violation'), {
+            code: 'P2002',
+          });
+        }
+
         const now = new Date();
         const message: StoreMessage = {
           actionProvenance: data.actionProvenance ?? {},
@@ -319,6 +333,13 @@ function createContext(): TestContext {
         }
         Object.assign(message, data);
         return Promise.resolve(message);
+      }),
+      updateMany: vi.fn().mockImplementation(({ data, where }) => {
+        const matched = messages.filter((item) => matchesWhere(item, where));
+        for (const message of matched) {
+          Object.assign(message, data, { updatedAt: new Date() });
+        }
+        return Promise.resolve({ count: matched.length });
       }),
     },
   };
@@ -430,6 +451,170 @@ describe('SocialInboxService', () => {
     });
     expect(first.workflowRunId).toBe('workflow-run-1');
     expect(first.status).toBe('sent');
+  });
+
+  it('claims a reply idempotency key before concurrent provider calls', async () => {
+    const { instagramService, messages, service } = createContext();
+    const inbound = await service.ingestInboundMessage({
+      body: 'Inbound',
+      brandId: 'brand-1',
+      conversationType: 'comment',
+      externalConversationId: 'thread-1',
+      externalMessageId: 'comment-1',
+      externalParentId: 'comment-1',
+      organizationId: 'org-1',
+      participantExternalId: 'author-1',
+      platform: 'instagram',
+    });
+    const scope = {
+      brandId: 'brand-1',
+      organizationId: 'org-1',
+      userId: 'user-1',
+    };
+    const input = {
+      idempotencyKey: 'concurrent-reply',
+      text: 'Thanks for the comment',
+    };
+
+    const results = await Promise.all([
+      service
+        .postReply(scope, inbound.conversationId, input)
+        .catch((error: unknown) => error),
+      service
+        .postReply(scope, inbound.conversationId, input)
+        .catch((error: unknown) => error),
+    ]);
+
+    expect(instagramService.replyToComment).toHaveBeenCalledTimes(1);
+    expect(
+      messages.filter(
+        (message) => message.idempotencyKey === input.idempotencyKey,
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        conversationId: inbound.conversationId,
+        organizationId: scope.organizationId,
+        status: 'sent',
+      }),
+    ]);
+    expect(
+      results.every(
+        (result) =>
+          result instanceof ConflictException ||
+          (typeof result === 'object' && result !== null && 'id' in result),
+      ),
+    ).toBe(true);
+  });
+
+  it('claims a DM idempotency key before concurrent provider calls', async () => {
+    const { instagramService, messages, service } = createContext();
+    const inbound = await service.ingestInboundMessage({
+      body: 'Inbound',
+      brandId: 'brand-1',
+      conversationType: 'dm',
+      externalConversationId: 'thread-1',
+      externalMessageId: 'message-1',
+      organizationId: 'org-1',
+      participantExternalId: 'author-1',
+      platform: 'instagram',
+    });
+    const scope = {
+      brandId: 'brand-1',
+      organizationId: 'org-1',
+      userId: 'user-1',
+    };
+    const input = {
+      idempotencyKey: 'concurrent-dm',
+      recipientId: 'author-1',
+      text: 'Following up',
+    };
+
+    const results = await Promise.all([
+      service
+        .sendDm(scope, inbound.conversationId, input)
+        .catch((error: unknown) => error),
+      service
+        .sendDm(scope, inbound.conversationId, input)
+        .catch((error: unknown) => error),
+    ]);
+
+    expect(instagramService.sendCommentReplyDm).toHaveBeenCalledTimes(1);
+    expect(
+      messages.filter(
+        (message) => message.idempotencyKey === input.idempotencyKey,
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        conversationId: inbound.conversationId,
+        organizationId: scope.organizationId,
+        status: 'sent',
+      }),
+    ]);
+    expect(
+      results.every(
+        (result) =>
+          result instanceof ConflictException ||
+          (typeof result === 'object' && result !== null && 'id' in result),
+      ),
+    ).toBe(true);
+  });
+
+  it('reclaims a failed reply reservation and retries the provider once', async () => {
+    const { instagramService, messages, service } = createContext();
+    const inbound = await service.ingestInboundMessage({
+      body: 'Inbound',
+      brandId: 'brand-1',
+      conversationType: 'comment',
+      externalConversationId: 'thread-1',
+      externalMessageId: 'comment-1',
+      externalParentId: 'comment-1',
+      organizationId: 'org-1',
+      participantExternalId: 'author-1',
+      platform: 'instagram',
+    });
+    const scope = {
+      brandId: 'brand-1',
+      organizationId: 'org-1',
+      userId: 'user-1',
+    };
+    const input = {
+      idempotencyKey: 'retry-reply',
+      text: 'Thanks for the comment',
+    };
+    instagramService.replyToComment
+      .mockRejectedValueOnce(new Error('provider unavailable'))
+      .mockResolvedValueOnce({ commentId: 'ig-reply-retried' });
+
+    await expect(
+      service.postReply(scope, inbound.conversationId, input),
+    ).rejects.toThrow('provider unavailable');
+    expect(messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          failureReason: 'provider unavailable',
+          idempotencyKey: input.idempotencyKey,
+          status: 'failed',
+        }),
+      ]),
+    );
+
+    const retried = await service.postReply(
+      scope,
+      inbound.conversationId,
+      input,
+    );
+
+    expect(instagramService.replyToComment).toHaveBeenCalledTimes(2);
+    expect(
+      messages.filter(
+        (message) => message.idempotencyKey === input.idempotencyKey,
+      ),
+    ).toHaveLength(1);
+    expect(retried).toMatchObject({
+      externalMessageId: 'ig-reply-retried',
+      failureReason: null,
+      status: 'sent',
+    });
   });
 
   it('queues comment trigger workflows when the inbound message has a user owner', async () => {

--- a/apps/server/api/src/collections/social-inbox/services/social-inbox.service.ts
+++ b/apps/server/api/src/collections/social-inbox/services/social-inbox.service.ts
@@ -13,7 +13,12 @@ import { findOrThrow } from '@api/shared/utils/find-or-throw/find-or-throw.util'
 import { PostStatus } from '@genfeedai/enums';
 import type { Prisma } from '@genfeedai/prisma';
 import { CredentialPlatform as PrismaCredentialPlatform } from '@genfeedai/prisma';
-import { BadRequestException, Injectable, Optional } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  Optional,
+} from '@nestjs/common';
 
 export interface SocialInboxScope {
   organizationId: string;
@@ -93,6 +98,13 @@ export type SocialInboxPage<T> = {
 };
 
 type JsonRecord = Record<string, unknown>;
+type OutboundAction = 'post_reply' | 'send_dm';
+type OutboundMessageType = 'dm' | 'reply';
+type OutboundPublishResult = { messageId: string; url?: string };
+type OutboundReservation = {
+  isClaimed: boolean;
+  message: SocialMessageDocument;
+};
 
 const SUPPORTED_PLATFORMS = new Set(['youtube', 'instagram']);
 const DEFAULT_PAGE_SIZE = 25;
@@ -416,63 +428,16 @@ export class SocialInboxService {
       );
     }
 
-    const existing = await this.findByIdempotency(
-      scope.organizationId,
-      input.idempotencyKey,
-    );
-    if (existing) {
-      return existing;
-    }
-
     const body = this.sanitizeBody(input.text);
-    const external = await this.publishReply(conversation, body);
-    const now = new Date();
-
-    const message = await this.prisma.socialMessage.create({
-      data: {
-        actionProvenance: this.buildActionProvenance({
-          action: 'post_reply',
-          conversation,
-          input,
-          scope,
-          status: 'sent',
-        }) as Prisma.InputJsonValue,
-        agentRunId: input.agentRunId,
-        body,
-        brandId: conversation.brandId,
-        conversationId: conversation.id,
-        credentialId: conversation.credentialId,
-        direction: 'outbound',
-        externalMessageId: external.messageId,
-        externalParentMessageId: conversation.externalParentId,
-        idempotencyKey: input.idempotencyKey,
-        messageType: 'reply',
-        organizationId: conversation.organizationId,
-        platform: conversation.platform,
-        postId: conversation.postId,
-        sourceUrl: external.url,
-        status: 'sent',
-        userId: scope.userId,
-        workflowRunId: input.workflowRunId,
-      },
-    });
-
-    await this.prisma.socialConversation.update({
-      data: {
-        automationState:
-          input.workflowRunId || input.agentRunId ? 'automated' : 'manual',
-        latestMessageAt: now,
-        latestMessageText: this.clamp(body, 500),
-        lastOutboundAt: now,
-        needsReview: false,
-        status: 'open',
-        unreadCount: 0,
-        updatedAt: now,
-      },
-      where: { id: conversation.id },
-    });
-
-    return this.toMessageDocument(message);
+    return await this.executeOutboundAction(
+      'post_reply',
+      'reply',
+      conversation,
+      scope,
+      input,
+      body,
+      () => this.publishReply(conversation, body),
+    );
   }
 
   async sendDm(
@@ -488,64 +453,20 @@ export class SocialInboxService {
       );
     }
 
-    const existing = await this.findByIdempotency(
-      scope.organizationId,
-      input.idempotencyKey,
-    );
-    if (existing) {
-      return existing;
-    }
-
     const body = this.sanitizeBody(input.text);
-    const external = await this.publishDm(conversation, {
-      recipientId: input.recipientId,
-      text: body,
-    });
-    const now = new Date();
-
-    const message = await this.prisma.socialMessage.create({
-      data: {
-        actionProvenance: this.buildActionProvenance({
-          action: 'send_dm',
-          conversation,
-          input,
-          scope,
-          status: 'sent',
-        }) as Prisma.InputJsonValue,
-        agentRunId: input.agentRunId,
-        body,
-        brandId: conversation.brandId,
-        conversationId: conversation.id,
-        credentialId: conversation.credentialId,
-        direction: 'outbound',
-        externalMessageId: external.messageId,
-        idempotencyKey: input.idempotencyKey,
-        messageType: 'dm',
-        organizationId: conversation.organizationId,
-        platform: conversation.platform,
-        postId: conversation.postId,
-        status: 'sent',
-        userId: scope.userId,
-        workflowRunId: input.workflowRunId,
-      },
-    });
-
-    await this.prisma.socialConversation.update({
-      data: {
-        automationState:
-          input.workflowRunId || input.agentRunId ? 'automated' : 'manual',
-        latestMessageAt: now,
-        latestMessageText: this.clamp(body, 500),
-        lastOutboundAt: now,
-        needsReview: false,
-        status: 'open',
-        unreadCount: 0,
-        updatedAt: now,
-      },
-      where: { id: conversation.id },
-    });
-
-    return this.toMessageDocument(message);
+    return await this.executeOutboundAction(
+      'send_dm',
+      'dm',
+      conversation,
+      scope,
+      input,
+      body,
+      () =>
+        this.publishDm(conversation, {
+          recipientId: input.recipientId,
+          text: body,
+        }),
+    );
   }
 
   async updateConversation(
@@ -1117,19 +1038,321 @@ export class SocialInboxService {
     return where;
   }
 
-  private async findByIdempotency(
-    organizationId: string,
-    idempotencyKey?: string,
-  ): Promise<SocialMessageDocument | null> {
-    if (!idempotencyKey) {
-      return null;
+  private async executeOutboundAction(
+    action: OutboundAction,
+    messageType: OutboundMessageType,
+    conversation: SocialConversationDocument,
+    scope: SocialInboxScope,
+    input: SocialActionInput,
+    body: string,
+    publish: () => Promise<OutboundPublishResult>,
+  ): Promise<SocialMessageDocument> {
+    const reservation = await this.reserveOutboundAction(
+      action,
+      messageType,
+      conversation,
+      scope,
+      input,
+      body,
+    );
+
+    if (!reservation.isClaimed) {
+      return reservation.message;
     }
 
-    const existing = await this.prisma.socialMessage.findFirst({
-      where: { idempotencyKey, organizationId },
+    let external: OutboundPublishResult;
+    try {
+      external = await publish();
+    } catch (error: unknown) {
+      await this.failOutboundAction(
+        reservation.message.id,
+        action,
+        conversation,
+        scope,
+        input,
+        error,
+      );
+      throw error;
+    }
+
+    const now = new Date();
+    const finalized = await this.prisma.socialMessage.updateMany({
+      data: {
+        actionProvenance: this.buildActionProvenance({
+          action,
+          conversation,
+          input,
+          scope,
+          status: 'sent',
+        }) as Prisma.InputJsonValue,
+        externalMessageId: external.messageId,
+        failureReason: null,
+        sourceUrl: external.url,
+        status: 'sent',
+      },
+      where: {
+        conversationId: conversation.id,
+        id: reservation.message.id,
+        isDeleted: false,
+        organizationId: scope.organizationId,
+        status: 'pending',
+      },
     });
 
-    return existing ? this.toMessageDocument(existing) : null;
+    if (finalized.count !== 1) {
+      throw new ConflictException('Social action reservation was lost');
+    }
+
+    await this.prisma.socialConversation.update({
+      data: {
+        automationState:
+          input.workflowRunId || input.agentRunId ? 'automated' : 'manual',
+        latestMessageAt: now,
+        latestMessageText: this.clamp(body, 500),
+        lastOutboundAt: now,
+        needsReview: false,
+        status: 'open',
+        unreadCount: 0,
+        updatedAt: now,
+      },
+      where: {
+        id: conversation.id,
+        organizationId: scope.organizationId,
+      },
+    });
+
+    const message = await this.prisma.socialMessage.findFirst({
+      where: {
+        conversationId: conversation.id,
+        id: reservation.message.id,
+        isDeleted: false,
+        organizationId: scope.organizationId,
+      },
+    });
+    if (!message) {
+      throw new ConflictException('Finalized social action was not found');
+    }
+
+    return this.toMessageDocument(message);
+  }
+
+  private async reserveOutboundAction(
+    action: OutboundAction,
+    messageType: OutboundMessageType,
+    conversation: SocialConversationDocument,
+    scope: SocialInboxScope,
+    input: SocialActionInput,
+    body: string,
+  ): Promise<OutboundReservation> {
+    if (input.idempotencyKey) {
+      const existing = await this.prisma.socialMessage.findFirst({
+        where: {
+          idempotencyKey: input.idempotencyKey,
+          isDeleted: false,
+          organizationId: scope.organizationId,
+        },
+      });
+      if (existing) {
+        return await this.claimExistingOutboundAction(
+          existing,
+          action,
+          messageType,
+          conversation,
+          scope,
+          input,
+          body,
+        );
+      }
+    }
+
+    try {
+      const created = await this.prisma.socialMessage.create({
+        data: {
+          actionProvenance: this.buildActionProvenance({
+            action,
+            conversation,
+            input,
+            scope,
+            status: 'pending',
+          }) as Prisma.InputJsonValue,
+          agentRunId: input.agentRunId,
+          body,
+          brandId: conversation.brandId,
+          conversationId: conversation.id,
+          credentialId: conversation.credentialId,
+          direction: 'outbound',
+          externalParentMessageId:
+            messageType === 'reply' ? conversation.externalParentId : undefined,
+          idempotencyKey: input.idempotencyKey,
+          messageType,
+          organizationId: conversation.organizationId,
+          platform: conversation.platform,
+          postId: conversation.postId,
+          status: 'pending',
+          userId: scope.userId,
+          workflowRunId: input.workflowRunId,
+        },
+      });
+
+      return { isClaimed: true, message: this.toMessageDocument(created) };
+    } catch (error: unknown) {
+      if (
+        !input.idempotencyKey ||
+        (error as { code?: string })?.code !== 'P2002'
+      ) {
+        throw error;
+      }
+
+      const winner = await this.prisma.socialMessage.findFirst({
+        where: {
+          idempotencyKey: input.idempotencyKey,
+          isDeleted: false,
+          organizationId: scope.organizationId,
+        },
+      });
+      if (!winner) {
+        throw error;
+      }
+
+      return await this.claimExistingOutboundAction(
+        winner,
+        action,
+        messageType,
+        conversation,
+        scope,
+        input,
+        body,
+      );
+    }
+  }
+
+  private async claimExistingOutboundAction(
+    existing: SocialMessage,
+    action: OutboundAction,
+    messageType: OutboundMessageType,
+    conversation: SocialConversationDocument,
+    scope: SocialInboxScope,
+    input: SocialActionInput,
+    body: string,
+  ): Promise<OutboundReservation> {
+    if (
+      existing.conversationId !== conversation.id ||
+      existing.messageType !== messageType ||
+      existing.body !== body
+    ) {
+      throw new BadRequestException(
+        'Idempotency key is already used by another social action',
+      );
+    }
+
+    if (existing.status === 'sent') {
+      return {
+        isClaimed: false,
+        message: this.toMessageDocument(existing),
+      };
+    }
+
+    if (existing.status === 'pending') {
+      throw new ConflictException('Social action is already in progress');
+    }
+
+    if (existing.status !== 'failed') {
+      throw new ConflictException(
+        `Social action cannot be retried from status ${existing.status}`,
+      );
+    }
+
+    const claimed = await this.prisma.socialMessage.updateMany({
+      data: {
+        actionProvenance: this.buildActionProvenance({
+          action,
+          conversation,
+          input,
+          scope,
+          status: 'pending',
+        }) as Prisma.InputJsonValue,
+        failureReason: null,
+        status: 'pending',
+      },
+      where: {
+        conversationId: conversation.id,
+        id: existing.id,
+        isDeleted: false,
+        organizationId: scope.organizationId,
+        status: 'failed',
+      },
+    });
+
+    if (claimed.count !== 1) {
+      const current = await this.prisma.socialMessage.findFirst({
+        where: {
+          conversationId: conversation.id,
+          id: existing.id,
+          isDeleted: false,
+          organizationId: scope.organizationId,
+        },
+      });
+      if (current?.status === 'sent') {
+        return {
+          isClaimed: false,
+          message: this.toMessageDocument(current),
+        };
+      }
+      throw new ConflictException('Social action retry is already in progress');
+    }
+
+    const reservation = await this.prisma.socialMessage.findFirst({
+      where: {
+        conversationId: conversation.id,
+        id: existing.id,
+        isDeleted: false,
+        organizationId: scope.organizationId,
+        status: 'pending',
+      },
+    });
+    if (!reservation) {
+      throw new ConflictException('Social action reservation was not found');
+    }
+
+    return {
+      isClaimed: true,
+      message: this.toMessageDocument(reservation),
+    };
+  }
+
+  private async failOutboundAction(
+    messageId: string,
+    action: OutboundAction,
+    conversation: SocialConversationDocument,
+    scope: SocialInboxScope,
+    input: SocialActionInput,
+    error: unknown,
+  ): Promise<void> {
+    const reason = this.clamp(
+      error instanceof Error ? error.message : String(error),
+      1000,
+    );
+
+    await this.prisma.socialMessage.updateMany({
+      data: {
+        actionProvenance: this.buildActionProvenance({
+          action,
+          conversation,
+          input,
+          scope,
+          status: 'failed',
+        }) as Prisma.InputJsonValue,
+        failureReason: reason ?? 'Provider publish failed',
+        status: 'failed',
+      },
+      where: {
+        conversationId: conversation.id,
+        id: messageId,
+        isDeleted: false,
+        organizationId: scope.organizationId,
+        status: 'pending',
+      },
+    });
   }
 
   private async getDraftMessage(


### PR DESCRIPTION
## Summary

- reserve organization-scoped social action idempotency keys as pending before calling YouTube or Instagram
- finalize reservations conditionally as sent, persist provider failures, and atomically reclaim failed actions for safe retries
- cover concurrent reply and DM requests plus provider failure/retry with Promise.all regression specs

## Verification

- `git diff --check`
- `bunx biome check apps/server/api/src/collections/social-inbox/services/social-inbox.service.ts apps/server/api/src/collections/social-inbox/services/social-inbox.service.spec.ts`
- `bun scripts/run-secretlint.ts --no-glob <touched files>`
- `bun scripts/ui/control-guard.ts <touched files>`
- repository pre-commit staged-file pipeline passed

Tests, typechecks, builds, coverage, and E2E were not run locally per the MacBook Pro verification policy; PR CI is the validation handoff.

## Residual risk

If a provider succeeds but database finalization fails, the reservation remains pending and prevents a duplicate resend; operational reconciliation is still required for that ambiguous outcome.

Closes #1546