### PR TITLE
feat(app): launch products as trusted work surfaces

### DIFF
--- a/.agents/memory/reference_app_page_map.md
+++ b/.agents/memory/reference_app_page_map.md
@@ -17,9 +17,15 @@ Source of truth:
 
 - Next App Router pages under `apps/app/app/**/page.tsx`
 - Route constants in `packages/constants/src/routes.constant.ts`
+- Executable protected-route classification in
+  `apps/app/src/lib/workspace-shell/workspace-shell-registry.ts`
 - Shell surface resolver in `apps/app/packages/components/useAppProtectedLayout.ts`
 - Sidebar resolver in `apps/app/packages/components/AppProtectedLayoutSidebar.tsx`
 - App switcher in `packages/ui/src/components/shell/app-switcher/AppSwitcher.tsx`
+
+The application registry mirrors all 206 parity-eligible patterns below and
+keeps Notifications plus the Community/Desktop terminal dock as explicit
+trusted non-route surfaces. The two hard-cut families remain outside it.
 
 Regenerate the raw route list with:
 

--- a/apps/app/packages/components/app-protected-layout.test.tsx
+++ b/apps/app/packages/components/app-protected-layout.test.tsx
@@ -707,7 +707,7 @@ describe('AppProtectedLayout', () => {
 
   it('mounts the flagged universal shell without the legacy terminal dock', async () => {
     featureFlagState.conversationShell = true;
-    mockPathname.value = '/studio/image';
+    mockPathname.value = '/org-123/brand-123/studio/image';
 
     render(
       <AppProtectedLayout>
@@ -734,7 +734,7 @@ describe('AppProtectedLayout', () => {
   it('restores the exact legacy dock when the flagged shell fails to render', () => {
     featureFlagState.conversationShell = true;
     featureFlagState.shellThrows = true;
-    mockPathname.value = '/studio/image';
+    mockPathname.value = '/org-123/brand-123/studio/image';
     const consoleError = vi
       .spyOn(console, 'error')
       .mockImplementation(() => undefined);

--- a/apps/app/packages/components/useAppProtectedLayout.ts
+++ b/apps/app/packages/components/useAppProtectedLayout.ts
@@ -166,8 +166,8 @@ export function useAppProtectedLayout(
   const isAnalyticsRoute = pathname.startsWith(APP_ROUTE_PREFIXES.ANALYTICS);
   const isConversationShellEnabled = useConversationShellEnabled();
   const workspaceShellRoute = useMemo(
-    () => resolveWorkspaceShellRoute(pathname),
-    [pathname],
+    () => resolveWorkspaceShellRoute(rawPathname),
+    [rawPathname],
   );
   const isUniversalWorkspaceShell = Boolean(
     isConversationShellEnabled &&

--- a/apps/app/src/components/shell/AppProtectedTopbar.test.tsx
+++ b/apps/app/src/components/shell/AppProtectedTopbar.test.tsx
@@ -12,6 +12,7 @@ const mockPathname = vi.hoisted(() => ({
 const mockAccessState = vi.hoisted(() => ({
   isSuperAdmin: false,
 }));
+const mockConversationShell = vi.hoisted(() => ({ enabled: false }));
 const originalLocation = window.location;
 
 vi.mock('@genfeedai/enums', () => ({
@@ -68,6 +69,10 @@ vi.mock(
     useAccessState: () => mockAccessState,
   }),
 );
+
+vi.mock('@/lib/workspace-shell/use-conversation-shell', () => ({
+  useConversationShellEnabled: () => mockConversationShell.enabled,
+}));
 
 vi.mock('@ui/primitives/button', () => ({
   Button: ({
@@ -129,6 +134,11 @@ vi.mock('@ui/shell/app-switcher/AppSwitcher', () => ({
     brandSlug?: string;
     currentApp?: string;
     orgSlug: string;
+    preservedSearch?: string;
+    resolveNavigation?: (href: string) => {
+      announcement?: string;
+      href: string;
+    };
     showAdmin?: boolean;
     variant?: string;
   }) => {
@@ -177,6 +187,7 @@ describe('AppProtectedTopbar', () => {
     mockSearchParams = new URLSearchParams();
     mockPathname.value = '/acme/brand/workspace/overview';
     mockAccessState.isSuperAdmin = false;
+    mockConversationShell.enabled = false;
     appSwitcherSpy.mockClear();
     brandSwitcherSpy.mockClear();
     mockPush.mockClear();
@@ -330,6 +341,43 @@ describe('AppProtectedTopbar', () => {
         showAdmin: false,
       }),
     );
+  });
+
+  it('launches switcher destinations through the trusted shell resolver', () => {
+    mockConversationShell.enabled = true;
+    mockSearchParams = new URLSearchParams([
+      ['taskId', 'task-1'],
+      ['taskSource', 'workspace'],
+      ['thread', 'thread-1'],
+    ]);
+
+    render(
+      <AppProtectedTopbar
+        orgSlug="acme"
+        brandSlug="brand"
+        currentApp="agent"
+      />,
+    );
+
+    const switcherProps = appSwitcherSpy.mock.lastCall?.[0] as {
+      preservedSearch?: string;
+      resolveNavigation?: (href: string) => {
+        announcement?: string;
+        href: string;
+      };
+    };
+
+    expect(switcherProps.preservedSearch).toBe(
+      'taskId=task-1&taskSource=workspace',
+    );
+    expect(
+      switcherProps.resolveNavigation?.(
+        '/acme/brand/analytics/overview?taskId=task-1',
+      ),
+    ).toEqual({
+      announcement: 'Opening analytics in canvas mode.',
+      href: '/acme/brand/analytics/overview?taskId=task-1&thread=thread-1',
+    });
   });
 
   it('renders the cloud sync indicator beside the terminal dock control', () => {

--- a/apps/app/src/components/shell/AppProtectedTopbar.tsx
+++ b/apps/app/src/components/shell/AppProtectedTopbar.tsx
@@ -36,7 +36,10 @@ import CloudSyncIndicator from '@/components/cloud-sync-indicator/CloudSyncIndic
 import {
   appendSearchParamsToHref,
   getBrandSwitchHref,
+  pickOperatorTaskContextSearchParams,
 } from '@/lib/navigation/operator-shell';
+import { useConversationShellEnabled } from '@/lib/workspace-shell/use-conversation-shell';
+import { resolveWorkspaceSurfaceLaunch } from '@/lib/workspace-shell/workspace-surface-launcher';
 
 const TOPBAR_BREADCRUMB_ROOT_LABELS: Record<
   NonNullable<TopbarProps['currentApp']>,
@@ -119,6 +122,7 @@ function AppProtectedTopbarContent({
   const searchParams = useSearchParams();
   const pathname = usePathname();
   const { push } = useRouter();
+  const isConversationShellEnabled = useConversationShellEnabled();
   const { brandId, brands, selectedBrand, setBrandId, setOrganizationId } =
     useBrand();
   const { isAssetGateLocked, isSuperAdmin } = useAccessState();
@@ -204,6 +208,32 @@ function AppProtectedTopbarContent({
 
   const taskId = searchParams.get('taskId');
   const taskTitle = searchParams.get('taskTitle');
+  const currentHref = appendSearchParamsToHref(
+    pathname,
+    new URLSearchParams(searchParams.toString()),
+  );
+  const preservedTaskSearch = pickOperatorTaskContextSearchParams(
+    new URLSearchParams(searchParams.toString()),
+  ).toString();
+  const resolveAppSwitcherNavigation = useCallback(
+    (destinationHref: string) => {
+      if (!isConversationShellEnabled) {
+        return { href: destinationHref };
+      }
+
+      const launch = resolveWorkspaceSurfaceLaunch({
+        currentHref,
+        destinationHref,
+        threadId: searchParams.get('thread'),
+      });
+
+      return {
+        announcement: launch.announcement,
+        href: launch.href,
+      };
+    },
+    [currentHref, isConversationShellEnabled, searchParams],
+  );
   const ToggleIcon = isMenuOpen ? HiXMark : HiBars3;
   const isAdminChrome = chrome === 'admin';
   const shouldRenderAgentToggle = Boolean(onAgentToggle) && !isSaaS();
@@ -337,6 +367,8 @@ function AppProtectedTopbarContent({
                 brandAwareSlug={brandAwareAppSlug}
                 brandSlug={effectiveBrandSlug}
                 isAssetGateLocked={isAssetGateLocked}
+                preservedSearch={preservedTaskSearch || undefined}
+                resolveNavigation={resolveAppSwitcherNavigation}
                 showAdmin={isAdminChrome || isSuperAdmin}
               />
             ) : null}

--- a/apps/app/src/components/workspace-shell/UniversalWorkspaceShell.tsx
+++ b/apps/app/src/components/workspace-shell/UniversalWorkspaceShell.tsx
@@ -122,10 +122,11 @@ function UniversalWorkspaceShellContent({
       requireWorkspaceShellLocation(
         restoreWorkspaceShellLocation({
           normalizedPathname,
+          pathname: rawPathname,
           searchParams: new URLSearchParams(searchParamsString),
         }),
       ),
-    [normalizedPathname, searchParamsString],
+    [normalizedPathname, rawPathname, searchParamsString],
   );
 
   const {
@@ -134,7 +135,9 @@ function UniversalWorkspaceShellContent({
     isCanonical,
     overlayReference,
     restorationFailure,
+    safeFallbackHref,
     state,
+    surfaceKey,
     threadId,
   } = shellLocation;
   const canonicalSearchParamsString = canonicalSearchParams.toString();
@@ -181,16 +184,16 @@ function UniversalWorkspaceShellContent({
     }
     replace(
       restorationFailure === 'invalid_thread'
-        ? orgHref(APP_ROUTES.AGENT.ROOT)
+        ? safeFallbackHref
         : canonicalHref,
     );
   }, [
     canonicalSearchParamsString,
     isCanonical,
-    orgHref,
     rawPathname,
     replace,
     restorationFailure,
+    safeFallbackHref,
   ]);
 
   useEffect(() => {
@@ -370,7 +373,7 @@ function UniversalWorkspaceShellContent({
       <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4">
         <div className="gen-shell-empty-state p-4">
           <p className="text-sm font-medium text-foreground">
-            Registered inspector slot
+            Registered {surfaceKey} adapter slot
           </p>
           <p className="mt-1 text-xs leading-5 text-muted-foreground">
             Product-owned context adapters land here without changing their
@@ -401,10 +404,11 @@ function UniversalWorkspaceShellContent({
     <div
       className="relative min-h-[calc(100dvh-var(--desktop-titlebar-height)-3rem)] overflow-hidden bg-black p-2"
       data-shell-state={state}
+      data-workspace-surface={surfaceKey}
       data-testid="universal-workspace-shell"
     >
       <div aria-live="polite" className="sr-only" role="status">
-        Workspace state: {state}
+        Workspace mode: {state}. Active surface: {surfaceKey}.
       </div>
 
       <div

--- a/apps/app/src/lib/workspace-shell/workspace-shell-location.spec.ts
+++ b/apps/app/src/lib/workspace-shell/workspace-shell-location.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { normalizeProtectedPathname } from '@/lib/navigation/operator-shell';
 import {
   buildWorkspaceShellHref,
   removeWorkspaceShellOverlayParams,
@@ -10,6 +11,7 @@ describe('workspace shell URL restoration', () => {
     expect(
       restoreWorkspaceShellLocation({
         normalizedPathname: '/agent/thread-1',
+        pathname: '/acme/~/agent/thread-1',
         searchParams: new URLSearchParams(),
       }),
     ).toMatchObject({
@@ -21,6 +23,7 @@ describe('workspace shell URL restoration', () => {
     expect(
       restoreWorkspaceShellLocation({
         normalizedPathname: '/studio/image',
+        pathname: '/acme/moonrise/studio/image',
         searchParams: new URLSearchParams({ thread: 'thread-1' }),
       }),
     ).toMatchObject({
@@ -31,24 +34,24 @@ describe('workspace shell URL restoration', () => {
   });
 
   it.each([
-    '/analytics/overview',
-    '/compose/post',
-    '/editor/new',
-    '/library/moodboard',
-    '/messages',
-    '/orchestration/skills',
-    '/overview/activities',
-    '/posts/calendar',
-    '/research/discovery',
-    '/studio/fastlane',
-    '/tasks/task-1',
-    '/workflows/templates',
-    '/workspace/inbox',
-    '/write',
+    '/acme/moonrise/analytics/overview',
+    '/acme/moonrise/compose/post',
+    '/acme/moonrise/library/moodboard',
+    '/acme/moonrise/messages',
+    '/acme/moonrise/orchestration/skills',
+    '/acme/moonrise/overview/activities',
+    '/acme/moonrise/posts/calendar',
+    '/acme/moonrise/research/discovery',
+    '/acme/moonrise/studio/fastlane',
+    '/acme/moonrise/tasks/task-1',
+    '/acme/moonrise/workflows/templates',
+    '/acme/moonrise/workspace/inbox/all',
+    '/acme/~/write',
   ])('registers the protected product family %s as canvas', (pathname) => {
     expect(
       restoreWorkspaceShellLocation({
-        normalizedPathname: pathname,
+        normalizedPathname: normalizeProtectedPathname(pathname),
+        pathname,
         searchParams: new URLSearchParams(),
       }),
     ).toMatchObject({ baseState: 'canvas', state: 'canvas' });
@@ -58,6 +61,7 @@ describe('workspace shell URL restoration', () => {
     expect(
       restoreWorkspaceShellLocation({
         normalizedPathname: '/library/images',
+        pathname: '/acme/moonrise/library/images',
         searchParams: new URLSearchParams({
           overlay: 'shell-preview',
           overlayRef: 'asset:asset-123',
@@ -76,6 +80,7 @@ describe('workspace shell URL restoration', () => {
   it('removes invalid overlay state without changing scope or opaque queries', () => {
     const restored = restoreWorkspaceShellLocation({
       normalizedPathname: '/posts/calendar',
+      pathname: '/acme/moonrise/posts/calendar',
       searchParams: new URLSearchParams({
         overlay: 'model-produced-surface',
         taskId: 'task-1',
@@ -97,6 +102,7 @@ describe('workspace shell URL restoration', () => {
   it('fails an invalid typed reference back to the base route', () => {
     const restored = restoreWorkspaceShellLocation({
       normalizedPathname: '/workspace/overview',
+      pathname: '/acme/moonrise/workspace/overview',
       searchParams: new URLSearchParams({
         overlay: 'shell-preview',
         overlayRef: 'approval:grant-access',
@@ -114,13 +120,28 @@ describe('workspace shell URL restoration', () => {
     expect(
       restoreWorkspaceShellLocation({
         normalizedPathname: '/agent/undefined',
+        pathname: '/acme/~/agent/undefined',
         searchParams: new URLSearchParams(),
       }),
     ).toMatchObject({
       isCanonical: false,
       restorationFailure: 'invalid_thread',
+      safeFallbackHref: '/acme/~/agent',
       state: 'conversation',
       threadId: null,
+    });
+  });
+
+  it('keeps malformed brand conversation fallbacks inside the same brand', () => {
+    expect(
+      restoreWorkspaceShellLocation({
+        normalizedPathname: '/agent/undefined',
+        pathname: '/acme/moonrise/agent/undefined',
+        searchParams: new URLSearchParams(),
+      }),
+    ).toMatchObject({
+      restorationFailure: 'invalid_thread',
+      safeFallbackHref: '/acme/moonrise/agent',
     });
   });
 
@@ -128,24 +149,28 @@ describe('workspace shell URL restoration', () => {
     expect(
       restoreWorkspaceShellLocation({
         normalizedPathname: '/agent/journey',
+        pathname: '/acme/~/agent/journey',
         searchParams: new URLSearchParams(),
       }),
     ).toBeNull();
     expect(
       restoreWorkspaceShellLocation({
         normalizedPathname: '/agent/onboarding',
+        pathname: '/acme/~/agent/onboarding',
         searchParams: new URLSearchParams(),
       }),
     ).toBeNull();
     expect(
       restoreWorkspaceShellLocation({
         normalizedPathname: '/settings/billing',
+        pathname: '/acme/~/settings/billing',
         searchParams: new URLSearchParams(),
       }),
     ).toBeNull();
     expect(
       restoreWorkspaceShellLocation({
         normalizedPathname: '/unregistered-product',
+        pathname: '/acme/moonrise/unregistered-product',
         searchParams: new URLSearchParams(),
       }),
     ).toBeNull();

--- a/apps/app/src/lib/workspace-shell/workspace-shell-location.ts
+++ b/apps/app/src/lib/workspace-shell/workspace-shell-location.ts
@@ -1,49 +1,29 @@
+import type {
+  RestoreWorkspaceShellLocationParams,
+  WorkspaceShellLocation,
+  WorkspaceShellReferenceKind,
+  WorkspaceShellTypedReference,
+} from '@genfeedai/interfaces/ui/workspace-shell.interface';
 import { appendSearchParamsToHref } from '@/lib/navigation/operator-shell';
 import {
   getWorkspaceShellOverlayRegistration,
   resolveWorkspaceShellRoute,
   resolveWorkspaceShellSafeFallback,
-  type WorkspaceShellBaseState,
-  type WorkspaceShellReferenceKind,
 } from './workspace-shell-registry';
+
+export type {
+  RestoreWorkspaceShellLocationParams,
+  WorkspaceShellLocation,
+  WorkspaceShellRestorationFailure,
+  WorkspaceShellState,
+  WorkspaceShellTypedReference,
+} from '@genfeedai/interfaces/ui/workspace-shell.interface';
 
 export const WORKSPACE_SHELL_QUERY_KEYS = [
   'overlay',
   'overlayRef',
   'thread',
 ] as const;
-
-export type WorkspaceShellState = WorkspaceShellBaseState | 'overlay';
-
-export type WorkspaceShellTypedReference = {
-  readonly id: string;
-  readonly kind: WorkspaceShellReferenceKind;
-};
-
-export type WorkspaceShellRestorationFailure =
-  | 'invalid_overlay'
-  | 'invalid_overlay_reference'
-  | 'invalid_thread';
-
-export type WorkspaceShellLocation = {
-  readonly baseState: WorkspaceShellBaseState;
-  readonly canonicalSearchParams: URLSearchParams;
-  readonly isCanonical: boolean;
-  readonly overlayKey: string | null;
-  readonly overlayReference: WorkspaceShellTypedReference | null;
-  readonly restorationFailure: WorkspaceShellRestorationFailure | null;
-  readonly routeKey: string;
-  readonly safeFallbackHref: string;
-  readonly state: WorkspaceShellState;
-  readonly surfaceKey: string;
-  readonly threadId: string | null;
-};
-
-type RestoreWorkspaceShellLocationParams = {
-  readonly normalizedPathname: string;
-  readonly pathname: string;
-  readonly searchParams: URLSearchParams;
-};
 
 function isSafeOpaqueId(value: string | null): value is string {
   return Boolean(

--- a/apps/app/src/lib/workspace-shell/workspace-shell-location.ts
+++ b/apps/app/src/lib/workspace-shell/workspace-shell-location.ts
@@ -1,7 +1,8 @@
 import { appendSearchParamsToHref } from '@/lib/navigation/operator-shell';
 import {
+  getWorkspaceShellOverlayRegistration,
   resolveWorkspaceShellRoute,
-  WORKSPACE_SHELL_OVERLAY_REGISTRY,
+  resolveWorkspaceShellSafeFallback,
   type WorkspaceShellBaseState,
   type WorkspaceShellReferenceKind,
 } from './workspace-shell-registry';
@@ -32,12 +33,15 @@ export type WorkspaceShellLocation = {
   readonly overlayReference: WorkspaceShellTypedReference | null;
   readonly restorationFailure: WorkspaceShellRestorationFailure | null;
   readonly routeKey: string;
+  readonly safeFallbackHref: string;
   readonly state: WorkspaceShellState;
+  readonly surfaceKey: string;
   readonly threadId: string | null;
 };
 
 type RestoreWorkspaceShellLocationParams = {
   readonly normalizedPathname: string;
+  readonly pathname: string;
   readonly searchParams: URLSearchParams;
 };
 
@@ -82,14 +86,16 @@ function extractConversationThreadId(pathname: string): string | null {
 
 export function restoreWorkspaceShellLocation({
   normalizedPathname,
+  pathname,
   searchParams,
 }: RestoreWorkspaceShellLocationParams): WorkspaceShellLocation | null {
-  const route = resolveWorkspaceShellRoute(normalizedPathname);
+  const route = resolveWorkspaceShellRoute(pathname);
   if (!route || route.mode === 'dedicated') {
     return null;
   }
 
   const canonicalSearchParams = new URLSearchParams(searchParams);
+  const safeFallbackHref = resolveWorkspaceShellSafeFallback(route);
   const requestedThreadId = searchParams.get('thread');
   const threadId =
     route.mode === 'conversation'
@@ -114,7 +120,9 @@ export function restoreWorkspaceShellLocation({
       overlayReference: null,
       restorationFailure: 'invalid_thread',
       routeKey: route.key,
+      safeFallbackHref,
       state: route.mode,
+      surfaceKey: route.surfaceKey,
       threadId: null,
     };
   }
@@ -135,7 +143,7 @@ export function restoreWorkspaceShellLocation({
   const overlayKey = searchParams.get('overlay');
   const requestedOverlayReference = searchParams.get('overlayRef');
   const overlay = overlayKey
-    ? WORKSPACE_SHELL_OVERLAY_REGISTRY.get(overlayKey)
+    ? getWorkspaceShellOverlayRegistration(overlayKey)
     : null;
 
   if (!overlay) {
@@ -151,7 +159,9 @@ export function restoreWorkspaceShellLocation({
         overlayReference: null,
         restorationFailure: 'invalid_overlay',
         routeKey: route.key,
+        safeFallbackHref,
         state: route.mode,
+        surfaceKey: route.surfaceKey,
         threadId,
       };
     }
@@ -164,7 +174,9 @@ export function restoreWorkspaceShellLocation({
       overlayReference: null,
       restorationFailure: null,
       routeKey: route.key,
+      safeFallbackHref,
       state: route.mode,
+      surfaceKey: route.surfaceKey,
       threadId,
     };
   }
@@ -185,7 +197,9 @@ export function restoreWorkspaceShellLocation({
       overlayReference: null,
       restorationFailure: 'invalid_overlay_reference',
       routeKey: route.key,
+      safeFallbackHref,
       state: route.mode,
+      surfaceKey: route.surfaceKey,
       threadId,
     };
   }
@@ -198,7 +212,9 @@ export function restoreWorkspaceShellLocation({
     overlayReference,
     restorationFailure: null,
     routeKey: route.key,
+    safeFallbackHref,
     state: 'overlay',
+    surfaceKey: route.surfaceKey,
     threadId,
   };
 }

--- a/apps/app/src/lib/workspace-shell/workspace-shell-registry.spec.ts
+++ b/apps/app/src/lib/workspace-shell/workspace-shell-registry.spec.ts
@@ -101,6 +101,13 @@ describe('workspace shell trusted registry', () => {
     ).toBeNull();
   });
 
+  it('does not treat reserved application prefixes as scoped routes', () => {
+    expect(resolveWorkspaceShellRoute('/settings/~/overview')).toBeNull();
+    expect(resolveWorkspaceShellRoute('/settings/example/posts')).toBeNull();
+    expect(resolveWorkspaceShellRoute('/admin/~/overview')).toBeNull();
+    expect(resolveWorkspaceShellRoute('/admin/example/posts')).toBeNull();
+  });
+
   it('interpolates a safe fallback without widening scope', () => {
     const route = resolveWorkspaceShellRoute(
       '/acme/moonrise/analytics/trends/detail/trend-1',

--- a/apps/app/src/lib/workspace-shell/workspace-shell-registry.spec.ts
+++ b/apps/app/src/lib/workspace-shell/workspace-shell-registry.spec.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getWorkspaceShellOverlayRegistration,
+  PROTECTED_ROUTE_INVENTORY,
+  resolveWorkspaceShellRoute,
+  resolveWorkspaceShellSafeFallback,
+  WORKSPACE_SHELL_AUXILIARY_REGISTRY,
+} from './workspace-shell-registry';
+
+const ROUTE_PARAM_FIXTURES: Readonly<Record<string, string>> = {
+  agentId: 'agent-1',
+  brandSlug: 'moonrise',
+  filter: 'all',
+  id: 'resource-1',
+  orgSlug: 'acme',
+  platform: 'instagram',
+  runId: 'run-1',
+  segment: 'post',
+  slug: 'character-1',
+  threadId: 'thread-1',
+  type: 'image',
+  view: 'all',
+};
+
+function materializeRoutePattern(pattern: string): string {
+  return pattern.replace(
+    /:([A-Za-z][A-Za-z0-9]*)/g,
+    (_, key: string) => ROUTE_PARAM_FIXTURES[key] ?? `${key}-1`,
+  );
+}
+
+describe('workspace shell trusted registry', () => {
+  it('owns the complete accepted protected-route denominator', () => {
+    expect(PROTECTED_ROUTE_INVENTORY).toHaveLength(206);
+    expect(
+      new Set(PROTECTED_ROUTE_INVENTORY.map((route) => route.canonicalUrl))
+        .size,
+    ).toBe(206);
+
+    for (const route of PROTECTED_ROUTE_INVENTORY) {
+      expect(route.accessPolicy).toMatch(
+        /^(authenticated|brand-member|organization-member|platform-admin)$/,
+      );
+      expect(route.allowedShellModes).toEqual([route.mode]);
+      expect(route.availability).toBe(
+        route.mode === 'dedicated' ? 'always' : 'conversation-shell',
+      );
+      expect(route.canonicalUrl).toMatch(/^\//);
+      expect(route.deployments).toEqual([
+        'cloud-web',
+        'self-hosted-web',
+        'desktop',
+      ]);
+      expect(route.restoration).toEqual({
+        history: 'canonical-url',
+        invalidShellParams: 'replace',
+        searchParams: 'preserve-opaque',
+      });
+      expect(route.launchTarget).toBe(
+        route.mode === 'canvas'
+          ? 'focused-canvas'
+          : route.mode === 'conversation'
+            ? 'inline'
+            : 'dedicated-route',
+      );
+      expect(route.safeFallback).toMatch(/^\//);
+      expect(route.surfaceKey).not.toHaveLength(0);
+    }
+  });
+
+  it('resolves every canonical inventory pattern to its exact registration', () => {
+    for (const registration of PROTECTED_ROUTE_INVENTORY) {
+      const route = resolveWorkspaceShellRoute(
+        materializeRoutePattern(registration.canonicalUrl),
+      );
+
+      expect(route?.key).toBe(registration.key);
+    }
+  });
+
+  it.each([
+    ['/:orgSlug/:brandSlug/posts/calendar', 'canvas'],
+    ['/:orgSlug/:brandSlug/library/moodboard', 'canvas'],
+    ['/:orgSlug/:brandSlug/orchestration/skills', 'canvas'],
+    ['/:orgSlug/:brandSlug/studio/batch', 'canvas'],
+    ['/:orgSlug/:brandSlug/studio/clips', 'canvas'],
+    ['/:orgSlug/:brandSlug/studio/fastlane', 'canvas'],
+    ['/:orgSlug/:brandSlug/settings/publishing', 'dedicated'],
+    ['/:orgSlug/~/settings/billing', 'dedicated'],
+    ['/admin/administration/users', 'dedicated'],
+  ] as const)('classifies %s as %s', (pattern, mode) => {
+    expect(
+      resolveWorkspaceShellRoute(materializeRoutePattern(pattern))?.mode,
+    ).toBe(mode);
+  });
+
+  it('keeps the two accepted hard-cut families outside the registry', () => {
+    expect(resolveWorkspaceShellRoute('/acme/~/workspace/overview')).toBeNull();
+    expect(
+      resolveWorkspaceShellRoute('/acme/~/settings/organization/billing'),
+    ).toBeNull();
+  });
+
+  it('interpolates a safe fallback without widening scope', () => {
+    const route = resolveWorkspaceShellRoute(
+      '/acme/moonrise/analytics/trends/detail/trend-1',
+    );
+
+    expect(route).not.toBeNull();
+    if (!route) {
+      throw new Error('Expected analytics detail route to be registered.');
+    }
+    expect(resolveWorkspaceShellSafeFallback(route)).toBe(
+      '/acme/moonrise/analytics/overview',
+    );
+  });
+
+  it('keeps notifications and deployment-specific dock chrome explicit', () => {
+    expect(getWorkspaceShellOverlayRegistration('notifications')).toMatchObject(
+      {
+        allowedShellModes: ['overlay'],
+        canonicalUrl: null,
+        kind: 'overlay',
+      },
+    );
+    expect(
+      WORKSPACE_SHELL_AUXILIARY_REGISTRY.find(
+        (registration) => registration.key === 'terminal-dock',
+      ),
+    ).toMatchObject({
+      deployments: ['self-hosted-web', 'desktop'],
+      kind: 'chrome',
+    });
+  });
+
+  it('is immutable and rejects untrusted registry keys', () => {
+    expect(Object.isFrozen(PROTECTED_ROUTE_INVENTORY)).toBe(true);
+    expect(Object.isFrozen(PROTECTED_ROUTE_INVENTORY[0])).toBe(true);
+    expect(Object.isFrozen(PROTECTED_ROUTE_INVENTORY[0]?.adapter)).toBe(true);
+    expect(
+      Reflect.set(PROTECTED_ROUTE_INVENTORY, 0, {
+        key: 'model-produced-surface',
+      }),
+    ).toBe(false);
+    expect(
+      getWorkspaceShellOverlayRegistration('model-produced-surface'),
+    ).toBeNull();
+    expect(
+      resolveWorkspaceShellRoute('https://untrusted.example/canvas'),
+    ).toBeNull();
+  });
+});

--- a/apps/app/src/lib/workspace-shell/workspace-shell-registry.ts
+++ b/apps/app/src/lib/workspace-shell/workspace-shell-registry.ts
@@ -667,8 +667,8 @@ export const WORKSPACE_SHELL_AUXILIARY_REGISTRY = Object.freeze([
   Object.freeze({
     accessPolicy: 'organization-member',
     adapter: Object.freeze({ key: 'notifications', status: 'placeholder' }),
-    allowedReferenceKinds: Object.freeze([]),
-    allowedShellModes: Object.freeze(['overlay']),
+    allowedReferenceKinds: Object.freeze([] as const),
+    allowedShellModes: Object.freeze(['overlay'] as const),
     availability: 'conversation-shell',
     canonicalUrl: null,
     deployments: ALL_DEPLOYMENTS,
@@ -683,8 +683,8 @@ export const WORKSPACE_SHELL_AUXILIARY_REGISTRY = Object.freeze([
   Object.freeze({
     accessPolicy: 'organization-member',
     adapter: Object.freeze({ key: 'shell-preview', status: 'placeholder' }),
-    allowedReferenceKinds: Object.freeze(['asset', 'post']),
-    allowedShellModes: Object.freeze(['overlay']),
+    allowedReferenceKinds: Object.freeze(['asset', 'post'] as const),
+    allowedShellModes: Object.freeze(['overlay'] as const),
     availability: 'conversation-shell',
     canonicalUrl: null,
     deployments: ALL_DEPLOYMENTS,
@@ -699,10 +699,10 @@ export const WORKSPACE_SHELL_AUXILIARY_REGISTRY = Object.freeze([
   Object.freeze({
     accessPolicy: 'organization-member',
     adapter: Object.freeze({ key: 'terminal-dock', status: 'dedicated-route' }),
-    allowedShellModes: Object.freeze(['dedicated']),
+    allowedShellModes: Object.freeze(['dedicated'] as const),
     availability: 'legacy-shell',
     canonicalUrl: null,
-    deployments: Object.freeze(['self-hosted-web', 'desktop']),
+    deployments: Object.freeze(['self-hosted-web', 'desktop'] as const),
     key: 'terminal-dock',
     kind: 'chrome',
     launchTarget: 'dedicated-route',
@@ -851,11 +851,10 @@ export function getWorkspaceShellOverlayRegistration(
   key: string,
 ): WorkspaceShellOverlayRegistration | null {
   const registration = WORKSPACE_SHELL_AUXILIARY_REGISTRY.find(
-    (candidate): candidate is WorkspaceShellOverlayRegistration =>
-      candidate.kind === 'overlay' && candidate.key === key,
+    (candidate) => candidate.kind === 'overlay' && candidate.key === key,
   );
 
-  return registration ?? null;
+  return registration?.kind === 'overlay' ? registration : null;
 }
 
 function interpolateCanonicalPattern(

--- a/apps/app/src/lib/workspace-shell/workspace-shell-registry.ts
+++ b/apps/app/src/lib/workspace-shell/workspace-shell-registry.ts
@@ -2,99 +2,938 @@ export type WorkspaceShellBaseState = 'canvas' | 'conversation';
 
 export type WorkspaceShellRouteMode = WorkspaceShellBaseState | 'dedicated';
 
-export type WorkspaceShellRouteRegistration = {
-  readonly key: string;
-  readonly mode: WorkspaceShellRouteMode;
-  readonly telemetryClass: 'agent' | 'management' | 'product';
-};
+export type WorkspaceShellSurfaceMode = WorkspaceShellRouteMode | 'overlay';
 
-export type WorkspaceShellOverlayRegistration = {
-  readonly allowedReferenceKinds: readonly WorkspaceShellReferenceKind[];
-  readonly key: string;
-  readonly telemetryClass: 'shell_preview';
-};
+export type WorkspaceShellScopeRequirement =
+  | 'brand'
+  | 'organization'
+  | 'personal'
+  | 'platform-admin';
+
+export type WorkspaceShellDeployment =
+  | 'cloud-web'
+  | 'desktop'
+  | 'self-hosted-web';
+
+export type WorkspaceShellAccessPolicy =
+  | 'authenticated'
+  | 'brand-member'
+  | 'organization-member'
+  | 'platform-admin';
+
+export type WorkspaceShellAvailability =
+  | 'always'
+  | 'conversation-shell'
+  | 'legacy-shell';
+
+export type WorkspaceShellLaunchTarget =
+  | 'dedicated-route'
+  | 'focused-canvas'
+  | 'inline'
+  | 'inspector'
+  | 'overlay';
 
 export type WorkspaceShellReferenceKind = 'asset' | 'post';
 
-const PRODUCT_CANVAS_PREFIXES = [
-  '/analytics',
-  '/compose',
-  '/editor',
-  '/library',
-  '/messages',
-  '/orchestration',
-  '/overview',
-  '/posts',
-  '/research',
-  '/studio',
-  '/tasks',
-  '/workflows',
-  '/workspace',
-  '/write',
+export type WorkspaceShellRestorationPolicy = {
+  readonly history: 'canonical-url';
+  readonly invalidShellParams: 'replace';
+  readonly searchParams: 'preserve-opaque';
+};
+
+export type WorkspaceShellAdapterSeam = {
+  readonly key: string;
+  readonly status: 'dedicated-route' | 'placeholder';
+};
+
+export type WorkspaceShellRouteRegistration = {
+  readonly accessPolicy: WorkspaceShellAccessPolicy;
+  readonly adapter: WorkspaceShellAdapterSeam;
+  readonly allowedShellModes: readonly [WorkspaceShellRouteMode];
+  readonly availability: Exclude<WorkspaceShellAvailability, 'legacy-shell'>;
+  readonly canonicalUrl: string;
+  readonly deployments: readonly WorkspaceShellDeployment[];
+  readonly key: string;
+  readonly kind: 'route';
+  readonly launchTarget: Extract<
+    WorkspaceShellLaunchTarget,
+    'dedicated-route' | 'focused-canvas' | 'inline'
+  >;
+  readonly mode: WorkspaceShellRouteMode;
+  readonly restoration: WorkspaceShellRestorationPolicy;
+  readonly safeFallback: string;
+  readonly scope: WorkspaceShellScopeRequirement;
+  readonly surfaceKey: string;
+  readonly switcherItems: readonly string[];
+  readonly telemetryClass: 'agent' | 'management' | 'product';
+};
+
+export type ResolvedWorkspaceShellRoute = WorkspaceShellRouteRegistration & {
+  readonly params: Readonly<Record<string, string>>;
+};
+
+export type WorkspaceShellOverlayRegistration = {
+  readonly accessPolicy: 'organization-member';
+  readonly adapter: WorkspaceShellAdapterSeam;
+  readonly allowedReferenceKinds: readonly WorkspaceShellReferenceKind[];
+  readonly allowedShellModes: readonly ['overlay'];
+  readonly availability: 'conversation-shell';
+  readonly canonicalUrl: null;
+  readonly deployments: readonly WorkspaceShellDeployment[];
+  readonly key: string;
+  readonly kind: 'overlay';
+  readonly launchTarget: 'overlay';
+  readonly restoration: WorkspaceShellRestorationPolicy;
+  readonly safeFallback: 'same-canonical-url';
+  readonly scope: 'organization';
+  readonly telemetryClass: 'notifications' | 'shell_preview';
+};
+
+export type WorkspaceShellChromeRegistration = {
+  readonly accessPolicy: 'organization-member';
+  readonly adapter: WorkspaceShellAdapterSeam;
+  readonly allowedShellModes: readonly ['dedicated'];
+  readonly availability: 'legacy-shell';
+  readonly canonicalUrl: null;
+  readonly deployments: readonly WorkspaceShellDeployment[];
+  readonly key: 'terminal-dock';
+  readonly kind: 'chrome';
+  readonly launchTarget: 'dedicated-route';
+  readonly restoration: WorkspaceShellRestorationPolicy;
+  readonly safeFallback: 'same-canonical-url';
+  readonly scope: 'organization';
+  readonly telemetryClass: 'legacy_chrome';
+};
+
+export type WorkspaceShellAuxiliaryRegistration =
+  | WorkspaceShellChromeRegistration
+  | WorkspaceShellOverlayRegistration;
+
+type RouteGroupConfig = {
+  readonly fallback: string;
+  readonly mode: WorkspaceShellRouteMode;
+  readonly scope: WorkspaceShellScopeRequirement;
+  readonly surfaceKey: string;
+  readonly switcherItems?: readonly string[];
+  readonly telemetryClass: WorkspaceShellRouteRegistration['telemetryClass'];
+};
+
+type CompiledRouteRegistration = {
+  readonly matcher: RegExp;
+  readonly parameterNames: readonly string[];
+  readonly registration: WorkspaceShellRouteRegistration;
+  readonly specificity: number;
+};
+
+const ALL_DEPLOYMENTS = Object.freeze([
+  'cloud-web',
+  'self-hosted-web',
+  'desktop',
+] as const satisfies readonly WorkspaceShellDeployment[]);
+
+const URL_RESTORATION_POLICY = Object.freeze({
+  history: 'canonical-url',
+  invalidShellParams: 'replace',
+  searchParams: 'preserve-opaque',
+} as const satisfies WorkspaceShellRestorationPolicy);
+
+function freezeRouteRegistration(
+  canonicalUrl: string,
+  config: RouteGroupConfig,
+): WorkspaceShellRouteRegistration {
+  const status =
+    config.mode === 'dedicated' ? 'dedicated-route' : 'placeholder';
+  const accessPolicy: WorkspaceShellAccessPolicy =
+    config.scope === 'personal'
+      ? 'authenticated'
+      : config.scope === 'organization'
+        ? 'organization-member'
+        : config.scope === 'brand'
+          ? 'brand-member'
+          : 'platform-admin';
+  const launchTarget: WorkspaceShellRouteRegistration['launchTarget'] =
+    config.mode === 'canvas'
+      ? 'focused-canvas'
+      : config.mode === 'conversation'
+        ? 'inline'
+        : 'dedicated-route';
+
+  return Object.freeze({
+    accessPolicy,
+    adapter: Object.freeze({
+      key: config.surfaceKey,
+      status,
+    }),
+    allowedShellModes: Object.freeze([config.mode] as const),
+    availability: config.mode === 'dedicated' ? 'always' : 'conversation-shell',
+    canonicalUrl,
+    deployments: ALL_DEPLOYMENTS,
+    key: `route:${canonicalUrl}`,
+    kind: 'route',
+    launchTarget,
+    mode: config.mode,
+    restoration: URL_RESTORATION_POLICY,
+    safeFallback: config.fallback,
+    scope: config.scope,
+    surfaceKey: config.surfaceKey,
+    switcherItems: Object.freeze([...(config.switcherItems ?? [])]),
+    telemetryClass: config.telemetryClass,
+  });
+}
+
+function registerRoutes(
+  canonicalUrls: readonly string[],
+  config: RouteGroupConfig,
+): readonly WorkspaceShellRouteRegistration[] {
+  return canonicalUrls.map((canonicalUrl) =>
+    freezeRouteRegistration(canonicalUrl, config),
+  );
+}
+
+const PERSONAL_ROUTE_REGISTRATIONS = [
+  ...registerRoutes(['/'], {
+    fallback: '/',
+    mode: 'dedicated',
+    scope: 'personal',
+    surfaceKey: 'protected-bootstrap',
+    telemetryClass: 'management',
+  }),
+  ...registerRoutes(['/settings', '/settings/help'], {
+    fallback: '/settings',
+    mode: 'dedicated',
+    scope: 'personal',
+    surfaceKey: 'personal-settings',
+    telemetryClass: 'management',
+  }),
 ] as const;
 
-const DEDICATED_PREFIXES = [
-  '/admin',
-  '/agent/journey',
-  '/agent/onboarding',
-  '/lab',
-  '/settings',
-] as const;
-
-export const WORKSPACE_SHELL_OVERLAY_REGISTRY = new Map<
-  string,
-  WorkspaceShellOverlayRegistration
->([
-  [
-    'shell-preview',
+const ORGANIZATION_ROUTE_REGISTRATIONS = [
+  ...registerRoutes(
+    ['/:orgSlug', '/:orgSlug/~/overview', '/:orgSlug/~/analytics/overview'],
     {
-      allowedReferenceKinds: ['asset', 'post'],
-      key: 'shell-preview',
-      telemetryClass: 'shell_preview',
+      fallback: '/:orgSlug/~/overview',
+      mode: 'canvas',
+      scope: 'organization',
+      surfaceKey: 'organization-overview',
+      switcherItems: ['workspace', 'messages', 'research'],
+      telemetryClass: 'product',
     },
-  ],
+  ),
+  ...registerRoutes(
+    ['/:orgSlug/~/agent', '/:orgSlug/~/agent/new', '/:orgSlug/~/agent/:id'],
+    {
+      fallback: '/:orgSlug/~/agent',
+      mode: 'conversation',
+      scope: 'organization',
+      surfaceKey: 'agent-conversation',
+      switcherItems: ['agent'],
+      telemetryClass: 'agent',
+    },
+  ),
+  ...registerRoutes(
+    [
+      '/:orgSlug/~/agent/journey',
+      '/:orgSlug/~/agent/onboarding',
+      '/:orgSlug/~/agent/onboarding/:threadId',
+    ],
+    {
+      fallback: '/:orgSlug/~/agent',
+      mode: 'dedicated',
+      scope: 'organization',
+      surfaceKey: 'agent-onboarding',
+      telemetryClass: 'management',
+    },
+  ),
+  ...registerRoutes(
+    [
+      '/:orgSlug/~/settings',
+      '/:orgSlug/~/settings/personal',
+      '/:orgSlug/~/settings/help',
+      '/:orgSlug/~/settings/members',
+      '/:orgSlug/~/settings/billing',
+      '/:orgSlug/~/settings/credits',
+      '/:orgSlug/~/settings/api-keys',
+      '/:orgSlug/~/settings/webhooks',
+      '/:orgSlug/~/settings/policy',
+      '/:orgSlug/~/settings/brands',
+      '/:orgSlug/~/settings/models',
+      '/:orgSlug/~/settings/models/:type',
+      '/:orgSlug/~/settings/elements/scenes',
+    ],
+    {
+      fallback: '/:orgSlug/~/settings',
+      mode: 'dedicated',
+      scope: 'organization',
+      surfaceKey: 'organization-settings',
+      telemetryClass: 'management',
+    },
+  ),
+  ...registerRoutes(['/:orgSlug/~/library', '/:orgSlug/~/library/:type'], {
+    fallback: '/:orgSlug/~/library',
+    mode: 'canvas',
+    scope: 'organization',
+    surfaceKey: 'library',
+    switcherItems: ['library'],
+    telemetryClass: 'product',
+  }),
+  ...registerRoutes(['/:orgSlug/~/studio', '/:orgSlug/~/studio/:type'], {
+    fallback: '/:orgSlug/~/studio',
+    mode: 'canvas',
+    scope: 'organization',
+    surfaceKey: 'studio',
+    switcherItems: ['studio'],
+    telemetryClass: 'product',
+  }),
+  ...registerRoutes(
+    [
+      '/:orgSlug/~/posts',
+      '/:orgSlug/~/posts/published',
+      '/:orgSlug/~/posts/scheduled',
+    ],
+    {
+      fallback: '/:orgSlug/~/posts',
+      mode: 'canvas',
+      scope: 'organization',
+      surfaceKey: 'publish',
+      switcherItems: ['posts', 'remix'],
+      telemetryClass: 'product',
+    },
+  ),
+  ...registerRoutes(
+    [
+      '/:orgSlug/~/write',
+      '/:orgSlug/~/write/:segment',
+      '/:orgSlug/~/compose',
+      '/:orgSlug/~/compose/:segment',
+    ],
+    {
+      fallback: '/:orgSlug/~/compose',
+      mode: 'canvas',
+      scope: 'organization',
+      surfaceKey: 'compose',
+      telemetryClass: 'product',
+    },
+  ),
+  ...registerRoutes(
+    [
+      '/:orgSlug/~/workflows',
+      '/:orgSlug/~/workflows/library',
+      '/:orgSlug/~/workflows/templates',
+      '/:orgSlug/~/workflows/executions',
+      '/:orgSlug/~/workflows/new',
+      '/:orgSlug/~/workflows/:id',
+    ],
+    {
+      fallback: '/:orgSlug/~/workflows',
+      mode: 'canvas',
+      scope: 'organization',
+      surfaceKey: 'workflows',
+      telemetryClass: 'product',
+    },
+  ),
+  ...registerRoutes(
+    [
+      '/:orgSlug/~/editor',
+      '/:orgSlug/~/editor/projects',
+      '/:orgSlug/~/editor/new',
+      '/:orgSlug/~/editor/:id',
+    ],
+    {
+      fallback: '/:orgSlug/~/editor',
+      mode: 'dedicated',
+      scope: 'organization',
+      surfaceKey: 'editor',
+      telemetryClass: 'management',
+    },
+  ),
+] as const;
+
+const BRAND_ROUTE_REGISTRATIONS = [
+  ...registerRoutes(
+    [
+      '/:orgSlug/:brandSlug/workspace',
+      '/:orgSlug/:brandSlug/workspace/overview',
+      '/:orgSlug/:brandSlug/workspace/inbox/:view',
+      '/:orgSlug/:brandSlug/workspace/activity',
+      '/:orgSlug/:brandSlug/tasks',
+      '/:orgSlug/:brandSlug/tasks/:id',
+      '/:orgSlug/:brandSlug/overview/activities',
+    ],
+    {
+      fallback: '/:orgSlug/:brandSlug/workspace/overview',
+      mode: 'canvas',
+      scope: 'brand',
+      surfaceKey: 'workspace',
+      switcherItems: ['workspace'],
+      telemetryClass: 'product',
+    },
+  ),
+  ...registerRoutes(
+    [
+      '/:orgSlug/:brandSlug/agent',
+      '/:orgSlug/:brandSlug/agent/new',
+      '/:orgSlug/:brandSlug/agent/:id',
+    ],
+    {
+      fallback: '/:orgSlug/:brandSlug/agent',
+      mode: 'conversation',
+      scope: 'brand',
+      surfaceKey: 'agent-conversation',
+      switcherItems: ['agent'],
+      telemetryClass: 'agent',
+    },
+  ),
+  ...registerRoutes(
+    [
+      '/:orgSlug/:brandSlug/agent/journey',
+      '/:orgSlug/:brandSlug/agent/onboarding',
+      '/:orgSlug/:brandSlug/agent/onboarding/:threadId',
+    ],
+    {
+      fallback: '/:orgSlug/:brandSlug/agent',
+      mode: 'dedicated',
+      scope: 'brand',
+      surfaceKey: 'agent-onboarding',
+      telemetryClass: 'management',
+    },
+  ),
+  ...registerRoutes(['/:orgSlug/:brandSlug/messages'], {
+    fallback: '/:orgSlug/:brandSlug/workspace/overview',
+    mode: 'canvas',
+    scope: 'brand',
+    surfaceKey: 'messages',
+    switcherItems: ['messages'],
+    telemetryClass: 'product',
+  }),
+  ...registerRoutes(
+    [
+      '/:orgSlug/:brandSlug/research/discovery',
+      '/:orgSlug/:brandSlug/research/following',
+      '/:orgSlug/:brandSlug/research/socials',
+      '/:orgSlug/:brandSlug/research/ads',
+      '/:orgSlug/:brandSlug/research/ads/google',
+      '/:orgSlug/:brandSlug/research/ads/meta',
+      '/:orgSlug/:brandSlug/research/:platform',
+    ],
+    {
+      fallback: '/:orgSlug/:brandSlug/research/discovery',
+      mode: 'canvas',
+      scope: 'brand',
+      surfaceKey: 'research',
+      switcherItems: ['research'],
+      telemetryClass: 'product',
+    },
+  ),
+  ...registerRoutes(
+    [
+      '/:orgSlug/:brandSlug/studio/:type',
+      '/:orgSlug/:brandSlug/studio/:type/:id',
+      '/:orgSlug/:brandSlug/studio/batch',
+      '/:orgSlug/:brandSlug/studio/clips',
+      '/:orgSlug/:brandSlug/studio/fastlane',
+    ],
+    {
+      fallback: '/:orgSlug/:brandSlug/studio/image',
+      mode: 'canvas',
+      scope: 'brand',
+      surfaceKey: 'studio',
+      switcherItems: ['studio'],
+      telemetryClass: 'product',
+    },
+  ),
+  ...registerRoutes(
+    [
+      '/:orgSlug/:brandSlug/compose/article',
+      '/:orgSlug/:brandSlug/compose/post',
+      '/:orgSlug/:brandSlug/compose/newsletter',
+    ],
+    {
+      fallback: '/:orgSlug/:brandSlug/compose/post',
+      mode: 'canvas',
+      scope: 'brand',
+      surfaceKey: 'compose',
+      telemetryClass: 'product',
+    },
+  ),
+  ...registerRoutes(
+    [
+      '/:orgSlug/:brandSlug/editor',
+      '/:orgSlug/:brandSlug/editor/new',
+      '/:orgSlug/:brandSlug/editor/:id',
+    ],
+    {
+      fallback: '/:orgSlug/:brandSlug/editor',
+      mode: 'dedicated',
+      scope: 'brand',
+      surfaceKey: 'editor',
+      telemetryClass: 'management',
+    },
+  ),
+  ...registerRoutes(
+    [
+      '/:orgSlug/:brandSlug/library/ingredients',
+      '/:orgSlug/:brandSlug/library/videos',
+      '/:orgSlug/:brandSlug/library/images',
+      '/:orgSlug/:brandSlug/library/gifs',
+      '/:orgSlug/:brandSlug/library/avatars',
+      '/:orgSlug/:brandSlug/library/voices',
+      '/:orgSlug/:brandSlug/library/music',
+      '/:orgSlug/:brandSlug/library/captions',
+      '/:orgSlug/:brandSlug/library/moodboard',
+    ],
+    {
+      fallback: '/:orgSlug/:brandSlug/library/ingredients',
+      mode: 'canvas',
+      scope: 'brand',
+      surfaceKey: 'library',
+      switcherItems: ['library'],
+      telemetryClass: 'product',
+    },
+  ),
+  ...registerRoutes(
+    [
+      '/:orgSlug/:brandSlug/posts',
+      '/:orgSlug/:brandSlug/posts/:id',
+      '/:orgSlug/:brandSlug/posts/analytics',
+      '/:orgSlug/:brandSlug/posts/calendar',
+      '/:orgSlug/:brandSlug/posts/newsletters',
+      '/:orgSlug/:brandSlug/posts/published',
+      '/:orgSlug/:brandSlug/posts/remix',
+      '/:orgSlug/:brandSlug/posts/review',
+      '/:orgSlug/:brandSlug/posts/scheduled',
+    ],
+    {
+      fallback: '/:orgSlug/:brandSlug/posts',
+      mode: 'canvas',
+      scope: 'brand',
+      surfaceKey: 'publish',
+      switcherItems: ['posts', 'remix'],
+      telemetryClass: 'product',
+    },
+  ),
+  ...registerRoutes(['/:orgSlug/:brandSlug/posts/composer'], {
+    fallback: '/:orgSlug/:brandSlug/posts',
+    mode: 'dedicated',
+    scope: 'brand',
+    surfaceKey: 'post-composer',
+    telemetryClass: 'management',
+  }),
+  ...registerRoutes(
+    [
+      '/:orgSlug/:brandSlug/analytics/overview',
+      '/:orgSlug/:brandSlug/analytics/posts',
+      '/:orgSlug/:brandSlug/analytics/brands',
+      '/:orgSlug/:brandSlug/analytics/brands/:id',
+      '/:orgSlug/:brandSlug/analytics/brands/:id/platforms/:platform',
+      '/:orgSlug/:brandSlug/analytics/insights',
+      '/:orgSlug/:brandSlug/analytics/hooks',
+      '/:orgSlug/:brandSlug/analytics/performance-lab',
+      '/:orgSlug/:brandSlug/analytics/trends',
+      '/:orgSlug/:brandSlug/analytics/trends/detail/:id',
+      '/:orgSlug/:brandSlug/analytics/trends/platforms/:platform',
+      '/:orgSlug/:brandSlug/analytics/trend-turnover',
+      '/:orgSlug/:brandSlug/analytics/streaks',
+    ],
+    {
+      fallback: '/:orgSlug/:brandSlug/analytics/overview',
+      mode: 'canvas',
+      scope: 'brand',
+      surfaceKey: 'analytics',
+      switcherItems: ['analytics'],
+      telemetryClass: 'product',
+    },
+  ),
+  ...registerRoutes(
+    [
+      '/:orgSlug/:brandSlug/workflows',
+      '/:orgSlug/:brandSlug/workflows/new',
+      '/:orgSlug/:brandSlug/workflows/:id',
+      '/:orgSlug/:brandSlug/workflows/templates',
+      '/:orgSlug/:brandSlug/workflows/executions',
+      '/:orgSlug/:brandSlug/workflows/executions/:id',
+    ],
+    {
+      fallback: '/:orgSlug/:brandSlug/workflows',
+      mode: 'canvas',
+      scope: 'brand',
+      surfaceKey: 'workflows',
+      telemetryClass: 'product',
+    },
+  ),
+  ...registerRoutes(
+    [
+      '/:orgSlug/:brandSlug/orchestration',
+      '/:orgSlug/:brandSlug/orchestration/:agentId',
+      '/:orgSlug/:brandSlug/orchestration/overview',
+      '/:orgSlug/:brandSlug/orchestration/analytics',
+      '/:orgSlug/:brandSlug/orchestration/autopilot',
+      '/:orgSlug/:brandSlug/orchestration/runs',
+      '/:orgSlug/:brandSlug/orchestration/skills',
+      '/:orgSlug/:brandSlug/orchestration/content-runs/:runId',
+    ],
+    {
+      fallback: '/:orgSlug/:brandSlug/orchestration/overview',
+      mode: 'canvas',
+      scope: 'brand',
+      surfaceKey: 'orchestration',
+      telemetryClass: 'product',
+    },
+  ),
+  ...registerRoutes(
+    [
+      '/:orgSlug/:brandSlug/orchestration/new',
+      '/:orgSlug/:brandSlug/orchestration/configuration',
+      '/:orgSlug/:brandSlug/orchestration/hire',
+      '/:orgSlug/:brandSlug/orchestration/orchestrator',
+      '/:orgSlug/:brandSlug/orchestration/campaigns',
+      '/:orgSlug/:brandSlug/orchestration/campaigns/new',
+      '/:orgSlug/:brandSlug/orchestration/campaigns/:id',
+      '/:orgSlug/:brandSlug/orchestration/outreach-campaigns',
+      '/:orgSlug/:brandSlug/orchestration/outreach-campaigns/new',
+      '/:orgSlug/:brandSlug/orchestration/outreach-campaigns/:id',
+      '/:orgSlug/:brandSlug/orchestration/library',
+      '/:orgSlug/:brandSlug/orchestration/library/:type',
+    ],
+    {
+      fallback: '/:orgSlug/:brandSlug/orchestration/overview',
+      mode: 'dedicated',
+      scope: 'brand',
+      surfaceKey: 'orchestration-management',
+      telemetryClass: 'management',
+    },
+  ),
+  ...registerRoutes(
+    [
+      '/:orgSlug/:brandSlug/settings',
+      '/:orgSlug/:brandSlug/settings/voice',
+      '/:orgSlug/:brandSlug/settings/harness',
+      '/:orgSlug/:brandSlug/settings/interview',
+      '/:orgSlug/:brandSlug/settings/publishing',
+      '/:orgSlug/:brandSlug/settings/agent-defaults',
+    ],
+    {
+      fallback: '/:orgSlug/:brandSlug/settings',
+      mode: 'dedicated',
+      scope: 'brand',
+      surfaceKey: 'brand-settings',
+      telemetryClass: 'management',
+    },
+  ),
+  ...registerRoutes(
+    [
+      '/:orgSlug/:brandSlug/lab/articles',
+      '/:orgSlug/:brandSlug/lab/cron-jobs',
+      '/:orgSlug/:brandSlug/lab/library-preview',
+      '/:orgSlug/:brandSlug/lab/twitter-engage',
+    ],
+    {
+      fallback: '/:orgSlug/:brandSlug/workspace/overview',
+      mode: 'dedicated',
+      scope: 'brand',
+      surfaceKey: 'lab',
+      telemetryClass: 'management',
+    },
+  ),
+] as const;
+
+const ADMIN_ROUTE_PATTERNS = [
+  '/admin',
+  '/admin/agent',
+  '/admin/agent/new',
+  '/admin/agent/:threadId',
+  '/admin/overview/dashboard',
+  '/admin/overview/activities',
+  '/admin/overview/analytics/all',
+  '/admin/overview/analytics/brands',
+  '/admin/overview/analytics/brands/:id',
+  '/admin/overview/analytics/brands/:id/platforms/:platform',
+  '/admin/overview/analytics/business',
+  '/admin/overview/analytics/organizations',
+  '/admin/overview/analytics/organizations/:id',
+  '/admin/content/posts',
+  '/admin/content/posts/:id',
+  '/admin/content/templates',
+  '/admin/content/templates/:id',
+  '/admin/content/prompts/list',
+  '/admin/content/ingredients/:type',
+  '/admin/folders',
+  '/admin/images/:id',
+  '/admin/videos/:id',
+  '/admin/automation/bots',
+  '/admin/automation/models/:type',
+  '/admin/automation/trainings',
+  '/admin/automation/trainings/:id/images',
+  '/admin/automation/trainings/:id/sources',
+  '/admin/automation/workflows',
+  '/admin/configuration/elements/blacklists',
+  '/admin/configuration/elements/camera-movements',
+  '/admin/configuration/elements/cameras',
+  '/admin/configuration/elements/lenses',
+  '/admin/configuration/elements/lightings',
+  '/admin/configuration/elements/moods',
+  '/admin/configuration/elements/scenes',
+  '/admin/configuration/elements/sounds',
+  '/admin/configuration/elements/styles',
+  '/admin/configuration/font-families',
+  '/admin/configuration/presets',
+  '/admin/configuration/tags',
+  '/admin/configuration/tags/:filter',
+  '/admin/fleet/characters',
+  '/admin/fleet/characters/:slug',
+  '/admin/fleet/gallery',
+  '/admin/fleet/generate',
+  '/admin/fleet/infrastructure',
+  '/admin/fleet/lip-sync',
+  '/admin/fleet/pipeline',
+  '/admin/fleet/training',
+  '/admin/fleet/voices',
+  '/admin/library/voices',
+  '/admin/organization',
+  '/admin/administration/users',
+  '/admin/administration/warmup-accounts',
+  '/admin/administration/roles',
+  '/admin/administration/subscriptions',
+  '/admin/administration/credit-usage',
+  '/admin/administration/announcements',
+  '/admin/administration/system-emails',
+  '/admin/administration/platform-settings',
+] as const;
+
+const ADMIN_ROUTE_REGISTRATIONS = registerRoutes(ADMIN_ROUTE_PATTERNS, {
+  fallback: '/admin',
+  mode: 'dedicated',
+  scope: 'platform-admin',
+  surfaceKey: 'platform-admin',
+  switcherItems: ['admin'],
+  telemetryClass: 'management',
+});
+
+/**
+ * Canonical application-owned inventory for the 206 protected route patterns
+ * accepted in ADR-CONVERSATION-SHELL-CONTRACTS v1.0.0. The two intentional hard
+ * cuts (`/:orgSlug/~/workspace/*` and
+ * `/:orgSlug/~/settings/organization/*`) are deliberately absent.
+ */
+export const PROTECTED_ROUTE_INVENTORY = Object.freeze([
+  ...PERSONAL_ROUTE_REGISTRATIONS,
+  ...ORGANIZATION_ROUTE_REGISTRATIONS,
+  ...BRAND_ROUTE_REGISTRATIONS,
+  ...ADMIN_ROUTE_REGISTRATIONS,
 ]);
 
-function matchesRoutePrefix(pathname: string, prefix: string): boolean {
-  return pathname === prefix || pathname.startsWith(`${prefix}/`);
+export const WORKSPACE_SHELL_AUXILIARY_REGISTRY = Object.freeze([
+  Object.freeze({
+    accessPolicy: 'organization-member',
+    adapter: Object.freeze({ key: 'notifications', status: 'placeholder' }),
+    allowedReferenceKinds: Object.freeze([]),
+    allowedShellModes: Object.freeze(['overlay']),
+    availability: 'conversation-shell',
+    canonicalUrl: null,
+    deployments: ALL_DEPLOYMENTS,
+    key: 'notifications',
+    kind: 'overlay',
+    launchTarget: 'overlay',
+    restoration: URL_RESTORATION_POLICY,
+    safeFallback: 'same-canonical-url',
+    scope: 'organization',
+    telemetryClass: 'notifications',
+  }),
+  Object.freeze({
+    accessPolicy: 'organization-member',
+    adapter: Object.freeze({ key: 'shell-preview', status: 'placeholder' }),
+    allowedReferenceKinds: Object.freeze(['asset', 'post']),
+    allowedShellModes: Object.freeze(['overlay']),
+    availability: 'conversation-shell',
+    canonicalUrl: null,
+    deployments: ALL_DEPLOYMENTS,
+    key: 'shell-preview',
+    kind: 'overlay',
+    launchTarget: 'overlay',
+    restoration: URL_RESTORATION_POLICY,
+    safeFallback: 'same-canonical-url',
+    scope: 'organization',
+    telemetryClass: 'shell_preview',
+  }),
+  Object.freeze({
+    accessPolicy: 'organization-member',
+    adapter: Object.freeze({ key: 'terminal-dock', status: 'dedicated-route' }),
+    allowedShellModes: Object.freeze(['dedicated']),
+    availability: 'legacy-shell',
+    canonicalUrl: null,
+    deployments: Object.freeze(['self-hosted-web', 'desktop']),
+    key: 'terminal-dock',
+    kind: 'chrome',
+    launchTarget: 'dedicated-route',
+    restoration: URL_RESTORATION_POLICY,
+    safeFallback: 'same-canonical-url',
+    scope: 'organization',
+    telemetryClass: 'legacy_chrome',
+  }),
+] as const satisfies readonly WorkspaceShellAuxiliaryRegistration[]);
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function compileRoutePattern(
+  registration: WorkspaceShellRouteRegistration,
+): CompiledRouteRegistration {
+  if (registration.canonicalUrl === '/') {
+    return {
+      matcher: /^\/$/,
+      parameterNames: [],
+      registration,
+      specificity: 10_000,
+    };
+  }
+
+  const parameterNames: string[] = [];
+  let staticSegments = 0;
+  const matcherSegments = registration.canonicalUrl
+    .split('/')
+    .filter(Boolean)
+    .map((segment) => {
+      if (segment.startsWith(':')) {
+        parameterNames.push(segment.slice(1));
+        return '([^/]+)';
+      }
+
+      staticSegments += 1;
+      return escapeRegExp(segment);
+    });
+
+  return {
+    matcher: new RegExp(`^/${matcherSegments.join('/')}/?$`),
+    parameterNames,
+    registration,
+    specificity:
+      staticSegments * 1_000 +
+      matcherSegments.length * 10 -
+      parameterNames.length,
+  };
+}
+
+const COMPILED_ROUTE_INVENTORY = Object.freeze(
+  PROTECTED_ROUTE_INVENTORY.map(compileRoutePattern),
+);
+
+function getPathname(value: string): string | null {
+  try {
+    const url = new URL(value, 'https://workspace.genfeed.invalid');
+    if (url.origin !== 'https://workspace.genfeed.invalid') {
+      return null;
+    }
+
+    return url.pathname;
+  } catch {
+    return null;
+  }
+}
+
+function decodeRouteParam(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function hasRequiredPathScope(
+  pathname: string,
+  scope: WorkspaceShellScopeRequirement,
+): boolean {
+  const segments = pathname.split('/').filter(Boolean);
+
+  switch (scope) {
+    case 'brand':
+      return segments.length >= 3 && segments[1] !== '~';
+    case 'organization':
+      return segments.length === 1 || segments[1] === '~';
+    case 'personal':
+      return pathname === '/' || pathname.startsWith('/settings');
+    case 'platform-admin':
+      return pathname === '/admin' || pathname.startsWith('/admin/');
+  }
 }
 
 export function resolveWorkspaceShellRoute(
-  normalizedPathname: string,
-): WorkspaceShellRouteRegistration | null {
-  const dedicatedPrefix = DEDICATED_PREFIXES.find((prefix) =>
-    matchesRoutePrefix(normalizedPathname, prefix),
+  hrefOrPathname: string,
+): ResolvedWorkspaceShellRoute | null {
+  const pathname = getPathname(hrefOrPathname);
+  if (!pathname) {
+    return null;
+  }
+
+  let bestMatch:
+    | (CompiledRouteRegistration & { readonly match: RegExpExecArray })
+    | null = null;
+
+  for (const compiled of COMPILED_ROUTE_INVENTORY) {
+    if (!hasRequiredPathScope(pathname, compiled.registration.scope)) {
+      continue;
+    }
+
+    const match = compiled.matcher.exec(pathname);
+    if (
+      !match ||
+      (bestMatch && bestMatch.specificity >= compiled.specificity)
+    ) {
+      continue;
+    }
+
+    bestMatch = { ...compiled, match };
+  }
+
+  if (!bestMatch) {
+    return null;
+  }
+
+  const params = Object.freeze(
+    Object.fromEntries(
+      bestMatch.parameterNames.map((parameterName, index) => [
+        parameterName,
+        decodeRouteParam(bestMatch?.match[index + 1] ?? ''),
+      ]),
+    ),
   );
-  if (dedicatedPrefix) {
-    return {
-      key: `dedicated:${dedicatedPrefix.slice(1)}`,
-      mode: 'dedicated',
-      telemetryClass: 'management',
-    };
-  }
 
-  if (
-    normalizedPathname === '/agent' ||
-    normalizedPathname === '/agent/new' ||
-    /^\/agent\/[^/]+$/.test(normalizedPathname)
-  ) {
-    return {
-      key: 'agent-conversation',
-      mode: 'conversation',
-      telemetryClass: 'agent',
-    };
-  }
+  return Object.freeze({ ...bestMatch.registration, params });
+}
 
-  const canvasPrefix = PRODUCT_CANVAS_PREFIXES.find((prefix) =>
-    matchesRoutePrefix(normalizedPathname, prefix),
+export function getWorkspaceShellOverlayRegistration(
+  key: string,
+): WorkspaceShellOverlayRegistration | null {
+  const registration = WORKSPACE_SHELL_AUXILIARY_REGISTRY.find(
+    (candidate): candidate is WorkspaceShellOverlayRegistration =>
+      candidate.kind === 'overlay' && candidate.key === key,
   );
-  if (canvasPrefix) {
-    return {
-      key: `canvas:${canvasPrefix.slice(1)}`,
-      mode: 'canvas',
-      telemetryClass: 'product',
-    };
-  }
 
-  return null;
+  return registration ?? null;
+}
+
+function interpolateCanonicalPattern(
+  pattern: string,
+  params: Readonly<Record<string, string>>,
+): string | null {
+  let isComplete = true;
+  const href = pattern.replace(/:([A-Za-z][A-Za-z0-9]*)/g, (_, key: string) => {
+    const value = params[key];
+    if (!value) {
+      isComplete = false;
+      return '';
+    }
+
+    return encodeURIComponent(value);
+  });
+
+  return isComplete ? href : null;
+}
+
+export function resolveWorkspaceShellSafeFallback(
+  route: ResolvedWorkspaceShellRoute,
+): string {
+  return (
+    interpolateCanonicalPattern(route.safeFallback, route.params) ??
+    route.canonicalUrl
+  );
 }

--- a/apps/app/src/lib/workspace-shell/workspace-shell-registry.ts
+++ b/apps/app/src/lib/workspace-shell/workspace-shell-registry.ts
@@ -1,113 +1,33 @@
-export type WorkspaceShellBaseState = 'canvas' | 'conversation';
+import type {
+  ResolvedWorkspaceShellRoute,
+  WorkspaceShellAccessPolicy,
+  WorkspaceShellAuxiliaryRegistration,
+  WorkspaceShellDeployment,
+  WorkspaceShellOverlayRegistration,
+  WorkspaceShellRestorationPolicy,
+  WorkspaceShellRouteMode,
+  WorkspaceShellRouteRegistration,
+  WorkspaceShellScopeRequirement,
+} from '@genfeedai/interfaces/ui/workspace-shell.interface';
 
-export type WorkspaceShellRouteMode = WorkspaceShellBaseState | 'dedicated';
-
-export type WorkspaceShellSurfaceMode = WorkspaceShellRouteMode | 'overlay';
-
-export type WorkspaceShellScopeRequirement =
-  | 'brand'
-  | 'organization'
-  | 'personal'
-  | 'platform-admin';
-
-export type WorkspaceShellDeployment =
-  | 'cloud-web'
-  | 'desktop'
-  | 'self-hosted-web';
-
-export type WorkspaceShellAccessPolicy =
-  | 'authenticated'
-  | 'brand-member'
-  | 'organization-member'
-  | 'platform-admin';
-
-export type WorkspaceShellAvailability =
-  | 'always'
-  | 'conversation-shell'
-  | 'legacy-shell';
-
-export type WorkspaceShellLaunchTarget =
-  | 'dedicated-route'
-  | 'focused-canvas'
-  | 'inline'
-  | 'inspector'
-  | 'overlay';
-
-export type WorkspaceShellReferenceKind = 'asset' | 'post';
-
-export type WorkspaceShellRestorationPolicy = {
-  readonly history: 'canonical-url';
-  readonly invalidShellParams: 'replace';
-  readonly searchParams: 'preserve-opaque';
-};
-
-export type WorkspaceShellAdapterSeam = {
-  readonly key: string;
-  readonly status: 'dedicated-route' | 'placeholder';
-};
-
-export type WorkspaceShellRouteRegistration = {
-  readonly accessPolicy: WorkspaceShellAccessPolicy;
-  readonly adapter: WorkspaceShellAdapterSeam;
-  readonly allowedShellModes: readonly [WorkspaceShellRouteMode];
-  readonly availability: Exclude<WorkspaceShellAvailability, 'legacy-shell'>;
-  readonly canonicalUrl: string;
-  readonly deployments: readonly WorkspaceShellDeployment[];
-  readonly key: string;
-  readonly kind: 'route';
-  readonly launchTarget: Extract<
-    WorkspaceShellLaunchTarget,
-    'dedicated-route' | 'focused-canvas' | 'inline'
-  >;
-  readonly mode: WorkspaceShellRouteMode;
-  readonly restoration: WorkspaceShellRestorationPolicy;
-  readonly safeFallback: string;
-  readonly scope: WorkspaceShellScopeRequirement;
-  readonly surfaceKey: string;
-  readonly switcherItems: readonly string[];
-  readonly telemetryClass: 'agent' | 'management' | 'product';
-};
-
-export type ResolvedWorkspaceShellRoute = WorkspaceShellRouteRegistration & {
-  readonly params: Readonly<Record<string, string>>;
-};
-
-export type WorkspaceShellOverlayRegistration = {
-  readonly accessPolicy: 'organization-member';
-  readonly adapter: WorkspaceShellAdapterSeam;
-  readonly allowedReferenceKinds: readonly WorkspaceShellReferenceKind[];
-  readonly allowedShellModes: readonly ['overlay'];
-  readonly availability: 'conversation-shell';
-  readonly canonicalUrl: null;
-  readonly deployments: readonly WorkspaceShellDeployment[];
-  readonly key: string;
-  readonly kind: 'overlay';
-  readonly launchTarget: 'overlay';
-  readonly restoration: WorkspaceShellRestorationPolicy;
-  readonly safeFallback: 'same-canonical-url';
-  readonly scope: 'organization';
-  readonly telemetryClass: 'notifications' | 'shell_preview';
-};
-
-export type WorkspaceShellChromeRegistration = {
-  readonly accessPolicy: 'organization-member';
-  readonly adapter: WorkspaceShellAdapterSeam;
-  readonly allowedShellModes: readonly ['dedicated'];
-  readonly availability: 'legacy-shell';
-  readonly canonicalUrl: null;
-  readonly deployments: readonly WorkspaceShellDeployment[];
-  readonly key: 'terminal-dock';
-  readonly kind: 'chrome';
-  readonly launchTarget: 'dedicated-route';
-  readonly restoration: WorkspaceShellRestorationPolicy;
-  readonly safeFallback: 'same-canonical-url';
-  readonly scope: 'organization';
-  readonly telemetryClass: 'legacy_chrome';
-};
-
-export type WorkspaceShellAuxiliaryRegistration =
-  | WorkspaceShellChromeRegistration
-  | WorkspaceShellOverlayRegistration;
+export type {
+  ResolvedWorkspaceShellRoute,
+  WorkspaceShellAccessPolicy,
+  WorkspaceShellAdapterSeam,
+  WorkspaceShellAuxiliaryRegistration,
+  WorkspaceShellAvailability,
+  WorkspaceShellBaseState,
+  WorkspaceShellChromeRegistration,
+  WorkspaceShellDeployment,
+  WorkspaceShellLaunchTarget,
+  WorkspaceShellOverlayRegistration,
+  WorkspaceShellReferenceKind,
+  WorkspaceShellRestorationPolicy,
+  WorkspaceShellRouteMode,
+  WorkspaceShellRouteRegistration,
+  WorkspaceShellScopeRequirement,
+  WorkspaceShellSurfaceMode,
+} from '@genfeedai/interfaces/ui/workspace-shell.interface';
 
 type RouteGroupConfig = {
   readonly fallback: string;
@@ -137,40 +57,62 @@ const URL_RESTORATION_POLICY = Object.freeze({
   searchParams: 'preserve-opaque',
 } as const satisfies WorkspaceShellRestorationPolicy);
 
+const RESERVED_SCOPED_ROUTE_PREFIXES = Object.freeze(['admin', 'settings']);
+
+const ACCESS_POLICY_BY_SCOPE = Object.freeze({
+  brand: 'brand-member',
+  organization: 'organization-member',
+  personal: 'authenticated',
+  'platform-admin': 'platform-admin',
+} as const satisfies Record<
+  WorkspaceShellScopeRequirement,
+  WorkspaceShellAccessPolicy
+>);
+
+const ADAPTER_STATUS_BY_MODE = Object.freeze({
+  canvas: 'placeholder',
+  conversation: 'placeholder',
+  dedicated: 'dedicated-route',
+} as const satisfies Record<
+  WorkspaceShellRouteMode,
+  WorkspaceShellRouteRegistration['adapter']['status']
+>);
+
+const AVAILABILITY_BY_MODE = Object.freeze({
+  canvas: 'conversation-shell',
+  conversation: 'conversation-shell',
+  dedicated: 'always',
+} as const satisfies Record<
+  WorkspaceShellRouteMode,
+  WorkspaceShellRouteRegistration['availability']
+>);
+
+const LAUNCH_TARGET_BY_MODE = Object.freeze({
+  canvas: 'focused-canvas',
+  conversation: 'inline',
+  dedicated: 'dedicated-route',
+} as const satisfies Record<
+  WorkspaceShellRouteMode,
+  WorkspaceShellRouteRegistration['launchTarget']
+>);
+
 function freezeRouteRegistration(
   canonicalUrl: string,
   config: RouteGroupConfig,
 ): WorkspaceShellRouteRegistration {
-  const status =
-    config.mode === 'dedicated' ? 'dedicated-route' : 'placeholder';
-  const accessPolicy: WorkspaceShellAccessPolicy =
-    config.scope === 'personal'
-      ? 'authenticated'
-      : config.scope === 'organization'
-        ? 'organization-member'
-        : config.scope === 'brand'
-          ? 'brand-member'
-          : 'platform-admin';
-  const launchTarget: WorkspaceShellRouteRegistration['launchTarget'] =
-    config.mode === 'canvas'
-      ? 'focused-canvas'
-      : config.mode === 'conversation'
-        ? 'inline'
-        : 'dedicated-route';
-
   return Object.freeze({
-    accessPolicy,
+    accessPolicy: ACCESS_POLICY_BY_SCOPE[config.scope],
     adapter: Object.freeze({
       key: config.surfaceKey,
-      status,
+      status: ADAPTER_STATUS_BY_MODE[config.mode],
     }),
     allowedShellModes: Object.freeze([config.mode] as const),
-    availability: config.mode === 'dedicated' ? 'always' : 'conversation-shell',
+    availability: AVAILABILITY_BY_MODE[config.mode],
     canonicalUrl,
     deployments: ALL_DEPLOYMENTS,
     key: `route:${canonicalUrl}`,
     kind: 'route',
-    launchTarget,
+    launchTarget: LAUNCH_TARGET_BY_MODE[config.mode],
     mode: config.mode,
     restoration: URL_RESTORATION_POLICY,
     safeFallback: config.fallback,
@@ -843,12 +785,17 @@ function hasRequiredPathScope(
   scope: WorkspaceShellScopeRequirement,
 ): boolean {
   const segments = pathname.split('/').filter(Boolean);
+  const hasReservedPrefix = RESERVED_SCOPED_ROUTE_PREFIXES.some(
+    (prefix) => segments[0] === prefix,
+  );
 
   switch (scope) {
     case 'brand':
-      return segments.length >= 3 && segments[1] !== '~';
+      return !hasReservedPrefix && segments.length >= 3 && segments[1] !== '~';
     case 'organization':
-      return segments.length === 1 || segments[1] === '~';
+      return (
+        !hasReservedPrefix && (segments.length === 1 || segments[1] === '~')
+      );
     case 'personal':
       return pathname === '/' || pathname.startsWith('/settings');
     case 'platform-admin':

--- a/apps/app/src/lib/workspace-shell/workspace-surface-launcher.spec.ts
+++ b/apps/app/src/lib/workspace-shell/workspace-surface-launcher.spec.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import { resolveWorkspaceSurfaceLaunch } from './workspace-surface-launcher';
+
+describe('workspace surface launcher', () => {
+  it('preserves the active thread and destination search params for canvas launches', () => {
+    expect(
+      resolveWorkspaceSurfaceLaunch({
+        currentHref: '/acme/~/agent/thread-1',
+        destinationHref:
+          '/acme/~/analytics/overview?taskId=task-1&taskSource=workspace',
+      }),
+    ).toMatchObject({
+      announcement: 'Opening organization overview in canvas mode.',
+      history: 'push',
+      href: '/acme/~/analytics/overview?taskId=task-1&taskSource=workspace&thread=thread-1',
+      mode: 'canvas',
+    });
+  });
+
+  it('returns to the canonical active-thread conversation URL', () => {
+    expect(
+      resolveWorkspaceSurfaceLaunch({
+        currentHref:
+          '/acme/moonrise/posts/calendar?filter=scheduled&thread=thread-1',
+        destinationHref: '/acme/moonrise/agent',
+      }),
+    ).toMatchObject({
+      href: '/acme/moonrise/agent/thread-1',
+      mode: 'conversation',
+    });
+  });
+
+  it('does not carry a thread across organizations', () => {
+    expect(
+      resolveWorkspaceSurfaceLaunch({
+        currentHref: '/acme/~/agent/thread-1',
+        destinationHref: '/other/~/overview?thread=attacker-thread',
+      }).href,
+    ).toBe('/other/~/overview');
+  });
+
+  it('uses dedicated navigation for settings and strips shell authority params', () => {
+    expect(
+      resolveWorkspaceSurfaceLaunch({
+        currentHref: '/acme/~/agent/thread-1',
+        destinationHref:
+          '/acme/~/settings/billing?overlay=shell-preview&thread=thread-1',
+      }),
+    ).toMatchObject({
+      announcement: 'Opening organization settings as a dedicated route.',
+      href: '/acme/~/settings/billing',
+      mode: 'dedicated',
+    });
+  });
+
+  it('keeps unknown routes outside shell state without navigating', () => {
+    expect(
+      resolveWorkspaceSurfaceLaunch({
+        currentHref: '/acme/~/agent/thread-1',
+        destinationHref:
+          '/acme/moonrise/model-surface?overlay=untrusted&thread=thread-1',
+      }),
+    ).toEqual({
+      adapter: null,
+      announcement: 'Surface unavailable.',
+      history: 'none',
+      href: '/acme/~/agent/thread-1',
+      mode: 'dedicated',
+      registryKey: null,
+    });
+  });
+
+  it('does not navigate to an untrusted external destination', () => {
+    expect(
+      resolveWorkspaceSurfaceLaunch({
+        currentHref: '/acme/~/agent/thread-1',
+        destinationHref: 'https://untrusted.example/canvas',
+      }),
+    ).toMatchObject({
+      history: 'none',
+      href: '/acme/~/agent/thread-1',
+      registryKey: null,
+    });
+  });
+
+  it('preserves copied canonical hashes and opaque destination queries', () => {
+    expect(
+      resolveWorkspaceSurfaceLaunch({
+        currentHref: '/acme/moonrise/agent/thread-1',
+        destinationHref: '/acme/moonrise/library/images?folder=launch#asset-1',
+      }).href,
+    ).toBe(
+      '/acme/moonrise/library/images?folder=launch&thread=thread-1#asset-1',
+    );
+  });
+});

--- a/apps/app/src/lib/workspace-shell/workspace-surface-launcher.ts
+++ b/apps/app/src/lib/workspace-shell/workspace-surface-launcher.ts
@@ -1,23 +1,15 @@
-import {
-  resolveWorkspaceShellRoute,
-  type WorkspaceShellAdapterSeam,
-  type WorkspaceShellRouteMode,
-} from './workspace-shell-registry';
+import type {
+  ResolvedWorkspaceShellRoute,
+  ResolveWorkspaceSurfaceLaunchParams,
+  WorkspaceShellRouteMode,
+  WorkspaceSurfaceLaunch,
+} from '@genfeedai/interfaces/ui/workspace-shell.interface';
+import { resolveWorkspaceShellRoute } from './workspace-shell-registry';
 
-export type WorkspaceSurfaceLaunch = {
-  readonly adapter: WorkspaceShellAdapterSeam | null;
-  readonly announcement: string;
-  readonly history: 'none' | 'push';
-  readonly href: string;
-  readonly mode: WorkspaceShellRouteMode;
-  readonly registryKey: string | null;
-};
-
-type ResolveWorkspaceSurfaceLaunchParams = {
-  readonly currentHref: string;
-  readonly destinationHref: string;
-  readonly threadId?: string | null;
-};
+export type {
+  ResolveWorkspaceSurfaceLaunchParams,
+  WorkspaceSurfaceLaunch,
+} from '@genfeedai/interfaces/ui/workspace-shell.interface';
 
 const INTERNAL_ORIGIN = 'https://workspace.genfeed.invalid';
 
@@ -75,6 +67,79 @@ function stripAllShellParams(url: URL): void {
   url.searchParams.delete('thread');
 }
 
+function createUnavailableLaunch(
+  currentUrl: URL | null,
+): WorkspaceSurfaceLaunch {
+  return {
+    adapter: null,
+    announcement: 'Surface unavailable.',
+    history: 'none',
+    href: currentUrl ? toRelativeHref(currentUrl) : '/',
+    mode: 'dedicated',
+    registryKey: null,
+  };
+}
+
+function resolveRetainedThreadId(
+  currentUrl: URL | null,
+  currentRoute: ResolvedWorkspaceShellRoute | null,
+  destinationRoute: ResolvedWorkspaceShellRoute,
+  explicitThreadId: string | null | undefined,
+): string | null {
+  if (!currentUrl) {
+    return null;
+  }
+
+  const currentOrganizationSlug = currentRoute?.params.orgSlug;
+  const destinationOrganizationSlug = destinationRoute.params.orgSlug;
+  if (
+    !currentOrganizationSlug ||
+    !destinationOrganizationSlug ||
+    currentOrganizationSlug !== destinationOrganizationSlug
+  ) {
+    return null;
+  }
+
+  return getCurrentThreadId(currentUrl, explicitThreadId);
+}
+
+function applyCanvasLaunch(url: URL, retainedThreadId: string | null): void {
+  stripOverlayParams(url);
+  if (retainedThreadId) {
+    url.searchParams.set('thread', retainedThreadId);
+  } else {
+    url.searchParams.delete('thread');
+  }
+}
+
+function applyConversationLaunch(
+  url: URL,
+  route: ResolvedWorkspaceShellRoute,
+  retainedThreadId: string | null,
+): void {
+  stripAllShellParams(url);
+  if (retainedThreadId && route.canonicalUrl.endsWith('/agent')) {
+    url.pathname = `${url.pathname.replace(/\/$/, '')}/${encodeURIComponent(retainedThreadId)}`;
+  }
+}
+
+function applyDestinationPolicy(
+  url: URL,
+  route: ResolvedWorkspaceShellRoute,
+  retainedThreadId: string | null,
+): void {
+  switch (route.mode) {
+    case 'canvas':
+      applyCanvasLaunch(url, retainedThreadId);
+      return;
+    case 'conversation':
+      applyConversationLaunch(url, route, retainedThreadId);
+      return;
+    case 'dedicated':
+      stripAllShellParams(url);
+  }
+}
+
 function formatAnnouncement(
   surfaceKey: string,
   mode: WorkspaceShellRouteMode,
@@ -102,14 +167,7 @@ export function resolveWorkspaceSurfaceLaunch({
   const destinationUrl = parseInternalHref(destinationHref);
 
   if (!destinationUrl) {
-    return {
-      adapter: null,
-      announcement: 'Surface unavailable.',
-      history: 'none',
-      href: currentUrl ? toRelativeHref(currentUrl) : '/',
-      mode: 'dedicated',
-      registryKey: null,
-    };
+    return createUnavailableLaunch(currentUrl);
   }
 
   const currentRoute = currentUrl
@@ -118,43 +176,16 @@ export function resolveWorkspaceSurfaceLaunch({
   const destinationRoute = resolveWorkspaceShellRoute(destinationUrl.pathname);
 
   if (!destinationRoute) {
-    return {
-      adapter: null,
-      announcement: 'Surface unavailable.',
-      history: 'none',
-      href: currentUrl ? toRelativeHref(currentUrl) : '/',
-      mode: 'dedicated',
-      registryKey: null,
-    };
+    return createUnavailableLaunch(currentUrl);
   }
 
-  const currentOrganizationSlug = currentRoute?.params.orgSlug ?? null;
-  const destinationOrganizationSlug = destinationRoute.params.orgSlug ?? null;
-  const canRetainThread = Boolean(
-    currentOrganizationSlug &&
-      destinationOrganizationSlug &&
-      currentOrganizationSlug === destinationOrganizationSlug,
+  const retainedThreadId = resolveRetainedThreadId(
+    currentUrl,
+    currentRoute,
+    destinationRoute,
+    threadId,
   );
-  const retainedThreadId =
-    canRetainThread && currentUrl
-      ? getCurrentThreadId(currentUrl, threadId)
-      : null;
-
-  if (destinationRoute.mode === 'canvas') {
-    stripOverlayParams(destinationUrl);
-    if (retainedThreadId) {
-      destinationUrl.searchParams.set('thread', retainedThreadId);
-    } else {
-      destinationUrl.searchParams.delete('thread');
-    }
-  } else if (destinationRoute.mode === 'conversation') {
-    stripAllShellParams(destinationUrl);
-    if (retainedThreadId && destinationRoute.canonicalUrl.endsWith('/agent')) {
-      destinationUrl.pathname = `${destinationUrl.pathname.replace(/\/$/, '')}/${encodeURIComponent(retainedThreadId)}`;
-    }
-  } else {
-    stripAllShellParams(destinationUrl);
-  }
+  applyDestinationPolicy(destinationUrl, destinationRoute, retainedThreadId);
 
   return {
     adapter: destinationRoute.adapter,

--- a/apps/app/src/lib/workspace-shell/workspace-surface-launcher.ts
+++ b/apps/app/src/lib/workspace-shell/workspace-surface-launcher.ts
@@ -1,0 +1,170 @@
+import {
+  resolveWorkspaceShellRoute,
+  type WorkspaceShellAdapterSeam,
+  type WorkspaceShellRouteMode,
+} from './workspace-shell-registry';
+
+export type WorkspaceSurfaceLaunch = {
+  readonly adapter: WorkspaceShellAdapterSeam | null;
+  readonly announcement: string;
+  readonly history: 'none' | 'push';
+  readonly href: string;
+  readonly mode: WorkspaceShellRouteMode;
+  readonly registryKey: string | null;
+};
+
+type ResolveWorkspaceSurfaceLaunchParams = {
+  readonly currentHref: string;
+  readonly destinationHref: string;
+  readonly threadId?: string | null;
+};
+
+const INTERNAL_ORIGIN = 'https://workspace.genfeed.invalid';
+
+function parseInternalHref(href: string): URL | null {
+  try {
+    const url = new URL(href, INTERNAL_ORIGIN);
+    return url.origin === INTERNAL_ORIGIN ? url : null;
+  } catch {
+    return null;
+  }
+}
+
+function toRelativeHref(url: URL): string {
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
+function isSafeOpaqueId(value: string | null | undefined): value is string {
+  return Boolean(
+    value &&
+      value !== 'undefined' &&
+      value !== 'null' &&
+      /^[A-Za-z0-9_-]+$/.test(value),
+  );
+}
+
+function getCurrentThreadId(
+  currentUrl: URL,
+  explicitThreadId: string | null | undefined,
+): string | null {
+  if (isSafeOpaqueId(explicitThreadId)) {
+    return explicitThreadId;
+  }
+
+  const queryThreadId = currentUrl.searchParams.get('thread');
+  if (isSafeOpaqueId(queryThreadId)) {
+    return queryThreadId;
+  }
+
+  const currentRoute = resolveWorkspaceShellRoute(currentUrl.pathname);
+  const routeThreadId = currentRoute?.params.id;
+
+  return currentRoute?.surfaceKey === 'agent-conversation' &&
+    isSafeOpaqueId(routeThreadId)
+    ? routeThreadId
+    : null;
+}
+
+function stripOverlayParams(url: URL): void {
+  url.searchParams.delete('overlay');
+  url.searchParams.delete('overlayRef');
+}
+
+function stripAllShellParams(url: URL): void {
+  stripOverlayParams(url);
+  url.searchParams.delete('thread');
+}
+
+function formatAnnouncement(
+  surfaceKey: string,
+  mode: WorkspaceShellRouteMode,
+): string {
+  const label = surfaceKey.replaceAll('-', ' ');
+
+  if (mode === 'dedicated') {
+    return `Opening ${label} as a dedicated route.`;
+  }
+
+  return `Opening ${label} in ${mode} mode.`;
+}
+
+/**
+ * Resolves one explicit user launch through the trusted application registry.
+ * Unknown routes fail closed without navigation. The current thread is carried
+ * only within the same organization.
+ */
+export function resolveWorkspaceSurfaceLaunch({
+  currentHref,
+  destinationHref,
+  threadId,
+}: ResolveWorkspaceSurfaceLaunchParams): WorkspaceSurfaceLaunch {
+  const currentUrl = parseInternalHref(currentHref);
+  const destinationUrl = parseInternalHref(destinationHref);
+
+  if (!destinationUrl) {
+    return {
+      adapter: null,
+      announcement: 'Surface unavailable.',
+      history: 'none',
+      href: currentUrl ? toRelativeHref(currentUrl) : '/',
+      mode: 'dedicated',
+      registryKey: null,
+    };
+  }
+
+  const currentRoute = currentUrl
+    ? resolveWorkspaceShellRoute(currentUrl.pathname)
+    : null;
+  const destinationRoute = resolveWorkspaceShellRoute(destinationUrl.pathname);
+
+  if (!destinationRoute) {
+    return {
+      adapter: null,
+      announcement: 'Surface unavailable.',
+      history: 'none',
+      href: currentUrl ? toRelativeHref(currentUrl) : '/',
+      mode: 'dedicated',
+      registryKey: null,
+    };
+  }
+
+  const currentOrganizationSlug = currentRoute?.params.orgSlug ?? null;
+  const destinationOrganizationSlug = destinationRoute.params.orgSlug ?? null;
+  const canRetainThread = Boolean(
+    currentOrganizationSlug &&
+      destinationOrganizationSlug &&
+      currentOrganizationSlug === destinationOrganizationSlug,
+  );
+  const retainedThreadId =
+    canRetainThread && currentUrl
+      ? getCurrentThreadId(currentUrl, threadId)
+      : null;
+
+  if (destinationRoute.mode === 'canvas') {
+    stripOverlayParams(destinationUrl);
+    if (retainedThreadId) {
+      destinationUrl.searchParams.set('thread', retainedThreadId);
+    } else {
+      destinationUrl.searchParams.delete('thread');
+    }
+  } else if (destinationRoute.mode === 'conversation') {
+    stripAllShellParams(destinationUrl);
+    if (retainedThreadId && destinationRoute.canonicalUrl.endsWith('/agent')) {
+      destinationUrl.pathname = `${destinationUrl.pathname.replace(/\/$/, '')}/${encodeURIComponent(retainedThreadId)}`;
+    }
+  } else {
+    stripAllShellParams(destinationUrl);
+  }
+
+  return {
+    adapter: destinationRoute.adapter,
+    announcement: formatAnnouncement(
+      destinationRoute.surfaceKey,
+      destinationRoute.mode,
+    ),
+    history: 'push',
+    href: toRelativeHref(destinationUrl),
+    mode: destinationRoute.mode,
+    registryKey: destinationRoute.key,
+  };
+}

--- a/packages/interfaces/src/index.ts
+++ b/packages/interfaces/src/index.ts
@@ -250,6 +250,7 @@ export * from './ui/textarea.interface';
 export * from './ui/toolbar.interface';
 export * from './ui/tooltip-position.interface';
 export * from './ui/ui.interface';
+export * from './ui/workspace-shell.interface';
 export * from './users/user.interface';
 export * from './utils/abort-controller.interface';
 export * from './utils/config.interface';

--- a/packages/interfaces/src/ui/workspace-shell.interface.ts
+++ b/packages/interfaces/src/ui/workspace-shell.interface.ts
@@ -1,0 +1,158 @@
+export type WorkspaceShellBaseState = 'canvas' | 'conversation';
+
+export type WorkspaceShellRouteMode = WorkspaceShellBaseState | 'dedicated';
+
+export type WorkspaceShellSurfaceMode = WorkspaceShellRouteMode | 'overlay';
+
+export type WorkspaceShellState = WorkspaceShellBaseState | 'overlay';
+
+export type WorkspaceShellScopeRequirement =
+  | 'brand'
+  | 'organization'
+  | 'personal'
+  | 'platform-admin';
+
+export type WorkspaceShellDeployment =
+  | 'cloud-web'
+  | 'desktop'
+  | 'self-hosted-web';
+
+export type WorkspaceShellAccessPolicy =
+  | 'authenticated'
+  | 'brand-member'
+  | 'organization-member'
+  | 'platform-admin';
+
+export type WorkspaceShellAvailability =
+  | 'always'
+  | 'conversation-shell'
+  | 'legacy-shell';
+
+export type WorkspaceShellLaunchTarget =
+  | 'dedicated-route'
+  | 'focused-canvas'
+  | 'inline'
+  | 'inspector'
+  | 'overlay';
+
+export type WorkspaceShellReferenceKind = 'asset' | 'post';
+
+export interface WorkspaceShellRestorationPolicy {
+  readonly history: 'canonical-url';
+  readonly invalidShellParams: 'replace';
+  readonly searchParams: 'preserve-opaque';
+}
+
+export interface WorkspaceShellAdapterSeam {
+  readonly key: string;
+  readonly status: 'dedicated-route' | 'placeholder';
+}
+
+export interface WorkspaceShellRouteRegistration {
+  readonly accessPolicy: WorkspaceShellAccessPolicy;
+  readonly adapter: WorkspaceShellAdapterSeam;
+  readonly allowedShellModes: readonly [WorkspaceShellRouteMode];
+  readonly availability: Exclude<WorkspaceShellAvailability, 'legacy-shell'>;
+  readonly canonicalUrl: string;
+  readonly deployments: readonly WorkspaceShellDeployment[];
+  readonly key: string;
+  readonly kind: 'route';
+  readonly launchTarget: Extract<
+    WorkspaceShellLaunchTarget,
+    'dedicated-route' | 'focused-canvas' | 'inline'
+  >;
+  readonly mode: WorkspaceShellRouteMode;
+  readonly restoration: WorkspaceShellRestorationPolicy;
+  readonly safeFallback: string;
+  readonly scope: WorkspaceShellScopeRequirement;
+  readonly surfaceKey: string;
+  readonly switcherItems: readonly string[];
+  readonly telemetryClass: 'agent' | 'management' | 'product';
+}
+
+export interface ResolvedWorkspaceShellRoute
+  extends WorkspaceShellRouteRegistration {
+  readonly params: Readonly<Record<string, string>>;
+}
+
+export interface WorkspaceShellOverlayRegistration {
+  readonly accessPolicy: 'organization-member';
+  readonly adapter: WorkspaceShellAdapterSeam;
+  readonly allowedReferenceKinds: readonly WorkspaceShellReferenceKind[];
+  readonly allowedShellModes: readonly ['overlay'];
+  readonly availability: 'conversation-shell';
+  readonly canonicalUrl: null;
+  readonly deployments: readonly WorkspaceShellDeployment[];
+  readonly key: string;
+  readonly kind: 'overlay';
+  readonly launchTarget: 'overlay';
+  readonly restoration: WorkspaceShellRestorationPolicy;
+  readonly safeFallback: 'same-canonical-url';
+  readonly scope: 'organization';
+  readonly telemetryClass: 'notifications' | 'shell_preview';
+}
+
+export interface WorkspaceShellChromeRegistration {
+  readonly accessPolicy: 'organization-member';
+  readonly adapter: WorkspaceShellAdapterSeam;
+  readonly allowedShellModes: readonly ['dedicated'];
+  readonly availability: 'legacy-shell';
+  readonly canonicalUrl: null;
+  readonly deployments: readonly WorkspaceShellDeployment[];
+  readonly key: 'terminal-dock';
+  readonly kind: 'chrome';
+  readonly launchTarget: 'dedicated-route';
+  readonly restoration: WorkspaceShellRestorationPolicy;
+  readonly safeFallback: 'same-canonical-url';
+  readonly scope: 'organization';
+  readonly telemetryClass: 'legacy_chrome';
+}
+
+export type WorkspaceShellAuxiliaryRegistration =
+  | WorkspaceShellChromeRegistration
+  | WorkspaceShellOverlayRegistration;
+
+export interface WorkspaceSurfaceLaunch {
+  readonly adapter: WorkspaceShellAdapterSeam | null;
+  readonly announcement: string;
+  readonly history: 'none' | 'push';
+  readonly href: string;
+  readonly mode: WorkspaceShellRouteMode;
+  readonly registryKey: string | null;
+}
+
+export interface ResolveWorkspaceSurfaceLaunchParams {
+  readonly currentHref: string;
+  readonly destinationHref: string;
+  readonly threadId?: string | null;
+}
+
+export interface WorkspaceShellTypedReference {
+  readonly id: string;
+  readonly kind: WorkspaceShellReferenceKind;
+}
+
+export type WorkspaceShellRestorationFailure =
+  | 'invalid_overlay'
+  | 'invalid_overlay_reference'
+  | 'invalid_thread';
+
+export interface WorkspaceShellLocation {
+  readonly baseState: WorkspaceShellBaseState;
+  readonly canonicalSearchParams: URLSearchParams;
+  readonly isCanonical: boolean;
+  readonly overlayKey: string | null;
+  readonly overlayReference: WorkspaceShellTypedReference | null;
+  readonly restorationFailure: WorkspaceShellRestorationFailure | null;
+  readonly routeKey: string;
+  readonly safeFallbackHref: string;
+  readonly state: WorkspaceShellState;
+  readonly surfaceKey: string;
+  readonly threadId: string | null;
+}
+
+export interface RestoreWorkspaceShellLocationParams {
+  readonly normalizedPathname: string;
+  readonly pathname: string;
+  readonly searchParams: URLSearchParams;
+}

--- a/packages/props/ui/app-switcher.props.ts
+++ b/packages/props/ui/app-switcher.props.ts
@@ -1,5 +1,10 @@
 import type { AppContext } from '@genfeedai/interfaces';
 
+export interface AppSwitcherNavigationTarget {
+  announcement?: string;
+  href: string;
+}
+
 export interface AppSwitcherProps {
   /** Selected brand context used by brand-aware apps when the current route is org-scoped. */
   brandAwareSlug?: string;
@@ -14,6 +19,8 @@ export interface AppSwitcherProps {
   isAssetGateLocked?: boolean;
   orgSlug: string;
   preservedSearch?: string;
+  /** Application-owned resolver for trusted shell launches. */
+  resolveNavigation?: (href: string) => AppSwitcherNavigationTarget;
   /** Include platform-admin navigation for users with platform access. */
   showAdmin?: boolean;
   /** Trigger style: compact grid icon (sidebar) or labeled section pill (topbar) */

--- a/packages/ui/src/components/shell/app-switcher/AppSwitcher.test.tsx
+++ b/packages/ui/src/components/shell/app-switcher/AppSwitcher.test.tsx
@@ -260,6 +260,31 @@ describe('AppSwitcher', () => {
     expect(activeButton).toHaveAttribute('aria-current', 'page');
   });
 
+  it('uses the application-owned navigation resolver and announces the mode change', () => {
+    render(
+      <AppSwitcher
+        orgSlug="acme"
+        currentApp="agent"
+        resolveNavigation={(href) => ({
+          announcement: 'Opening workspace in canvas mode.',
+          href: `${href}?thread=thread-1`,
+        })}
+      />,
+    );
+
+    const workspaceLink = screen.getByRole('link', { name: 'Workspace' });
+    expect(workspaceLink).toHaveAttribute(
+      'href',
+      '/acme/~/overview?thread=thread-1',
+    );
+
+    fireEvent.click(workspaceLink);
+
+    expect(
+      screen.getByText('Opening workspace in canvas mode.'),
+    ).toBeInTheDocument();
+  });
+
   it('marks the operator agent item active on the agent surface', () => {
     render(<AppSwitcher orgSlug="acme" currentApp="agent" />);
 

--- a/packages/ui/src/components/shell/app-switcher/AppSwitcher.tsx
+++ b/packages/ui/src/components/shell/app-switcher/AppSwitcher.tsx
@@ -7,7 +7,10 @@ import {
 import { ButtonSize, ButtonVariant } from '@genfeedai/enums';
 import { cn } from '@genfeedai/helpers/formatting/cn/cn.util';
 import type { AppContext, AppSwitcherItemConfig } from '@genfeedai/interfaces';
-import type { AppSwitcherProps } from '@genfeedai/props/ui/app-switcher.props';
+import type {
+  AppSwitcherNavigationTarget,
+  AppSwitcherProps,
+} from '@genfeedai/props/ui/app-switcher.props';
 import Link from 'next/link';
 import { useMemo, useRef, useState } from 'react';
 import {
@@ -369,13 +372,15 @@ function AppSwitcherGridItem({
   isActive,
   isLocked = false,
   href,
+  navigationAnnouncement,
   onNavigateStart,
 }: {
   app: LifecycleAppSwitcherItemConfig;
   isActive: boolean;
   isLocked?: boolean;
   href: string;
-  onNavigateStart: () => void;
+  navigationAnnouncement?: string;
+  onNavigateStart: (announcement?: string) => void;
 }) {
   const Icon =
     PRIMARY_APP_ICONS[app.itemKey as (typeof PRIMARY_APP_ITEM_KEYS)[number]] ??
@@ -391,7 +396,7 @@ function AppSwitcherGridItem({
             ? `${app.label} — locked. Generate your first asset to unlock.`
             : undefined
         }
-        onClick={onNavigateStart}
+        onClick={() => onNavigateStart(navigationAnnouncement)}
         className={cn(
           'group grid min-h-[5.75rem] min-w-0 grid-rows-[2.75rem_1.25rem] place-items-center gap-1.5 rounded-lg border border-transparent px-1.5 py-2 text-center outline-none transition-[border-color,background-color,box-shadow]',
           'hover:border-border hover:bg-foreground/[0.04] focus-visible:border-border focus-visible:bg-foreground/[0.06] focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-popover',
@@ -437,12 +442,14 @@ export function AppSwitcher({
   isAssetGateLocked = false,
   orgSlug,
   preservedSearch,
+  resolveNavigation,
   showAdmin = false,
   variant = 'icon',
 }: AppSwitcherProps) {
   const preventTriggerAutoFocusRef = useRef(false);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const [searchQuery, setSearchQuery] = useState('');
+  const [navigationAnnouncement, setNavigationAnnouncement] = useState('');
 
   function getRouteBrandSlug(app: AppSwitcherItemConfig) {
     if (app.id === 'agent') {
@@ -484,8 +491,17 @@ export function AppSwitcher({
     return `${agentHref}${separator}locked=${encodeURIComponent(app.id)}`;
   }
 
-  const handleNavigateStart = () => {
+  function resolveAppNavigation(
+    app: AppSwitcherItemConfig,
+  ): AppSwitcherNavigationTarget {
+    const href = resolveAppHref(app);
+
+    return resolveNavigation?.(href) ?? { href };
+  }
+
+  const handleNavigateStart = (announcement?: string) => {
     preventTriggerAutoFocusRef.current = true;
+    setNavigationAnnouncement(announcement ?? 'Opening app.');
   };
 
   const sections = useMemo(
@@ -617,16 +633,21 @@ export function AppSwitcher({
         </div>
 
         <div className="grid grid-cols-3 gap-x-1 gap-y-2 px-3.5 py-3.5">
-          {visibleApps.map((app) => (
-            <AppSwitcherGridItem
-              key={app.itemKey}
-              app={app}
-              isActive={app.itemKey === activeItemKey}
-              isLocked={isAppLocked(app)}
-              href={resolveAppHref(app)}
-              onNavigateStart={handleNavigateStart}
-            />
-          ))}
+          {visibleApps.map((app) => {
+            const navigation = resolveAppNavigation(app);
+
+            return (
+              <AppSwitcherGridItem
+                key={app.itemKey}
+                app={app}
+                isActive={app.itemKey === activeItemKey}
+                isLocked={isAppLocked(app)}
+                href={navigation.href}
+                navigationAnnouncement={navigation.announcement}
+                onNavigateStart={handleNavigateStart}
+              />
+            );
+          })}
         </div>
 
         {visibleApps.length === 0 ? (
@@ -650,6 +671,9 @@ export function AppSwitcher({
           ) : null}
         </div>
       </DropdownMenuContent>
+      <span aria-live="polite" className="sr-only" role="status">
+        {navigationAnnouncement}
+      </span>
     </DropdownMenu>
   );
 }


### PR DESCRIPTION
Closes #1676
Part of #1670

## Summary
- replace the prefix heuristic with an immutable application-owned registry for all 206 protected route patterns, plus trusted Notifications and Community/Desktop dock entries
- add typed launch, restoration, search-param, history, scope, deployment, access, fallback, and adapter seams with fail-closed handling for unknown or external destinations
- route app-switcher launches through the registry, retain active threads only within the same organization, keep management surfaces dedicated, and announce mode changes accessibly
- add focused registry, launcher, restoration, persistence, switcher, and trust-boundary regression coverage

## Verification
- `bunx biome check` on all changed TypeScript/TSX files
- `bun run design:lint` (0 errors; 9 existing unused-token warnings)
- `bun run scripts/ui/control-guard.ts` (required guards passed; one existing advisory in `asset-gate-guard.tsx`)
- executable inventory diff matches the 206-pattern ADR reference exactly; the two hard-cut families remain excluded
- staged and committed content scanned with secretlint hooks and gitleaks; no leaks found
- tests, typechecks, builds, and E2E were not run locally per workstation policy; PR CI is authoritative