### PR TITLE
fix(docker): drop folded workflow-saas refs, build @genfeedai/workflows

### DIFF
--- a/docker/Dockerfile.selfhosted
+++ b/docker/Dockerfile.selfhosted
@@ -169,12 +169,11 @@ RUN set -e; \
     pids=""; \
     bun --filter @genfeedai/types build & pids="$pids $!"; \
     bun --filter @genfeedai/config build & pids="$pids $!"; \
-    bun --filter @genfeedai/workflow-engine build & pids="$pids $!"; \
     ec=0; for p in $pids; do wait "$p" || ec=1; done; [ "$ec" = 0 ]; \
     bun --filter @genfeedai/helpers build; \
     bun --filter @genfeedai/integrations build; \
     bun --filter @genfeedai/serializers build; \
-    bun --filter @genfeedai/workflow-saas build
+    bun --filter @genfeedai/workflows build
 
 # Disable deleteOutDir for parallel builds
 RUN sed -i 's/"deleteOutDir": true/"deleteOutDir": false/' apps/server/nest-cli.json

--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -48,7 +48,7 @@ COPY package.json ./
 
 # Narrow the workspace graph to the packages needed for the unified server
 # image so Bun does not try to resolve unrelated web/mobile/extension apps.
-RUN node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json','utf8')); p.workspaces=['apps/server/*','packages/auth-client','packages/client','packages/config','packages/constants','packages/contexts','packages/enums','packages/harness','packages/helpers','packages/hooks','packages/integrations','packages/interfaces','packages/models','packages/pricing','packages/prisma','packages/props','packages/queue-contracts','packages/serializers','packages/services','packages/storage','packages/tools','packages/types','packages/ui','packages/utils','packages/workflow-engine','packages/workflow-saas','packages/workflows','ee/packages/billing']; if (p.scripts) delete p.scripts.postinstall; if (p.dependencies?.resend==='^6.9.3') p.dependencies.resend='6.9.3'; fs.writeFileSync('package.json', JSON.stringify(p, null, 2)+'\n');"
+RUN node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json','utf8')); p.workspaces=['apps/server/*','packages/auth-client','packages/client','packages/config','packages/constants','packages/contexts','packages/enums','packages/harness','packages/helpers','packages/hooks','packages/integrations','packages/interfaces','packages/models','packages/pricing','packages/prisma','packages/props','packages/queue-contracts','packages/serializers','packages/services','packages/storage','packages/tools','packages/types','packages/ui','packages/utils','packages/workflows','ee/packages/billing']; if (p.scripts) delete p.scripts.postinstall; if (p.dependencies?.resend==='^6.9.3') p.dependencies.resend='6.9.3'; fs.writeFileSync('package.json', JSON.stringify(p, null, 2)+'\n');"
 
 # Copy all 12 service package.json files for bun workspace resolution
 COPY apps/server/api/package.json ./apps/server/api/
@@ -90,8 +90,6 @@ RUN --mount=type=bind,source=.,target=/ctx \
       /ctx/packages/types/package.json \
       /ctx/packages/ui/package.json \
       /ctx/packages/utils/package.json \
-      /ctx/packages/workflow-engine/package.json \
-      /ctx/packages/workflow-saas/package.json \
       /ctx/packages/workflows/package.json \
       /ctx/ee/packages/billing/package.json \
       /ctx/apps/server/*/package.json; do \
@@ -147,12 +145,11 @@ RUN set -e; \
     pids=""; \
     bun --filter @genfeedai/types build & pids="$pids $!"; \
     bun --filter @genfeedai/config build & pids="$pids $!"; \
-    bun --filter @genfeedai/workflow-engine build & pids="$pids $!"; \
     ec=0; for p in $pids; do wait "$p" || ec=1; done; [ "$ec" = 0 ]; \
     bun --filter @genfeedai/helpers build; \
     bun --filter @genfeedai/integrations build; \
     bun --filter @genfeedai/serializers build; \
-    bun --filter @genfeedai/workflow-saas build
+    bun --filter @genfeedai/workflows build
 
 # --- Layer 2: Service source code (changes most frequently) ---
 COPY apps/server/ apps/server/
@@ -284,8 +281,6 @@ RUN mkdir -p apps/server/api \
              packages/tools \
              packages/types \
              packages/utils \
-             packages/workflow-engine \
-             packages/workflow-saas \
              packages/workflows \
              ee/packages/billing
 
@@ -332,8 +327,6 @@ COPY --from=builder /usr/src/app/packages/storage/package.json ./packages/storag
 COPY --from=builder /usr/src/app/packages/tools/package.json ./packages/tools/package.json
 COPY --from=builder /usr/src/app/packages/types/package.json ./packages/types/package.json
 COPY --from=builder /usr/src/app/packages/utils/package.json ./packages/utils/package.json
-COPY --from=builder /usr/src/app/packages/workflow-engine/package.json ./packages/workflow-engine/package.json
-COPY --from=builder /usr/src/app/packages/workflow-saas/package.json ./packages/workflow-saas/package.json
 COPY --from=builder /usr/src/app/packages/workflows/package.json ./packages/workflows/package.json
 COPY --from=builder /usr/src/app/ee/packages/billing/package.json ./ee/packages/billing/package.json
 


### PR DESCRIPTION
## Problem

The server-image build (`Build & Push Server Image`) fails on `master`:
```
error: Workspace not found "packages/workflow-saas"
ERROR: process "/bin/sh -c HUSKY=0 bun install --linker hoisted" did not complete successfully: exit code: 1
```
`packages/workflow-saas` was folded into `@genfeedai/workflows/nodes` in #1624 (`52856e493`), but the server + self-hosted Dockerfiles still referenced the removed workspace. This breaks `bun install` in the Docker build and blocks every production server-image build (and thus `Deploy ECS (production)`).

## Fix
- Remove the stale `packages/workflow-saas` entry from the pruned workspaces list, the two package.json COPYs, and the deploy-prune copy list in `Dockerfile.server`.
- Build `@genfeedai/workflows` (a tsup/`dist` package whose exports resolve to `./dist/*`, and which was not built anywhere in the image) in the slot `workflow-saas` occupied — in both Dockerfiles.

## Verification
The `Build & Push Server Image` check on this PR is the direct test.

Pre-existing since #1624; surfaced while unblocking the agent-first onboarding deploy (epic #1644).