### PR TITLE
feat(app): unify workspace overlay coordination

### DIFF
--- a/apps/app/packages/components/app-protected-layout.test.tsx
+++ b/apps/app/packages/components/app-protected-layout.test.tsx
@@ -1,6 +1,8 @@
 import {
-  ENTITY_OVERLAY_CLOSED_EVENT,
-  ENTITY_OVERLAY_OPENED_EVENT,
+  notifyEntityOverlayClosed,
+  notifyEntityOverlayOpened,
+  requestAgentFromEntityOverlay,
+  setCoordinatedAgentPanelOpen,
 } from '@services/core/agent-overlay-coordination.service';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { type ReactNode, useEffect } from 'react';
@@ -504,7 +506,6 @@ vi.mock('@services/core/agent-overlay-coordination.service', async () => {
 
   return {
     ...actual,
-    dispatchAgentPanelStateChanged: vi.fn(),
     isDesktopAgentViewport: vi.fn(() => true),
   };
 });
@@ -534,6 +535,8 @@ describe('AppProtectedLayout', () => {
     setIsOpenSpy.mockClear();
     toggleOpenSpy.mockClear();
     universalShellSpy.mockClear();
+    notifyEntityOverlayClosed('ingredient-overlay');
+    setCoordinatedAgentPanelOpen(false);
     delete process.env.NEXT_PUBLIC_DESKTOP_SHELL;
     delete process.env.NEXT_PUBLIC_GENFEED_CLOUD;
     Object.defineProperty(window, 'location', {
@@ -1185,26 +1188,32 @@ describe('AppProtectedLayout', () => {
     );
   });
 
-  it('syncs overlay visibility events for the embedded workspace rail', () => {
+  it('syncs typed overlay visibility state for the embedded workspace rail', () => {
     render(
       <AppProtectedLayout>
         <div>Protected content</div>
       </AppProtectedLayout>,
     );
 
-    window.dispatchEvent(
-      new CustomEvent(ENTITY_OVERLAY_OPENED_EVENT, {
-        detail: { overlayId: 'ingredient-overlay' },
-      }),
-    );
-    window.dispatchEvent(
-      new CustomEvent(ENTITY_OVERLAY_CLOSED_EVENT, {
-        detail: { overlayId: 'ingredient-overlay' },
-      }),
-    );
+    notifyEntityOverlayOpened('ingredient-overlay');
+    notifyEntityOverlayClosed('ingredient-overlay');
 
     expect(beginOverlaySessionSpy).toHaveBeenCalledWith('ingredient-overlay');
     expect(endOverlaySessionSpy).toHaveBeenCalledWith('ingredient-overlay');
+  });
+
+  it('handles typed open-agent requests from active entity inspection', () => {
+    render(
+      <AppProtectedLayout>
+        <div>Protected content</div>
+      </AppProtectedLayout>,
+    );
+
+    notifyEntityOverlayOpened('ingredient-overlay');
+    requestAgentFromEntityOverlay('ingredient-overlay');
+
+    expect(setIsOpenSpy).toHaveBeenCalledWith(true);
+    notifyEntityOverlayClosed('ingredient-overlay');
   });
 
   it('skips editor-only providers and streak bridge on editor canvas routes', () => {

--- a/apps/app/packages/components/useAppProtectedLayout.ts
+++ b/apps/app/packages/components/useAppProtectedLayout.ts
@@ -43,12 +43,11 @@ import { useOrgUrl } from '@hooks/navigation/use-org-url';
 import { useMenuItems } from '@hooks/ui/use-menu-items';
 import type { ProtectedBootstrapData } from '@props/layout/protected-bootstrap.props';
 import {
-  dispatchAgentPanelStateChanged,
-  ENTITY_OVERLAY_CLOSED_EVENT,
-  ENTITY_OVERLAY_OPEN_AGENT_REQUESTED_EVENT,
-  ENTITY_OVERLAY_OPENED_EVENT,
-  type EntityOverlayVisibilityDetail,
+  getAgentOverlayCoordinationState,
   isDesktopAgentViewport,
+  setCoordinatedAgentPanelOpen,
+  subscribeAgentOverlayCoordination,
+  subscribeDesktopAgentViewport,
 } from '@services/core/agent-overlay-coordination.service';
 import {
   useParams,
@@ -294,62 +293,67 @@ export function useAppProtectedLayout(
   }, [setIsOpen, shouldMountAgentPanel]);
 
   useEffect(() => {
-    if (!shouldMountAgentPanel) {
-      return;
-    }
-
-    dispatchAgentPanelStateChanged(isAgentOpen);
+    setCoordinatedAgentPanelOpen(shouldMountAgentPanel && isAgentOpen);
   }, [isAgentOpen, shouldMountAgentPanel]);
+
+  useEffect(
+    () => () => {
+      setCoordinatedAgentPanelOpen(false);
+    },
+    [],
+  );
 
   useEffect(() => {
     if (!shouldMountAgentPanel || typeof window === 'undefined') {
       return undefined;
     }
 
-    const handleOverlayOpened = (event: Event): void => {
-      if (!isDesktopAgentViewport()) {
-        return;
+    const handledOverlayIds = new Set<string>();
+    let handledAgentRequestVersion =
+      getAgentOverlayCoordinationState().agentOpenRequestVersion;
+    const syncOverlayCoordination = (): void => {
+      const coordination = getAgentOverlayCoordinationState();
+      const activeOverlayIds = new Set(coordination.activeEntityOverlayIds);
+      const shouldCoordinateOverlays = isDesktopAgentViewport();
+
+      if (shouldCoordinateOverlays) {
+        for (const overlayId of activeOverlayIds) {
+          if (!handledOverlayIds.has(overlayId)) {
+            beginOverlaySession(overlayId);
+            handledOverlayIds.add(overlayId);
+          }
+        }
       }
 
-      beginOverlaySession(
-        (event as CustomEvent<EntityOverlayVisibilityDetail>).detail.overlayId,
-      );
-    };
-
-    const handleOverlayClosed = (event: Event): void => {
-      endOverlaySession(
-        (event as CustomEvent<EntityOverlayVisibilityDetail>).detail.overlayId,
-      );
-    };
-
-    const handleOpenAgentRequested = (): void => {
-      if (!isDesktopAgentViewport()) {
-        return;
+      for (const overlayId of handledOverlayIds) {
+        if (!shouldCoordinateOverlays || !activeOverlayIds.has(overlayId)) {
+          endOverlaySession(overlayId);
+          handledOverlayIds.delete(overlayId);
+        }
       }
 
-      setIsOpen(true);
+      if (handledAgentRequestVersion !== coordination.agentOpenRequestVersion) {
+        handledAgentRequestVersion = coordination.agentOpenRequestVersion;
+        if (shouldCoordinateOverlays) {
+          setIsOpen(true);
+        }
+      }
     };
 
-    window.addEventListener(ENTITY_OVERLAY_OPENED_EVENT, handleOverlayOpened);
-    window.addEventListener(ENTITY_OVERLAY_CLOSED_EVENT, handleOverlayClosed);
-    window.addEventListener(
-      ENTITY_OVERLAY_OPEN_AGENT_REQUESTED_EVENT,
-      handleOpenAgentRequested,
+    const unsubscribe = subscribeAgentOverlayCoordination(
+      syncOverlayCoordination,
     );
+    const unsubscribeDesktopViewport = subscribeDesktopAgentViewport(
+      syncOverlayCoordination,
+    );
+    syncOverlayCoordination();
 
     return () => {
-      window.removeEventListener(
-        ENTITY_OVERLAY_OPENED_EVENT,
-        handleOverlayOpened,
-      );
-      window.removeEventListener(
-        ENTITY_OVERLAY_CLOSED_EVENT,
-        handleOverlayClosed,
-      );
-      window.removeEventListener(
-        ENTITY_OVERLAY_OPEN_AGENT_REQUESTED_EVENT,
-        handleOpenAgentRequested,
-      );
+      unsubscribe();
+      unsubscribeDesktopViewport();
+      for (const overlayId of handledOverlayIds) {
+        endOverlaySession(overlayId);
+      }
     };
   }, [
     beginOverlaySession,

--- a/apps/app/src/components/workspace-shell/UniversalWorkspaceShell.test.tsx
+++ b/apps/app/src/components/workspace-shell/UniversalWorkspaceShell.test.tsx
@@ -202,7 +202,6 @@ describe('UniversalWorkspaceShell', () => {
     navigation.pathname = '/acme/moonrise/library/images';
     navigation.searchParams = new URLSearchParams({
       overlay: 'shell-preview',
-      overlayRef: 'asset:asset-1',
       thread: 'thread-1',
     });
 
@@ -217,7 +216,14 @@ describe('UniversalWorkspaceShell', () => {
       'overlay',
     );
     expect(screen.getByTestId('workspace-dialog')).toBeInTheDocument();
-    expect(screen.getByText('asset reference selected')).toBeInTheDocument();
+    expect(screen.getByText('Library')).toBeInTheDocument();
+    expect(screen.getByLabelText('Context inspector')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('persistent-agent-conversation'),
+    ).toHaveTextContent('thread-1');
+    expect(
+      screen.getByText('No resource reference selected'),
+    ).toBeInTheDocument();
 
     fireEvent.click(
       screen.getByRole('button', { name: 'Dismiss workspace overlay' }),
@@ -261,6 +267,56 @@ describe('UniversalWorkspaceShell', () => {
     );
 
     expect(router.back).toHaveBeenCalledTimes(1);
+  });
+
+  it('lets browser Back dismiss the overlay before the canvas', () => {
+    navigation.pathname = '/acme/moonrise/workspace/overview';
+    navigation.searchParams = new URLSearchParams({
+      overlay: 'shell-preview',
+      thread: 'thread-1',
+    });
+
+    const view = render(
+      <UniversalWorkspaceShell agentApiService={agentApiService}>
+        <div data-testid="underlying-canvas">Workspace</div>
+      </UniversalWorkspaceShell>,
+    );
+
+    expect(screen.getByTestId('workspace-dialog')).toBeInTheDocument();
+    expect(screen.getByTestId('underlying-canvas')).toBeInTheDocument();
+
+    navigation.searchParams = new URLSearchParams({ thread: 'thread-1' });
+    view.rerender(
+      <UniversalWorkspaceShell agentApiService={agentApiService}>
+        <div data-testid="underlying-canvas">Workspace</div>
+      </UniversalWorkspaceShell>,
+    );
+
+    expect(screen.queryByTestId('workspace-dialog')).not.toBeInTheDocument();
+    expect(screen.getByTestId('underlying-canvas')).toBeInTheDocument();
+    expect(router.push).not.toHaveBeenCalled();
+    expect(router.replace).not.toHaveBeenCalled();
+  });
+
+  it('fails an unauthorized overlay reference to its underlying canvas', () => {
+    navigation.pathname = '/acme/moonrise/library/images';
+    navigation.searchParams = new URLSearchParams({
+      folder: 'launch',
+      overlay: 'shell-preview',
+      overlayRef: 'asset:asset-1',
+      thread: 'thread-1',
+    });
+
+    render(
+      <UniversalWorkspaceShell agentApiService={agentApiService}>
+        <div>Library</div>
+      </UniversalWorkspaceShell>,
+    );
+
+    expect(screen.queryByTestId('workspace-dialog')).not.toBeInTheDocument();
+    expect(router.replace).toHaveBeenCalledWith(
+      '/acme/moonrise/library/images?folder=launch&thread=thread-1',
+    );
   });
 
   it('does not retain a conversation when the canonical organization changes', () => {

--- a/apps/app/src/components/workspace-shell/UniversalWorkspaceShell.tsx
+++ b/apps/app/src/components/workspace-shell/UniversalWorkspaceShell.tsx
@@ -9,13 +9,6 @@ import { cn } from '@helpers/formatting/cn/cn.util';
 import { useOrgUrl } from '@hooks/navigation/use-org-url';
 import { Button } from '@ui/primitives/button';
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from '@ui/primitives/dialog';
-import {
   Drawer,
   DrawerContent,
   DrawerDescription,
@@ -45,6 +38,7 @@ import {
   appendSearchParamsToHref,
   normalizeProtectedPathname,
 } from '@/lib/navigation/operator-shell';
+import { resolveWorkspaceOverlayLaunch } from '@/lib/workspace-shell/workspace-overlay-launcher';
 import {
   buildWorkspaceShellHref,
   removeWorkspaceShellOverlayParams,
@@ -52,10 +46,12 @@ import {
   type WorkspaceShellLocation,
   type WorkspaceShellState,
 } from '@/lib/workspace-shell/workspace-shell-location';
+import { getWorkspaceShellOverlayRegistration } from '@/lib/workspace-shell/workspace-shell-registry';
 import {
   captureWorkspaceShellRestorationFailure,
   captureWorkspaceShellTransition,
 } from '@/lib/workspace-shell/workspace-shell-telemetry';
+import WorkspaceOverlayHost from './WorkspaceOverlayHost';
 
 const INSPECTOR_DEFAULT_WIDTH = 320;
 const INSPECTOR_MIN_WIDTH = 256;
@@ -133,13 +129,17 @@ function UniversalWorkspaceShellContent({
     baseState,
     canonicalSearchParams,
     isCanonical,
-    overlayReference,
+    overlay,
     restorationFailure,
     safeFallbackHref,
     state,
     surfaceKey,
     threadId,
   } = shellLocation;
+  const overlayRegistration = useMemo(
+    () => (overlay ? getWorkspaceShellOverlayRegistration(overlay.key) : null),
+    [overlay],
+  );
   const canonicalSearchParamsString = canonicalSearchParams.toString();
   const isUnthreadedConversation =
     baseState === 'conversation' &&
@@ -283,19 +283,32 @@ function UniversalWorkspaceShellContent({
   }, [activeThreadId, effectiveThreadId, orgHref, push]);
 
   const handleOpenOverlay = useCallback(() => {
+    const launch = resolveWorkspaceOverlayLaunch({
+      currentHref,
+      invocation: 'user',
+      overlay: {
+        key: 'shell-preview',
+        parameters: { reference: null },
+      },
+    });
+    if (launch.history === 'none') {
+      return;
+    }
+
     pendingTransitionRef.current = 'overlay_open';
-    isOwnedOverlayEntryRef.current = true;
     overlayReturnFocusRef.current =
       document.activeElement instanceof HTMLElement
         ? document.activeElement
         : null;
     hasOverlayReturnFocusRef.current = Boolean(overlayReturnFocusRef.current);
-    push(
-      buildWorkspaceShellHref(currentHref, {
-        overlayKey: 'shell-preview',
-      }),
-    );
-  }, [currentHref, push]);
+    if (launch.history === 'replace') {
+      replace(launch.href);
+      return;
+    }
+
+    isOwnedOverlayEntryRef.current = true;
+    push(launch.href);
+  }, [currentHref, push, replace]);
 
   const handleDismissOverlay = useCallback(() => {
     pendingTransitionRef.current = 'overlay_dismiss';
@@ -409,6 +422,9 @@ function UniversalWorkspaceShellContent({
     >
       <div aria-live="polite" className="sr-only" role="status">
         Workspace mode: {state}. Active surface: {surfaceKey}.
+        {state === 'overlay' && overlayRegistration
+          ? ` ${overlayRegistration.presentation.openAnnouncement}`
+          : null}
       </div>
 
       <div
@@ -553,42 +569,14 @@ function UniversalWorkspaceShellContent({
         </DrawerContent>
       </Drawer>
 
-      <Dialog
-        open={state === 'overlay'}
-        onOpenChange={(isOpen) => {
-          if (!isOpen) {
-            handleDismissOverlay();
-          }
-        }}
-      >
-        <DialogContent
-          className="w-[min(92vw,42rem)] bg-background p-0 shadow-dialog"
-          data-workspace-shell-overlay="true"
-          onCloseAutoFocus={(event) => {
-            const returnFocusTarget = overlayReturnFocusRef.current;
-            if (!returnFocusTarget) {
-              return;
-            }
-
-            event.preventDefault();
-            returnFocusTarget.focus({ preventScroll: true });
-            overlayReturnFocusRef.current = null;
-          }}
-        >
-          <DialogHeader className="border-b border-border p-5 pr-12">
-            <DialogTitle>Temporary workspace overlay</DialogTitle>
-            <DialogDescription>
-              This trusted placeholder demonstrates restorable overlay state. It
-              does not mutate scope or approve an action.
-            </DialogDescription>
-          </DialogHeader>
-          <div className="p-5 text-sm text-muted-foreground">
-            {overlayReference
-              ? `${overlayReference.kind} reference selected`
-              : 'No resource reference selected'}
-          </div>
-        </DialogContent>
-      </Dialog>
+      <WorkspaceOverlayHost
+        fallbackFocusRef={primaryRegionRef}
+        isOpen={state === 'overlay'}
+        onDismiss={handleDismissOverlay}
+        overlay={overlay}
+        registration={overlayRegistration}
+        returnFocusRef={overlayReturnFocusRef}
+      />
     </div>
   );
 }

--- a/apps/app/src/components/workspace-shell/WorkspaceOverlayHost.test.tsx
+++ b/apps/app/src/components/workspace-shell/WorkspaceOverlayHost.test.tsx
@@ -1,0 +1,171 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { FocusEvent, FocusEventHandler, ReactNode } from 'react';
+import { createRef } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { getWorkspaceShellOverlayRegistration } from '@/lib/workspace-shell/workspace-shell-registry';
+
+vi.mock('@ui/primitives/dialog', () => ({
+  Dialog: ({
+    children,
+    onOpenChange,
+    open,
+  }: {
+    children: ReactNode;
+    onOpenChange: (isOpen: boolean) => void;
+    open: boolean;
+  }) =>
+    open ? (
+      <div role="dialog">
+        {children}
+        <button type="button" onClick={() => onOpenChange(false)}>
+          Dismiss
+        </button>
+      </div>
+    ) : null,
+  DialogContent: ({
+    children,
+    onCloseAutoFocus,
+    ...props
+  }: {
+    children: ReactNode;
+    onCloseAutoFocus?: FocusEventHandler<HTMLDivElement>;
+  }) => (
+    <div {...props}>
+      {children}
+      <button
+        type="button"
+        onClick={() =>
+          onCloseAutoFocus?.({
+            preventDefault: vi.fn(),
+          } as unknown as FocusEvent<HTMLDivElement>)
+        }
+      >
+        Complete close autofocus
+      </button>
+    </div>
+  ),
+  DialogDescription: ({ children }: { children: ReactNode }) => (
+    <p>{children}</p>
+  ),
+  DialogHeader: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+}));
+
+import WorkspaceOverlayHost from './WorkspaceOverlayHost';
+
+describe('WorkspaceOverlayHost', () => {
+  it('renders one coherently named trusted dialog and dismisses through its owner', () => {
+    const onDismiss = vi.fn();
+    const returnFocusRef = createRef<HTMLElement>();
+    const registration = getWorkspaceShellOverlayRegistration('shell-preview');
+
+    render(
+      <WorkspaceOverlayHost
+        fallbackFocusRef={createRef<HTMLElement>()}
+        isOpen
+        onDismiss={onDismiss}
+        overlay={{
+          key: 'shell-preview',
+          parameters: { reference: null },
+        }}
+        registration={registration}
+        returnFocusRef={returnFocusRef}
+      />,
+    );
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Temporary workspace overlay' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /trusted placeholder demonstrates restorable overlay state/i,
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText('No resource reference selected')).toBeVisible();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('restores the connected invoking control after dialog close', () => {
+    const returnFocusRef = createRef<HTMLElement>();
+    const invoker = document.createElement('button');
+    document.body.append(invoker);
+    returnFocusRef.current = invoker;
+    const focusSpy = vi.spyOn(invoker, 'focus');
+
+    render(
+      <WorkspaceOverlayHost
+        fallbackFocusRef={createRef<HTMLElement>()}
+        isOpen
+        onDismiss={vi.fn()}
+        overlay={{
+          key: 'notifications',
+          parameters: {},
+        }}
+        registration={getWorkspaceShellOverlayRegistration('notifications')}
+        returnFocusRef={returnFocusRef}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Complete close autofocus' }),
+    );
+
+    expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
+    expect(returnFocusRef.current).toBeNull();
+    invoker.remove();
+  });
+
+  it('restores the shell primary region when the invoker was removed', () => {
+    const returnFocusRef = createRef<HTMLElement>();
+    const fallbackFocusRef = createRef<HTMLElement>();
+    const removedInvoker = document.createElement('button');
+    const primaryRegion = document.createElement('main');
+    document.body.append(primaryRegion);
+    returnFocusRef.current = removedInvoker;
+    fallbackFocusRef.current = primaryRegion;
+    const focusSpy = vi.spyOn(primaryRegion, 'focus');
+
+    render(
+      <WorkspaceOverlayHost
+        fallbackFocusRef={fallbackFocusRef}
+        isOpen
+        onDismiss={vi.fn()}
+        overlay={{
+          key: 'notifications',
+          parameters: {},
+        }}
+        registration={getWorkspaceShellOverlayRegistration('notifications')}
+        returnFocusRef={returnFocusRef}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Complete close autofocus' }),
+    );
+
+    expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
+    expect(returnFocusRef.current).toBeNull();
+    primaryRegion.remove();
+  });
+
+  it('renders nothing for unresolved or untrusted overlay state', () => {
+    render(
+      <WorkspaceOverlayHost
+        fallbackFocusRef={createRef<HTMLElement>()}
+        isOpen
+        onDismiss={vi.fn()}
+        overlay={null}
+        registration={null}
+        returnFocusRef={createRef<HTMLElement>()}
+      />,
+    );
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});

--- a/apps/app/src/components/workspace-shell/WorkspaceOverlayHost.tsx
+++ b/apps/app/src/components/workspace-shell/WorkspaceOverlayHost.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import type { WorkspaceOverlayHostProps } from '@genfeedai/props/ui/workspace-overlay-host.props';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@ui/primitives/dialog';
+
+function formatOverlayParameters(
+  overlay: WorkspaceOverlayHostProps['overlay'],
+): string {
+  if (overlay?.key !== 'shell-preview' || !overlay.parameters.reference) {
+    return 'No resource reference selected';
+  }
+
+  return `${overlay.parameters.reference.kind} reference selected`;
+}
+
+/**
+ * The only dialog host owned by the universal workspace shell. Product entity
+ * inspection sheets remain outside this host and registered shell overlays may
+ * contribute only their trusted metadata and typed parameters.
+ */
+export default function WorkspaceOverlayHost({
+  fallbackFocusRef,
+  isOpen,
+  onDismiss,
+  overlay,
+  registration,
+  returnFocusRef,
+}: WorkspaceOverlayHostProps) {
+  const isResolved = Boolean(
+    overlay && registration && overlay.key === registration.key,
+  );
+
+  return (
+    <Dialog
+      open={isOpen && isResolved}
+      onOpenChange={(nextIsOpen) => {
+        if (!nextIsOpen) {
+          onDismiss();
+        }
+      }}
+    >
+      {isResolved && registration ? (
+        <DialogContent
+          className="w-[min(92vw,42rem)] bg-background p-0 shadow-dialog"
+          data-workspace-overlay-key={registration.key}
+          data-workspace-shell-overlay="true"
+          onCloseAutoFocus={(event) => {
+            const returnFocusTarget = returnFocusRef.current?.isConnected
+              ? returnFocusRef.current
+              : fallbackFocusRef.current;
+            returnFocusRef.current = null;
+            if (!returnFocusTarget?.isConnected) {
+              return;
+            }
+
+            event.preventDefault();
+            returnFocusTarget.focus({ preventScroll: true });
+          }}
+        >
+          <DialogHeader className="border-b border-border p-5 pr-12">
+            <DialogTitle>{registration.presentation.title}</DialogTitle>
+            <DialogDescription>
+              {registration.presentation.description}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="p-5 text-sm text-muted-foreground">
+            {formatOverlayParameters(overlay)}
+          </div>
+        </DialogContent>
+      ) : null}
+    </Dialog>
+  );
+}

--- a/apps/app/src/lib/analytics/analytics-events.ts
+++ b/apps/app/src/lib/analytics/analytics-events.ts
@@ -82,7 +82,9 @@ export type ConversationShellFallbackReason =
   | 'invalid_overlay_reference'
   | 'invalid_thread'
   | 'registry_miss'
-  | 'render_error';
+  | 'render_error'
+  | 'stale_overlay_reference'
+  | 'unauthorized_overlay_reference';
 
 /**
  * Property shape for each event. Keys map 1:1 to {@link ANALYTICS_EVENTS} values.
@@ -104,7 +106,11 @@ export interface AnalyticsEventProperties {
   [ANALYTICS_EVENTS.CONVERSATION_SHELL_RESTORATION_FAILURE]: {
     readonly reason: Extract<
       ConversationShellFallbackReason,
-      'invalid_overlay' | 'invalid_overlay_reference' | 'invalid_thread'
+      | 'invalid_overlay'
+      | 'invalid_overlay_reference'
+      | 'invalid_thread'
+      | 'stale_overlay_reference'
+      | 'unauthorized_overlay_reference'
     >;
   };
   [ANALYTICS_EVENTS.SIGNUP_STARTED]: {

--- a/apps/app/src/lib/workspace-shell/workspace-overlay-launcher.spec.ts
+++ b/apps/app/src/lib/workspace-shell/workspace-overlay-launcher.spec.ts
@@ -1,0 +1,136 @@
+import type { WorkspaceShellOverlayRequest } from '@genfeedai/interfaces/ui/workspace-shell.interface';
+import { describe, expect, it } from 'vitest';
+import { resolveWorkspaceOverlayLaunch } from './workspace-overlay-launcher';
+
+const SHELL_PREVIEW_OVERLAY = {
+  key: 'shell-preview',
+  parameters: { reference: null },
+} as const satisfies WorkspaceShellOverlayRequest;
+
+describe('workspace overlay launcher', () => {
+  it('pushes one trusted overlay over the complete underlying URL', () => {
+    expect(
+      resolveWorkspaceOverlayLaunch({
+        currentHref:
+          '/acme/moonrise/library/images?folder=launch&thread=thread-1#asset-grid',
+        invocation: 'user',
+        overlay: SHELL_PREVIEW_OVERLAY,
+      }),
+    ).toEqual({
+      announcement: 'Temporary workspace overlay opened.',
+      history: 'push',
+      href: '/acme/moonrise/library/images?folder=launch&thread=thread-1&overlay=shell-preview#asset-grid',
+      overlay: SHELL_PREVIEW_OVERLAY,
+    });
+  });
+
+  it('requires explicit authorization for typed reference parameters', () => {
+    const overlay = {
+      key: 'shell-preview',
+      parameters: { reference: { id: 'asset-1', kind: 'asset' } },
+    } as const satisfies WorkspaceShellOverlayRequest;
+
+    expect(
+      resolveWorkspaceOverlayLaunch({
+        currentHref: '/acme/moonrise/library/images?thread=thread-1',
+        invocation: 'user',
+        overlay,
+      }),
+    ).toMatchObject({ history: 'none', overlay: null });
+
+    expect(
+      resolveWorkspaceOverlayLaunch({
+        currentHref: '/acme/moonrise/library/images?thread=thread-1',
+        invocation: 'user',
+        overlay,
+        resolveOverlayReferenceAccess: () => 'authorized',
+      }),
+    ).toMatchObject({
+      history: 'push',
+      href: '/acme/moonrise/library/images?thread=thread-1&overlay=shell-preview&overlayRef=asset%3Aasset-1',
+      overlay,
+    });
+  });
+
+  it('never lets a model proposal mutate shell history', () => {
+    expect(
+      resolveWorkspaceOverlayLaunch({
+        currentHref: '/acme/~/agent/thread-1',
+        invocation: 'model',
+        overlay: SHELL_PREVIEW_OVERLAY,
+      }),
+    ).toEqual({
+      announcement: 'Overlay proposal requires an explicit user action.',
+      history: 'none',
+      href: '/acme/~/agent/thread-1',
+      overlay: null,
+    });
+  });
+
+  it('fails a forged runtime key without navigating', () => {
+    expect(
+      resolveWorkspaceOverlayLaunch({
+        currentHref: '/acme/~/agent/thread-1',
+        invocation: 'user',
+        overlay: {
+          key: 'model-produced-surface',
+          parameters: {},
+        } as unknown as WorkspaceShellOverlayRequest,
+      }),
+    ).toMatchObject({
+      history: 'none',
+      href: '/acme/~/agent/thread-1',
+      overlay: null,
+    });
+  });
+
+  it('replaces an existing overlay instead of nesting another history entry', () => {
+    expect(
+      resolveWorkspaceOverlayLaunch({
+        currentHref:
+          '/acme/~/agent/thread-1?overlay=notifications&filter=unread',
+        invocation: 'user',
+        overlay: SHELL_PREVIEW_OVERLAY,
+      }),
+    ).toMatchObject({
+      history: 'replace',
+      href: '/acme/~/agent/thread-1?filter=unread&overlay=shell-preview',
+    });
+  });
+
+  it('does not add history when the exact overlay is already active', () => {
+    expect(
+      resolveWorkspaceOverlayLaunch({
+        currentHref:
+          '/acme/~/agent/thread-1?overlay=shell-preview&filter=unread',
+        invocation: 'user',
+        overlay: SHELL_PREVIEW_OVERLAY,
+      }),
+    ).toMatchObject({
+      history: 'none',
+      href: '/acme/~/agent/thread-1?overlay=shell-preview&filter=unread',
+    });
+  });
+
+  it('keeps dedicated and external locations outside overlay state', () => {
+    expect(
+      resolveWorkspaceOverlayLaunch({
+        currentHref: '/acme/~/settings/billing',
+        invocation: 'user',
+        overlay: SHELL_PREVIEW_OVERLAY,
+      }),
+    ).toMatchObject({ history: 'none', overlay: null });
+    expect(
+      resolveWorkspaceOverlayLaunch({
+        currentHref: 'https://untrusted.example/workspace',
+        invocation: 'user',
+        overlay: SHELL_PREVIEW_OVERLAY,
+      }),
+    ).toEqual({
+      announcement: 'Overlay unavailable.',
+      history: 'none',
+      href: '/',
+      overlay: null,
+    });
+  });
+});

--- a/apps/app/src/lib/workspace-shell/workspace-overlay-launcher.ts
+++ b/apps/app/src/lib/workspace-shell/workspace-overlay-launcher.ts
@@ -1,0 +1,163 @@
+import type {
+  ResolveWorkspaceOverlayLaunchParams,
+  WorkspaceOverlayLaunch,
+  WorkspaceShellOverlayRequest,
+} from '@genfeedai/interfaces/ui/workspace-shell.interface';
+import {
+  buildWorkspaceShellHref,
+  resolveWorkspaceShellOverlayRequest,
+} from './workspace-shell-location';
+import {
+  getWorkspaceShellOverlayRegistration,
+  resolveWorkspaceShellRoute,
+} from './workspace-shell-registry';
+
+export type {
+  ResolveWorkspaceOverlayLaunchParams,
+  WorkspaceOverlayLaunch,
+} from '@genfeedai/interfaces/ui/workspace-shell.interface';
+
+const INTERNAL_ORIGIN = 'https://workspace.genfeed.invalid';
+
+function parseInternalHref(href: string): URL | null {
+  try {
+    const url = new URL(href, INTERNAL_ORIGIN);
+    return url.origin === INTERNAL_ORIGIN ? url : null;
+  } catch {
+    return null;
+  }
+}
+
+function toRelativeHref(url: URL): string {
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
+function createUnavailableLaunch(
+  currentUrl: URL | null,
+  announcement = 'Overlay unavailable.',
+): WorkspaceOverlayLaunch {
+  return {
+    announcement,
+    history: 'none',
+    href: currentUrl ? toRelativeHref(currentUrl) : '/',
+    overlay: null,
+  };
+}
+
+function encodeOverlayReference(
+  overlay: WorkspaceShellOverlayRequest,
+): string | null | undefined {
+  if (
+    !overlay.parameters ||
+    typeof overlay.parameters !== 'object' ||
+    Array.isArray(overlay.parameters)
+  ) {
+    return undefined;
+  }
+
+  if (overlay.key === 'notifications') {
+    return Object.keys(overlay.parameters).length === 0 ? null : undefined;
+  }
+
+  if (
+    Object.keys(overlay.parameters).some((key) => key !== 'reference') ||
+    !Object.hasOwn(overlay.parameters, 'reference')
+  ) {
+    return undefined;
+  }
+
+  const { reference } = overlay.parameters;
+  if (reference === null) {
+    return null;
+  }
+  if (
+    !reference ||
+    typeof reference !== 'object' ||
+    typeof reference.id !== 'string' ||
+    typeof reference.kind !== 'string'
+  ) {
+    return undefined;
+  }
+
+  return `${reference.kind}:${reference.id}`;
+}
+
+/**
+ * Resolves an overlay transition through the trusted application registry.
+ * Model output can propose a key, but only an explicit user invocation may
+ * mutate history. Replacing an existing overlay uses one history entry so a
+ * nested dialog stack can never form.
+ */
+export function resolveWorkspaceOverlayLaunch({
+  currentHref,
+  invocation,
+  overlay,
+  resolveOverlayReferenceAccess,
+}: ResolveWorkspaceOverlayLaunchParams): WorkspaceOverlayLaunch {
+  const currentUrl = parseInternalHref(currentHref);
+  if (!currentUrl) {
+    return createUnavailableLaunch(null);
+  }
+  if (invocation !== 'user') {
+    return createUnavailableLaunch(
+      currentUrl,
+      'Overlay proposal requires an explicit user action.',
+    );
+  }
+
+  const currentRoute = resolveWorkspaceShellRoute(currentUrl.pathname);
+  if (!currentRoute || currentRoute.mode === 'dedicated') {
+    return createUnavailableLaunch(currentUrl);
+  }
+
+  const runtimeKey = (overlay as { readonly key?: unknown }).key;
+  if (typeof runtimeKey !== 'string') {
+    return createUnavailableLaunch(currentUrl);
+  }
+  const registration = getWorkspaceShellOverlayRegistration(runtimeKey);
+  if (!registration) {
+    return createUnavailableLaunch(currentUrl);
+  }
+
+  const encodedReference = encodeOverlayReference(overlay);
+  if (encodedReference === undefined) {
+    return createUnavailableLaunch(currentUrl);
+  }
+  const resolution = resolveWorkspaceShellOverlayRequest(
+    registration,
+    encodedReference,
+    resolveOverlayReferenceAccess,
+  );
+  if (resolution.failure || !resolution.overlay) {
+    return createUnavailableLaunch(currentUrl);
+  }
+
+  const currentOverlayKey = currentUrl.searchParams.get('overlay');
+  const currentOverlayReference = currentUrl.searchParams.get('overlayRef');
+  if (
+    currentOverlayKey === resolution.overlay.key &&
+    currentOverlayReference === encodedReference
+  ) {
+    return {
+      announcement: `${registration.presentation.title} is already open.`,
+      history: 'none',
+      href: toRelativeHref(currentUrl),
+      overlay: resolution.overlay,
+    };
+  }
+
+  const isReplacingOverlay = Boolean(
+    currentOverlayKey || currentUrl.searchParams.has('overlayRef'),
+  );
+  currentUrl.searchParams.delete('overlay');
+  currentUrl.searchParams.delete('overlayRef');
+
+  return {
+    announcement: registration.presentation.openAnnouncement,
+    history: isReplacingOverlay ? 'replace' : 'push',
+    href: buildWorkspaceShellHref(toRelativeHref(currentUrl), {
+      overlay: resolution.overlay,
+    }),
+    overlay: resolution.overlay,
+  };
+}

--- a/apps/app/src/lib/workspace-shell/workspace-shell-location.spec.ts
+++ b/apps/app/src/lib/workspace-shell/workspace-shell-location.spec.ts
@@ -57,11 +57,12 @@ describe('workspace shell URL restoration', () => {
     ).toMatchObject({ baseState: 'canvas', state: 'canvas' });
   });
 
-  it('restores an allowlisted overlay with an existing-model reference', () => {
+  it('restores an allowlisted overlay with an authorized canonical reference', () => {
     expect(
       restoreWorkspaceShellLocation({
         normalizedPathname: '/library/images',
         pathname: '/acme/moonrise/library/images',
+        resolveOverlayReferenceAccess: () => 'authorized',
         searchParams: new URLSearchParams({
           overlay: 'shell-preview',
           overlayRef: 'asset:asset-123',
@@ -70,8 +71,10 @@ describe('workspace shell URL restoration', () => {
       }),
     ).toMatchObject({
       baseState: 'canvas',
-      overlayKey: 'shell-preview',
-      overlayReference: { id: 'asset-123', kind: 'asset' },
+      overlay: {
+        key: 'shell-preview',
+        parameters: { reference: { id: 'asset-123', kind: 'asset' } },
+      },
       state: 'overlay',
       threadId: 'thread-1',
     });
@@ -114,6 +117,51 @@ describe('workspace shell URL restoration', () => {
       state: 'canvas',
     });
     expect(restored?.canonicalSearchParams.toString()).toBe('');
+  });
+
+  it.each([
+    [undefined, 'unauthorized_overlay_reference'],
+    [() => 'unauthorized' as const, 'unauthorized_overlay_reference'],
+    [() => 'stale' as const, 'stale_overlay_reference'],
+  ])('fails %s reference access back to the exact underlying URL', (resolveOverlayReferenceAccess, restorationFailure) => {
+    const restored = restoreWorkspaceShellLocation({
+      normalizedPathname: '/library/images',
+      pathname: '/acme/moonrise/library/images',
+      resolveOverlayReferenceAccess,
+      searchParams: new URLSearchParams({
+        folder: 'launch',
+        overlay: 'shell-preview',
+        overlayRef: 'asset:asset-123',
+        thread: 'thread-1',
+      }),
+    });
+
+    expect(restored).toMatchObject({
+      overlay: null,
+      restorationFailure,
+      state: 'canvas',
+      threadId: 'thread-1',
+    });
+    expect(restored?.canonicalSearchParams.toString()).toBe(
+      'folder=launch&thread=thread-1',
+    );
+  });
+
+  it('rejects parameters on an overlay registered without parameters', () => {
+    expect(
+      restoreWorkspaceShellLocation({
+        normalizedPathname: '/agent/thread-1',
+        pathname: '/acme/~/agent/thread-1',
+        searchParams: new URLSearchParams({
+          overlay: 'notifications',
+          overlayRef: 'asset:asset-123',
+        }),
+      }),
+    ).toMatchObject({
+      overlay: null,
+      restorationFailure: 'invalid_overlay_reference',
+      state: 'conversation',
+    });
   });
 
   it('marks malformed conversation thread routes for safe canonical fallback', () => {
@@ -179,7 +227,10 @@ describe('workspace shell URL restoration', () => {
   it('builds registered transitions and direct-link overlay dismissal URLs', () => {
     expect(
       buildWorkspaceShellHref('/acme/~/overview?filter=active', {
-        overlayKey: 'shell-preview',
+        overlay: {
+          key: 'shell-preview',
+          parameters: { reference: null },
+        },
         threadId: 'thread-1',
       }),
     ).toBe(

--- a/apps/app/src/lib/workspace-shell/workspace-shell-location.ts
+++ b/apps/app/src/lib/workspace-shell/workspace-shell-location.ts
@@ -1,6 +1,10 @@
 import type {
   RestoreWorkspaceShellLocationParams,
   WorkspaceShellLocation,
+  WorkspaceShellOverlayReferenceAccessResolver,
+  WorkspaceShellOverlayRegistration,
+  WorkspaceShellOverlayRequest,
+  WorkspaceShellOverlayResolution,
   WorkspaceShellReferenceKind,
   WorkspaceShellTypedReference,
 } from '@genfeedai/interfaces/ui/workspace-shell.interface';
@@ -14,6 +18,8 @@ import {
 export type {
   RestoreWorkspaceShellLocationParams,
   WorkspaceShellLocation,
+  WorkspaceShellOverlayReferenceAccessResolver,
+  WorkspaceShellOverlayRequest,
   WorkspaceShellRestorationFailure,
   WorkspaceShellState,
   WorkspaceShellTypedReference,
@@ -57,6 +63,73 @@ function parseOverlayReference(
   return { id, kind };
 }
 
+function createOverlayRequest(
+  registration: WorkspaceShellOverlayRegistration,
+  reference: WorkspaceShellTypedReference | null,
+): WorkspaceShellOverlayRequest | null {
+  switch (registration.key) {
+    case 'notifications':
+      return reference
+        ? null
+        : { key: 'notifications', parameters: Object.freeze({}) };
+    case 'shell-preview':
+      return {
+        key: 'shell-preview',
+        parameters: { reference },
+      };
+  }
+}
+
+export function resolveWorkspaceShellOverlayRequest(
+  registration: WorkspaceShellOverlayRegistration,
+  encodedReference: string | null,
+  resolveReferenceAccess?: WorkspaceShellOverlayReferenceAccessResolver,
+): WorkspaceShellOverlayResolution {
+  if (registration.parameterContract.kind === 'none') {
+    return encodedReference
+      ? { failure: 'invalid_overlay_reference', overlay: null }
+      : {
+          failure: null,
+          overlay: createOverlayRequest(registration, null),
+        };
+  }
+
+  if (!encodedReference) {
+    return {
+      failure: null,
+      overlay: createOverlayRequest(registration, null),
+    };
+  }
+
+  const reference = parseOverlayReference(
+    encodedReference,
+    registration.parameterContract.allowedReferenceKinds,
+  );
+  if (!reference) {
+    return { failure: 'invalid_overlay_reference', overlay: null };
+  }
+
+  const access =
+    resolveReferenceAccess?.({
+      overlayKey: registration.key,
+      reference,
+    }) ?? 'unauthorized';
+  if (access !== 'authorized') {
+    return {
+      failure:
+        access === 'stale'
+          ? 'stale_overlay_reference'
+          : 'unauthorized_overlay_reference',
+      overlay: null,
+    };
+  }
+
+  return {
+    failure: null,
+    overlay: createOverlayRequest(registration, reference),
+  };
+}
+
 function extractConversationThreadId(pathname: string): string | null {
   const match = /^\/agent\/([^/]+)$/.exec(pathname);
   const candidate = match?.[1] ?? null;
@@ -67,6 +140,7 @@ function extractConversationThreadId(pathname: string): string | null {
 export function restoreWorkspaceShellLocation({
   normalizedPathname,
   pathname,
+  resolveOverlayReferenceAccess,
   searchParams,
 }: RestoreWorkspaceShellLocationParams): WorkspaceShellLocation | null {
   const route = resolveWorkspaceShellRoute(pathname);
@@ -96,8 +170,7 @@ export function restoreWorkspaceShellLocation({
       baseState: route.mode,
       canonicalSearchParams,
       isCanonical: false,
-      overlayKey: null,
-      overlayReference: null,
+      overlay: null,
       restorationFailure: 'invalid_thread',
       routeKey: route.key,
       safeFallbackHref,
@@ -135,8 +208,7 @@ export function restoreWorkspaceShellLocation({
         baseState: route.mode,
         canonicalSearchParams,
         isCanonical: false,
-        overlayKey: null,
-        overlayReference: null,
+        overlay: null,
         restorationFailure: 'invalid_overlay',
         routeKey: route.key,
         safeFallbackHref,
@@ -150,8 +222,7 @@ export function restoreWorkspaceShellLocation({
       baseState: route.mode,
       canonicalSearchParams,
       isCanonical,
-      overlayKey: null,
-      overlayReference: null,
+      overlay: null,
       restorationFailure: null,
       routeKey: route.key,
       safeFallbackHref,
@@ -161,11 +232,12 @@ export function restoreWorkspaceShellLocation({
     };
   }
 
-  const overlayReference = parseOverlayReference(
+  const overlayResolution = resolveWorkspaceShellOverlayRequest(
+    overlay,
     requestedOverlayReference,
-    overlay.allowedReferenceKinds,
+    resolveOverlayReferenceAccess,
   );
-  if (requestedOverlayReference && !overlayReference) {
+  if (overlayResolution.failure || !overlayResolution.overlay) {
     canonicalSearchParams.delete('overlay');
     canonicalSearchParams.delete('overlayRef');
 
@@ -173,9 +245,9 @@ export function restoreWorkspaceShellLocation({
       baseState: route.mode,
       canonicalSearchParams,
       isCanonical: false,
-      overlayKey: null,
-      overlayReference: null,
-      restorationFailure: 'invalid_overlay_reference',
+      overlay: null,
+      restorationFailure:
+        overlayResolution.failure ?? 'invalid_overlay_reference',
       routeKey: route.key,
       safeFallbackHref,
       state: route.mode,
@@ -188,8 +260,7 @@ export function restoreWorkspaceShellLocation({
     baseState: route.mode,
     canonicalSearchParams,
     isCanonical,
-    overlayKey: overlay.key,
-    overlayReference,
+    overlay: overlayResolution.overlay,
     restorationFailure: null,
     routeKey: route.key,
     safeFallbackHref,
@@ -202,8 +273,7 @@ export function restoreWorkspaceShellLocation({
 export function buildWorkspaceShellHref(
   href: string,
   params: {
-    readonly overlayKey?: string;
-    readonly overlayReference?: WorkspaceShellTypedReference;
+    readonly overlay?: WorkspaceShellOverlayRequest;
     readonly threadId?: string | null;
   },
 ): string {
@@ -212,14 +282,15 @@ export function buildWorkspaceShellHref(
   if (params.threadId) {
     shellSearchParams.set('thread', params.threadId);
   }
-  if (params.overlayKey) {
-    shellSearchParams.set('overlay', params.overlayKey);
+  if (params.overlay) {
+    shellSearchParams.set('overlay', params.overlay.key);
   }
-  if (params.overlayReference) {
-    shellSearchParams.set(
-      'overlayRef',
-      `${params.overlayReference.kind}:${params.overlayReference.id}`,
-    );
+  if (
+    params.overlay?.key === 'shell-preview' &&
+    params.overlay.parameters.reference
+  ) {
+    const { reference } = params.overlay.parameters;
+    shellSearchParams.set('overlayRef', `${reference.kind}:${reference.id}`);
   }
 
   return appendSearchParamsToHref(href, shellSearchParams);

--- a/apps/app/src/lib/workspace-shell/workspace-shell-registry.spec.ts
+++ b/apps/app/src/lib/workspace-shell/workspace-shell-registry.spec.ts
@@ -128,6 +128,18 @@ describe('workspace shell trusted registry', () => {
         allowedShellModes: ['overlay'],
         canonicalUrl: null,
         kind: 'overlay',
+        parameterContract: { kind: 'none' },
+        presentation: { title: 'Notifications' },
+      },
+    );
+    expect(getWorkspaceShellOverlayRegistration('shell-preview')).toMatchObject(
+      {
+        parameterContract: {
+          allowedReferenceKinds: ['asset', 'post'],
+          kind: 'optional-reference',
+          referenceAccess: 'server-authorized',
+        },
+        presentation: { title: 'Temporary workspace overlay' },
       },
     );
     expect(

--- a/apps/app/src/lib/workspace-shell/workspace-shell-registry.ts
+++ b/apps/app/src/lib/workspace-shell/workspace-shell-registry.ts
@@ -667,7 +667,6 @@ export const WORKSPACE_SHELL_AUXILIARY_REGISTRY = Object.freeze([
   Object.freeze({
     accessPolicy: 'organization-member',
     adapter: Object.freeze({ key: 'notifications', status: 'placeholder' }),
-    allowedReferenceKinds: Object.freeze([] as const),
     allowedShellModes: Object.freeze(['overlay'] as const),
     availability: 'conversation-shell',
     canonicalUrl: null,
@@ -675,6 +674,13 @@ export const WORKSPACE_SHELL_AUXILIARY_REGISTRY = Object.freeze([
     key: 'notifications',
     kind: 'overlay',
     launchTarget: 'overlay',
+    parameterContract: Object.freeze({ kind: 'none' } as const),
+    presentation: Object.freeze({
+      description:
+        'Review workspace notifications without leaving the active conversation or canvas.',
+      openAnnouncement: 'Notifications overlay opened.',
+      title: 'Notifications',
+    }),
     restoration: URL_RESTORATION_POLICY,
     safeFallback: 'same-canonical-url',
     scope: 'organization',
@@ -683,7 +689,6 @@ export const WORKSPACE_SHELL_AUXILIARY_REGISTRY = Object.freeze([
   Object.freeze({
     accessPolicy: 'organization-member',
     adapter: Object.freeze({ key: 'shell-preview', status: 'placeholder' }),
-    allowedReferenceKinds: Object.freeze(['asset', 'post'] as const),
     allowedShellModes: Object.freeze(['overlay'] as const),
     availability: 'conversation-shell',
     canonicalUrl: null,
@@ -691,6 +696,17 @@ export const WORKSPACE_SHELL_AUXILIARY_REGISTRY = Object.freeze([
     key: 'shell-preview',
     kind: 'overlay',
     launchTarget: 'overlay',
+    parameterContract: Object.freeze({
+      allowedReferenceKinds: Object.freeze(['asset', 'post'] as const),
+      kind: 'optional-reference',
+      referenceAccess: 'server-authorized',
+    } as const),
+    presentation: Object.freeze({
+      description:
+        'This trusted placeholder demonstrates restorable overlay state without mutating scope or approving an action.',
+      openAnnouncement: 'Temporary workspace overlay opened.',
+      title: 'Temporary workspace overlay',
+    }),
     restoration: URL_RESTORATION_POLICY,
     safeFallback: 'same-canonical-url',
     scope: 'organization',

--- a/apps/app/src/lib/workspace-shell/workspace-shell-telemetry.ts
+++ b/apps/app/src/lib/workspace-shell/workspace-shell-telemetry.ts
@@ -26,7 +26,12 @@ export function captureWorkspaceShellFallback(
 }
 
 export function captureWorkspaceShellRestorationFailure(
-  reason: 'invalid_overlay' | 'invalid_overlay_reference' | 'invalid_thread',
+  reason:
+    | 'invalid_overlay'
+    | 'invalid_overlay_reference'
+    | 'invalid_thread'
+    | 'stale_overlay_reference'
+    | 'unauthorized_overlay_reference',
 ): void {
   captureAnalyticsEvent(
     ANALYTICS_EVENTS.CONVERSATION_SHELL_RESTORATION_FAILURE,

--- a/packages/agent/src/stores/agent-chat.store.test.ts
+++ b/packages/agent/src/stores/agent-chat.store.test.ts
@@ -1,15 +1,18 @@
 import { useAgentChatStore } from '@genfeedai/agent/stores/agent-chat.store';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+const setItemSpy = vi.fn();
+
 describe('useAgentChatStore overlay coordination', () => {
   beforeEach(() => {
     Object.defineProperty(globalThis, 'localStorage', {
       configurable: true,
       value: {
         getItem: vi.fn(),
-        setItem: vi.fn(),
+        setItem: setItemSpy,
       },
     });
+    setItemSpy.mockClear();
 
     useAgentChatStore.setState({
       isOpen: true,
@@ -33,6 +36,7 @@ describe('useAgentChatStore overlay coordination', () => {
     expect(useAgentChatStore.getState().isOpen).toBe(true);
     expect(useAgentChatStore.getState().overlayActiveIds).toEqual([]);
     expect(useAgentChatStore.getState().overlayAutoCollapsedAgent).toBe(false);
+    expect(setItemSpy).not.toHaveBeenCalled();
   });
 
   it('leaves the agent closed when it was already closed before the overlay', () => {

--- a/packages/agent/src/stores/agent-chat.store.ts
+++ b/packages/agent/src/stores/agent-chat.store.ts
@@ -382,8 +382,6 @@ export const useAgentChatStore = create<AgentChatStore>((set, get) => ({
         };
       }
 
-      persistPanelPreference(false);
-
       return {
         isOpen: false,
         overlayActiveIds: nextOverlayActiveIds,
@@ -435,10 +433,6 @@ export const useAgentChatStore = create<AgentChatStore>((set, get) => ({
         state.wasAgentOpenBeforeOverlay &&
         !state.userChangedAgentDuringOverlay &&
         !state.isOpen;
-
-      if (shouldRestoreAgent) {
-        persistPanelPreference(true);
-      }
 
       return {
         isOpen: shouldRestoreAgent ? true : state.isOpen,

--- a/packages/interfaces/src/ui/workspace-shell.interface.ts
+++ b/packages/interfaces/src/ui/workspace-shell.interface.ts
@@ -37,6 +37,57 @@ export type WorkspaceShellLaunchTarget =
 
 export type WorkspaceShellReferenceKind = 'asset' | 'post';
 
+export interface WorkspaceShellTypedReference {
+  readonly id: string;
+  readonly kind: WorkspaceShellReferenceKind;
+}
+
+export type WorkspaceShellOverlayKey = 'notifications' | 'shell-preview';
+
+export interface WorkspaceShellOverlayParameterMap {
+  readonly notifications: Readonly<Record<string, never>>;
+  readonly 'shell-preview': {
+    readonly reference: WorkspaceShellTypedReference | null;
+  };
+}
+
+export type WorkspaceShellOverlayRequest = {
+  readonly [Key in WorkspaceShellOverlayKey]: {
+    readonly key: Key;
+    readonly parameters: WorkspaceShellOverlayParameterMap[Key];
+  };
+}[WorkspaceShellOverlayKey];
+
+export type WorkspaceShellOverlayReferenceAccess =
+  | 'authorized'
+  | 'stale'
+  | 'unauthorized';
+
+export interface WorkspaceShellOverlayReferenceAccessRequest {
+  readonly overlayKey: WorkspaceShellOverlayKey;
+  readonly reference: WorkspaceShellTypedReference;
+}
+
+export type WorkspaceShellOverlayReferenceAccessResolver = (
+  request: WorkspaceShellOverlayReferenceAccessRequest,
+) => WorkspaceShellOverlayReferenceAccess;
+
+export type WorkspaceShellOverlayParameterContract =
+  | {
+      readonly kind: 'none';
+    }
+  | {
+      readonly allowedReferenceKinds: readonly WorkspaceShellReferenceKind[];
+      readonly kind: 'optional-reference';
+      readonly referenceAccess: 'server-authorized';
+    };
+
+export interface WorkspaceShellOverlayPresentation {
+  readonly description: string;
+  readonly openAnnouncement: string;
+  readonly title: string;
+}
+
 export interface WorkspaceShellRestorationPolicy {
   readonly history: 'canonical-url';
   readonly invalidShellParams: 'replace';
@@ -78,14 +129,15 @@ export interface ResolvedWorkspaceShellRoute
 export interface WorkspaceShellOverlayRegistration {
   readonly accessPolicy: 'organization-member';
   readonly adapter: WorkspaceShellAdapterSeam;
-  readonly allowedReferenceKinds: readonly WorkspaceShellReferenceKind[];
   readonly allowedShellModes: readonly ['overlay'];
   readonly availability: 'conversation-shell';
   readonly canonicalUrl: null;
   readonly deployments: readonly WorkspaceShellDeployment[];
-  readonly key: string;
+  readonly key: WorkspaceShellOverlayKey;
   readonly kind: 'overlay';
   readonly launchTarget: 'overlay';
+  readonly parameterContract: WorkspaceShellOverlayParameterContract;
+  readonly presentation: WorkspaceShellOverlayPresentation;
   readonly restoration: WorkspaceShellRestorationPolicy;
   readonly safeFallback: 'same-canonical-url';
   readonly scope: 'organization';
@@ -127,22 +179,18 @@ export interface ResolveWorkspaceSurfaceLaunchParams {
   readonly threadId?: string | null;
 }
 
-export interface WorkspaceShellTypedReference {
-  readonly id: string;
-  readonly kind: WorkspaceShellReferenceKind;
-}
-
 export type WorkspaceShellRestorationFailure =
   | 'invalid_overlay'
   | 'invalid_overlay_reference'
+  | 'stale_overlay_reference'
+  | 'unauthorized_overlay_reference'
   | 'invalid_thread';
 
 export interface WorkspaceShellLocation {
   readonly baseState: WorkspaceShellBaseState;
   readonly canonicalSearchParams: URLSearchParams;
   readonly isCanonical: boolean;
-  readonly overlayKey: string | null;
-  readonly overlayReference: WorkspaceShellTypedReference | null;
+  readonly overlay: WorkspaceShellOverlayRequest | null;
   readonly restorationFailure: WorkspaceShellRestorationFailure | null;
   readonly routeKey: string;
   readonly safeFallbackHref: string;
@@ -154,5 +202,32 @@ export interface WorkspaceShellLocation {
 export interface RestoreWorkspaceShellLocationParams {
   readonly normalizedPathname: string;
   readonly pathname: string;
+  readonly resolveOverlayReferenceAccess?: WorkspaceShellOverlayReferenceAccessResolver;
   readonly searchParams: URLSearchParams;
+}
+
+export interface WorkspaceShellOverlayResolution {
+  readonly failure: Extract<
+    WorkspaceShellRestorationFailure,
+    | 'invalid_overlay_reference'
+    | 'stale_overlay_reference'
+    | 'unauthorized_overlay_reference'
+  > | null;
+  readonly overlay: WorkspaceShellOverlayRequest | null;
+}
+
+export type WorkspaceShellOverlayInvocation = 'model' | 'user';
+
+export interface ResolveWorkspaceOverlayLaunchParams {
+  readonly currentHref: string;
+  readonly invocation: WorkspaceShellOverlayInvocation;
+  readonly overlay: WorkspaceShellOverlayRequest;
+  readonly resolveOverlayReferenceAccess?: WorkspaceShellOverlayReferenceAccessResolver;
+}
+
+export interface WorkspaceOverlayLaunch {
+  readonly announcement: string;
+  readonly history: 'none' | 'push' | 'replace';
+  readonly href: string;
+  readonly overlay: WorkspaceShellOverlayRequest | null;
 }

--- a/packages/props/ui/workspace-overlay-host.props.ts
+++ b/packages/props/ui/workspace-overlay-host.props.ts
@@ -1,0 +1,14 @@
+import type {
+  WorkspaceShellOverlayRegistration,
+  WorkspaceShellOverlayRequest,
+} from '@genfeedai/interfaces/ui/workspace-shell.interface';
+import type { RefObject } from 'react';
+
+export interface WorkspaceOverlayHostProps {
+  readonly fallbackFocusRef: RefObject<HTMLElement | null>;
+  readonly isOpen: boolean;
+  readonly onDismiss: () => void;
+  readonly overlay: WorkspaceShellOverlayRequest | null;
+  readonly registration: WorkspaceShellOverlayRegistration | null;
+  readonly returnFocusRef: RefObject<HTMLElement | null>;
+}

--- a/packages/services/core/agent-overlay-coordination.service.spec.ts
+++ b/packages/services/core/agent-overlay-coordination.service.spec.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  getAgentOverlayCoordinationState,
+  notifyEntityOverlayClosed,
+  notifyEntityOverlayOpened,
+  requestAgentFromEntityOverlay,
+  setCoordinatedAgentPanelOpen,
+  subscribeAgentOverlayCoordination,
+} from './agent-overlay-coordination.service';
+
+const TEST_OVERLAY_ID = 'coordination-spec-overlay';
+
+describe('agent overlay coordination state', () => {
+  afterEach(() => {
+    notifyEntityOverlayClosed(TEST_OVERLAY_ID);
+    setCoordinatedAgentPanelOpen(false);
+    vi.unstubAllGlobals();
+  });
+
+  it('tracks an entity inspection lifecycle without browser events or storage', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeAgentOverlayCoordination(listener);
+    const dispatchEventSpy = vi.fn();
+    const storageWriteSpy = vi.fn();
+    vi.stubGlobal('window', {
+      dispatchEvent: dispatchEventSpy,
+      localStorage: { setItem: storageWriteSpy },
+    });
+
+    notifyEntityOverlayOpened(TEST_OVERLAY_ID);
+    notifyEntityOverlayOpened(TEST_OVERLAY_ID);
+
+    expect(getAgentOverlayCoordinationState().activeEntityOverlayIds).toEqual([
+      TEST_OVERLAY_ID,
+    ]);
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(dispatchEventSpy).not.toHaveBeenCalled();
+    expect(storageWriteSpy).not.toHaveBeenCalled();
+
+    notifyEntityOverlayClosed(TEST_OVERLAY_ID);
+    expect(getAgentOverlayCoordinationState().activeEntityOverlayIds).toEqual(
+      [],
+    );
+    expect(listener).toHaveBeenCalledTimes(2);
+    unsubscribe();
+  });
+
+  it('accepts an agent-open request only from an active inspection overlay', () => {
+    const versionBefore =
+      getAgentOverlayCoordinationState().agentOpenRequestVersion;
+
+    requestAgentFromEntityOverlay(TEST_OVERLAY_ID);
+    expect(getAgentOverlayCoordinationState().agentOpenRequestVersion).toBe(
+      versionBefore,
+    );
+
+    notifyEntityOverlayOpened(TEST_OVERLAY_ID);
+    requestAgentFromEntityOverlay(TEST_OVERLAY_ID);
+    expect(getAgentOverlayCoordinationState().agentOpenRequestVersion).toBe(
+      versionBefore + 1,
+    );
+  });
+
+  it('publishes the current agent visibility to entity inspection controls', () => {
+    setCoordinatedAgentPanelOpen(true);
+    expect(getAgentOverlayCoordinationState().isAgentPanelOpen).toBe(true);
+
+    setCoordinatedAgentPanelOpen(false);
+    expect(getAgentOverlayCoordinationState().isAgentPanelOpen).toBe(false);
+  });
+});

--- a/packages/services/core/agent-overlay-coordination.service.ts
+++ b/packages/services/core/agent-overlay-coordination.service.ts
@@ -1,59 +1,111 @@
 export const AGENT_PANEL_OPEN_KEY = 'genfeed-agent-panel-open';
-export const AGENT_PANEL_STATE_CHANGED_EVENT =
-  'genfeed:agent-panel-state-changed';
-export const ENTITY_OVERLAY_OPENED_EVENT = 'genfeed:entity-overlay-opened';
-export const ENTITY_OVERLAY_CLOSED_EVENT = 'genfeed:entity-overlay-closed';
-export const ENTITY_OVERLAY_OPEN_AGENT_REQUESTED_EVENT =
-  'genfeed:entity-overlay-open-agent-requested';
 export const AGENT_PANEL_DESKTOP_MEDIA_QUERY = '(min-width: 1024px)';
 
-export interface AgentPanelStateChangedDetail {
-  isOpen: boolean;
+export interface AgentOverlayCoordinationState {
+  readonly activeEntityOverlayIds: readonly string[];
+  readonly agentOpenRequestVersion: number;
+  readonly isAgentPanelOpen: boolean;
 }
 
-export interface EntityOverlayVisibilityDetail {
-  overlayId: string;
-}
+type AgentOverlayCoordinationListener = () => void;
 
-function dispatchWindowEvent<TDetail>(
-  eventName: string,
-  detail: TDetail,
-): void {
-  if (typeof window === 'undefined') {
+const listeners = new Set<AgentOverlayCoordinationListener>();
+
+const SERVER_STATE: AgentOverlayCoordinationState = Object.freeze({
+  activeEntityOverlayIds: Object.freeze([]),
+  agentOpenRequestVersion: 0,
+  isAgentPanelOpen: false,
+});
+
+let state: AgentOverlayCoordinationState = SERVER_STATE;
+
+function publishState(nextState: AgentOverlayCoordinationState): void {
+  if (nextState === state) {
     return;
   }
 
-  window.dispatchEvent(new CustomEvent<TDetail>(eventName, { detail }));
+  state = Object.freeze({
+    ...nextState,
+    activeEntityOverlayIds: Object.freeze([
+      ...nextState.activeEntityOverlayIds,
+    ]),
+  });
+  for (const listener of listeners) {
+    listener();
+  }
 }
 
-export function dispatchAgentPanelStateChanged(isOpen: boolean): void {
-  dispatchWindowEvent<AgentPanelStateChangedDetail>(
-    AGENT_PANEL_STATE_CHANGED_EVENT,
-    { isOpen },
-  );
+export function getAgentOverlayCoordinationState(): AgentOverlayCoordinationState {
+  return state;
 }
 
-export function dispatchEntityOverlayOpened(overlayId: string): void {
-  dispatchWindowEvent<EntityOverlayVisibilityDetail>(
-    ENTITY_OVERLAY_OPENED_EVENT,
-    { overlayId },
-  );
+export function getServerAgentOverlayCoordinationState(): AgentOverlayCoordinationState {
+  return SERVER_STATE;
 }
 
-export function dispatchEntityOverlayClosed(overlayId: string): void {
-  dispatchWindowEvent<EntityOverlayVisibilityDetail>(
-    ENTITY_OVERLAY_CLOSED_EVENT,
-    { overlayId },
-  );
+export function subscribeAgentOverlayCoordination(
+  listener: AgentOverlayCoordinationListener,
+): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
 }
 
-export function dispatchEntityOverlayOpenAgentRequested(
-  overlayId: string,
-): void {
-  dispatchWindowEvent<EntityOverlayVisibilityDetail>(
-    ENTITY_OVERLAY_OPEN_AGENT_REQUESTED_EVENT,
-    { overlayId },
-  );
+export function notifyEntityOverlayOpened(overlayId: string): void {
+  if (!overlayId || state.activeEntityOverlayIds.includes(overlayId)) {
+    return;
+  }
+
+  publishState({
+    ...state,
+    activeEntityOverlayIds: [...state.activeEntityOverlayIds, overlayId],
+  });
+}
+
+export function notifyEntityOverlayClosed(overlayId: string): void {
+  if (!state.activeEntityOverlayIds.includes(overlayId)) {
+    return;
+  }
+
+  publishState({
+    ...state,
+    activeEntityOverlayIds: state.activeEntityOverlayIds.filter(
+      (activeOverlayId) => activeOverlayId !== overlayId,
+    ),
+  });
+}
+
+export function requestAgentFromEntityOverlay(overlayId: string): void {
+  if (!overlayId || !state.activeEntityOverlayIds.includes(overlayId)) {
+    return;
+  }
+
+  publishState({
+    ...state,
+    agentOpenRequestVersion: state.agentOpenRequestVersion + 1,
+  });
+}
+
+export function setCoordinatedAgentPanelOpen(isOpen: boolean): void {
+  if (state.isAgentPanelOpen === isOpen) {
+    return;
+  }
+
+  publishState({ ...state, isAgentPanelOpen: isOpen });
+}
+
+export function subscribeDesktopAgentViewport(
+  listener: () => void,
+): () => void {
+  if (
+    typeof window === 'undefined' ||
+    typeof window.matchMedia !== 'function'
+  ) {
+    return () => undefined;
+  }
+
+  const mediaQuery = window.matchMedia(AGENT_PANEL_DESKTOP_MEDIA_QUERY);
+  mediaQuery.addEventListener('change', listener);
+  return () => mediaQuery.removeEventListener('change', listener);
 }
 
 export function isDesktopAgentViewport(): boolean {
@@ -65,18 +117,4 @@ export function isDesktopAgentViewport(): boolean {
   }
 
   return window.matchMedia(AGENT_PANEL_DESKTOP_MEDIA_QUERY).matches;
-}
-
-export function getStoredAgentPanelOpenState(): boolean | null {
-  if (typeof window === 'undefined') {
-    return null;
-  }
-
-  const stored = window.localStorage.getItem(AGENT_PANEL_OPEN_KEY);
-
-  if (stored === null) {
-    return null;
-  }
-
-  return stored === 'true';
 }

--- a/packages/ui/src/components/overlays/entity/EntityOverlayShell.test.tsx
+++ b/packages/ui/src/components/overlays/entity/EntityOverlayShell.test.tsx
@@ -1,12 +1,13 @@
 import '@testing-library/jest-dom/vitest';
 import {
-  ENTITY_OVERLAY_OPEN_AGENT_REQUESTED_EVENT,
-  ENTITY_OVERLAY_OPENED_EVENT,
+  getAgentOverlayCoordinationState,
+  notifyEntityOverlayClosed,
+  setCoordinatedAgentPanelOpen,
 } from '@genfeedai/services/core/agent-overlay-coordination.service';
 import { fireEvent, render, screen } from '@testing-library/react';
 import EntityOverlayShell from '@ui/overlays/entity/EntityOverlayShell';
 import type { PropsWithChildren, ReactNode } from 'react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@genfeedai/helpers/ui/modal/modal.helper', () => ({
   closeModal: vi.fn(),
@@ -72,13 +73,11 @@ describe('EntityOverlayShell', () => {
       }),
     });
 
-    Object.defineProperty(globalThis, 'localStorage', {
-      configurable: true,
-      value: {
-        getItem: vi.fn().mockReturnValue('false'),
-      },
-    });
+    notifyEntityOverlayClosed('entity-overlay');
+    setCoordinatedAgentPanelOpen(false);
   });
+
+  afterEach(() => notifyEntityOverlayClosed('entity-overlay'));
 
   it('renders the standard open-page action when provided', () => {
     const handleOpenDetail = vi.fn();
@@ -100,14 +99,9 @@ describe('EntityOverlayShell', () => {
     expect(screen.getByText('Body')).toBeInTheDocument();
   });
 
-  it('dispatches an overlay-open event and exposes the open-agent action on desktop', () => {
-    const dispatchEventSpy = vi.spyOn(window, 'dispatchEvent');
-    const openAgentRequestedSpy = vi.fn();
-
-    window.addEventListener(
-      ENTITY_OVERLAY_OPEN_AGENT_REQUESTED_EVENT,
-      openAgentRequestedSpy,
-    );
+  it('publishes typed inspection state and exposes the open-agent action on desktop', () => {
+    const requestVersionBefore =
+      getAgentOverlayCoordinationState().agentOpenRequestVersion;
 
     render(
       <EntityOverlayShell
@@ -119,20 +113,32 @@ describe('EntityOverlayShell', () => {
       </EntityOverlayShell>,
     );
 
-    expect(dispatchEventSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        detail: { overlayId: 'entity-overlay' },
-        type: ENTITY_OVERLAY_OPENED_EVENT,
-      }),
+    expect(getAgentOverlayCoordinationState().activeEntityOverlayIds).toContain(
+      'entity-overlay',
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Open agent' }));
 
-    expect(openAgentRequestedSpy).toHaveBeenCalledTimes(1);
-
-    window.removeEventListener(
-      ENTITY_OVERLAY_OPEN_AGENT_REQUESTED_EVENT,
-      openAgentRequestedSpy,
+    expect(getAgentOverlayCoordinationState().agentOpenRequestVersion).toBe(
+      requestVersionBefore + 1,
     );
+  });
+
+  it('hides the redundant open-agent action while the agent is open', () => {
+    setCoordinatedAgentPanelOpen(true);
+
+    render(
+      <EntityOverlayShell
+        id="entity-overlay"
+        title="Entity"
+        description="Entity description"
+      >
+        <div>Body</div>
+      </EntityOverlayShell>,
+    );
+
+    expect(
+      screen.queryByRole('button', { name: 'Open agent' }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/packages/ui/src/components/overlays/entity/EntityOverlayShell.tsx
+++ b/packages/ui/src/components/overlays/entity/EntityOverlayShell.tsx
@@ -10,13 +10,13 @@ import {
 } from '@genfeedai/helpers/ui/modal/modal.helper';
 import {
   AGENT_PANEL_DESKTOP_MEDIA_QUERY,
-  AGENT_PANEL_STATE_CHANGED_EVENT,
-  type AgentPanelStateChangedDetail,
-  dispatchEntityOverlayClosed,
-  dispatchEntityOverlayOpenAgentRequested,
-  dispatchEntityOverlayOpened,
-  getStoredAgentPanelOpenState,
+  getAgentOverlayCoordinationState,
+  getServerAgentOverlayCoordinationState,
   isDesktopAgentViewport,
+  notifyEntityOverlayClosed,
+  notifyEntityOverlayOpened,
+  requestAgentFromEntityOverlay,
+  subscribeAgentOverlayCoordination,
 } from '@genfeedai/services/core/agent-overlay-coordination.service';
 import { Button } from '@ui/primitives/button';
 import {
@@ -92,16 +92,21 @@ export default function EntityOverlayShell({
   );
   const getSnapshot = useCallback(() => isModalOpen(id), [id]);
   const isOpen = useSyncExternalStore(subscribe, getSnapshot, () => false);
+  const overlayCoordinationState = useSyncExternalStore(
+    subscribeAgentOverlayCoordination,
+    getAgentOverlayCoordinationState,
+    getServerAgentOverlayCoordinationState,
+  );
 
   const onCloseRef = useRef(onClose);
   onCloseRef.current = onClose;
   const previousOpenRef = useRef(isOpen);
   const overlaySessionOpenRef = useRef(false);
-  const [canOpenAgent, setCanOpenAgent] = useState<boolean>(() => {
-    const storedAgentState = getStoredAgentPanelOpenState();
-
-    return isDesktopAgentViewport() && storedAgentState !== true;
-  });
+  const [isDesktopViewport, setIsDesktopViewport] = useState(
+    isDesktopAgentViewport,
+  );
+  const canOpenAgent =
+    isDesktopViewport && !overlayCoordinationState.isAgentPanelOpen;
 
   const handleOpenChange = useCallback(
     (open: boolean) => {
@@ -126,12 +131,12 @@ export default function EntityOverlayShell({
   useEffect(() => {
     if (isOpen && !overlaySessionOpenRef.current) {
       overlaySessionOpenRef.current = true;
-      dispatchEntityOverlayOpened(id);
+      notifyEntityOverlayOpened(id);
     }
 
     if (!isOpen && overlaySessionOpenRef.current) {
       overlaySessionOpenRef.current = false;
-      dispatchEntityOverlayClosed(id);
+      notifyEntityOverlayClosed(id);
     }
   }, [id, isOpen]);
 
@@ -141,38 +146,21 @@ export default function EntityOverlayShell({
     }
 
     const mediaQuery = window.matchMedia(AGENT_PANEL_DESKTOP_MEDIA_QUERY);
-    const syncAgentActionAvailability = (): void => {
-      const storedAgentState = getStoredAgentPanelOpenState();
+    const syncDesktopViewport = (): void =>
+      setIsDesktopViewport(mediaQuery.matches);
 
-      setCanOpenAgent(mediaQuery.matches && storedAgentState !== true);
-    };
-    const handleAgentStateChanged = (event: Event): void => {
-      setCanOpenAgent(
-        mediaQuery.matches &&
-          !(event as CustomEvent<AgentPanelStateChangedDetail>).detail.isOpen,
-      );
-    };
-
-    syncAgentActionAvailability();
-    mediaQuery.addEventListener('change', syncAgentActionAvailability);
-    window.addEventListener(
-      AGENT_PANEL_STATE_CHANGED_EVENT,
-      handleAgentStateChanged,
-    );
+    syncDesktopViewport();
+    mediaQuery.addEventListener('change', syncDesktopViewport);
 
     return () => {
-      mediaQuery.removeEventListener('change', syncAgentActionAvailability);
-      window.removeEventListener(
-        AGENT_PANEL_STATE_CHANGED_EVENT,
-        handleAgentStateChanged,
-      );
+      mediaQuery.removeEventListener('change', syncDesktopViewport);
     };
   }, []);
 
   useEffect(() => {
     return () => {
       if (overlaySessionOpenRef.current) {
-        dispatchEntityOverlayClosed(id);
+        notifyEntityOverlayClosed(id);
         overlaySessionOpenRef.current = false;
       }
     };
@@ -227,9 +215,7 @@ export default function EntityOverlayShell({
                       <Button
                         label="Open agent"
                         variant={ButtonVariant.SECONDARY}
-                        onClick={() =>
-                          dispatchEntityOverlayOpenAgentRequested(id)
-                        }
+                        onClick={() => requestAgentFromEntityOverlay(id)}
                       />
                     ) : null}
                     {actions}


### PR DESCRIPTION
## Summary

- define trusted typed overlay keys and parameter contracts in the existing workspace registry, with fail-closed URL restoration and a user-gated launcher
- add one shell-owned accessible overlay host that preserves the mounted conversation, canvas, inspector, and history state while preventing nested overlays
- replace shell-level CustomEvent/localStorage entity-overlay coordination with a typed subscription lifecycle while retaining direct entity inspection sheets
- cover Back dismissal, canonical fallback, authorization failures, focus restoration, registry trust, and removal of legacy coordination call sites

## Verification

- `bunx biome check` on all 22 changed files
- `bun run check:design-system`
- pre-commit UI control, bespoke-card, Biome, and secretlint guards
- Gitleaks staged and commit scans
- no local tests, typechecks, builds, or E2E per workstation policy; PR CI is authoritative

## Concurrent work

- PR #1693 shares only the required `UniversalWorkspaceShell` integration seam; #1694 and #1695 have no file overlap

Closes #1677
Part of #1670