### PR TITLE
feat(agent): build conversation composer actions

### DIFF
--- a/apps/app/src/components/workspace-shell/UniversalWorkspaceShell.test.tsx
+++ b/apps/app/src/components/workspace-shell/UniversalWorkspaceShell.test.tsx
@@ -14,6 +14,12 @@ const router = vi.hoisted(() => ({
 }));
 const agentState = vi.hoisted(() => ({
   activeThreadId: 'thread-1' as string | null,
+  threads: [
+    {
+      contextVersion: 3,
+      id: 'thread-1',
+    },
+  ],
 }));
 const agentActions = vi.hoisted(() => ({
   resetActiveConversationState: vi.fn(),
@@ -23,6 +29,73 @@ const pageShellMount = vi.hoisted(() => vi.fn());
 const agentApiService = {} as never;
 
 vi.mock('@genfeedai/agent', () => ({
+  ConversationComposerShellProvider: ({
+    children,
+    dispatchAction,
+    draftScopeKey,
+    scopeControls,
+  }: {
+    children: ReactNode;
+    dispatchAction: (invocation: {
+      action: {
+        isConsequentialProposal: boolean;
+        label: string;
+        name: string;
+        requiredScope: string;
+        route: string;
+      };
+      arguments: string;
+    }) => void;
+    draftScopeKey: string;
+    scopeControls?: ReactNode;
+  }) => (
+    <div data-draft-scope={draftScopeKey}>
+      {children}
+      {scopeControls}
+      <button
+        aria-label="Dispatch publish action"
+        onClick={() =>
+          dispatchAction({
+            action: {
+              isConsequentialProposal: true,
+              label: 'Publish',
+              name: 'publish',
+              requiredScope: 'brand',
+              route: '/posts/review',
+            },
+            arguments: 'post-1',
+          })
+        }
+        type="button"
+      />
+      <button
+        aria-label="Dispatch forged publish action"
+        onClick={() =>
+          dispatchAction({
+            action: {
+              isConsequentialProposal: true,
+              label: 'Publish',
+              name: 'publish',
+              requiredScope: 'brand',
+              route: '/posts/calendar',
+            },
+            arguments: 'post-1',
+          })
+        }
+        type="button"
+      />
+    </div>
+  ),
+  getConversationComposerAction: (name: string) =>
+    name === 'publish'
+      ? {
+          isConsequentialProposal: true,
+          label: 'Publish',
+          name: 'publish',
+          requiredScope: 'brand',
+          route: '/posts/review',
+        }
+      : null,
   useAgentChatStore: Object.assign(
     (selector: (state: typeof agentState) => unknown) => selector(agentState),
     {
@@ -53,7 +126,10 @@ vi.mock(
 
 vi.mock('@hooks/navigation/use-org-url', () => ({
   useOrgUrl: () => ({
+    brandSlug: navigation.pathname.includes('/moonrise/') ? 'moonrise' : '',
+    href: (href: string) => `/acme/moonrise${href}`,
     orgHref: (href: string) => `/acme/~${href}`,
+    orgSlug: navigation.pathname.split('/').filter(Boolean)[0] ?? '',
   }),
 }));
 
@@ -217,6 +293,9 @@ describe('UniversalWorkspaceShell', () => {
       'overlay',
     );
     expect(screen.getByTestId('workspace-dialog')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('workspace-overlay-composer-slot'),
+    ).toBeInTheDocument();
     expect(screen.getByText('asset reference selected')).toBeInTheDocument();
 
     fireEvent.click(
@@ -226,6 +305,74 @@ describe('UniversalWorkspaceShell', () => {
     expect(router.back).not.toHaveBeenCalled();
     expect(router.replace).toHaveBeenCalledWith(
       '/acme/moonrise/library/images?thread=thread-1',
+    );
+  });
+
+  it('dispatches publish only as a trusted brand-scoped review route', () => {
+    navigation.pathname = '/acme/moonrise/workspace/overview';
+    navigation.searchParams = new URLSearchParams({ thread: 'thread-1' });
+
+    render(
+      <UniversalWorkspaceShell agentApiService={agentApiService}>
+        <div>Workspace</div>
+      </UniversalWorkspaceShell>,
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Dispatch publish action' }),
+    );
+
+    expect(router.push).toHaveBeenCalledWith(
+      '/acme/moonrise/posts/review?thread=thread-1',
+    );
+  });
+
+  it('exposes the optional scope-control composition slot without owning it', () => {
+    render(
+      <UniversalWorkspaceShell
+        agentApiService={agentApiService}
+        composerScopeControls={<span>Scoped controls</span>}
+      >
+        <div>Conversation</div>
+      </UniversalWorkspaceShell>,
+    );
+
+    expect(screen.getByText('Scoped controls')).toBeInTheDocument();
+  });
+
+  it('preserves an unauthorized brand action instead of widening org scope', () => {
+    navigation.pathname = '/acme/~/agent/thread-1';
+
+    render(
+      <UniversalWorkspaceShell agentApiService={agentApiService}>
+        <div>Conversation</div>
+      </UniversalWorkspaceShell>,
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Dispatch publish action' }),
+    );
+
+    expect(router.push).not.toHaveBeenCalledWith(
+      expect.stringContaining('/posts/review'),
+    );
+  });
+
+  it('rejects forged command metadata instead of trusting the invocation', () => {
+    navigation.pathname = '/acme/moonrise/workspace/overview';
+
+    render(
+      <UniversalWorkspaceShell agentApiService={agentApiService}>
+        <div>Workspace</div>
+      </UniversalWorkspaceShell>,
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Dispatch forged publish action' }),
+    );
+
+    expect(router.push).not.toHaveBeenCalledWith(
+      expect.stringContaining('/posts/calendar'),
     );
   });
 

--- a/apps/app/src/components/workspace-shell/UniversalWorkspaceShell.tsx
+++ b/apps/app/src/components/workspace-shell/UniversalWorkspaceShell.tsx
@@ -2,7 +2,14 @@
 
 import { AgentWorkspaceLayoutClient } from '@app/(protected)/[orgSlug]/~/agent/AgentWorkspaceLayoutClient';
 import { AgentWorkspacePageShell } from '@app/(protected)/[orgSlug]/~/agent/AgentWorkspacePageShell';
-import { type AgentApiService, useAgentChatStore } from '@genfeedai/agent';
+import {
+  type AgentApiService,
+  type ConversationComposerActionInvocation,
+  type ConversationComposerDispatchResult,
+  ConversationComposerShellProvider,
+  getConversationComposerAction,
+  useAgentChatStore,
+} from '@genfeedai/agent';
 import { APP_ROUTES } from '@genfeedai/constants';
 import { ButtonSize, ButtonVariant } from '@genfeedai/enums';
 import { cn } from '@helpers/formatting/cn/cn.util';
@@ -52,6 +59,7 @@ import {
   type WorkspaceShellLocation,
   type WorkspaceShellState,
 } from '@/lib/workspace-shell/workspace-shell-location';
+import { resolveWorkspaceShellRoute } from '@/lib/workspace-shell/workspace-shell-registry';
 import {
   captureWorkspaceShellRestorationFailure,
   captureWorkspaceShellTransition,
@@ -64,11 +72,12 @@ const INSPECTOR_MAX_WIDTH = 480;
 type UniversalWorkspaceShellProps = {
   readonly agentApiService: AgentApiService;
   readonly children: ReactNode;
+  readonly composerScopeControls?: ReactNode;
 };
 
 type UniversalWorkspaceShellContentProps = Pick<
   UniversalWorkspaceShellProps,
-  'children'
+  'children' | 'composerScopeControls'
 >;
 
 function clampInspectorWidth(width: number): number {
@@ -89,16 +98,20 @@ function requireWorkspaceShellLocation(
 
 function UniversalWorkspaceShellContent({
   children,
+  composerScopeControls,
 }: UniversalWorkspaceShellContentProps) {
   const rawPathname = usePathname();
   const searchParams = useSearchParams();
   const searchParamsString = searchParams.toString();
   const { back, push, replace } = useRouter();
-  const { orgHref } = useOrgUrl();
+  const { brandSlug, href, orgHref, orgSlug } = useOrgUrl();
   const activeThreadId = useAgentChatStore((state) => state.activeThreadId);
+  const threads = useAgentChatStore((state) => state.threads);
   const [isInspectorOpen, setIsInspectorOpen] = useState(true);
   const [isMobileInspectorOpen, setIsMobileInspectorOpen] = useState(false);
   const [inspectorWidth, setInspectorWidth] = useState(INSPECTOR_DEFAULT_WIDTH);
+  const [composerPortalTarget, setComposerPortalTarget] =
+    useState<HTMLElement | null>(null);
   const primaryRegionRef = useRef<HTMLElement>(null);
   const previousPathnameRef = useRef<string | null>(null);
   const previousStateRef = useRef<WorkspaceShellState | null>(null);
@@ -155,6 +168,17 @@ function UniversalWorkspaceShellContent({
     rawPathname,
     new URLSearchParams(searchParamsString),
   );
+  const activeThread = useMemo(
+    () => threads.find((thread) => thread.id === effectiveThreadId) ?? null,
+    [effectiveThreadId, threads],
+  );
+  const draftScopeKey = `${orgSlug || 'unknown'}:${effectiveThreadId ?? 'new'}:${activeThread?.contextVersion ?? 0}`;
+  const composerContextLabel =
+    state === 'conversation'
+      ? 'Conversation'
+      : state === 'overlay'
+        ? 'Overlay · conversation connected'
+        : `Canvas · ${shellLocation.routeKey.replace(/^canvas:/, '')}`;
 
   useLayoutEffect(() => {
     if (!isUnthreadedConversation) {
@@ -294,6 +318,62 @@ function UniversalWorkspaceShellContent({
     );
   }, [currentHref, push]);
 
+  const handleComposerAction = useCallback(
+    (
+      invocation: ConversationComposerActionInvocation,
+    ): ConversationComposerDispatchResult => {
+      const trustedAction = getConversationComposerAction(
+        invocation.action.name,
+      );
+      if (
+        !trustedAction ||
+        trustedAction.route !== invocation.action.route ||
+        trustedAction.requiredScope !== invocation.action.requiredScope
+      ) {
+        return {
+          message:
+            'That action is not registered. Your draft and references are unchanged.',
+          status: 'unavailable',
+        };
+      }
+
+      const registeredSurface = resolveWorkspaceShellRoute(trustedAction.route);
+      if (registeredSurface?.mode !== 'canvas') {
+        return {
+          message:
+            'That product surface is unavailable. Your draft and references are unchanged.',
+          status: 'unavailable',
+        };
+      }
+
+      if (trustedAction.requiredScope === 'brand' && !brandSlug) {
+        return {
+          message: `/${trustedAction.name} needs an explicit brand route. Select a brand through the scoped controls; your draft has been preserved.`,
+          status: 'unauthorized',
+        };
+      }
+
+      pendingTransitionRef.current = 'canvas_launch';
+      const destination =
+        trustedAction.requiredScope === 'brand'
+          ? href(trustedAction.route)
+          : orgHref(trustedAction.route);
+      push(
+        buildWorkspaceShellHref(destination, {
+          threadId: effectiveThreadId ?? activeThreadId,
+        }),
+      );
+
+      return {
+        message: trustedAction.isConsequentialProposal
+          ? `Opened ${trustedAction.label}. Your draft is preserved; execution still requires the product's explicit typed confirmation and authorization.`
+          : `Opened ${trustedAction.label}. Your draft and references are preserved.`,
+        status: 'dispatched',
+      };
+    },
+    [activeThreadId, brandSlug, effectiveThreadId, href, orgHref, push],
+  );
+
   const handleDismissOverlay = useCallback(() => {
     pendingTransitionRef.current = 'overlay_dismiss';
     if (isOwnedOverlayEntryRef.current) {
@@ -398,41 +478,105 @@ function UniversalWorkspaceShellContent({
   );
 
   return (
-    <div
-      className="relative min-h-[calc(100dvh-var(--desktop-titlebar-height)-3rem)] overflow-hidden bg-black p-2"
-      data-shell-state={state}
-      data-testid="universal-workspace-shell"
+    <ConversationComposerShellProvider
+      contextLabel={composerContextLabel}
+      dispatchAction={handleComposerAction}
+      draftScopeKey={draftScopeKey}
+      portalTarget={composerPortalTarget}
+      scopeControls={composerScopeControls}
+      shellState={state}
     >
-      <div aria-live="polite" className="sr-only" role="status">
-        Workspace state: {state}
-      </div>
-
       <div
-        className={cn(
-          'h-[calc(100dvh-var(--desktop-titlebar-height)-4rem)] min-h-0 gap-2 xl:grid',
-          isInspectorOpen
-            ? 'xl:grid-cols-[minmax(0,1fr)_auto]'
-            : 'xl:grid-cols-1',
-        )}
-        data-testid="workspace-shell-regions"
+        className="relative min-h-[calc(100dvh-var(--desktop-titlebar-height)-3rem)] overflow-hidden bg-black p-2"
+        data-shell-state={state}
+        data-testid="universal-workspace-shell"
       >
-        <div className="h-full min-h-0 min-w-0">
-          <div
-            aria-hidden={baseState !== 'conversation'}
-            className={cn(
-              'gen-workspace-shell-region-emphasis h-full min-h-0 overflow-hidden bg-background shadow-border',
-              baseState !== 'conversation' && 'hidden',
-            )}
-            data-testid="workspace-conversation-region"
-            inert={baseState !== 'conversation'}
-          >
-            <div className="flex h-11 items-center justify-between border-b border-border px-3">
-              <p className="text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">
-                Conversation
-              </p>
-              <div className="flex items-center gap-1">
+        <div aria-live="polite" className="sr-only" role="status">
+          Workspace state: {state}
+        </div>
+
+        <div
+          className={cn(
+            'h-[calc(100dvh-var(--desktop-titlebar-height)-4rem)] min-h-0 gap-2 xl:grid',
+            isInspectorOpen
+              ? 'xl:grid-cols-[minmax(0,1fr)_auto]'
+              : 'xl:grid-cols-1',
+          )}
+          data-testid="workspace-shell-regions"
+        >
+          <div className="relative h-full min-h-0 min-w-0">
+            <div
+              aria-hidden={baseState !== 'conversation'}
+              className={cn(
+                'gen-workspace-shell-region-emphasis h-full min-h-0 overflow-hidden bg-background shadow-border',
+                baseState !== 'conversation' && 'hidden',
+              )}
+              data-testid="workspace-conversation-region"
+              inert={baseState !== 'conversation'}
+            >
+              <div className="flex h-11 items-center justify-between border-b border-border px-3">
+                <p className="text-xs font-medium uppercase tracking-[0.16em] text-muted-foreground">
+                  Conversation
+                </p>
+                <div className="flex items-center gap-1">
+                  <Button
+                    className="xl:hidden"
+                    icon={<HiOutlineViewColumns className="size-4" />}
+                    onClick={() => setIsMobileInspectorOpen(true)}
+                    size={ButtonSize.SM}
+                    variant={ButtonVariant.GHOST}
+                    withWrapper={false}
+                  >
+                    Context
+                  </Button>
+                  <Button
+                    icon={<HiOutlineSquares2X2 className="size-4" />}
+                    onClick={handleOpenCanvas}
+                    size={ButtonSize.SM}
+                    variant={ButtonVariant.GHOST}
+                    withWrapper={false}
+                  >
+                    Open workspace canvas
+                  </Button>
+                </div>
+              </div>
+              <section
+                aria-label="Primary conversation workspace"
+                className="flex h-[calc(100%-2.75rem)] min-h-0"
+                ref={
+                  baseState === 'conversation' ? primaryRegionRef : undefined
+                }
+                tabIndex={-1}
+              >
+                <AgentWorkspacePageShell
+                  threadId={effectiveThreadId ?? undefined}
+                />
+              </section>
+            </div>
+
+            <section
+              aria-hidden={baseState !== 'canvas'}
+              aria-label="Primary workspace canvas"
+              className={cn(
+                'gen-workspace-shell-region-emphasis h-full min-w-0 overflow-auto bg-background pb-48 shadow-border md:pb-56',
+                baseState !== 'canvas' && 'hidden',
+              )}
+              data-testid="workspace-canvas-layout"
+              inert={baseState !== 'canvas'}
+              ref={baseState === 'canvas' ? primaryRegionRef : undefined}
+              tabIndex={-1}
+            >
+              <div className="flex h-11 items-center justify-between border-b border-border px-3 xl:hidden">
                 <Button
-                  className="xl:hidden"
+                  icon={<HiOutlineArrowLeft className="size-4" />}
+                  onClick={handleReturnToConversation}
+                  size={ButtonSize.SM}
+                  variant={ButtonVariant.GHOST}
+                  withWrapper={false}
+                >
+                  Conversation
+                </Button>
+                <Button
                   icon={<HiOutlineViewColumns className="size-4" />}
                   onClick={() => setIsMobileInspectorOpen(true)}
                   size={ButtonSize.SM}
@@ -441,161 +585,128 @@ function UniversalWorkspaceShellContent({
                 >
                   Context
                 </Button>
-                <Button
-                  icon={<HiOutlineSquares2X2 className="size-4" />}
-                  onClick={handleOpenCanvas}
-                  size={ButtonSize.SM}
-                  variant={ButtonVariant.GHOST}
-                  withWrapper={false}
-                >
-                  Open workspace canvas
-                </Button>
               </div>
-            </div>
-            <section
-              aria-label="Primary conversation workspace"
-              className="flex h-[calc(100%-2.75rem)] min-h-0"
-              ref={baseState === 'conversation' ? primaryRegionRef : undefined}
-              tabIndex={-1}
-            >
-              <AgentWorkspacePageShell
-                threadId={effectiveThreadId ?? undefined}
-              />
+              {baseState === 'canvas' ? children : null}
             </section>
+
+            {state !== 'overlay' ? (
+              <div
+                className="pointer-events-none absolute inset-x-3 bottom-3 z-40 md:inset-x-5 md:bottom-5"
+                data-testid="workspace-composer-slot"
+              >
+                <div
+                  className="pointer-events-auto"
+                  ref={setComposerPortalTarget}
+                />
+              </div>
+            ) : null}
           </div>
 
-          <section
-            aria-hidden={baseState !== 'canvas'}
-            aria-label="Primary workspace canvas"
-            className={cn(
-              'gen-workspace-shell-region-emphasis h-full min-w-0 overflow-auto bg-background shadow-border',
-              baseState !== 'canvas' && 'hidden',
-            )}
-            data-testid="workspace-canvas-layout"
-            inert={baseState !== 'canvas'}
-            ref={baseState === 'canvas' ? primaryRegionRef : undefined}
-            tabIndex={-1}
-          >
-            <div className="flex h-11 items-center justify-between border-b border-border px-3 xl:hidden">
+          {isInspectorOpen ? (
+            <aside
+              aria-label="Context inspector"
+              className="gen-workspace-shell-region relative hidden min-h-0 overflow-hidden bg-background-secondary shadow-border xl:block"
+              style={{ width: inspectorWidth }}
+            >
               <Button
-                icon={<HiOutlineArrowLeft className="size-4" />}
-                onClick={handleReturnToConversation}
-                size={ButtonSize.SM}
-                variant={ButtonVariant.GHOST}
+                aria-orientation="vertical"
+                aria-valuemax={INSPECTOR_MAX_WIDTH}
+                aria-valuemin={INSPECTOR_MIN_WIDTH}
+                aria-valuenow={inspectorWidth}
+                ariaLabel="Resize context inspector"
+                className="absolute inset-y-0 left-0 z-10 w-1.5 cursor-col-resize"
+                onKeyDown={handleInspectorResizeKeyDown}
+                onMouseDown={handleInspectorResizeStart}
+                role="separator"
+                variant={ButtonVariant.UNSTYLED}
                 withWrapper={false}
-              >
-                Conversation
-              </Button>
-              <Button
-                icon={<HiOutlineViewColumns className="size-4" />}
-                onClick={() => setIsMobileInspectorOpen(true)}
-                size={ButtonSize.SM}
-                variant={ButtonVariant.GHOST}
-                withWrapper={false}
-              >
-                Context
-              </Button>
-            </div>
-            {baseState === 'canvas' ? children : null}
-          </section>
-        </div>
-
-        {isInspectorOpen ? (
-          <aside
-            aria-label="Context inspector"
-            className="gen-workspace-shell-region relative hidden min-h-0 overflow-hidden bg-background-secondary shadow-border xl:block"
-            style={{ width: inspectorWidth }}
-          >
+              />
+              {inspectorContent}
+            </aside>
+          ) : (
             <Button
-              aria-orientation="vertical"
-              aria-valuemax={INSPECTOR_MAX_WIDTH}
-              aria-valuemin={INSPECTOR_MIN_WIDTH}
-              aria-valuenow={inspectorWidth}
-              ariaLabel="Resize context inspector"
-              className="absolute inset-y-0 left-0 z-10 w-1.5 cursor-col-resize"
-              onKeyDown={handleInspectorResizeKeyDown}
-              onMouseDown={handleInspectorResizeStart}
-              role="separator"
-              variant={ButtonVariant.UNSTYLED}
+              ariaLabel="Open context inspector"
+              className="absolute right-4 top-4 z-10 hidden size-8 xl:inline-flex"
+              icon={<HiOutlineViewColumns className="size-4" />}
+              onClick={() => setIsInspectorOpen(true)}
+              size={ButtonSize.ICON}
+              variant={ButtonVariant.OUTLINE}
               withWrapper={false}
             />
-            {inspectorContent}
-          </aside>
-        ) : (
-          <Button
-            ariaLabel="Open context inspector"
-            className="absolute right-4 top-4 z-10 hidden size-8 xl:inline-flex"
-            icon={<HiOutlineViewColumns className="size-4" />}
-            onClick={() => setIsInspectorOpen(true)}
-            size={ButtonSize.ICON}
-            variant={ButtonVariant.OUTLINE}
-            withWrapper={false}
-          />
-        )}
-      </div>
+          )}
+        </div>
 
-      <Drawer
-        open={isMobileInspectorOpen}
-        onOpenChange={setIsMobileInspectorOpen}
-      >
-        <DrawerContent className="max-h-[85vh] rounded-t-[var(--radius-workspace-overlay)]">
-          <DrawerHeader>
-            <DrawerTitle>Context inspector</DrawerTitle>
-            <DrawerDescription>
-              Context for the active canonical product route.
-            </DrawerDescription>
-          </DrawerHeader>
-          <div className="min-h-0 overflow-y-auto">{inspectorContent}</div>
-        </DrawerContent>
-      </Drawer>
+        <Drawer
+          open={isMobileInspectorOpen}
+          onOpenChange={setIsMobileInspectorOpen}
+        >
+          <DrawerContent className="max-h-[85vh] rounded-t-[var(--radius-workspace-overlay)]">
+            <DrawerHeader>
+              <DrawerTitle>Context inspector</DrawerTitle>
+              <DrawerDescription>
+                Context for the active canonical product route.
+              </DrawerDescription>
+            </DrawerHeader>
+            <div className="min-h-0 overflow-y-auto">{inspectorContent}</div>
+          </DrawerContent>
+        </Drawer>
 
-      <Dialog
-        open={state === 'overlay'}
-        onOpenChange={(isOpen) => {
-          if (!isOpen) {
-            handleDismissOverlay();
-          }
-        }}
-      >
-        <DialogContent
-          className="w-[min(92vw,42rem)] bg-background p-0 shadow-dialog"
-          data-workspace-shell-overlay="true"
-          onCloseAutoFocus={(event) => {
-            const returnFocusTarget = overlayReturnFocusRef.current;
-            if (!returnFocusTarget) {
-              return;
+        <Dialog
+          open={state === 'overlay'}
+          onOpenChange={(isOpen) => {
+            if (!isOpen) {
+              handleDismissOverlay();
             }
-
-            event.preventDefault();
-            returnFocusTarget.focus({ preventScroll: true });
-            overlayReturnFocusRef.current = null;
           }}
         >
-          <DialogHeader className="border-b border-border p-5 pr-12">
-            <DialogTitle>Temporary workspace overlay</DialogTitle>
-            <DialogDescription>
-              This trusted placeholder demonstrates restorable overlay state. It
-              does not mutate scope or approve an action.
-            </DialogDescription>
-          </DialogHeader>
-          <div className="p-5 text-sm text-muted-foreground">
-            {overlayReference
-              ? `${overlayReference.kind} reference selected`
-              : 'No resource reference selected'}
-          </div>
-        </DialogContent>
-      </Dialog>
-    </div>
+          <DialogContent
+            className="w-[min(92vw,42rem)] bg-background p-0 shadow-dialog"
+            data-workspace-shell-overlay="true"
+            onCloseAutoFocus={(event) => {
+              const returnFocusTarget = overlayReturnFocusRef.current;
+              if (!returnFocusTarget) {
+                return;
+              }
+
+              event.preventDefault();
+              returnFocusTarget.focus({ preventScroll: true });
+              overlayReturnFocusRef.current = null;
+            }}
+          >
+            <DialogHeader className="border-b border-border p-5 pr-12">
+              <DialogTitle>Temporary workspace overlay</DialogTitle>
+              <DialogDescription>
+                This trusted placeholder demonstrates restorable overlay state.
+                It does not mutate scope or approve an action.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="p-5 pb-2 text-sm text-muted-foreground">
+              {overlayReference
+                ? `${overlayReference.kind} reference selected`
+                : 'No resource reference selected'}
+            </div>
+            <div
+              className="border-t border-border p-3"
+              data-testid="workspace-overlay-composer-slot"
+              ref={setComposerPortalTarget}
+            />
+          </DialogContent>
+        </Dialog>
+      </div>
+    </ConversationComposerShellProvider>
   );
 }
 
 export default function UniversalWorkspaceShell({
   agentApiService,
   children,
+  composerScopeControls,
 }: UniversalWorkspaceShellProps) {
   return (
     <AgentWorkspaceLayoutClient agentApiService={agentApiService}>
-      <UniversalWorkspaceShellContent>
+      <UniversalWorkspaceShellContent
+        composerScopeControls={composerScopeControls}
+      >
         {children}
       </UniversalWorkspaceShellContent>
     </AgentWorkspaceLayoutClient>

--- a/bun.lock
+++ b/bun.lock
@@ -716,6 +716,7 @@
       },
       "peerDependencies": {
         "react": ">=18",
+        "react-dom": ">=18",
       },
     },
     "packages/api-types": {

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -108,7 +108,8 @@
   "private": true,
   "type": "module",
   "peerDependencies": {
-    "react": ">=18"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "scripts": {
     "test": "vitest run --config vitest.config.ts",

--- a/packages/agent/src/components/AgentChatContainer.spec.tsx
+++ b/packages/agent/src/components/AgentChatContainer.spec.tsx
@@ -293,6 +293,7 @@ type StoreState = {
     title: string;
   } | null;
   runStartedAt: string | null;
+  socketConnectionState: 'connected';
   setActiveThread: ReturnType<typeof vi.fn>;
   setActiveRun: ReturnType<typeof vi.fn>;
   setActiveRunStatus: ReturnType<typeof vi.fn>;
@@ -341,6 +342,7 @@ const storeState: StoreState = {
     title: 'Prompt bar mode',
   },
   runStartedAt: null,
+  socketConnectionState: 'connected',
   setActiveRun: vi.fn(),
   setActiveRunStatus: vi.fn(),
   setActiveThread: vi.fn(),

--- a/packages/agent/src/components/AgentChatContainer.tsx
+++ b/packages/agent/src/components/AgentChatContainer.tsx
@@ -5,6 +5,7 @@ import { AgentChatTimeline } from '@genfeedai/agent/components/AgentChatTimeline
 import { AgentConversationSkeleton } from '@genfeedai/agent/components/AgentConversationSkeleton';
 import { AgentInputRequestOverlay } from '@genfeedai/agent/components/AgentInputRequestOverlay';
 import { AgentPlanReviewSection } from '@genfeedai/agent/components/AgentPlanReviewSection';
+import { useConversationComposerShell } from '@genfeedai/agent/components/ConversationComposerShellContext';
 import { OnboardingConversationCard } from '@genfeedai/agent/components/OnboardingConversationCard';
 import { WorkflowPhaseProgressBar } from '@genfeedai/agent/components/WorkflowPhaseProgressBar';
 import { useAgentChatContainer } from '@genfeedai/agent/hooks/use-agent-chat-container';
@@ -15,7 +16,7 @@ import { AlertCategory, ButtonSize, ButtonVariant } from '@genfeedai/enums';
 import { cn } from '@helpers/formatting/cn/cn.util';
 import Alert from '@ui/feedback/alert/Alert';
 import { Button } from '@ui/primitives/button';
-import { type ReactElement, useCallback } from 'react';
+import { type ReactElement, useCallback, useMemo } from 'react';
 import { HiOutlineArrowDown } from 'react-icons/hi2';
 
 interface AgentChatContainerProps {
@@ -76,6 +77,7 @@ export function AgentChatContainer({
   isWideLayout = false,
   workspacePlanningTaskId = null,
 }: AgentChatContainerProps): ReactElement {
+  const composerShell = useConversationComposerShell();
   const {
     isGenerating,
     error,
@@ -85,6 +87,8 @@ export function AgentChatContainer({
     onboardingSignupGiftCredits,
     onboardingTotalJourneyCredits,
     pendingInputRequest,
+    socketConnectionState,
+    workEvents,
     isBusy,
     isRunActive,
     isStreamingActive,
@@ -135,6 +139,15 @@ export function AgentChatContainer({
   const conversationColumnMaxWidthClass = isWideLayout
     ? 'max-w-[52rem]'
     : 'max-w-[46rem]';
+  const activeWorkEvent = useMemo(
+    () =>
+      [...workEvents]
+        .reverse()
+        .find(
+          (event) => event.status === 'pending' || event.status === 'running',
+        ) ?? null,
+    [workEvents],
+  );
 
   const handleSuggestionSend = useCallback(
     (prompt: string) => {
@@ -154,18 +167,18 @@ export function AgentChatContainer({
 
   return (
     <div className="relative flex h-full flex-col">
-      {error && (
+      {error && !composerShell ? (
         <Alert
-          type={AlertCategory.ERROR}
-          onClose={() => setError(null)}
           className={cn(
             'mx-auto mt-3 w-[calc(100%-2rem)]',
             isWideLayout ? 'max-w-5xl' : 'max-w-4xl',
           )}
+          onClose={() => setError(null)}
+          type={AlertCategory.ERROR}
         >
           {error}
         </Alert>
-      )}
+      ) : null}
 
       {archivedNotice && (
         <Alert
@@ -190,146 +203,159 @@ export function AgentChatContainer({
         </div>
       ) : isEmpty && !onboardingMode ? (
         <AgentChatEmptyState
+          addFiles={addFiles}
           apiService={apiService}
+          chatAttachments={chatAttachments}
+          clearAllAttachments={clearAllAttachments}
+          dragHandlers={dragHandlers}
+          dragState={dragState}
           emptyStateTitle={emptyStateTitle}
           emptyStateDescription={emptyStateDescription}
-          isWideLayout={isWideLayout}
+          getCompletedAttachments={getCompletedAttachments}
+          isAttachmentUploading={isAttachmentUploading}
           isBusy={isBusy}
+          isComposerVisible={!composerShell}
           isReadOnly={isReadOnly}
           isRunActive={isRunActive}
-          placeholder={placeholder}
-          chatAttachments={chatAttachments}
-          isAttachmentUploading={isAttachmentUploading}
-          dragState={dragState}
-          dragHandlers={dragHandlers}
-          addFiles={addFiles}
-          removeAttachment={removeAttachment}
-          getCompletedAttachments={getCompletedAttachments}
-          clearAllAttachments={clearAllAttachments}
+          isWideLayout={isWideLayout}
           onSend={handleSend}
           onStop={handleStopRun}
+          placeholder={placeholder}
           promptBarSuggestions={promptBarSuggestions}
+          removeAttachment={removeAttachment}
         />
       ) : (
-        <>
-          <div
-            className={cn(
-              'relative flex flex-1 overflow-hidden',
-              isReadOnly && 'opacity-60',
-            )}
-          >
-            {pendingInputRequest ? (
-              <AgentInputRequestOverlay
-                isSubmitting={isSubmittingInputRequest}
-                onSubmit={handleSubmitInputRequest}
-                request={pendingInputRequest}
-                variant={onboardingMode ? 'inline' : 'overlay'}
-              />
-            ) : null}
-            <div ref={scrollContainerRef} className="flex-1 overflow-y-auto">
-              <div
-                className={cn(
-                  'mx-auto space-y-1 p-4 pb-56 md:px-6 md:pb-72',
-                  conversationColumnMaxWidthClass,
-                )}
-              >
-                {activeThreadTitle ? (
-                  <div className="mb-5 px-1">
-                    <p className="truncate text-sm font-medium text-foreground/70">
-                      {activeThreadTitle}
-                    </p>
-                  </div>
-                ) : null}
+        <div
+          className={cn(
+            'relative flex flex-1 overflow-hidden',
+            isReadOnly && 'opacity-60',
+          )}
+        >
+          {pendingInputRequest && (onboardingMode || !composerShell) ? (
+            <AgentInputRequestOverlay
+              isSubmitting={isSubmittingInputRequest}
+              onSubmit={handleSubmitInputRequest}
+              request={pendingInputRequest}
+              variant={onboardingMode ? 'inline' : 'overlay'}
+            />
+          ) : null}
+          <div ref={scrollContainerRef} className="flex-1 overflow-y-auto">
+            <div
+              className={cn(
+                'mx-auto space-y-1 p-4 pb-56 md:px-6 md:pb-72',
+                conversationColumnMaxWidthClass,
+              )}
+            >
+              {activeThreadTitle ? (
+                <div className="mb-5 px-1">
+                  <p className="truncate text-sm font-medium text-foreground/70">
+                    {activeThreadTitle}
+                  </p>
+                </div>
+              ) : null}
 
-                <WorkflowPhaseProgressBar />
+              <WorkflowPhaseProgressBar />
 
-                {latestProposedPlan ? (
-                  <AgentPlanReviewSection
-                    plan={latestProposedPlan}
-                    isBusy={isBusy}
-                    activeUiAction={activeUiAction}
-                    isCreatingFollowUpTasks={isCreatingFollowUpTasks}
-                    followUpTaskMessage={followUpTaskMessage}
-                    showFollowUpButton={
-                      Boolean(workspacePlanningTaskId) &&
-                      Boolean(onCreateFollowUpTasks) &&
-                      latestProposedPlan.status === 'approved'
-                    }
-                    onApprove={handleApprovePlan}
-                    onRequestChanges={handleRequestPlanChanges}
-                    onCreateFollowUpTasks={handleCreateFollowUpTasks}
-                  />
-                ) : null}
-
-                {isEmpty && onboardingMode && (
-                  <div className="flex flex-col items-center px-2 pt-8 pb-4">
-                    <OnboardingConversationCard
-                      signupGiftCredits={onboardingSignupGiftCredits}
-                      totalJourneyCredits={onboardingTotalJourneyCredits}
-                      onStart={handleSend}
-                      isDisabled={isBusy || isReadOnly}
-                    />
-                  </div>
-                )}
-
-                <AgentChatTimeline
-                  timeline={timeline}
-                  pendingUiActions={streamState.pendingUiActions}
-                  isGenerating={isGenerating}
-                  isStreamingActive={isStreamingActive}
+              {latestProposedPlan ? (
+                <AgentPlanReviewSection
+                  plan={latestProposedPlan}
                   isBusy={isBusy}
-                  highlightedMessageId={highlightedMessageId}
-                  apiService={apiService}
-                  messagesEndRef={messagesEndRef}
-                  onCopy={handleCopy}
-                  onRetry={handleRetry}
-                  onRegenerate={onRegenerate}
-                  onOAuthConnect={onOAuthConnect}
-                  onBrandCreate={onBrandCreate}
-                  onSelectCreditPack={onSelectCreditPack}
-                  onSelectIngredient={handleIngredientSelect}
-                  onUiAction={handleUiAction}
+                  activeUiAction={activeUiAction}
+                  isCreatingFollowUpTasks={isCreatingFollowUpTasks}
+                  followUpTaskMessage={followUpTaskMessage}
+                  showFollowUpButton={
+                    Boolean(workspacePlanningTaskId) &&
+                    Boolean(onCreateFollowUpTasks) &&
+                    latestProposedPlan.status === 'approved'
+                  }
+                  onApprove={handleApprovePlan}
+                  onRequestChanges={handleRequestPlanChanges}
+                  onCreateFollowUpTasks={handleCreateFollowUpTasks}
                 />
-              </div>
-            </div>
+              ) : null}
 
-            {!isAtBottom && (
-              <div className="absolute bottom-24 left-1/2 z-20 -translate-x-1/2 md:bottom-28">
-                <Button
-                  variant={ButtonVariant.GHOST}
-                  size={ButtonSize.ICON}
-                  icon={<HiOutlineArrowDown className="size-4" />}
-                  ariaLabel="Scroll to latest message"
-                  className="rounded-full border border-border/70 bg-background/88 text-foreground/72 shadow-[0_16px_36px_-24px_rgba(0,0,0,0.85)] backdrop-blur-sm hover:text-foreground"
-                  withWrapper={false}
-                  onClick={scrollToBottom}
-                />
-              </div>
-            )}
+              {isEmpty && onboardingMode && (
+                <div className="flex flex-col items-center px-2 pt-8 pb-4">
+                  <OnboardingConversationCard
+                    signupGiftCredits={onboardingSignupGiftCredits}
+                    totalJourneyCredits={onboardingTotalJourneyCredits}
+                    onStart={handleSend}
+                    isDisabled={isBusy || isReadOnly}
+                  />
+                </div>
+              )}
+
+              <AgentChatTimeline
+                timeline={timeline}
+                pendingUiActions={streamState.pendingUiActions}
+                isGenerating={isGenerating}
+                isStreamingActive={isStreamingActive}
+                isBusy={isBusy}
+                highlightedMessageId={highlightedMessageId}
+                apiService={apiService}
+                messagesEndRef={messagesEndRef}
+                onCopy={handleCopy}
+                onRetry={handleRetry}
+                onRegenerate={onRegenerate}
+                onOAuthConnect={onOAuthConnect}
+                onBrandCreate={onBrandCreate}
+                onSelectCreditPack={onSelectCreditPack}
+                onSelectIngredient={handleIngredientSelect}
+                onUiAction={handleUiAction}
+              />
+            </div>
           </div>
 
-          <AgentChatPromptBar
-            apiService={apiService}
-            layoutMode={promptBarLayoutMode}
-            isBusy={isBusy}
-            isReadOnly={isReadOnly}
-            isRunActive={isRunActive}
-            placeholder={placeholder}
-            showSuggestedActionsWhenNotEmpty={showSuggestedActionsWhenNotEmpty}
-            promptBarSuggestions={promptBarSuggestions}
-            chatAttachments={chatAttachments}
-            isAttachmentUploading={isAttachmentUploading}
-            dragState={dragState}
-            dragHandlers={dragHandlers}
-            addFiles={addFiles}
-            removeAttachment={removeAttachment}
-            getCompletedAttachments={getCompletedAttachments}
-            clearAllAttachments={clearAllAttachments}
-            onSend={handleSend}
-            onStop={handleStopRun}
-          />
-        </>
+          {!isAtBottom && (
+            <div className="absolute bottom-24 left-1/2 z-20 -translate-x-1/2 md:bottom-28">
+              <Button
+                variant={ButtonVariant.GHOST}
+                size={ButtonSize.ICON}
+                icon={<HiOutlineArrowDown className="size-4" />}
+                ariaLabel="Scroll to latest message"
+                className="rounded-full border border-border/70 bg-background/88 text-foreground/72 shadow-[0_16px_36px_-24px_rgba(0,0,0,0.85)] backdrop-blur-sm hover:text-foreground"
+                withWrapper={false}
+                onClick={scrollToBottom}
+              />
+            </div>
+          )}
+        </div>
       )}
+
+      {composerShell || !isEmpty || onboardingMode ? (
+        <AgentChatPromptBar
+          activeWorkEvent={activeWorkEvent}
+          addFiles={addFiles}
+          apiService={apiService}
+          chatAttachments={chatAttachments}
+          clearAllAttachments={clearAllAttachments}
+          dragHandlers={dragHandlers}
+          dragState={dragState}
+          error={composerShell ? error : null}
+          getCompletedAttachments={getCompletedAttachments}
+          isAttachmentUploading={isAttachmentUploading}
+          isBusy={
+            isBusy || isLoadingThread || socketConnectionState !== 'connected'
+          }
+          isReadOnly={isReadOnly}
+          isRunActive={isRunActive}
+          isSubmittingInputRequest={isSubmittingInputRequest}
+          latestProposedPlan={latestProposedPlan}
+          layoutMode={promptBarLayoutMode}
+          onClearError={() => setError(null)}
+          onSend={handleSend}
+          onStop={handleStopRun}
+          onSubmitInputRequest={handleSubmitInputRequest}
+          pendingInputRequest={
+            composerShell && !onboardingMode ? pendingInputRequest : null
+          }
+          placeholder={placeholder}
+          promptBarSuggestions={promptBarSuggestions}
+          removeAttachment={removeAttachment}
+          showSuggestedActionsWhenNotEmpty={showSuggestedActionsWhenNotEmpty}
+          socketConnectionState={socketConnectionState}
+        />
+      ) : null}
     </div>
   );
 }

--- a/packages/agent/src/components/AgentChatEmptyState.tsx
+++ b/packages/agent/src/components/AgentChatEmptyState.tsx
@@ -15,22 +15,21 @@ import type { ReactElement, ReactNode } from 'react';
 import { HiOutlineSparkles } from 'react-icons/hi2';
 
 type AgentChatEmptyStateProps = {
+  addFiles: (files: File[]) => void;
   apiService: AgentApiService;
+  chatAttachments: AttachmentItem[];
+  clearAllAttachments: () => void;
+  dragHandlers: DragHandlers;
+  dragState: DragState;
   emptyStateTitle: string;
   emptyStateDescription: string;
-  isWideLayout: boolean;
+  getCompletedAttachments: () => ChatAttachment[];
+  isAttachmentUploading: boolean;
   isBusy: boolean;
+  isComposerVisible: boolean;
   isReadOnly: boolean;
   isRunActive: boolean;
-  placeholder?: string;
-  chatAttachments: AttachmentItem[];
-  isAttachmentUploading: boolean;
-  dragState: DragState;
-  dragHandlers: DragHandlers;
-  addFiles: (files: File[]) => void;
-  removeAttachment: (id: string) => void;
-  getCompletedAttachments: () => ChatAttachment[];
-  clearAllAttachments: () => void;
+  isWideLayout: boolean;
   onSend: (
     content: string,
     mentions?: ExtractedMention[],
@@ -38,29 +37,32 @@ type AgentChatEmptyStateProps = {
     options?: { planModeEnabled?: boolean },
   ) => void;
   onStop: () => void;
+  placeholder?: string;
   promptBarSuggestions: ReactNode;
+  removeAttachment: (id: string) => void;
 };
 
 export function AgentChatEmptyState({
+  addFiles,
   apiService,
+  chatAttachments,
+  clearAllAttachments,
+  dragHandlers,
+  dragState,
   emptyStateTitle,
   emptyStateDescription,
-  isWideLayout,
+  getCompletedAttachments,
+  isAttachmentUploading,
   isBusy,
+  isComposerVisible,
   isReadOnly,
   isRunActive,
-  placeholder,
-  chatAttachments,
-  isAttachmentUploading,
-  dragState,
-  dragHandlers,
-  addFiles,
-  removeAttachment,
-  getCompletedAttachments,
-  clearAllAttachments,
+  isWideLayout,
   onSend,
   onStop,
+  placeholder,
   promptBarSuggestions,
+  removeAttachment,
 }: AgentChatEmptyStateProps): ReactElement {
   return (
     <div className="relative flex min-h-0 flex-1 overflow-hidden">
@@ -82,29 +84,31 @@ export function AgentChatEmptyState({
             {emptyStateDescription}
           </p>
 
-          <PromptBarContainer
-            layoutMode="inflow"
-            maxWidth={isWideLayout ? '2xl' : '4xl'}
-            zIndex={60}
-            className="mt-4 w-full"
-          >
-            <AgentChatInput
-              onSend={onSend}
-              disabled={isBusy || isReadOnly}
-              placeholder={placeholder}
-              apiService={apiService}
-              onStop={onStop}
-              showStop={isRunActive}
-              attachments={chatAttachments}
-              isUploading={isAttachmentUploading}
-              dragState={dragState}
-              dragHandlers={dragHandlers}
-              addFiles={addFiles}
-              removeAttachment={removeAttachment}
-              getCompletedAttachments={getCompletedAttachments}
-              clearAllAttachments={clearAllAttachments}
-            />
-          </PromptBarContainer>
+          {isComposerVisible ? (
+            <PromptBarContainer
+              className="mt-4 w-full"
+              layoutMode="inflow"
+              maxWidth={isWideLayout ? '2xl' : '4xl'}
+              zIndex={60}
+            >
+              <AgentChatInput
+                addFiles={addFiles}
+                apiService={apiService}
+                attachments={chatAttachments}
+                clearAllAttachments={clearAllAttachments}
+                disabled={isBusy || isReadOnly}
+                dragHandlers={dragHandlers}
+                dragState={dragState}
+                getCompletedAttachments={getCompletedAttachments}
+                isUploading={isAttachmentUploading}
+                onSend={onSend}
+                onStop={onStop}
+                placeholder={placeholder}
+                removeAttachment={removeAttachment}
+                showStop={isRunActive}
+              />
+            </PromptBarContainer>
+          ) : null}
 
           {promptBarSuggestions ? (
             <div className="mt-5">{promptBarSuggestions}</div>

--- a/packages/agent/src/components/AgentChatInput.spec.tsx
+++ b/packages/agent/src/components/AgentChatInput.spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const storeState = {
@@ -41,6 +41,7 @@ vi.mock('@genfeedai/agent/stores/agent-chat.store', () => ({
 }));
 
 import { AgentChatInput } from '@genfeedai/agent/components/AgentChatInput';
+import { ConversationComposerShellProvider } from '@genfeedai/agent/components/ConversationComposerShellContext';
 
 describe('AgentChatInput', () => {
   beforeEach(() => {
@@ -62,11 +63,12 @@ describe('AgentChatInput', () => {
     expect(screen.getByLabelText('Stop agent')).toBeTruthy();
   });
 
-  it('keeps plan mode and file picker controls out of the composer', () => {
+  it('keeps plan mode out and exposes the compact attachment control', () => {
     render(<AgentChatInput onSend={vi.fn()} addFiles={vi.fn()} />);
 
     expect(screen.queryByText(/Plan mode/i)).not.toBeInTheDocument();
-    expect(screen.queryByLabelText('Attach image')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Attach files')).toBeInTheDocument();
+    expect(screen.getByLabelText('Open composer actions')).toBeInTheDocument();
   });
 
   it('adds pasted image files to the prompt attachments', () => {
@@ -110,5 +112,63 @@ describe('AgentChatInput', () => {
     expect(screen.getByAltText('image.png')).toBeInTheDocument();
     fireEvent.click(removeButton);
     expect(removeAttachment).toHaveBeenCalledWith('attachment-1');
+  });
+
+  it('presents interrupted attachment recovery without pretending it can upload', () => {
+    render(
+      <AgentChatInput
+        attachments={[
+          {
+            error: 'Upload was interrupted. Reattach this file to retry.',
+            id: 'attachment-1',
+            kind: 'video',
+            name: 'draft.mp4',
+            previewUrl: '',
+            status: 'failed',
+          },
+        ]}
+        onSend={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByLabelText('draft.mp4: failed')).toBeInTheDocument();
+    expect(screen.getByText('Reattach')).toBeInTheDocument();
+  });
+
+  it('dispatches a selected trusted action without clearing or sending the draft', async () => {
+    const dispatchAction = vi.fn(() => ({
+      message: 'Opened Publish. Explicit approval is still required.',
+      status: 'dispatched' as const,
+    }));
+    const onSend = vi.fn();
+
+    render(
+      <ConversationComposerShellProvider
+        contextLabel="Conversation"
+        dispatchAction={dispatchAction}
+        draftScopeKey="acme:thread-1:3"
+        portalTarget={null}
+        shellState="conversation"
+      >
+        <AgentChatInput onSend={onSend} />
+      </ConversationComposerShellProvider>,
+    );
+
+    fireEvent.click(screen.getByLabelText('Open composer actions'));
+    fireEvent.click(screen.getByRole('button', { name: /\/publish/i }));
+    fireEvent.click(await screen.findByLabelText('Send message'));
+
+    await waitFor(() => {
+      expect(dispatchAction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: expect.objectContaining({ name: 'publish' }),
+        }),
+      );
+    });
+    expect(onSend).not.toHaveBeenCalled();
+    expect(screen.getByRole('textbox')).toHaveTextContent('/publish');
+    expect(
+      screen.getByText('Opened Publish. Explicit approval is still required.'),
+    ).toBeInTheDocument();
   });
 });

--- a/packages/agent/src/components/AgentChatInput.tsx
+++ b/packages/agent/src/components/AgentChatInput.tsx
@@ -1,6 +1,7 @@
 import { AgentChatInputAttachmentTray } from '@genfeedai/agent/components/AgentChatInputAttachmentTray';
 import { AgentChatInputStyles } from '@genfeedai/agent/components/AgentChatInputStyles';
 import { AgentChatInputToolbar } from '@genfeedai/agent/components/AgentChatInputToolbar';
+import { AgentComposerContextRail } from '@genfeedai/agent/components/AgentComposerContextRail';
 import { useAgentChatInput } from '@genfeedai/agent/components/useAgentChatInput';
 import type { AgentApiService } from '@genfeedai/agent/services/agent-api.service';
 import type { PromptBarAttachedAsset } from '@genfeedai/props/studio/prompt-bar.props';
@@ -81,16 +82,20 @@ export function AgentChatInput({
   clearAllAttachments,
 }: AgentChatInputProps): ReactElement {
   const {
+    actionFeedback,
     canSendMessage,
     editor,
     handlePasteImages,
     handleRemoveAttachment,
+    handleInsertReference,
+    handleSelectAction,
     handleSend,
     handleShellPointerDown,
     hasAttachments,
     isDragActive,
     isListening,
     isTranscribing,
+    references,
     shouldShowSendButton,
     shouldShowVoiceInput,
     startListening,
@@ -114,6 +119,13 @@ export function AgentChatInput({
     () => attachments.map(mapAttachmentToTrayAsset),
     [attachments],
   );
+  const attachmentStatusById = useMemo(
+    () =>
+      Object.fromEntries(
+        attachments.map((attachment) => [attachment.id, attachment.status]),
+      ),
+    [attachments],
+  );
 
   return (
     <div
@@ -124,49 +136,69 @@ export function AgentChatInput({
       <AgentChatInputStyles />
 
       {isDragActive && (
-        <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center rounded-md border-2 border-dashed border-primary/50 bg-primary/5">
-          <p className="text-sm font-medium text-primary/70">
-            Drop images here
-          </p>
+        <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center rounded-xl border-2 border-dashed border-primary/50 bg-primary/5">
+          <p className="text-sm font-medium text-primary/70">Drop files here</p>
         </div>
       )}
 
+      {actionFeedback ? (
+        <div
+          aria-live="polite"
+          className="mb-2 rounded-lg border border-border bg-background-secondary/92 px-3 py-2 text-xs leading-5 text-foreground/78 shadow-border"
+          role="status"
+        >
+          {actionFeedback}
+        </div>
+      ) : null}
+
       <PromptBarShell
         className={cn(
-          'rounded-md border border-border bg-card p-2 shadow-border transition-[border-color,box-shadow] focus-within:border-foreground/[0.18] focus-within:shadow-border-strong',
+          'overflow-hidden rounded-xl border border-border bg-card shadow-border transition-[border-color,box-shadow] focus-within:border-foreground/[0.18] focus-within:shadow-border-strong',
           disabled && 'opacity-50',
           isDragActive && 'ring-1 ring-primary/40',
         )}
         data-testid="agent-chat-input-shell"
         onPointerDown={handleShellPointerDown}
       >
-        {hasAttachments && (
+        <AgentComposerContextRail
+          attachmentCount={attachments.length}
+          referenceCount={references.length}
+        />
+
+        {(hasAttachments || references.length > 0) && (
           <AgentChatInputAttachmentTray
             assets={trayAssets}
+            attachmentStatusById={attachmentStatusById}
             isDisabled={disabled}
             onRemoveAttachedAsset={handleRemoveAttachment}
+            references={references}
           />
         )}
 
-        <div className="p-2">
+        <div className="px-3 pb-1 pt-2">
           <EditorContent editor={editor} className="flex-1" />
-        </div>
 
-        <AgentChatInputToolbar
-          disabled={disabled}
-          isUploading={isUploading}
-          showStop={showStop}
-          onStop={onStop}
-          isTranscribing={isTranscribing}
-          isListening={isListening}
-          shouldShowVoiceInput={shouldShowVoiceInput}
-          shouldShowSendButton={shouldShowSendButton}
-          canSendMessage={canSendMessage}
-          hasEditor={Boolean(editor)}
-          onStartListening={startListening}
-          onStopListening={stopListening}
-          onSend={handleSend}
-        />
+          <AgentChatInputToolbar
+            canSendMessage={canSendMessage}
+            disabled={disabled}
+            hasEditor={Boolean(editor)}
+            isListening={isListening}
+            isTranscribing={isTranscribing}
+            isUploading={isUploading}
+            onAddFiles={addFiles}
+            onInsertReference={handleInsertReference}
+            onSelectAction={handleSelectAction}
+            onSend={() => {
+              void handleSend();
+            }}
+            onStartListening={startListening}
+            onStop={onStop}
+            onStopListening={stopListening}
+            shouldShowSendButton={shouldShowSendButton}
+            shouldShowVoiceInput={shouldShowVoiceInput}
+            showStop={showStop}
+          />
+        </div>
       </PromptBarShell>
     </div>
   );

--- a/packages/agent/src/components/AgentChatInputAttachmentTray.tsx
+++ b/packages/agent/src/components/AgentChatInputAttachmentTray.tsx
@@ -4,35 +4,63 @@ import { cn } from '@helpers/formatting/cn/cn.util';
 import { Button } from '@ui/primitives/button';
 import Image from 'next/image';
 import type { ReactElement } from 'react';
-import { HiPhoto, HiXMark } from 'react-icons/hi2';
+import {
+  HiFilm,
+  HiLink,
+  HiPhoto,
+  HiSpeakerWave,
+  HiXMark,
+} from 'react-icons/hi2';
+
+export interface AgentChatReferenceItem {
+  id: string;
+  label: string;
+  type: 'brand' | 'content' | 'credential' | 'team';
+}
 
 type AgentChatInputAttachmentTrayProps = {
   assets: PromptBarAttachedAsset[];
+  attachmentStatusById?: Record<
+    string,
+    'completed' | 'failed' | 'pending' | 'uploading'
+  >;
   isDisabled: boolean | undefined;
   onRemoveAttachedAsset: (assetId: string) => void;
+  references?: AgentChatReferenceItem[];
 };
 
 export function AgentChatInputAttachmentTray({
   assets,
+  attachmentStatusById = {},
   isDisabled,
   onRemoveAttachedAsset,
+  references = [],
 }: AgentChatInputAttachmentTrayProps): ReactElement {
   return (
-    <div className="px-2 pb-2 pt-1">
-      <div className="flex flex-wrap gap-2">
+    <div
+      aria-label="Composer attachments and references"
+      aria-live="polite"
+      className="px-2 pb-2 pt-1"
+      role="group"
+    >
+      <div className="flex flex-wrap items-center gap-2">
         {assets.map((asset) => {
           const assetName = asset.name ?? 'Attached asset';
+          const status = attachmentStatusById[asset.id] ?? 'completed';
 
           return (
             <div
+              aria-label={`${assetName}: ${status}`}
               key={asset.id}
               className={cn(
                 'group relative size-16 overflow-hidden rounded-md border border-border bg-background-secondary',
                 isDisabled && 'opacity-60',
+                status === 'failed' && 'border-destructive/50',
               )}
               title={assetName}
+              role="group"
             >
-              {asset.previewUrl ? (
+              {asset.previewUrl && asset.kind === 'image' ? (
                 <Image
                   src={asset.previewUrl}
                   alt={assetName}
@@ -43,7 +71,13 @@ export function AgentChatInputAttachmentTray({
                 />
               ) : (
                 <div className="flex size-full items-center justify-center text-muted-foreground">
-                  <HiPhoto className="size-5" />
+                  {asset.kind === 'video' ? (
+                    <HiFilm aria-hidden="true" className="size-5" />
+                  ) : asset.kind === 'audio' ? (
+                    <HiSpeakerWave aria-hidden="true" className="size-5" />
+                  ) : (
+                    <HiPhoto aria-hidden="true" className="size-5" />
+                  )}
                 </div>
               )}
               <Button
@@ -56,9 +90,32 @@ export function AgentChatInputAttachmentTray({
               >
                 <HiXMark className="size-3.5" />
               </Button>
+              {status !== 'completed' ? (
+                <span
+                  className={cn(
+                    'absolute inset-x-1 bottom-1 truncate rounded bg-background/90 px-1 py-0.5 text-center text-[9px] font-medium',
+                    status === 'failed'
+                      ? 'text-destructive'
+                      : 'text-muted-foreground',
+                  )}
+                >
+                  {status === 'failed' ? 'Reattach' : 'Uploading'}
+                </span>
+              ) : null}
             </div>
           );
         })}
+
+        {references.map((reference) => (
+          <span
+            className="inline-flex max-w-48 items-center gap-1.5 rounded-lg border border-border bg-background-secondary px-2.5 py-1.5 text-xs text-foreground/78"
+            key={`${reference.type}:${reference.id}`}
+            title={reference.label}
+          >
+            <HiLink className="size-3.5 shrink-0 text-muted-foreground" />
+            <span className="truncate">{reference.label}</span>
+          </span>
+        ))}
       </div>
     </div>
   );

--- a/packages/agent/src/components/AgentChatInputToolbar.tsx
+++ b/packages/agent/src/components/AgentChatInputToolbar.tsx
@@ -1,55 +1,164 @@
+import { CONVERSATION_COMPOSER_ACTIONS } from '@genfeedai/agent/constants/conversation-composer-actions.constant';
+import type { ConversationComposerActionName } from '@genfeedai/agent/models/conversation-composer.model';
 import { ButtonSize, ButtonVariant } from '@genfeedai/enums';
 import { Button } from '@ui/primitives/button';
-import type { ReactElement } from 'react';
+import { Input } from '@ui/primitives/input';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@ui/primitives/popover';
+import { type ChangeEvent, type ReactElement, useRef, useState } from 'react';
 import {
   HiArrowUp,
   HiOutlineArrowPath,
+  HiOutlineBolt,
+  HiOutlineLink,
   HiOutlineMicrophone,
+  HiOutlinePaperClip,
 } from 'react-icons/hi2';
 
-type AgentChatInputToolbarProps = {
-  disabled: boolean | undefined;
-  isUploading: boolean;
-  showStop: boolean;
-  onStop: (() => void | Promise<void>) | undefined;
-  isTranscribing: boolean;
-  isListening: boolean;
-  shouldShowVoiceInput: boolean;
-  shouldShowSendButton: boolean;
+interface AgentChatInputToolbarProps {
   canSendMessage: boolean;
+  disabled: boolean | undefined;
   hasEditor: boolean;
-  onStartListening: () => void;
-  onStopListening: () => void;
+  isListening: boolean;
+  isTranscribing: boolean;
+  isUploading: boolean;
+  onAddFiles?: (files: File[]) => void;
+  onInsertReference: () => void;
+  onSelectAction: (actionName: ConversationComposerActionName) => void;
   onSend: () => void;
-};
+  onStartListening: () => void;
+  onStop: (() => void | Promise<void>) | undefined;
+  onStopListening: () => void;
+  shouldShowSendButton: boolean;
+  shouldShowVoiceInput: boolean;
+  showStop: boolean;
+}
 
 export function AgentChatInputToolbar({
-  disabled,
-  isUploading,
-  showStop,
-  onStop,
-  isTranscribing,
-  isListening,
-  shouldShowVoiceInput,
-  shouldShowSendButton,
   canSendMessage,
+  disabled,
   hasEditor,
-  onStartListening,
-  onStopListening,
+  isListening,
+  isTranscribing,
+  isUploading,
+  onAddFiles,
+  onInsertReference,
+  onSelectAction,
   onSend,
+  onStartListening,
+  onStop,
+  onStopListening,
+  shouldShowSendButton,
+  shouldShowVoiceInput,
+  showStop,
 }: AgentChatInputToolbarProps): ReactElement {
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [isActionsOpen, setIsActionsOpen] = useState(false);
+
+  function handleFileChange(event: ChangeEvent<HTMLInputElement>): void {
+    const files = Array.from(event.target.files ?? []);
+    if (files.length > 0) {
+      onAddFiles?.(files);
+    }
+    event.target.value = '';
+  }
+
   return (
-    <div className="mt-1">
-      <div className="flex items-center justify-end gap-2">
+    <div className="mt-1 flex min-h-10 items-center justify-between gap-2 border-t border-border/70 pt-2">
+      <div className="flex min-w-0 items-center gap-1">
+        {onAddFiles ? (
+          <>
+            <Input
+              ref={fileInputRef}
+              accept="image/*,video/*,audio/*"
+              aria-label="Choose composer attachments"
+              className="sr-only"
+              multiple
+              onChange={handleFileChange}
+              type="file"
+            />
+            <Button
+              ariaLabel="Attach files"
+              className="size-9 shrink-0"
+              icon={<HiOutlinePaperClip className="size-4" />}
+              isDisabled={disabled}
+              onClick={() => fileInputRef.current?.click()}
+              size={ButtonSize.ICON}
+              tooltip="Attach files"
+              variant={ButtonVariant.GHOST}
+              withWrapper={false}
+            />
+          </>
+        ) : null}
+
+        <Button
+          ariaLabel="Add an existing content reference"
+          className="size-9 shrink-0"
+          icon={<HiOutlineLink className="size-4" />}
+          isDisabled={disabled || !hasEditor}
+          onClick={onInsertReference}
+          size={ButtonSize.ICON}
+          tooltip="Reference existing content"
+          variant={ButtonVariant.GHOST}
+          withWrapper={false}
+        />
+
+        <Popover open={isActionsOpen} onOpenChange={setIsActionsOpen}>
+          <PopoverTrigger asChild>
+            <Button
+              ariaLabel="Open composer actions"
+              className="h-9 shrink-0 gap-1.5 px-2.5"
+              icon={<HiOutlineBolt className="size-4" />}
+              isDisabled={disabled || !hasEditor}
+              variant={ButtonVariant.GHOST}
+              withWrapper={false}
+            >
+              <span className="hidden text-xs sm:inline">Actions</span>
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent
+            align="start"
+            className="w-72 rounded-xl border-border bg-popover p-1.5"
+            side="top"
+          >
+            <div aria-label="Trusted composer actions" role="group">
+              {CONVERSATION_COMPOSER_ACTIONS.map((action) => (
+                <Button
+                  className="flex w-full items-start justify-start gap-3 rounded-lg px-3 py-2.5 text-left"
+                  key={action.name}
+                  onClick={() => {
+                    onSelectAction(action.name);
+                    setIsActionsOpen(false);
+                  }}
+                  variant={ButtonVariant.GHOST}
+                  withWrapper={false}
+                >
+                  <span className="min-w-16 text-xs font-medium text-foreground">
+                    /{action.name}
+                  </span>
+                  <span className="text-xs leading-4 text-muted-foreground">
+                    {action.description}
+                  </span>
+                </Button>
+              ))}
+            </div>
+          </PopoverContent>
+        </Popover>
+      </div>
+
+      <div className="flex shrink-0 items-center gap-2">
         {showStop && onStop ? (
           <Button
-            variant={ButtonVariant.UNSTYLED}
-            withWrapper={false}
+            ariaLabel="Stop agent"
+            className="h-9 shrink-0 rounded-lg border border-destructive/30 bg-destructive/10 px-3 text-xs font-medium text-destructive transition-colors hover:bg-destructive/20"
             onClick={() => {
               void onStop();
             }}
-            className="shrink-0 rounded-lg border border-red-500/30 bg-red-500/10 px-2.5 py-1.5 text-xs font-medium text-red-300 transition-colors hover:bg-red-500/20"
-            ariaLabel="Stop agent"
+            variant={ButtonVariant.UNSTYLED}
+            withWrapper={false}
           >
             Stop
           </Button>
@@ -57,46 +166,55 @@ export function AgentChatInputToolbar({
 
         {isTranscribing ? (
           <Button
-            variant={ButtonVariant.UNSTYLED}
-            withWrapper={false}
+            ariaLabel="Transcribing"
+            className="size-9 shrink-0"
+            icon={
+              <HiOutlineArrowPath className="size-4 animate-spin motion-reduce:animate-none" />
+            }
             isDisabled
-            className="shrink-0 flex size-9 items-center justify-center rounded-md bg-primary/20 text-primary"
-            aria-label="Transcribing"
-          >
-            <HiOutlineArrowPath className="size-4 animate-spin" />
-          </Button>
+            size={ButtonSize.ICON}
+            variant={ButtonVariant.GHOST}
+            withWrapper={false}
+          />
         ) : !showStop && isListening ? (
           <Button
-            variant={ButtonVariant.UNSTYLED}
-            withWrapper={false}
+            ariaLabel="Stop listening"
+            className="relative size-9 shrink-0 bg-destructive/15 text-destructive"
             onClick={onStopListening}
-            className="relative shrink-0 flex size-9 items-center justify-center rounded-md bg-red-500/20 text-red-400 transition-colors hover:bg-red-500/30"
-            aria-label="Stop listening"
+            size={ButtonSize.ICON}
+            variant={ButtonVariant.GHOST}
+            withWrapper={false}
           >
             <HiOutlineMicrophone className="size-4" />
-            <span className="absolute right-0 top-0 size-2 animate-pulse rounded-full bg-red-500" />
+            <span
+              aria-hidden="true"
+              className="absolute right-0 top-0 size-2 animate-pulse rounded-full bg-destructive motion-reduce:animate-none"
+            />
           </Button>
         ) : shouldShowVoiceInput ? (
           <Button
-            variant={ButtonVariant.UNSTYLED}
-            withWrapper={false}
-            onClick={onStartListening}
-            isDisabled={disabled}
-            className="shrink-0 flex size-9 items-center justify-center rounded-md border border-white/12 bg-white/[0.04] text-muted-foreground transition-colors hover:bg-white/[0.08] hover:text-foreground"
             ariaLabel="Start voice input"
-          >
-            <HiOutlineMicrophone className="size-4" />
-          </Button>
+            className="size-9 shrink-0"
+            icon={<HiOutlineMicrophone className="size-4" />}
+            isDisabled={disabled}
+            onClick={onStartListening}
+            size={ButtonSize.ICON}
+            variant={ButtonVariant.GHOST}
+            withWrapper={false}
+          />
         ) : shouldShowSendButton ? (
           <Button
-            variant={ButtonVariant.GENERATE}
-            size={ButtonSize.ICON}
-            icon={<HiArrowUp />}
-            onClick={onSend}
+            ariaLabel="Send message"
+            className="size-9 shrink-0"
+            icon={<HiArrowUp className="size-4" />}
             isDisabled={
               disabled || !hasEditor || !canSendMessage || isUploading
             }
-            className="shrink-0"
+            onClick={onSend}
+            size={ButtonSize.ICON}
+            tooltip="Send (Enter)"
+            variant={ButtonVariant.GENERATE}
+            withWrapper={false}
           />
         ) : null}
       </div>

--- a/packages/agent/src/components/AgentChatPromptBar.tsx
+++ b/packages/agent/src/components/AgentChatPromptBar.tsx
@@ -2,7 +2,15 @@ import {
   AgentChatInput,
   type ExtractedMention,
 } from '@genfeedai/agent/components/AgentChatInput';
+import { AgentComposerStatusStack } from '@genfeedai/agent/components/AgentComposerStatusStack';
+import { useConversationComposerShell } from '@genfeedai/agent/components/ConversationComposerShellContext';
+import type {
+  AgentInputRequest,
+  AgentProposedPlan,
+  AgentWorkEvent,
+} from '@genfeedai/agent/models/agent-chat.model';
 import type { AgentApiService } from '@genfeedai/agent/services/agent-api.service';
+import type { AgentSocketConnectionState } from '@genfeedai/agent/stores/agent-chat.store';
 import type {
   AttachmentItem,
   ChatAttachment,
@@ -12,6 +20,7 @@ import type {
 import { cn } from '@helpers/formatting/cn/cn.util';
 import PromptBarContainer from '@ui/layout/prompt-bar-container/PromptBarContainer';
 import type { ReactElement, ReactNode } from 'react';
+import { createPortal } from 'react-dom';
 
 type AgentChatPromptBarProps = {
   apiService: AgentApiService;
@@ -37,6 +46,14 @@ type AgentChatPromptBarProps = {
     options?: { planModeEnabled?: boolean },
   ) => void;
   onStop: () => void;
+  activeWorkEvent: AgentWorkEvent | null;
+  error: string | null;
+  isSubmittingInputRequest: boolean;
+  latestProposedPlan: AgentProposedPlan | null;
+  onClearError: () => void;
+  onSubmitInputRequest: (answer: string) => void | Promise<void>;
+  pendingInputRequest: AgentInputRequest | null;
+  socketConnectionState: AgentSocketConnectionState;
 };
 
 export function AgentChatPromptBar({
@@ -58,19 +75,45 @@ export function AgentChatPromptBar({
   clearAllAttachments,
   onSend,
   onStop,
+  activeWorkEvent,
+  error,
+  isSubmittingInputRequest,
+  latestProposedPlan,
+  onClearError,
+  onSubmitInputRequest,
+  pendingInputRequest,
+  socketConnectionState,
 }: AgentChatPromptBarProps): ReactElement {
-  return (
+  const composerShell = useConversationComposerShell();
+  const statusStack = (
+    <AgentComposerStatusStack
+      activeWorkEvent={activeWorkEvent}
+      error={error}
+      isSubmittingInputRequest={isSubmittingInputRequest}
+      latestProposedPlan={latestProposedPlan}
+      onClearError={onClearError}
+      onSubmitInputRequest={onSubmitInputRequest}
+      pendingInputRequest={pendingInputRequest}
+      socketConnectionState={socketConnectionState}
+    />
+  );
+  const topContent = (
+    <>
+      {statusStack}
+      {showSuggestedActionsWhenNotEmpty && promptBarSuggestions ? (
+        <div className="px-1 pb-3">{promptBarSuggestions}</div>
+      ) : null}
+    </>
+  );
+  const promptBar = (
     <PromptBarContainer
-      layoutMode={layoutMode}
+      layoutMode={composerShell?.portalTarget ? 'inflow' : layoutMode}
       maxWidth="4xl"
-      showTopFade
-      topContent={
-        showSuggestedActionsWhenNotEmpty && promptBarSuggestions ? (
-          <div className="px-1 pb-3">{promptBarSuggestions}</div>
-        ) : undefined
-      }
+      showTopFade={!composerShell?.portalTarget}
+      topContent={topContent}
       zIndex={40}
       className={cn(
+        composerShell?.portalTarget && 'w-full',
         layoutMode === 'fixed' && 'bottom-2 md:bottom-4',
         layoutMode === 'surface-fixed' && 'bottom-3 md:bottom-5',
       )}
@@ -95,4 +138,8 @@ export function AgentChatPromptBar({
       />
     </PromptBarContainer>
   );
+
+  return composerShell?.portalTarget
+    ? createPortal(promptBar, composerShell.portalTarget)
+    : promptBar;
 }

--- a/packages/agent/src/components/AgentCommandList.tsx
+++ b/packages/agent/src/components/AgentCommandList.tsx
@@ -10,6 +10,8 @@ import {
   useState,
 } from 'react';
 import {
+  HiOutlineArrowUturnLeft,
+  HiOutlineBeaker,
   HiOutlineBolt,
   HiOutlineCalendarDays,
   HiOutlineChartBar,
@@ -17,8 +19,11 @@ import {
   HiOutlineDocumentText,
   HiOutlineHashtag,
   HiOutlineLightBulb,
+  HiOutlinePaperAirplane,
   HiOutlinePhoto,
+  HiOutlinePresentationChartLine,
   HiOutlineRocketLaunch,
+  HiOutlineSparkles,
   HiOutlineSquare2Stack,
 } from 'react-icons/hi2';
 
@@ -27,12 +32,17 @@ const COMMAND_ICONS: Record<string, ReactElement> = {
   batch: <HiOutlineSquare2Stack className="size-4" />,
   caption: <HiOutlineChatBubbleBottomCenterText className="size-4" />,
   'create-post': <HiOutlineDocumentText className="size-4" />,
+  create: <HiOutlineSparkles className="size-4" />,
   'generate-image': <HiOutlinePhoto className="size-4" />,
   hashtags: <HiOutlineHashtag className="size-4" />,
   ideas: <HiOutlineLightBulb className="size-4" />,
   repurpose: <HiOutlineRocketLaunch className="size-4" />,
+  remix: <HiOutlineArrowUturnLeft className="size-4" />,
+  reply: <HiOutlinePaperAirplane className="size-4" />,
+  research: <HiOutlineBeaker className="size-4" />,
   schedule: <HiOutlineCalendarDays className="size-4" />,
   trends: <HiOutlineBolt className="size-4" />,
+  workflow: <HiOutlinePresentationChartLine className="size-4" />,
 };
 
 interface AgentCommandListHandle {

--- a/packages/agent/src/components/AgentComposerContextRail.tsx
+++ b/packages/agent/src/components/AgentComposerContextRail.tsx
@@ -1,0 +1,44 @@
+import { useConversationComposerShell } from '@genfeedai/agent/components/ConversationComposerShellContext';
+import type { ReactElement } from 'react';
+import { HiOutlineChatBubbleLeftRight } from 'react-icons/hi2';
+
+interface AgentComposerContextRailProps {
+  attachmentCount: number;
+  referenceCount: number;
+}
+
+export function AgentComposerContextRail({
+  attachmentCount,
+  referenceCount,
+}: AgentComposerContextRailProps): ReactElement {
+  const shell = useConversationComposerShell();
+  const contextLabel = shell?.contextLabel ?? 'Conversation';
+
+  return (
+    <div className="flex min-h-9 items-center gap-2 rounded-t-lg border-b border-border/70 bg-background-secondary/82 px-3 py-1.5">
+      <HiOutlineChatBubbleLeftRight
+        aria-hidden="true"
+        className="size-3.5 shrink-0 text-muted-foreground"
+      />
+      <span className="min-w-0 truncate text-xs font-medium text-foreground/78">
+        {contextLabel}
+      </span>
+      {referenceCount > 0 ? (
+        <span className="shrink-0 text-[11px] text-muted-foreground">
+          {referenceCount} {referenceCount === 1 ? 'reference' : 'references'}
+        </span>
+      ) : null}
+      {attachmentCount > 0 ? (
+        <span className="shrink-0 text-[11px] text-muted-foreground">
+          {attachmentCount} {attachmentCount === 1 ? 'file' : 'files'}
+        </span>
+      ) : null}
+      <div
+        className="ml-auto flex shrink-0 items-center"
+        data-composer-scope-controls-slot="true"
+      >
+        {shell?.scopeControls}
+      </div>
+    </div>
+  );
+}

--- a/packages/agent/src/components/AgentComposerStatusStack.spec.tsx
+++ b/packages/agent/src/components/AgentComposerStatusStack.spec.tsx
@@ -1,0 +1,75 @@
+import {
+  AgentWorkEventStatus,
+  AgentWorkEventType,
+} from '@genfeedai/agent/models/agent-chat.model';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { AgentComposerStatusStack } from './AgentComposerStatusStack';
+
+const baseProps = {
+  error: null,
+  isSubmittingInputRequest: false,
+  latestProposedPlan: null,
+  onClearError: vi.fn(),
+  onSubmitInputRequest: vi.fn(),
+  pendingInputRequest: null,
+  socketConnectionState: 'connected' as const,
+};
+
+describe('AgentComposerStatusStack', () => {
+  it('renders determinate progress only for a measurable value', () => {
+    render(
+      <AgentComposerStatusStack
+        {...baseProps}
+        activeWorkEvent={{
+          createdAt: '2026-07-13T00:00:00.000Z',
+          event: AgentWorkEventType.TOOL_STARTED,
+          id: 'event-1',
+          label: 'Rendering frames',
+          progress: 42,
+          status: AgentWorkEventStatus.RUNNING,
+          threadId: 'thread-1',
+        }}
+      />,
+    );
+
+    expect(
+      screen.getByRole('progressbar', { name: 'Rendering frames progress' }),
+    ).toHaveAttribute('aria-valuetext', '42 percent');
+  });
+
+  it('uses activity status without inventing a percentage', () => {
+    render(
+      <AgentComposerStatusStack
+        {...baseProps}
+        activeWorkEvent={{
+          createdAt: '2026-07-13T00:00:00.000Z',
+          event: AgentWorkEventType.TOOL_STARTED,
+          id: 'event-1',
+          label: 'Researching sources',
+          status: AgentWorkEventStatus.RUNNING,
+          threadId: 'thread-1',
+        }}
+      />,
+    );
+
+    expect(screen.getByText('Active')).toBeInTheDocument();
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
+    expect(screen.queryByText(/%/)).not.toBeInTheDocument();
+  });
+
+  it('labels reconnect recovery without exposing prompt contents', () => {
+    render(
+      <AgentComposerStatusStack
+        {...baseProps}
+        activeWorkEvent={null}
+        socketConnectionState="offline"
+      />,
+    );
+
+    expect(
+      screen.getByText('Offline. Your draft is safe; sending is paused.'),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/agent/src/components/AgentComposerStatusStack.tsx
+++ b/packages/agent/src/components/AgentComposerStatusStack.tsx
@@ -1,0 +1,162 @@
+import { AgentInputRequestOverlay } from '@genfeedai/agent/components/AgentInputRequestOverlay';
+import type {
+  AgentInputRequest,
+  AgentProposedPlan,
+  AgentWorkEvent,
+} from '@genfeedai/agent/models/agent-chat.model';
+import type { AgentSocketConnectionState } from '@genfeedai/agent/stores/agent-chat.store';
+import { ButtonVariant } from '@genfeedai/enums';
+import { Button } from '@ui/primitives/button';
+import { Progress } from '@ui/primitives/progress';
+import type { ReactElement } from 'react';
+import {
+  HiOutlineExclamationTriangle,
+  HiOutlineSignalSlash,
+  HiXMark,
+} from 'react-icons/hi2';
+
+interface AgentComposerStatusStackProps {
+  activeWorkEvent: AgentWorkEvent | null;
+  error: string | null;
+  isSubmittingInputRequest: boolean;
+  latestProposedPlan: AgentProposedPlan | null;
+  onClearError: () => void;
+  onSubmitInputRequest: (answer: string) => void | Promise<void>;
+  pendingInputRequest: AgentInputRequest | null;
+  socketConnectionState: AgentSocketConnectionState;
+}
+
+function getDeterminateProgress(event: AgentWorkEvent): number | null {
+  if (
+    typeof event.progress !== 'number' ||
+    !Number.isFinite(event.progress) ||
+    event.progress < 0 ||
+    event.progress > 100
+  ) {
+    return null;
+  }
+
+  return event.progress;
+}
+
+export function AgentComposerStatusStack({
+  activeWorkEvent,
+  error,
+  isSubmittingInputRequest,
+  latestProposedPlan,
+  onClearError,
+  onSubmitInputRequest,
+  pendingInputRequest,
+  socketConnectionState,
+}: AgentComposerStatusStackProps): ReactElement | null {
+  const determinateProgress = activeWorkEvent
+    ? getDeterminateProgress(activeWorkEvent)
+    : null;
+  const hasConnectionWarning = socketConnectionState !== 'connected';
+  const hasPlanReview = latestProposedPlan?.status === 'awaiting_approval';
+
+  if (
+    !activeWorkEvent &&
+    !error &&
+    !hasConnectionWarning &&
+    !hasPlanReview &&
+    !pendingInputRequest
+  ) {
+    return null;
+  }
+
+  return (
+    <div
+      aria-label="Conversation status and pending input"
+      className="max-h-[60dvh] space-y-2 overflow-y-auto pb-2"
+      role="region"
+    >
+      {pendingInputRequest ? (
+        <AgentInputRequestOverlay
+          key={pendingInputRequest.inputRequestId}
+          isSubmitting={isSubmittingInputRequest}
+          onSubmit={onSubmitInputRequest}
+          request={pendingInputRequest}
+          variant="composer"
+        />
+      ) : null}
+
+      {error ? (
+        <div
+          className="flex items-start gap-2 rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive"
+          role="alert"
+        >
+          <HiOutlineExclamationTriangle className="mt-0.5 size-4 shrink-0" />
+          <span className="min-w-0 flex-1 leading-5">{error}</span>
+          <Button
+            ariaLabel="Dismiss composer error"
+            className="size-7 shrink-0"
+            icon={<HiXMark className="size-4" />}
+            onClick={onClearError}
+            variant={ButtonVariant.GHOST}
+            withWrapper={false}
+          />
+        </div>
+      ) : null}
+
+      {hasConnectionWarning ? (
+        <div
+          aria-live="polite"
+          className="flex items-center gap-2 rounded-lg border border-warning/30 bg-warning/10 px-3 py-2 text-xs text-warning"
+          role="status"
+        >
+          <HiOutlineSignalSlash className="size-4 shrink-0" />
+          {socketConnectionState === 'offline'
+            ? 'Offline. Your draft is safe; sending is paused.'
+            : socketConnectionState === 'connecting'
+              ? 'Connecting. Your draft is safe; sending starts when connected.'
+              : 'Reconnecting. Your draft is safe; sending resumes when connected.'}
+        </div>
+      ) : null}
+
+      {activeWorkEvent ? (
+        <div
+          aria-live="polite"
+          className="rounded-lg border border-border bg-background-secondary/92 px-3 py-2"
+          role="status"
+        >
+          <div className="flex items-center justify-between gap-3 text-xs">
+            <span className="truncate font-medium text-foreground/82">
+              {activeWorkEvent.label}
+            </span>
+            {determinateProgress !== null ? (
+              <span className="shrink-0 tabular-nums text-muted-foreground">
+                {Math.round(determinateProgress)}%
+              </span>
+            ) : (
+              <span className="shrink-0 text-muted-foreground">Active</span>
+            )}
+          </div>
+          {activeWorkEvent.detail ? (
+            <p className="mt-1 truncate text-[11px] text-muted-foreground">
+              {activeWorkEvent.detail}
+            </p>
+          ) : null}
+          {determinateProgress !== null ? (
+            <Progress
+              aria-label={`${activeWorkEvent.label} progress`}
+              aria-valuetext={`${Math.round(determinateProgress)} percent`}
+              className="mt-2 h-1"
+              value={determinateProgress}
+            />
+          ) : null}
+        </div>
+      ) : null}
+
+      {hasPlanReview ? (
+        <div
+          className="rounded-lg border border-border bg-background-secondary/92 px-3 py-2 text-xs leading-5 text-foreground/72"
+          role="status"
+        >
+          A plan is ready for explicit review in the conversation. This notice
+          does not approve or execute it.
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/agent/src/components/AgentInputRequestOverlay.tsx
+++ b/packages/agent/src/components/AgentInputRequestOverlay.tsx
@@ -8,7 +8,7 @@ interface AgentInputRequestOverlayProps {
   isSubmitting?: boolean;
   onSubmit: (answer: string) => void | Promise<void>;
   request: AgentInputRequest;
-  variant?: 'inline' | 'overlay';
+  variant?: 'composer' | 'inline' | 'overlay';
 }
 
 export function AgentInputRequestOverlay({
@@ -25,30 +25,49 @@ export function AgentInputRequestOverlay({
     [request.options, request.recommendedOptionId],
   );
   const [freeTextAnswer, setFreeTextAnswer] = useState('');
+  const isComposer = variant === 'composer';
 
   return (
     <div
       className={
-        variant === 'inline'
-          ? 'mx-auto my-4 w-full max-w-3xl'
-          : 'absolute inset-0 z-30 flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm'
+        isComposer
+          ? 'w-full'
+          : variant === 'inline'
+            ? 'mx-auto my-4 w-full max-w-3xl'
+            : 'absolute inset-0 z-30 flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm'
       }
     >
       <div
         className={
-          variant === 'inline'
-            ? 'w-full border border-primary/30 bg-[#0d0f16] p-6 shadow-[0_20px_60px_rgba(0,0,0,0.28)]'
-            : 'w-full max-w-4xl border border-primary/50 bg-[#0d0f16] p-6 shadow-2xl'
+          isComposer
+            ? 'max-h-[min(50dvh,24rem)] w-full overflow-y-auto rounded-lg border border-primary/25 bg-background-secondary/96 p-3 shadow-border'
+            : variant === 'inline'
+              ? 'w-full border border-primary/30 bg-[#0d0f16] p-6 shadow-[0_20px_60px_rgba(0,0,0,0.28)]'
+              : 'w-full max-w-4xl border border-primary/50 bg-[#0d0f16] p-6 shadow-2xl'
         }
       >
-        <div className="mb-4">
-          <p className="mb-2 text-xs uppercase tracking-[0.24em] text-foreground/40">
+        <div className={isComposer ? 'mb-3' : 'mb-4'}>
+          <p className="mb-1 text-[10px] font-medium uppercase tracking-[0.18em] text-muted-foreground">
             Interaction
           </p>
-          <h3 className="text-2xl font-semibold text-foreground">
+          <h3
+            className={
+              isComposer
+                ? 'text-sm font-semibold text-foreground'
+                : 'text-2xl font-semibold text-foreground'
+            }
+          >
             {request.title}
           </h3>
-          <p className="mt-3 text-sm text-foreground/70">{request.prompt}</p>
+          <p
+            className={
+              isComposer
+                ? 'mt-1 text-xs leading-5 text-foreground/70'
+                : 'mt-3 text-sm text-foreground/70'
+            }
+          >
+            {request.prompt}
+          </p>
         </div>
 
         <div className="space-y-3">
@@ -63,18 +82,28 @@ export function AgentInputRequestOverlay({
                 onClick={() => {
                   void onSubmit(option.label);
                 }}
-                className="flex w-full items-start gap-4 border border-white/[0.08] bg-white/[0.02] px-5 py-4 text-left transition-colors hover:border-primary/40 hover:bg-white/[0.04] disabled:opacity-50"
+                className={
+                  isComposer
+                    ? 'flex w-full items-start gap-3 rounded-lg border border-border bg-background px-3 py-2 text-left transition-colors hover:border-primary/40 hover:bg-hover disabled:opacity-50'
+                    : 'flex w-full items-start gap-4 border border-white/[0.08] bg-white/[0.02] px-5 py-4 text-left transition-colors hover:border-primary/40 hover:bg-white/[0.04] disabled:opacity-50'
+                }
               >
-                <span className="mt-0.5 flex size-8 shrink-0 items-center justify-center bg-white/[0.04] text-sm text-foreground/70">
+                <span className="mt-0.5 flex size-6 shrink-0 items-center justify-center rounded-md bg-foreground/[0.04] text-xs text-foreground/70">
                   {index + 1}
                 </span>
                 <span className="block">
-                  <span className="block text-lg font-semibold text-foreground">
+                  <span
+                    className={
+                      isComposer
+                        ? 'block text-xs font-medium text-foreground'
+                        : 'block text-lg font-semibold text-foreground'
+                    }
+                  >
                     {option.label}
                     {isRecommended ? ' (Recommended)' : ''}
                   </span>
                   {option.description ? (
-                    <span className="mt-1 block text-sm text-foreground/55">
+                    <span className="mt-1 block text-xs text-foreground/55">
                       {option.description}
                     </span>
                   ) : null}
@@ -85,8 +114,9 @@ export function AgentInputRequestOverlay({
         </div>
 
         {request.allowFreeText !== false ? (
-          <div className="mt-4">
+          <div className={isComposer ? 'mt-3' : 'mt-4'}>
             <Textarea
+              aria-label="Custom answer"
               value={freeTextAnswer}
               onChange={(event) => setFreeTextAnswer(event.target.value)}
               placeholder={
@@ -94,12 +124,20 @@ export function AgentInputRequestOverlay({
                   ? `Type your own answer, or leave this blank to use "${recommendedLabel}"`
                   : 'Type your answer'
               }
-              className="min-h-28 border-white/[0.08] bg-transparent px-4 py-3 placeholder:text-foreground/35 focus:border-primary/50"
+              className={
+                isComposer
+                  ? 'min-h-16 resize-none border-border bg-background px-3 py-2 text-xs placeholder:text-foreground/35 focus:border-primary/50'
+                  : 'min-h-28 border-white/[0.08] bg-transparent px-4 py-3 placeholder:text-foreground/35 focus:border-primary/50'
+              }
             />
           </div>
         ) : null}
 
-        <div className="mt-6 flex justify-end">
+        <div
+          className={
+            isComposer ? 'mt-3 flex justify-end' : 'mt-6 flex justify-end'
+          }
+        >
           <Button
             onClick={() => {
               const fallbackAnswer =

--- a/packages/agent/src/components/ConversationComposerShellContext.tsx
+++ b/packages/agent/src/components/ConversationComposerShellContext.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import type {
+  ConversationComposerActionInvocation,
+  ConversationComposerDispatchResult,
+} from '@genfeedai/agent/models/conversation-composer.model';
+import {
+  createContext,
+  type ReactElement,
+  type ReactNode,
+  useContext,
+  useMemo,
+} from 'react';
+
+export interface ConversationComposerShellContextValue {
+  contextLabel: string;
+  dispatchAction?: (
+    invocation: ConversationComposerActionInvocation,
+  ) =>
+    | ConversationComposerDispatchResult
+    | Promise<ConversationComposerDispatchResult>;
+  draftScopeKey: string | null;
+  portalTarget: HTMLElement | null;
+  scopeControls?: ReactNode;
+  shellState: 'canvas' | 'conversation' | 'overlay';
+}
+
+interface ConversationComposerShellProviderProps
+  extends ConversationComposerShellContextValue {
+  children: ReactNode;
+}
+
+const ConversationComposerShellContext =
+  createContext<ConversationComposerShellContextValue | null>(null);
+
+export function ConversationComposerShellProvider({
+  children,
+  contextLabel,
+  dispatchAction,
+  draftScopeKey,
+  portalTarget,
+  scopeControls,
+  shellState,
+}: ConversationComposerShellProviderProps): ReactElement {
+  const value = useMemo<ConversationComposerShellContextValue>(
+    () => ({
+      contextLabel,
+      dispatchAction,
+      draftScopeKey,
+      portalTarget,
+      scopeControls,
+      shellState,
+    }),
+    [
+      contextLabel,
+      dispatchAction,
+      draftScopeKey,
+      portalTarget,
+      scopeControls,
+      shellState,
+    ],
+  );
+
+  return (
+    <ConversationComposerShellContext.Provider value={value}>
+      {children}
+    </ConversationComposerShellContext.Provider>
+  );
+}
+
+export function useConversationComposerShell(): ConversationComposerShellContextValue | null {
+  return useContext(ConversationComposerShellContext);
+}

--- a/packages/agent/src/components/index.ts
+++ b/packages/agent/src/components/index.ts
@@ -29,6 +29,11 @@ export {
 } from '@genfeedai/agent/components/blocks';
 export { ClipWorkflowRunCard } from '@genfeedai/agent/components/ClipWorkflowRunCard';
 export {
+  type ConversationComposerShellContextValue,
+  ConversationComposerShellProvider,
+  useConversationComposerShell,
+} from '@genfeedai/agent/components/ConversationComposerShellContext';
+export {
   type AgentSetupConnection,
   type AgentSetupStatus,
   useAgentSetupStatus,

--- a/packages/agent/src/components/useAgentChatInput.ts
+++ b/packages/agent/src/components/useAgentChatInput.ts
@@ -1,7 +1,10 @@
+import type { AgentChatReferenceItem } from '@genfeedai/agent/components/AgentChatInputAttachmentTray';
 import { BrandMentionList } from '@genfeedai/agent/components/BrandMentionList';
 import { ContentMentionList } from '@genfeedai/agent/components/ContentMentionList';
+import { useConversationComposerShell } from '@genfeedai/agent/components/ConversationComposerShellContext';
 import { CredentialMentionList } from '@genfeedai/agent/components/CredentialMentionList';
 import { TeamMentionList } from '@genfeedai/agent/components/TeamMentionList';
+import { parseConversationComposerCommand } from '@genfeedai/agent/constants/conversation-composer-actions.constant';
 import { BrandMention } from '@genfeedai/agent/extensions/brand-mention.extension';
 import { ContentMention } from '@genfeedai/agent/extensions/content-mention.extension';
 import { CredentialMention } from '@genfeedai/agent/extensions/credential-mention.extension';
@@ -12,8 +15,15 @@ import { useContentMentions } from '@genfeedai/agent/hooks/use-content-mentions'
 import { useCredentialMentions } from '@genfeedai/agent/hooks/use-credential-mentions';
 import { useMicrophoneInput } from '@genfeedai/agent/hooks/use-microphone-input';
 import { useTeamMentions } from '@genfeedai/agent/hooks/use-team-mentions';
+import type { ConversationComposerActionName } from '@genfeedai/agent/models/conversation-composer.model';
 import type { AgentApiService } from '@genfeedai/agent/services/agent-api.service';
 import { useAgentChatStore } from '@genfeedai/agent/stores/agent-chat.store';
+import {
+  clearConversationComposerDraft,
+  readConversationComposerDraft,
+  writeConversationComposerDocument,
+  writeConversationComposerFocusIntent,
+} from '@genfeedai/agent/stores/conversation-composer-draft.store';
 import type {
   AttachmentItem,
   ChatAttachment,
@@ -32,6 +42,7 @@ import {
   type PointerEvent as ReactPointerEvent,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -223,6 +234,12 @@ export function useAgentChatInput({
   getCompletedAttachments,
   clearAllAttachments,
 }: UseAgentChatInputParams) {
+  const composerShell = useConversationComposerShell();
+  const draftScopeKey = composerShell?.draftScopeKey ?? null;
+  const restoredDraft = useMemo(
+    () => readConversationComposerDraft(draftScopeKey),
+    [draftScopeKey],
+  );
   const activeThreadId = useAgentChatStore((s) => s.activeThreadId);
   const composerSeed = useAgentChatStore((s) => s.composerSeed);
   const clearComposerSeed = useAgentChatStore((s) => s.clearComposerSeed);
@@ -234,7 +251,24 @@ export function useAgentChatInput({
   const { mentions: teamMentions } = useTeamMentions(apiService ?? null);
   const { mentions: contentMentions } = useContentMentions(apiService ?? null);
 
-  const [isEmpty, setIsEmpty] = useState(true);
+  const [actionFeedback, setActionFeedback] = useState<string | null>(null);
+  const [isEmpty, setIsEmpty] = useState(!restoredDraft.plainText.trim());
+  const [references, setReferences] = useState<AgentChatReferenceItem[]>(() =>
+    restoredDraft.document
+      ? extractMentions(restoredDraft.document).map((mention) => ({
+          id: mention.id,
+          label:
+            mention.type === 'brand'
+              ? `#${mention.brandName}`
+              : mention.type === 'team'
+                ? `@${mention.displayName}`
+                : mention.type === 'credential'
+                  ? `!${mention.handle}`
+                  : `^${mention.contentTitle}`,
+          type: mention.type,
+        }))
+      : [],
+  );
   const editorRef = useRef<Editor | null>(null);
 
   const hasAttachments = attachments.length > 0;
@@ -265,10 +299,14 @@ export function useAgentChatInput({
   });
 
   const editor = useEditor({
+    content: restoredDraft.document ?? undefined,
     editorProps: {
       attributes: {
+        'aria-label': 'Conversation prompt',
+        'aria-multiline': 'true',
         class:
           'prose prose-sm prose-invert max-w-none flex-1 bg-transparent py-1.5 text-sm text-foreground focus:outline-none',
+        role: 'textbox',
       },
     },
     extensions: [
@@ -344,19 +382,81 @@ export function useAgentChatInput({
     immediatelyRender: false,
   });
 
-  // Track editor empty state
+  // Track editor state and keep the tab-scoped reload draft current.
   useEffect(() => {
     if (!editor) {
       return;
     }
     const updateHandler = () => {
       setIsEmpty(editor.isEmpty);
+      const document = editor.getJSON();
+      const nextReferences = extractMentions(document).map((mention) => ({
+        id: mention.id,
+        label:
+          mention.type === 'brand'
+            ? `#${mention.brandName}`
+            : mention.type === 'team'
+              ? `@${mention.displayName}`
+              : mention.type === 'credential'
+                ? `!${mention.handle}`
+                : `^${mention.contentTitle}`,
+        type: mention.type,
+      }));
+      setReferences(nextReferences);
+      writeConversationComposerDocument(
+        draftScopeKey,
+        document,
+        editor.getText(),
+      );
+      setActionFeedback(null);
+    };
+    const focusHandler = () => {
+      writeConversationComposerFocusIntent(draftScopeKey, true);
+    };
+    const blurHandler = ({ event }: { event: FocusEvent }) => {
+      if (event.relatedTarget) {
+        writeConversationComposerFocusIntent(draftScopeKey, false);
+      }
     };
     editor.on('update', updateHandler);
+    editor.on('focus', focusHandler);
+    editor.on('blur', blurHandler);
     return () => {
       editor.off('update', updateHandler);
+      editor.off('focus', focusHandler);
+      editor.off('blur', blurHandler);
     };
-  }, [editor]);
+  }, [draftScopeKey, editor]);
+
+  useEffect(() => {
+    if (!editor) {
+      return;
+    }
+
+    const draft = readConversationComposerDraft(draftScopeKey);
+    editor.commands.setContent(draft.document ?? '');
+    setIsEmpty(!draft.plainText.trim());
+    setReferences(
+      draft.document
+        ? extractMentions(draft.document).map((mention) => ({
+            id: mention.id,
+            label:
+              mention.type === 'brand'
+                ? `#${mention.brandName}`
+                : mention.type === 'team'
+                  ? `@${mention.displayName}`
+                  : mention.type === 'credential'
+                    ? `!${mention.handle}`
+                    : `^${mention.contentTitle}`,
+            type: mention.type,
+          }))
+        : [],
+    );
+
+    if (draft.hasFocusIntent) {
+      window.requestAnimationFrame(() => editor.commands.focus('end'));
+    }
+  }, [draftScopeKey, editor]);
 
   // Keep editorRef in sync for the microphone callback
   useEffect(() => {
@@ -381,50 +481,15 @@ export function useAgentChatInput({
     clearComposerSeed();
   }, [activeThreadId, clearComposerSeed, composerSeed, editor]);
 
-  // Handle Enter key to send message
-  useEffect(() => {
-    function handleSendEvent() {
-      if (!editor || disabled) {
-        return;
-      }
-      const text = editor.getText().trim();
-      const canSend = Boolean(text) || hasCompletedAttachments;
-      if (!canSend) {
-        return;
-      }
-      const json = editor.getJSON();
-      const mentionData = extractMentions(json);
-      const completed = getCompletedAttachments?.();
-      onSend(
-        text,
-        mentionData.length > 0 ? mentionData : undefined,
-        completed && completed.length > 0 ? completed : undefined,
-        { planModeEnabled: false },
-      );
-      editor.commands.clearContent();
-      clearAllAttachments?.();
-    }
-
-    document.addEventListener('agent-chat-send', handleSendEvent);
-    return () =>
-      document.removeEventListener('agent-chat-send', handleSendEvent);
-  }, [
-    editor,
-    disabled,
-    onSend,
-    hasCompletedAttachments,
-    getCompletedAttachments,
-    clearAllAttachments,
-  ]);
-
   // Sync disabled state
   useEffect(() => {
     if (editor) {
       editor.setEditable(!disabled);
+      editor.view.dom.setAttribute('aria-disabled', String(Boolean(disabled)));
     }
   }, [editor, disabled]);
 
-  const handleSend = useCallback(() => {
+  const handleSend = useCallback(async () => {
     if (!editor || disabled) {
       return;
     }
@@ -433,6 +498,34 @@ export function useAgentChatInput({
     if (!canSend) {
       return;
     }
+    const parsedCommand = parseConversationComposerCommand(text);
+    if (parsedCommand.kind === 'unknown') {
+      setActionFeedback(
+        `Unknown command /${parsedCommand.command.command}. Choose a trusted action from the Actions menu.`,
+      );
+      return;
+    }
+    if (parsedCommand.kind === 'action') {
+      if (!composerShell?.dispatchAction) {
+        setActionFeedback(
+          'This action is unavailable here. Your draft has been preserved.',
+        );
+        return;
+      }
+
+      try {
+        const result = await composerShell.dispatchAction(
+          parsedCommand.invocation,
+        );
+        setActionFeedback(result.message);
+      } catch {
+        setActionFeedback(
+          'That action could not be opened. Your draft and references are unchanged.',
+        );
+      }
+      return;
+    }
+
     const json = editor.getJSON();
     const mentionData = extractMentions(json);
     const completed = getCompletedAttachments?.();
@@ -444,7 +537,10 @@ export function useAgentChatInput({
     );
     editor.commands.clearContent();
     clearAllAttachments?.();
+    clearConversationComposerDraft(draftScopeKey);
   }, [
+    composerShell,
+    draftScopeKey,
     editor,
     disabled,
     onSend,
@@ -452,6 +548,38 @@ export function useAgentChatInput({
     getCompletedAttachments,
     clearAllAttachments,
   ]);
+
+  // Handle Enter after handleSend is stable so keyboard and click paths share
+  // the same trusted-command checks and recovery behavior.
+  useEffect(() => {
+    function handleSendEvent() {
+      void handleSend();
+    }
+
+    document.addEventListener('agent-chat-send', handleSendEvent);
+    return () =>
+      document.removeEventListener('agent-chat-send', handleSendEvent);
+  }, [handleSend]);
+
+  const handleSelectAction = useCallback(
+    (actionName: ConversationComposerActionName) => {
+      if (!editor) {
+        return;
+      }
+
+      if (editor.isEmpty) {
+        editor.commands.setContent(`/${actionName} `);
+      } else {
+        editor.chain().focus('start').insertContent(`/${actionName} `).run();
+      }
+      editor.commands.focus('end');
+    },
+    [editor],
+  );
+
+  const handleInsertReference = useCallback(() => {
+    editor?.chain().focus('end').insertContent('^').run();
+  }, [editor]);
 
   const handleShellPointerDown = useCallback(
     (event: ReactPointerEvent<HTMLDivElement>) => {
@@ -476,8 +604,11 @@ export function useAgentChatInput({
         return;
       }
 
-      const files = Array.from(event.clipboardData.files ?? []).filter((file) =>
-        file.type.startsWith('image/'),
+      const files = Array.from(event.clipboardData.files ?? []).filter(
+        (file) =>
+          file.type.startsWith('image/') ||
+          file.type.startsWith('video/') ||
+          file.type.startsWith('audio/'),
       );
 
       if (files.length === 0) {
@@ -513,16 +644,20 @@ export function useAgentChatInput({
     (!isSupported || !isEmpty || hasCompletedAttachments);
 
   return {
+    actionFeedback,
     canSendMessage,
     editor,
     handlePasteImages,
     handleRemoveAttachment,
+    handleInsertReference,
+    handleSelectAction,
     handleSend,
     handleShellPointerDown,
     hasAttachments,
     isDragActive,
     isListening,
     isTranscribing,
+    references,
     shouldShowSendButton,
     shouldShowVoiceInput,
     startListening,

--- a/packages/agent/src/constants/agent-slash-commands.constant.ts
+++ b/packages/agent/src/constants/agent-slash-commands.constant.ts
@@ -1,67 +1,89 @@
+import { CONVERSATION_COMPOSER_ACTIONS } from '@genfeedai/agent/constants/conversation-composer-actions.constant';
+import type { ConversationComposerActionName } from '@genfeedai/agent/models/conversation-composer.model';
+
 export interface AgentSlashCommand {
-  name: string;
-  label: string;
   description: string;
-  promptPrefix: string;
+  kind: 'action' | 'prompt';
+  label: string;
+  name: string;
+  actionName?: ConversationComposerActionName;
+  promptPrefix?: string;
 }
 
 export const AGENT_SLASH_COMMANDS: AgentSlashCommand[] = [
+  ...CONVERSATION_COMPOSER_ACTIONS.map((action) => ({
+    actionName: action.name,
+    description: action.description,
+    kind: 'action' as const,
+    label: action.label,
+    name: action.name,
+  })),
   {
     description: 'Create an AI-generated image',
+    kind: 'prompt',
     label: 'Generate Image',
     name: 'generate-image',
     promptPrefix: 'Generate an image: ',
   },
   {
     description: 'Draft a social media post',
+    kind: 'prompt',
     label: 'Create Post',
     name: 'create-post',
     promptPrefix: 'Create a post for ',
   },
   {
-    description: 'Schedule a post',
-    label: 'Schedule',
-    name: 'schedule',
+    description: 'Draft a scheduling request as a prompt',
+    kind: 'prompt',
+    label: 'Schedule Prompt',
+    name: 'schedule-post',
     promptPrefix: 'Schedule a post for ',
   },
   {
-    description: 'Check content performance',
-    label: 'Analyze',
-    name: 'analyze',
+    description: 'Ask the agent to analyze content performance',
+    kind: 'prompt',
+    label: 'Analyze Prompt',
+    name: 'analyze-performance',
     promptPrefix: 'Analyze performance of ',
   },
   {
     description: 'Write a caption',
+    kind: 'prompt',
     label: 'Caption',
     name: 'caption',
     promptPrefix: 'Write a caption for ',
   },
   {
     description: 'Suggest hashtags',
+    kind: 'prompt',
     label: 'Hashtags',
     name: 'hashtags',
     promptPrefix: 'Suggest hashtags for ',
   },
   {
     description: 'Brainstorm content ideas',
+    kind: 'prompt',
     label: 'Ideas',
     name: 'ideas',
     promptPrefix: 'Generate content ideas for ',
   },
   {
     description: 'Adapt for another platform',
+    kind: 'prompt',
     label: 'Repurpose',
     name: 'repurpose',
     promptPrefix: 'Repurpose this content: ',
   },
   {
     description: 'Find trending topics',
+    kind: 'prompt',
     label: 'Trends',
     name: 'trends',
     promptPrefix: 'Find trending topics for ',
   },
   {
     description: 'Generate multiple posts',
+    kind: 'prompt',
     label: 'Batch Generate',
     name: 'batch',
     promptPrefix: 'Generate a batch of posts: ',

--- a/packages/agent/src/constants/conversation-composer-actions.constant.spec.ts
+++ b/packages/agent/src/constants/conversation-composer-actions.constant.spec.ts
@@ -1,0 +1,131 @@
+import { APP_ROUTES } from '@genfeedai/constants';
+import { describe, expect, it } from 'vitest';
+import { AGENT_SLASH_COMMANDS } from './agent-slash-commands.constant';
+import {
+  CONVERSATION_COMPOSER_ACTIONS,
+  getConversationComposerAction,
+  parseConversationComposerCommand,
+} from './conversation-composer-actions.constant';
+
+describe('conversation composer action registry', () => {
+  it('contains exactly the eight trusted issue actions', () => {
+    expect(CONVERSATION_COMPOSER_ACTIONS.map((action) => action.name)).toEqual([
+      'create',
+      'remix',
+      'research',
+      'workflow',
+      'schedule',
+      'publish',
+      'analyze',
+      'reply',
+    ]);
+  });
+
+  it('maps publish to review without granting publish authority', () => {
+    expect(getConversationComposerAction('publish')).toMatchObject({
+      isConsequentialProposal: true,
+      route: APP_ROUTES.POSTS.REVIEW,
+    });
+  });
+
+  it('resolves every action to its canonical route and required scope', () => {
+    expect(
+      CONVERSATION_COMPOSER_ACTIONS.map((action) => ({
+        name: action.name,
+        resolved: getConversationComposerAction(action.name),
+      })),
+    ).toEqual([
+      {
+        name: 'create',
+        resolved: expect.objectContaining({
+          requiredScope: 'brand',
+          route: APP_ROUTES.STUDIO.ROOT,
+        }),
+      },
+      {
+        name: 'remix',
+        resolved: expect.objectContaining({
+          requiredScope: 'brand',
+          route: APP_ROUTES.POSTS.REMIX,
+        }),
+      },
+      {
+        name: 'research',
+        resolved: expect.objectContaining({
+          requiredScope: 'brand',
+          route: APP_ROUTES.RESEARCH.ROOT,
+        }),
+      },
+      {
+        name: 'workflow',
+        resolved: expect.objectContaining({
+          requiredScope: 'brand',
+          route: APP_ROUTES.WORKFLOWS.ROOT,
+        }),
+      },
+      {
+        name: 'schedule',
+        resolved: expect.objectContaining({
+          requiredScope: 'brand',
+          route: APP_ROUTES.POSTS.CALENDAR,
+        }),
+      },
+      {
+        name: 'publish',
+        resolved: expect.objectContaining({
+          requiredScope: 'brand',
+          route: APP_ROUTES.POSTS.REVIEW,
+        }),
+      },
+      {
+        name: 'analyze',
+        resolved: expect.objectContaining({
+          requiredScope: 'organization',
+          route: APP_ROUTES.ANALYTICS.ROOT,
+        }),
+      },
+      {
+        name: 'reply',
+        resolved: expect.objectContaining({
+          requiredScope: 'brand',
+          route: APP_ROUTES.MESSAGES.ROOT,
+        }),
+      },
+    ]);
+  });
+
+  it('parses only an explicit leading allowlisted command', () => {
+    expect(parseConversationComposerCommand('/research competitors')).toEqual({
+      invocation: {
+        action: getConversationComposerAction('research'),
+        arguments: 'competitors',
+      },
+      kind: 'action',
+    });
+    expect(
+      parseConversationComposerCommand('Please publish this post'),
+    ).toEqual({ kind: 'none' });
+  });
+
+  it('keeps unknown commands distinguishable for recoverable guidance', () => {
+    expect(parseConversationComposerCommand('/delete everything')).toEqual({
+      command: { command: 'delete' },
+      kind: 'unknown',
+    });
+  });
+
+  it('keeps legacy schedule and analyze prompt shortcuts under explicit aliases', () => {
+    expect(AGENT_SLASH_COMMANDS).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'schedule-post',
+          promptPrefix: 'Schedule a post for ',
+        }),
+        expect.objectContaining({
+          name: 'analyze-performance',
+          promptPrefix: 'Analyze performance of ',
+        }),
+      ]),
+    );
+  });
+});

--- a/packages/agent/src/constants/conversation-composer-actions.constant.ts
+++ b/packages/agent/src/constants/conversation-composer-actions.constant.ts
@@ -1,0 +1,109 @@
+import type {
+  ConversationComposerActionDefinition,
+  ConversationComposerActionName,
+  ParsedConversationComposerCommand,
+} from '@genfeedai/agent/models/conversation-composer.model';
+import { APP_ROUTES } from '@genfeedai/constants';
+
+export const CONVERSATION_COMPOSER_ACTIONS = [
+  {
+    description: 'Open a trusted creation surface',
+    isConsequentialProposal: false,
+    label: 'Create',
+    name: 'create',
+    requiredScope: 'brand',
+    route: APP_ROUTES.STUDIO.ROOT,
+  },
+  {
+    description: 'Open the canonical remix workspace',
+    isConsequentialProposal: false,
+    label: 'Remix',
+    name: 'remix',
+    requiredScope: 'brand',
+    route: APP_ROUTES.POSTS.REMIX,
+  },
+  {
+    description: 'Open the research workspace',
+    isConsequentialProposal: false,
+    label: 'Research',
+    name: 'research',
+    requiredScope: 'brand',
+    route: APP_ROUTES.RESEARCH.ROOT,
+  },
+  {
+    description: 'Open deterministic workflows',
+    isConsequentialProposal: false,
+    label: 'Workflow',
+    name: 'workflow',
+    requiredScope: 'brand',
+    route: APP_ROUTES.WORKFLOWS.ROOT,
+  },
+  {
+    description: 'Open scheduling controls',
+    isConsequentialProposal: true,
+    label: 'Schedule',
+    name: 'schedule',
+    requiredScope: 'brand',
+    route: APP_ROUTES.POSTS.CALENDAR,
+  },
+  {
+    description: 'Open version-bound publish review',
+    isConsequentialProposal: true,
+    label: 'Publish',
+    name: 'publish',
+    requiredScope: 'brand',
+    route: APP_ROUTES.POSTS.REVIEW,
+  },
+  {
+    description: 'Open content analytics',
+    isConsequentialProposal: false,
+    label: 'Analyze',
+    name: 'analyze',
+    requiredScope: 'organization',
+    route: APP_ROUTES.ANALYTICS.ROOT,
+  },
+  {
+    description: 'Open the messaging reply surface',
+    isConsequentialProposal: true,
+    label: 'Reply',
+    name: 'reply',
+    requiredScope: 'brand',
+    route: APP_ROUTES.MESSAGES.ROOT,
+  },
+] as const satisfies readonly ConversationComposerActionDefinition[];
+
+const ACTIONS_BY_NAME = new Map<
+  ConversationComposerActionName,
+  ConversationComposerActionDefinition
+>(
+  CONVERSATION_COMPOSER_ACTIONS.map((action) => [action.name, action] as const),
+);
+
+export function getConversationComposerAction(
+  name: string,
+): ConversationComposerActionDefinition | null {
+  return ACTIONS_BY_NAME.get(name as ConversationComposerActionName) ?? null;
+}
+
+export function parseConversationComposerCommand(
+  text: string,
+): ParsedConversationComposerCommand {
+  const match = /^\/([^\s/]+)(?:\s+([\s\S]*))?$/.exec(text.trim());
+  if (!match) {
+    return { kind: 'none' };
+  }
+
+  const commandName = match[1]?.toLowerCase() ?? '';
+  const action = getConversationComposerAction(commandName);
+  if (!action) {
+    return { command: { command: commandName }, kind: 'unknown' };
+  }
+
+  return {
+    invocation: {
+      action,
+      arguments: match[2]?.trim() ?? '',
+    },
+    kind: 'action',
+  };
+}

--- a/packages/agent/src/extensions/slash-commands.extension.ts
+++ b/packages/agent/src/extensions/slash-commands.extension.ts
@@ -20,11 +20,15 @@ export const SlashCommands = Extension.create<{
       suggestion: {
         char: '/',
         command: ({ editor, range, props }) => {
+          const insertedContent =
+            props.kind === 'action'
+              ? `/${props.actionName ?? props.name} `
+              : (props.promptPrefix ?? '');
           editor
             .chain()
             .focus()
             .deleteRange(range)
-            .insertContent(props.promptPrefix)
+            .insertContent(insertedContent)
             .run();
         },
         items: ({ query }: { query: string }) => {

--- a/packages/agent/src/hooks/use-agent-chat-container.ts
+++ b/packages/agent/src/hooks/use-agent-chat-container.ts
@@ -1,5 +1,6 @@
 import type { ExtractedMention } from '@genfeedai/agent/components/AgentChatInput';
 import { AGENT_REFRESH_CONVERSATIONS_EVENT } from '@genfeedai/agent/components/AgentThreadList';
+import { useConversationComposerShell } from '@genfeedai/agent/components/ConversationComposerShellContext';
 import { useAgentChat } from '@genfeedai/agent/hooks/use-agent-chat';
 import { useAgentChatStream } from '@genfeedai/agent/hooks/use-agent-chat-stream';
 import {
@@ -14,15 +15,23 @@ import {
   AgentWorkEventStatus,
   AgentWorkEventType,
 } from '@genfeedai/agent/models/agent-chat.model';
+import type { PersistedConversationComposerAttachment } from '@genfeedai/agent/models/conversation-composer.model';
 import type { AgentApiService } from '@genfeedai/agent/services/agent-api.service';
 import { runAgentApiEffect } from '@genfeedai/agent/services/agent-base-api.service';
 import { useAgentChatStore } from '@genfeedai/agent/stores/agent-chat.store';
+import {
+  readConversationComposerDraft,
+  writeConversationComposerAttachments,
+} from '@genfeedai/agent/stores/conversation-composer-draft.store';
 import { applyDashboardOperation } from '@genfeedai/agent/utils/apply-dashboard-operation';
 import { deriveTimeline } from '@genfeedai/agent/utils/derive-timeline';
 import { mapToolCallResponse } from '@genfeedai/agent/utils/map-tool-call-response';
 import { resolveRetryPrompt } from '@genfeedai/agent/utils/resolve-retry-prompt';
 import { AgentThreadStatus } from '@genfeedai/enums';
-import type { ChatAttachment } from '@genfeedai/props/ui/attachments.props';
+import type {
+  AttachmentItem,
+  ChatAttachment,
+} from '@genfeedai/props/ui/attachments.props';
 import { useAttachments } from '@hooks/ui/use-attachments/use-attachments';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
@@ -40,6 +49,42 @@ interface UseAgentChatContainerParams {
   workspacePlanningTaskId?: string | null;
 }
 
+function restoreComposerAttachments(
+  attachments: PersistedConversationComposerAttachment[],
+): AttachmentItem[] {
+  return attachments.map((attachment) => {
+    const wasInterrupted =
+      attachment.status === 'pending' || attachment.status === 'uploading';
+
+    return {
+      ...attachment,
+      error: wasInterrupted
+        ? 'Upload was interrupted. Reattach this file to retry.'
+        : attachment.error,
+      previewUrl: attachment.previewUrl ?? attachment.url ?? '',
+      status: wasInterrupted ? 'failed' : attachment.status,
+    };
+  });
+}
+
+function persistableComposerAttachments(
+  attachments: AttachmentItem[],
+): PersistedConversationComposerAttachment[] {
+  return attachments.map((attachment) => ({
+    error: attachment.error,
+    id: attachment.id,
+    ingredientId: attachment.ingredientId,
+    kind: attachment.kind,
+    name: attachment.name,
+    previewUrl: attachment.previewUrl.startsWith('blob:')
+      ? attachment.url
+      : attachment.previewUrl,
+    progress: attachment.progress,
+    status: attachment.status,
+    url: attachment.url,
+  }));
+}
+
 export function useAgentChatContainer({
   apiService,
   isLoadingThread,
@@ -53,6 +98,24 @@ export function useAgentChatContainer({
   onSelectIngredient: onSelectIngredientProp,
   workspacePlanningTaskId,
 }: UseAgentChatContainerParams) {
+  const composerShell = useConversationComposerShell();
+  const draftScopeKey = composerShell?.draftScopeKey ?? null;
+  const initialComposerAttachments = useMemo(
+    () =>
+      restoreComposerAttachments(
+        readConversationComposerDraft(draftScopeKey).attachments,
+      ),
+    [draftScopeKey],
+  );
+  const handleComposerAttachmentsChange = useCallback(
+    (attachments: AttachmentItem[]) => {
+      writeConversationComposerAttachments(
+        draftScopeKey,
+        persistableComposerAttachments(attachments),
+      );
+    },
+    [draftScopeKey],
+  );
   const addMessage = useAgentChatStore((s) => s.addMessage);
   const messages = useAgentChatStore((s) => s.messages);
   const isGenerating = useAgentChatStore((s) => s.isGenerating);
@@ -81,6 +144,9 @@ export function useAgentChatContainer({
   const setActiveRun = useAgentChatStore((s) => s.setActiveRun);
   const setActiveRunStatus = useAgentChatStore((s) => s.setActiveRunStatus);
   const workEvents = useAgentChatStore((s) => s.workEvents);
+  const socketConnectionState = useAgentChatStore(
+    (s) => s.socketConnectionState,
+  );
   const setActiveThread = useAgentChatStore((s) => s.setActiveThread);
   const setDraftPlanModeEnabled = useAgentChatStore(
     (s) => s.setDraftPlanModeEnabled,
@@ -116,6 +182,9 @@ export function useAgentChatContainer({
     getCompletedAttachments,
     dragHandlers,
   } = useAttachments({
+    acceptedTypes: ['image/*', 'video/*', 'audio/*'],
+    initialAttachments: initialComposerAttachments,
+    onAttachmentsChange: handleComposerAttachmentsChange,
     onUpload: (file, onProgress) =>
       runAgentApiEffect(apiService.uploadAttachmentEffect(file, onProgress)),
   });
@@ -764,6 +833,7 @@ export function useAgentChatContainer({
     onboardingSignupGiftCredits,
     onboardingTotalJourneyCredits,
     pendingInputRequest,
+    socketConnectionState,
     workEvents,
     // derived
     isBusy,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -31,6 +31,11 @@ export {
   DynamicTable,
 } from '@genfeedai/agent/components/blocks';
 export { ClipRunCard } from '@genfeedai/agent/components/ClipRunCard';
+export {
+  type ConversationComposerShellContextValue,
+  ConversationComposerShellProvider,
+  useConversationComposerShell,
+} from '@genfeedai/agent/components/ConversationComposerShellContext';
 export { GenerationActionCard } from '@genfeedai/agent/components/GenerationActionCard';
 export { IngredientAlternativesCard } from '@genfeedai/agent/components/IngredientAlternativesCard';
 export { IngredientPickerCard } from '@genfeedai/agent/components/IngredientPickerCard';
@@ -48,6 +53,11 @@ export {
 export { AGENT_PANEL_ICON_STRIP_WIDTH } from '@genfeedai/agent/constants/agent-panel.constant';
 export type { AgentSlashCommand } from '@genfeedai/agent/constants/agent-slash-commands.constant';
 export { AGENT_SLASH_COMMANDS } from '@genfeedai/agent/constants/agent-slash-commands.constant';
+export {
+  CONVERSATION_COMPOSER_ACTIONS,
+  getConversationComposerAction,
+  parseConversationComposerCommand,
+} from '@genfeedai/agent/constants/conversation-composer-actions.constant';
 export type {
   DashboardBlocksParseResult,
   DashboardOpenUIComponent,
@@ -123,6 +133,17 @@ export type {
   ClipRunModes,
   ClipRunStep,
 } from '@genfeedai/agent/models/clip-run-card.model';
+export type {
+  ConversationComposerActionDefinition,
+  ConversationComposerActionInvocation,
+  ConversationComposerActionName,
+  ConversationComposerDispatchResult,
+  ConversationComposerDispatchStatus,
+  ConversationComposerScope,
+  ParsedConversationComposerCommand,
+  PersistedConversationComposerAttachment,
+  PersistedConversationComposerDraft,
+} from '@genfeedai/agent/models/conversation-composer.model';
 export type {
   AgentApiConfig,
   AgentApiEffectError,

--- a/packages/agent/src/models/conversation-composer.model.ts
+++ b/packages/agent/src/models/conversation-composer.model.ts
@@ -1,0 +1,66 @@
+import type { JSONContent } from '@tiptap/core';
+
+export type ConversationComposerActionName =
+  | 'analyze'
+  | 'create'
+  | 'publish'
+  | 'remix'
+  | 'reply'
+  | 'research'
+  | 'schedule'
+  | 'workflow';
+
+export type ConversationComposerScope = 'brand' | 'organization';
+
+export interface ConversationComposerActionDefinition {
+  description: string;
+  isConsequentialProposal: boolean;
+  label: string;
+  name: ConversationComposerActionName;
+  requiredScope: ConversationComposerScope;
+  route: string;
+}
+
+export type ConversationComposerDispatchStatus =
+  | 'dispatched'
+  | 'unauthorized'
+  | 'unavailable';
+
+export interface ConversationComposerDispatchResult {
+  message: string;
+  status: ConversationComposerDispatchStatus;
+}
+
+export interface ConversationComposerActionInvocation {
+  action: ConversationComposerActionDefinition;
+  arguments: string;
+}
+
+export interface UnknownConversationComposerCommand {
+  command: string;
+}
+
+export type ParsedConversationComposerCommand =
+  | { kind: 'action'; invocation: ConversationComposerActionInvocation }
+  | { kind: 'none' }
+  | { kind: 'unknown'; command: UnknownConversationComposerCommand };
+
+export interface PersistedConversationComposerAttachment {
+  error?: string;
+  id: string;
+  ingredientId?: string;
+  kind: 'audio' | 'image' | 'video';
+  name: string;
+  previewUrl?: string;
+  progress?: number;
+  status: 'completed' | 'failed' | 'pending' | 'uploading';
+  url?: string;
+}
+
+export interface PersistedConversationComposerDraft {
+  attachments: PersistedConversationComposerAttachment[];
+  document: JSONContent | null;
+  hasFocusIntent: boolean;
+  plainText: string;
+  updatedAt: string;
+}

--- a/packages/agent/src/stores/conversation-composer-draft.store.spec.ts
+++ b/packages/agent/src/stores/conversation-composer-draft.store.spec.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  clearConversationComposerDraft,
+  readConversationComposerDraft,
+  writeConversationComposerAttachments,
+  writeConversationComposerDocument,
+  writeConversationComposerFocusIntent,
+} from './conversation-composer-draft.store';
+
+describe('conversation composer draft persistence', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('restores document, typed nodes, attachments, and focus by scoped key', () => {
+    const scopeKey = 'acme:thread-1:4';
+    const document = {
+      content: [
+        {
+          content: [
+            { text: 'Draft with ', type: 'text' },
+            {
+              attrs: {
+                contentId: 'post-1',
+                contentTitle: 'Launch post',
+                contentType: 'post',
+              },
+              type: 'contentMention',
+            },
+          ],
+          type: 'paragraph',
+        },
+      ],
+      type: 'doc',
+    };
+
+    writeConversationComposerDocument(scopeKey, document, 'Draft');
+    writeConversationComposerAttachments(scopeKey, [
+      {
+        id: 'attachment-1',
+        ingredientId: 'ingredient-1',
+        kind: 'image',
+        name: 'reference.png',
+        status: 'completed',
+        url: 'https://cdn.example/reference.png',
+      },
+    ]);
+    writeConversationComposerFocusIntent(scopeKey, true);
+
+    expect(readConversationComposerDraft(scopeKey)).toMatchObject({
+      attachments: [expect.objectContaining({ ingredientId: 'ingredient-1' })],
+      document,
+      hasFocusIntent: true,
+      plainText: 'Draft',
+    });
+  });
+
+  it('isolates thread and context versions and clears only the sent draft', () => {
+    writeConversationComposerDocument('acme:thread-1:1', { type: 'doc' }, 'A');
+    writeConversationComposerDocument('acme:thread-1:2', { type: 'doc' }, 'B');
+
+    clearConversationComposerDraft('acme:thread-1:1');
+
+    expect(readConversationComposerDraft('acme:thread-1:1').plainText).toBe('');
+    expect(readConversationComposerDraft('acme:thread-1:2').plainText).toBe(
+      'B',
+    );
+  });
+
+  it('recovers the same thread draft while its server context version hydrates', () => {
+    writeConversationComposerDocument(
+      'acme:thread-1:3',
+      { type: 'doc' },
+      'Hydrated draft',
+    );
+
+    expect(readConversationComposerDraft('acme:thread-1:0').plainText).toBe(
+      'Hydrated draft',
+    );
+    expect(readConversationComposerDraft('other:thread-1:0').plainText).toBe(
+      '',
+    );
+  });
+});

--- a/packages/agent/src/stores/conversation-composer-draft.store.ts
+++ b/packages/agent/src/stores/conversation-composer-draft.store.ts
@@ -1,0 +1,159 @@
+import type {
+  PersistedConversationComposerAttachment,
+  PersistedConversationComposerDraft,
+} from '@genfeedai/agent/models/conversation-composer.model';
+import type { JSONContent } from '@tiptap/core';
+
+const STORAGE_PREFIX = 'genfeed:conversation-composer:v1';
+
+const EMPTY_DRAFT: PersistedConversationComposerDraft = {
+  attachments: [],
+  document: null,
+  hasFocusIntent: false,
+  plainText: '',
+  updatedAt: '',
+};
+
+function getStorage(): Storage | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+function getStorageKey(scopeKey: string): string {
+  return `${STORAGE_PREFIX}:${scopeKey}`;
+}
+
+function normalizeDraft(
+  value: Partial<PersistedConversationComposerDraft>,
+): PersistedConversationComposerDraft {
+  return {
+    attachments: Array.isArray(value.attachments) ? value.attachments : [],
+    document:
+      value.document && typeof value.document === 'object'
+        ? value.document
+        : null,
+    hasFocusIntent: value.hasFocusIntent === true,
+    plainText: typeof value.plainText === 'string' ? value.plainText : '',
+    updatedAt: typeof value.updatedAt === 'string' ? value.updatedAt : '',
+  };
+}
+
+export function readConversationComposerDraft(
+  scopeKey: string | null,
+): PersistedConversationComposerDraft {
+  const storage = getStorage();
+  if (!scopeKey || !storage) {
+    return EMPTY_DRAFT;
+  }
+
+  try {
+    const raw = storage.getItem(getStorageKey(scopeKey));
+    if (raw) {
+      return normalizeDraft(
+        JSON.parse(raw) as Partial<PersistedConversationComposerDraft>,
+      );
+    }
+
+    const versionSeparatorIndex = scopeKey.lastIndexOf(':');
+    if (versionSeparatorIndex <= 0) {
+      return EMPTY_DRAFT;
+    }
+
+    const scopePrefix = `${STORAGE_PREFIX}:${scopeKey.slice(
+      0,
+      versionSeparatorIndex + 1,
+    )}`;
+    let latestDraft: PersistedConversationComposerDraft | null = null;
+    for (let index = 0; index < storage.length; index += 1) {
+      const candidateKey = storage.key(index);
+      if (!candidateKey?.startsWith(scopePrefix)) {
+        continue;
+      }
+
+      const candidateRaw = storage.getItem(candidateKey);
+      if (!candidateRaw) {
+        continue;
+      }
+
+      const candidate = normalizeDraft(
+        JSON.parse(candidateRaw) as Partial<PersistedConversationComposerDraft>,
+      );
+      if (
+        !latestDraft ||
+        candidate.updatedAt.localeCompare(latestDraft.updatedAt) > 0
+      ) {
+        latestDraft = candidate;
+      }
+    }
+
+    return latestDraft ?? EMPTY_DRAFT;
+  } catch {
+    return EMPTY_DRAFT;
+  }
+}
+
+function writeDraft(
+  scopeKey: string | null,
+  update: Partial<PersistedConversationComposerDraft>,
+): void {
+  const storage = getStorage();
+  if (!scopeKey || !storage) {
+    return;
+  }
+
+  try {
+    const next = {
+      ...readConversationComposerDraft(scopeKey),
+      ...update,
+      updatedAt: new Date().toISOString(),
+    };
+    storage.setItem(getStorageKey(scopeKey), JSON.stringify(next));
+  } catch {
+    // Draft persistence is best-effort; the live editor remains authoritative.
+  }
+}
+
+export function writeConversationComposerDocument(
+  scopeKey: string | null,
+  document: JSONContent,
+  plainText: string,
+): void {
+  writeDraft(scopeKey, { document, plainText });
+}
+
+export function writeConversationComposerAttachments(
+  scopeKey: string | null,
+  attachments: PersistedConversationComposerAttachment[],
+): void {
+  writeDraft(scopeKey, { attachments });
+}
+
+export function writeConversationComposerFocusIntent(
+  scopeKey: string | null,
+  hasFocusIntent: boolean,
+): void {
+  writeDraft(scopeKey, { hasFocusIntent });
+}
+
+export function clearConversationComposerDraft(scopeKey: string | null): void {
+  const storage = getStorage();
+  if (!scopeKey || !storage) {
+    return;
+  }
+
+  try {
+    storage.setItem(
+      getStorageKey(scopeKey),
+      JSON.stringify({ ...EMPTY_DRAFT, updatedAt: new Date().toISOString() }),
+    );
+  } catch {
+    // The sent message still succeeds when storage is unavailable.
+  }
+}

--- a/packages/hooks/ui/use-attachments/use-attachments.test.ts
+++ b/packages/hooks/ui/use-attachments/use-attachments.test.ts
@@ -1,0 +1,50 @@
+import type { AttachmentItem } from '@genfeedai/props/ui/attachments.props';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useAttachments } from './use-attachments';
+
+function completedAttachment(id: string): AttachmentItem {
+  return {
+    id,
+    ingredientId: `${id}-ingredient`,
+    kind: 'image',
+    name: `${id}.png`,
+    previewUrl: `https://cdn.example/${id}.png`,
+    status: 'completed',
+    url: `https://cdn.example/${id}.png`,
+  };
+}
+
+describe('useAttachments initial attachment synchronization', () => {
+  it('does not write the previous scope attachments into a new scope', async () => {
+    const firstScopeAttachments = [completedAttachment('first')];
+    const secondScopeAttachments = [completedAttachment('second')];
+    const onAttachmentsChange = vi.fn();
+    const onUpload = vi.fn();
+    const { rerender } = renderHook(
+      ({ initialAttachments }) =>
+        useAttachments({
+          initialAttachments,
+          onAttachmentsChange,
+          onUpload,
+        }),
+      { initialProps: { initialAttachments: firstScopeAttachments } },
+    );
+
+    await waitFor(() => {
+      expect(onAttachmentsChange).toHaveBeenLastCalledWith(
+        firstScopeAttachments,
+      );
+    });
+    onAttachmentsChange.mockClear();
+
+    rerender({ initialAttachments: secondScopeAttachments });
+
+    await waitFor(() => {
+      expect(onAttachmentsChange).toHaveBeenLastCalledWith(
+        secondScopeAttachments,
+      );
+    });
+    expect(onAttachmentsChange).not.toHaveBeenCalledWith(firstScopeAttachments);
+  });
+});

--- a/packages/hooks/ui/use-attachments/use-attachments.ts
+++ b/packages/hooks/ui/use-attachments/use-attachments.ts
@@ -12,6 +12,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 const DEFAULT_MAX_FILES = 4;
 const DEFAULT_MAX_FILE_SIZE_MB = 10;
 const DEFAULT_ACCEPTED_TYPES = ['image/*'];
+const EMPTY_INITIAL_ATTACHMENTS: AttachmentItem[] = [];
 
 function generateAttachmentId(): string {
   const randomUuid = globalThis.crypto?.randomUUID;
@@ -55,12 +56,16 @@ export function useAttachments(
     maxFiles = DEFAULT_MAX_FILES,
     maxFileSizeMb = DEFAULT_MAX_FILE_SIZE_MB,
     acceptedTypes = DEFAULT_ACCEPTED_TYPES,
+    initialAttachments = EMPTY_INITIAL_ATTACHMENTS,
+    onAttachmentsChange,
     onUpload,
   } = options;
 
-  const [attachments, setAttachments] = useState<AttachmentItem[]>([]);
+  const [attachments, setAttachments] =
+    useState<AttachmentItem[]>(initialAttachments);
   const [dragState, setDragState] = useState<DragState>({ isActive: false });
   const dragDepthRef = useRef(0);
+  const pendingInitialAttachmentsRef = useRef<AttachmentItem[] | null>(null);
   const previewUrlsRef = useRef<Set<string>>(new Set());
 
   const isUploading = attachments.some(
@@ -78,8 +83,30 @@ export function useAttachments(
     };
   }, []);
 
+  useEffect(() => {
+    pendingInitialAttachmentsRef.current = initialAttachments;
+    setAttachments(initialAttachments);
+  }, [initialAttachments]);
+
+  useEffect(() => {
+    const pendingInitialAttachments = pendingInitialAttachmentsRef.current;
+    if (
+      pendingInitialAttachments &&
+      attachments !== pendingInitialAttachments
+    ) {
+      return;
+    }
+
+    pendingInitialAttachmentsRef.current = null;
+    onAttachmentsChange?.(attachments);
+  }, [attachments, onAttachmentsChange]);
+
   const uploadFile = useCallback(
     async (item: AttachmentItem) => {
+      if (!item.file) {
+        return;
+      }
+
       setAttachments((prev) =>
         prev.map((a) =>
           a.id === item.id ? { ...a, status: 'uploading' as const } : a,

--- a/packages/props/ui/attachments.props.ts
+++ b/packages/props/ui/attachments.props.ts
@@ -5,7 +5,7 @@ export interface AttachmentItem {
   ingredientId?: string;
   url?: string;
   previewUrl: string;
-  file: File;
+  file?: File;
   name: string;
   kind: 'image' | 'video' | 'audio';
   status: 'pending' | 'uploading' | 'completed' | 'failed';
@@ -21,9 +21,11 @@ export interface ChatAttachment {
 }
 
 export interface UseAttachmentsOptions {
+  acceptedTypes?: string[];
+  initialAttachments?: AttachmentItem[];
   maxFiles?: number;
   maxFileSizeMb?: number;
-  acceptedTypes?: string[];
+  onAttachmentsChange?: (attachments: AttachmentItem[]) => void;
   onUpload: (
     file: File,
     onProgress?: (pct: number) => void,


### PR DESCRIPTION
## Summary
- mount one persistent bottom composer across conversation, canvas, and overlay shell states with a joined context rail and an explicit scope-control composition slot
- preserve tab-scoped draft JSON, typed references, attachments, and focus intent across shell transitions and reloads
- add the eight allowlisted composer actions with canonical-route revalidation, brand-scope fail-closed behavior, and no natural-language publish authority
- present pending input, errors, connection recovery, honest progress, and non-authoritative plan notices beside accessible send/stop controls
- retain legacy prompt shortcuts and non-shell chat behavior while extending media attachment recovery

## Trust boundaries
- publish, schedule, and reply only open canonical product surfaces; this change does not approve or execute consequential actions
- forged, unknown, unavailable, and unauthorized commands preserve the draft and references
- no prompt, credential, message, or attachment contents are emitted to telemetry

## Verification
- Biome check on all changed files
- DESIGN.md lint (0 errors; existing unused-token warnings only)
- design-system, app UI, raw-control, bespoke-card, modal, org-navigation, and hardcoded-route guards
- staged secretlint plus gitleaks scans of staged content and commit (no findings)
- focused component/store/hook tests added for registry trust, draft restoration, attachment scope isolation/recovery, progress semantics, and shell dispatch
- local tests, typechecks, builds, and E2E were intentionally not run per repository workstation policy; PR CI is authoritative
- aggregate UI guard could not complete locally because the existing nested-card scanner loads an undefined TypeScript default import under the local Bun runtime; its other required checks passed individually

Closes #1683
Part of #1670