### PR TITLE
feat(app): tokenize approval decisions + artifact-history overlay

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/review/components/ReviewDecisionPanel.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/review/components/ReviewDecisionPanel.tsx
@@ -40,6 +40,38 @@ function getApproveLabel(item: ReviewPanelItem): string {
   return 'Approve and schedule';
 }
 
+function getResolvedDecisionStatus(item: ReviewPanelItem): {
+  className: string;
+  label: string;
+} {
+  if (isApproved(item)) {
+    return {
+      className: 'border border-success/25 bg-success/10 text-success',
+      label: 'This item has already been approved.',
+    };
+  }
+
+  if (isChangesRequested(item)) {
+    return {
+      className: 'border border-warning/25 bg-warning/10 text-warning',
+      label: 'Changes were requested for this item.',
+    };
+  }
+
+  if (item.reviewDecision === 'rejected') {
+    return {
+      className:
+        'border border-destructive/25 bg-destructive/10 text-destructive',
+      label: 'This item was rejected.',
+    };
+  }
+
+  return {
+    className: 'text-foreground/55',
+    label: 'This item is not currently actionable.',
+  };
+}
+
 export default function ReviewDecisionPanel({
   feedback,
   isActioning,
@@ -68,7 +100,7 @@ export default function ReviewDecisionPanel({
             value={feedback}
             onChange={(event) => setFeedback(event.target.value)}
             placeholder="Add revision guidance or rejection context"
-            className="min-h-28 w-full rounded-xl border border-white/10 bg-muted/40 px-3 py-2 text-sm text-foreground outline-none transition-colors placeholder:text-foreground/35 focus:border-white/20"
+            className="min-h-28 w-full rounded-xl border border-border bg-muted/40 px-3 py-2 text-sm text-foreground outline-none transition-colors placeholder:text-foreground/35 focus:border-border-strong"
           />
         </span>
 
@@ -79,7 +111,7 @@ export default function ReviewDecisionPanel({
               withWrapper={false}
               isDisabled={isActioning}
               onClick={() => onApprove(item.id)}
-              className="flex w-full items-center justify-center gap-2 rounded-xl bg-emerald-500/15 px-4 py-3 text-sm font-medium text-emerald-400 transition-colors hover:bg-emerald-500/25 disabled:opacity-50"
+              className="flex w-full items-center justify-center gap-2 rounded-xl bg-primary px-4 py-3 text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
             >
               <HiCheck className="size-4" />
               {getApproveLabel(item)}
@@ -89,7 +121,7 @@ export default function ReviewDecisionPanel({
               withWrapper={false}
               isDisabled={isActioning}
               onClick={() => onRequestChanges(item.id, feedback)}
-              className="flex w-full items-center justify-center gap-2 rounded-xl bg-amber-500/15 px-4 py-3 text-sm font-medium text-amber-300 transition-colors hover:bg-amber-500/25 disabled:opacity-50"
+              className="flex w-full items-center justify-center gap-2 rounded-xl border border-warning/25 bg-warning/10 px-4 py-3 text-sm font-medium text-warning transition-colors hover:bg-warning/20 disabled:opacity-50"
             >
               <HiSparkles className="size-4" />
               Request changes
@@ -99,7 +131,7 @@ export default function ReviewDecisionPanel({
               withWrapper={false}
               isDisabled={isActioning}
               onClick={() => onReject(item.id, feedback)}
-              className="flex w-full items-center justify-center gap-2 rounded-xl bg-rose-500/15 px-4 py-3 text-sm font-medium text-rose-400 transition-colors hover:bg-rose-500/25 disabled:opacity-50"
+              className="flex w-full items-center justify-center gap-2 rounded-xl border border-destructive/25 bg-destructive/10 px-4 py-3 text-sm font-medium text-destructive transition-colors hover:bg-destructive/20 disabled:opacity-50"
             >
               <HiXMark className="size-4" />
               Reject and remove
@@ -107,16 +139,10 @@ export default function ReviewDecisionPanel({
           </>
         ) : (
           <InsetSurface
-            className="px-4 py-3 text-sm text-foreground/55"
+            className={`px-4 py-3 text-sm ${getResolvedDecisionStatus(item).className}`}
             density="compact"
           >
-            {isApproved(item)
-              ? 'This item has already been approved.'
-              : isChangesRequested(item)
-                ? 'Changes were requested for this item.'
-                : item.reviewDecision === 'rejected'
-                  ? 'This item was rejected.'
-                  : 'This item is not currently actionable.'}
+            {getResolvedDecisionStatus(item).label}
           </InsetSurface>
         )}
 
@@ -125,7 +151,7 @@ export default function ReviewDecisionPanel({
             variant={ButtonVariant.UNSTYLED}
             withWrapper={false}
             onClick={() => onToggleSelect(item.id)}
-            className="rounded-xl border border-white/10 bg-muted/30 px-4 py-3 text-sm font-medium text-foreground/75 transition-colors hover:border-white/20 hover:bg-muted/60"
+            className="rounded-xl border border-border bg-muted/30 px-4 py-3 text-sm font-medium text-foreground/75 transition-colors hover:border-border-strong hover:bg-muted/60"
           >
             {isSelected
               ? 'Remove from bulk selection'

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/artifact-history-overlay.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/artifact-history-overlay.test.tsx
@@ -1,0 +1,100 @@
+import '@testing-library/jest-dom/vitest';
+import type { ArtifactVersionPin } from '@props/modals/artifact-history-overlay.props';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import ArtifactHistoryOverlay from './artifact-history-overlay';
+
+const versions: ArtifactVersionPin[] = [
+  {
+    id: 'v3',
+    isCurrent: true,
+    isImmutable: true,
+    label: 'v3',
+    subtitle: 'Approved scope ready',
+    title: 'Current · immutable',
+  },
+  {
+    id: 'v2',
+    isCurrent: false,
+    isImmutable: true,
+    label: 'v2',
+    subtitle: 'Founder voice refinement',
+    title: 'Previous',
+  },
+  {
+    id: 'v1',
+    isCurrent: false,
+    isImmutable: true,
+    label: 'v1',
+    subtitle: 'First generated carousel',
+    title: 'Initial',
+  },
+];
+
+function setup(
+  overrides: Partial<Parameters<typeof ArtifactHistoryOverlay>[0]> = {},
+) {
+  const onApprove = vi.fn();
+  const onOpenVersion = vi.fn();
+  const onOpenChange = vi.fn();
+
+  render(
+    <ArtifactHistoryOverlay
+      currentVersionId="v3"
+      isApproving={false}
+      isOpen
+      onApprove={onApprove}
+      onOpenChange={onOpenChange}
+      onOpenVersion={onOpenVersion}
+      versions={versions}
+      {...overrides}
+    />,
+  );
+
+  return { onApprove, onOpenChange, onOpenVersion };
+}
+
+describe('ArtifactHistoryOverlay', () => {
+  it('renders every version pin and marks the current one immutable', () => {
+    setup();
+
+    expect(screen.getByText('Artifact history')).toBeInTheDocument();
+    expect(screen.getByText('v3')).toBeInTheDocument();
+    expect(screen.getByText('v2')).toBeInTheDocument();
+    expect(screen.getByText('v1')).toBeInTheDocument();
+    expect(screen.getByText('Current · immutable')).toBeInTheDocument();
+  });
+
+  it('approves the current immutable version from the primary CTA', () => {
+    const { onApprove } = setup();
+
+    fireEvent.click(screen.getByRole('button', { name: /approve v3/i }));
+
+    expect(onApprove).toHaveBeenCalledWith('v3');
+  });
+
+  it('opens a prior version read-only without approving it', () => {
+    const { onApprove, onOpenVersion } = setup();
+
+    fireEvent.click(screen.getByRole('button', { name: /previous/i }));
+
+    expect(onOpenVersion).toHaveBeenCalledWith('v2');
+    expect(onApprove).not.toHaveBeenCalled();
+  });
+
+  it('exposes no open affordance on the current immutable version', () => {
+    setup();
+
+    // The current row is a static card, not a button — only prior versions and
+    // the footer are actionable. This is the single "open" affordance rule.
+    expect(
+      screen.queryByRole('button', { name: /current · immutable/i }),
+    ).toBeNull();
+  });
+
+  it('disables approval while a decision is in flight', () => {
+    setup({ isApproving: true });
+
+    expect(screen.getByRole('button', { name: /approving/i })).toBeDisabled();
+  });
+});

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/artifact-history-overlay.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/artifact-history-overlay.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+import { ButtonSize, ButtonVariant } from '@genfeedai/enums';
+import type {
+  ArtifactHistoryOverlayProps,
+  ArtifactVersionPin,
+} from '@props/modals/artifact-history-overlay.props';
+import { Button } from '@ui/primitives/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+} from '@ui/primitives/dialog';
+import { HiArrowUpRight, HiCheck, HiLockClosed } from 'react-icons/hi2';
+
+function isCurrentPin(version: ArtifactVersionPin, currentId: string): boolean {
+  return version.isCurrent || version.id === currentId;
+}
+
+export default function ArtifactHistoryOverlay({
+  currentVersionId,
+  isApproving,
+  isOpen,
+  onApprove,
+  onOpenChange,
+  onOpenVersion,
+  versions,
+}: ArtifactHistoryOverlayProps) {
+  const currentVersion = versions.find((version) =>
+    isCurrentPin(version, currentVersionId),
+  );
+  const approveTargetLabel = currentVersion?.label ?? 'the current version';
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
+      <DialogPortal>
+        {/* Light scrim — the active conversation stays mounted and visible behind it. */}
+        <DialogOverlay className="bg-black/40 backdrop-blur-[1px]" />
+        <DialogContent className="max-w-[600px] gap-4 border-border-strong bg-popover">
+          <DialogHeader>
+            <DialogTitle className="text-xl font-semibold">
+              Artifact history
+            </DialogTitle>
+            <DialogDescription>
+              Temporary overlay · active conversation remains mounted
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="flex flex-col gap-2.5">
+            {versions.map((version) => {
+              if (isCurrentPin(version, currentVersionId)) {
+                return (
+                  <div
+                    key={version.id}
+                    className="flex items-center gap-3.5 rounded-lg bg-accent p-3.5 ring-1 ring-inset ring-info"
+                  >
+                    <span className="text-base font-semibold text-info">
+                      {version.label}
+                    </span>
+                    <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                      <span className="text-[13px] font-medium text-foreground">
+                        {version.title}
+                      </span>
+                      <span className="truncate text-xs text-muted-foreground">
+                        {version.subtitle}
+                      </span>
+                    </div>
+                    <span className="flex items-center gap-1 text-[11px] font-medium uppercase tracking-wider text-info">
+                      <HiLockClosed className="size-3" aria-hidden />
+                      {version.isImmutable ? 'Current · immutable' : 'Current'}
+                    </span>
+                  </div>
+                );
+              }
+
+              return (
+                <Button
+                  key={version.id}
+                  variant={ButtonVariant.UNSTYLED}
+                  withWrapper={false}
+                  onClick={() => onOpenVersion(version.id)}
+                  className="flex w-full items-center gap-3.5 rounded-lg bg-background-secondary p-3.5 text-left shadow-border transition-colors hover:bg-accent/50 hover:shadow-border-strong"
+                >
+                  <span className="text-base font-semibold text-foreground">
+                    {version.label}
+                  </span>
+                  <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                    <span className="text-[13px] font-medium text-foreground">
+                      {version.title}
+                    </span>
+                    <span className="truncate text-xs text-muted-foreground">
+                      {version.subtitle}
+                    </span>
+                  </div>
+                  <span className="flex items-center gap-1 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+                    Open
+                    <HiArrowUpRight className="size-3" aria-hidden />
+                  </span>
+                </Button>
+              );
+            })}
+          </div>
+
+          <p className="text-xs text-muted-foreground">
+            Approval binds to {approveTargetLabel}. Any revision creates a new
+            version.
+          </p>
+
+          <DialogFooter>
+            <Button
+              variant={ButtonVariant.SECONDARY}
+              size={ButtonSize.SM}
+              onClick={() => onOpenChange(false)}
+            >
+              Close
+            </Button>
+            <Button
+              variant={ButtonVariant.DEFAULT}
+              size={ButtonSize.SM}
+              disabled={isApproving || !currentVersion}
+              onClick={() => onApprove(currentVersionId)}
+            >
+              <HiCheck className="size-4" />
+              {isApproving ? 'Approving…' : `Approve ${approveTargetLabel}`}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </DialogPortal>
+    </Dialog>
+  );
+}

--- a/packages/props/modals/artifact-history-overlay.props.ts
+++ b/packages/props/modals/artifact-history-overlay.props.ts
@@ -1,0 +1,52 @@
+/**
+ * Props for the artifact-history overlay (temporary conversation-shell overlay).
+ *
+ * Models the version-pin + approval contract from
+ * `.agents/memory/architecture/ADR-CONVERSATION-SHELL-CONTRACTS.md`:
+ * approval is a typed user decision bound to one immutable version pin, the
+ * current version is immutable, and any revision mints a new version. A version
+ * pin references an existing canonical record — it is not a duplicate artifact
+ * store.
+ */
+
+export interface ArtifactVersionPin {
+  /** Content digest for the pinned state (e.g. `Asset.sha256`), when available. */
+  digest?: string;
+  /** Stable, server-issued version-pin identity. */
+  id: string;
+  /** True for the single current version approval binds to. */
+  isCurrent: boolean;
+  /**
+   * Immutable version pins cannot be edited in place; a revision mints a new
+   * version. The current version is always immutable.
+   */
+  isImmutable: boolean;
+  /** Short rail label, e.g. `v3`. */
+  label: string;
+  /**
+   * Immutable canonical record version id when the underlying record supports
+   * one; otherwise the server-issued pin id acts as the identity.
+   */
+  recordVersion?: string;
+  /** One-line context beneath the title, e.g. `Approved scope ready`. */
+  subtitle: string;
+  /** Lifecycle heading, e.g. `Current · immutable`, `Previous`, `Initial`. */
+  title: string;
+}
+
+export interface ArtifactHistoryOverlayProps {
+  /** Id of the current immutable version approval binds to. */
+  currentVersionId: string;
+  /** Whether the overlay is mounted and visible. */
+  isOpen: boolean;
+  /** Approval decision in flight — disables the Approve CTA. */
+  isApproving: boolean;
+  /** Approve the current immutable version pin (`currentVersionId`). */
+  onApprove: (versionId: string) => void;
+  /** Open a prior version read-only for history inspection. */
+  onOpenVersion: (versionId: string) => void;
+  /** Overlay open/close transitions (scrim click, Escape, Close action). */
+  onOpenChange: (isOpen: boolean) => void;
+  /** Ordered newest-first; the current immutable version is first. */
+  versions: ArtifactVersionPin[];
+}


### PR DESCRIPTION
## Summary

Reviews and polishes the conversation-shell **approval** surfaces, then builds the net-new **artifact-history overlay** from the Figma mock (`10-5` / `46:183`). Everything is grounded in the tokens and primitives that **actually ship in `apps/app`** — verified against the code, not assumed.

### Key correction: real tokens, not `--gen-accent`
The original brief called for `--gen-accent`. Verified in-repo: **`--gen-accent` is monochrome (black/white) and used only in the marketing website — zero usage in `apps/app`.** The studio app uses the shadcn semantic tokens wired via `@theme inline` (`packages/styles/globals.css` + `packages/ui/web-tokens.css`): `success` (green), `warning` (amber), `info` (blue `#3c83f6`), `destructive`, `primary` (monochrome), `popover`, `border-strong`, `background-secondary`. The **Figma mock itself is built on these same tokens** (`var(--info)`, `var(--success)`, `var(--primary)`, `var(--popover)`), so this matches design 1:1.

## 1 · Polish (shippable now)

**`ReviewDecisionPanel.tsx`** — replaced raw `emerald/amber/rose` with wired semantic utilities and fixed the color overload:
- **Approve** → single high-emphasis solid action (`bg-primary`).
- **Request changes** / **Reject** → low-emphasis `warning` / `destructive` tints.
- **Green now means one thing:** approved/locked state only. Amber = changes-requested, red = rejected, neutral = transient bulk selection.

**`workspace-task-inspector-footer.tsx`** — audited, already compliant (Approve = solid primary `DEFAULT`, Request Changes = `SECONDARY`, all `@ui/primitives`, zero raw colors). Left unchanged to avoid gratuitous churn.

## 2 · Artifact-history overlay (net-new)

**`ArtifactHistoryOverlay`** on the real `Dialog` primitives + tokens:
- `v3` Current·immutable (info-accented, inset ring), `v2` Previous, `v1` Initial version pins.
- **`Approve v3`** primary CTA + `Close` secondary in the footer.
- **Resolves the mock's own inconsistencies:** one open affordance (prior-version rows carry `OPEN`; the footer is Approve, not a duplicate `Open v3`), and a **light scrim** (`bg-black/40`) so the active conversation stays mounted and visible behind it.
- Uses canonical surface tokens (`shadow-border` inset ring) rather than hand-rolled card borders (passes the bespoke-card guard).
- Typed against a **version-pin contract** in `packages/props/modals/artifact-history-overlay.props.ts`, modeled on **ADR-CONVERSATION-SHELL-CONTRACTS** (approval binds to one immutable version pin; any revision mints a new version).
- Colocated component test: render, approve-current, open-prior-read-only, no-open-on-current, in-flight disable.

### Wiring note
No artifact/version/approval **data model** exists in-repo yet (grep-confirmed), so the overlay is a controlled, presentational component wired to a typed props contract — ready to bind to the version/approval store when it lands. This PR does not fabricate a backend.

## Verification
Per repo policy, not run locally (MacBook rule) — relying on PR CI. Pre-commit guards passed: `biome`, `control-guard`, `lint-no-bespoke-card`, `secretlint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)