### PR TITLE
fix(docker): add packages/agent to server image workspace allowlist

### DIFF
--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -48,7 +48,7 @@ COPY package.json ./
 
 # Narrow the workspace graph to the packages needed for the unified server
 # image so Bun does not try to resolve unrelated web/mobile/extension apps.
-RUN node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json','utf8')); p.workspaces=['apps/server/*','packages/auth-client','packages/client','packages/config','packages/constants','packages/contexts','packages/enums','packages/harness','packages/helpers','packages/hooks','packages/integrations','packages/interfaces','packages/models','packages/pricing','packages/prisma','packages/props','packages/queue-contracts','packages/serializers','packages/services','packages/storage','packages/tools','packages/types','packages/ui','packages/utils','packages/workflows','ee/packages/billing']; if (p.scripts) delete p.scripts.postinstall; if (p.dependencies?.resend==='^6.9.3') p.dependencies.resend='6.9.3'; fs.writeFileSync('package.json', JSON.stringify(p, null, 2)+'\n');"
+RUN node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json','utf8')); p.workspaces=['apps/server/*','packages/agent','packages/auth-client','packages/client','packages/config','packages/constants','packages/contexts','packages/enums','packages/harness','packages/helpers','packages/hooks','packages/integrations','packages/interfaces','packages/models','packages/pricing','packages/prisma','packages/props','packages/queue-contracts','packages/serializers','packages/services','packages/storage','packages/tools','packages/types','packages/ui','packages/utils','packages/workflows','ee/packages/billing']; if (p.scripts) delete p.scripts.postinstall; if (p.dependencies?.resend==='^6.9.3') p.dependencies.resend='6.9.3'; fs.writeFileSync('package.json', JSON.stringify(p, null, 2)+'\n');"
 
 # Copy all 12 service package.json files for bun workspace resolution
 COPY apps/server/api/package.json ./apps/server/api/
@@ -67,6 +67,7 @@ COPY apps/server/videos/package.json ./apps/server/videos/
 # Match the reduced server-only workspace globs exactly.
 RUN --mount=type=bind,source=.,target=/ctx \
     for f in \
+      /ctx/packages/agent/package.json \
       /ctx/packages/auth-client/package.json \
       /ctx/packages/client/package.json \
       /ctx/packages/config/package.json \
@@ -262,6 +263,7 @@ RUN mkdir -p apps/server/api \
              apps/server/images \
              apps/server/voices \
              apps/server/videos \
+             packages/agent \
              packages/auth-client \
              packages/client \
              packages/config \


### PR DESCRIPTION
#1648 added @genfeedai/agent as an apps/server/api workspace dependency (AgentDashboardToolHandler uses the dashboard OpenUI validator), but packages/agent was absent from Dockerfile.server's hand-maintained workspace allowlist, breaking 'bun install' with 'Workspace dependency @genfeedai/agent not found'. Added to the pruned workspaces list, package.json copy set, and runtime prune list. Validated green via a dispatched image build on the branch (run 29229117151). Follow-up: auto-derive the Dockerfile workspace list to stop this recurring.