### PR TITLE
feat(agent): add prompt-bar scope controls

### DIFF
--- a/apps/app/src/components/workspace-shell/UniversalWorkspaceShell.test.tsx
+++ b/apps/app/src/components/workspace-shell/UniversalWorkspaceShell.test.tsx
@@ -206,6 +206,15 @@ vi.mock('@/lib/workspace-shell/workspace-shell-telemetry', () => ({
   captureWorkspaceShellTransition: vi.fn(),
 }));
 
+vi.mock('./use-conversation-scope-controls', () => ({
+  useConversationScopeControls: () => ({
+    contextLabel: 'Acme · Organization-wide',
+    inspectorScope: <div data-testid="workspace-effective-scope" />,
+    isConsequentiallyBlocked: false,
+    scopeControls: <span>Thread scope</span>,
+  }),
+}));
+
 import UniversalWorkspaceShell from './UniversalWorkspaceShell';
 
 describe('UniversalWorkspaceShell', () => {
@@ -358,6 +367,8 @@ describe('UniversalWorkspaceShell', () => {
     );
 
     expect(screen.getByText('Scoped controls')).toBeInTheDocument();
+    expect(screen.getByText('Thread scope')).toBeInTheDocument();
+    expect(screen.getByTestId('workspace-effective-scope')).toBeInTheDocument();
   });
 
   it('preserves an unauthorized brand action instead of widening org scope', () => {

--- a/apps/app/src/components/workspace-shell/UniversalWorkspaceShell.tsx
+++ b/apps/app/src/components/workspace-shell/UniversalWorkspaceShell.tsx
@@ -59,6 +59,7 @@ import {
   captureWorkspaceShellTransition,
 } from '@/lib/workspace-shell/workspace-shell-telemetry';
 import { resolveWorkspaceSurfaceLaunch } from '@/lib/workspace-shell/workspace-surface-launcher';
+import { useConversationScopeControls } from './use-conversation-scope-controls';
 import WorkspaceOverlayHost from './WorkspaceOverlayHost';
 
 const INSPECTOR_DEFAULT_WIDTH = 320;
@@ -74,7 +75,9 @@ type UniversalWorkspaceShellProps = {
 type UniversalWorkspaceShellContentProps = Pick<
   UniversalWorkspaceShellProps,
   'children' | 'composerScopeControls'
->;
+> & {
+  readonly agentApiService: AgentApiService;
+};
 
 function clampInspectorWidth(width: number): number {
   return Math.min(INSPECTOR_MAX_WIDTH, Math.max(INSPECTOR_MIN_WIDTH, width));
@@ -93,6 +96,7 @@ function requireWorkspaceShellLocation(
 }
 
 function UniversalWorkspaceShellContent({
+  agentApiService,
   children,
   composerScopeControls,
 }: UniversalWorkspaceShellContentProps) {
@@ -176,12 +180,20 @@ function UniversalWorkspaceShellContent({
     [effectiveThreadId, threads],
   );
   const draftScopeKey = `${orgSlug || 'unknown'}:${effectiveThreadId ?? 'new'}:${activeThread?.contextVersion ?? 0}`;
-  const composerContextLabel =
+  const shellContextLabel =
     state === 'conversation'
       ? 'Conversation'
       : state === 'overlay'
         ? 'Overlay · conversation connected'
         : `Canvas · ${shellLocation.routeKey.replace(/^canvas:/, '')}`;
+  const conversationScope = useConversationScopeControls({
+    activeThread,
+    apiService: agentApiService,
+    currentDraftScopeKey: draftScopeKey,
+    pathname: rawPathname,
+    searchParams: new URLSearchParams(searchParamsString),
+  });
+  const composerContextLabel = `${conversationScope.contextLabel} · ${shellContextLabel}`;
 
   useLayoutEffect(() => {
     if (!isUnthreadedConversation) {
@@ -341,6 +353,13 @@ function UniversalWorkspaceShellContent({
       const trustedAction = getConversationComposerAction(
         invocation.action.name,
       );
+      if (conversationScope.isConsequentiallyBlocked) {
+        return {
+          message:
+            'Synchronize the server-authoritative conversation scope before opening consequential actions. Your draft is unchanged.',
+          status: 'unauthorized',
+        };
+      }
       if (
         !trustedAction ||
         trustedAction.route !== invocation.action.route ||
@@ -390,6 +409,7 @@ function UniversalWorkspaceShellContent({
     [
       activeThreadId,
       brandSlug,
+      conversationScope.isConsequentiallyBlocked,
       currentHref,
       effectiveThreadId,
       href,
@@ -472,6 +492,7 @@ function UniversalWorkspaceShellContent({
         />
       </div>
       <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4">
+        {conversationScope.inspectorScope}
         <div className="gen-shell-empty-state p-4">
           <p className="text-sm font-medium text-foreground">
             Registered {surfaceKey} adapter slot
@@ -506,8 +527,14 @@ function UniversalWorkspaceShellContent({
       contextLabel={composerContextLabel}
       dispatchAction={handleComposerAction}
       draftScopeKey={draftScopeKey}
+      isConsequentiallyBlocked={conversationScope.isConsequentiallyBlocked}
       portalTarget={composerPortalTarget}
-      scopeControls={composerScopeControls}
+      scopeControls={
+        <>
+          {conversationScope.scopeControls}
+          {composerScopeControls}
+        </>
+      }
       shellState={state}
     >
       <div
@@ -701,6 +728,7 @@ export default function UniversalWorkspaceShell({
   return (
     <AgentWorkspaceLayoutClient agentApiService={agentApiService}>
       <UniversalWorkspaceShellContent
+        agentApiService={agentApiService}
         composerScopeControls={composerScopeControls}
       >
         {children}

--- a/apps/app/src/components/workspace-shell/use-conversation-scope-controls.test.tsx
+++ b/apps/app/src/components/workspace-shell/use-conversation-scope-controls.test.tsx
@@ -1,0 +1,242 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+
+const router = vi.hoisted(() => ({ push: vi.fn(), replace: vi.fn() }));
+const organizationService = vi.hoisted(() => ({
+  getMyOrganizations: vi.fn(),
+  switchOrganization: vi.fn(),
+}));
+const store = vi.hoisted(() => ({
+  activeRunStatus: 'idle',
+  isGenerating: false,
+  resetActiveConversationState: vi.fn(),
+  setActiveThread: vi.fn(),
+  upsertThread: vi.fn(),
+}));
+const api = vi.hoisted(() => ({
+  createThreadEffect: vi.fn(),
+  getThreadEffect: vi.fn(),
+  updateThreadContextEffect: vi.fn(),
+}));
+
+const brands = [
+  {
+    id: 'brand-a',
+    label: 'Brand A',
+    organization: { id: 'org-1', slug: 'acme' },
+    slug: 'brand-a',
+  },
+  {
+    id: 'brand-b',
+    label: 'Brand B',
+    organization: { id: 'org-1', slug: 'acme' },
+    slug: 'brand-b',
+  },
+];
+
+vi.mock('@genfeedai/agent', () => ({
+  runAgentApiEffect: (effect: Promise<unknown>) => effect,
+  useAgentChatStore: (selector: (state: typeof store) => unknown) =>
+    selector(store),
+}));
+
+vi.mock('@genfeedai/contexts/user/brand-context/brand-context', () => ({
+  useBrand: () => ({
+    brandId: 'brand-a',
+    brands,
+    organizationId: 'org-1',
+  }),
+}));
+
+vi.mock('@genfeedai/hooks/auth/use-authed-service/use-authed-service', () => ({
+  useAuthedService: () => async () => organizationService,
+}));
+
+vi.mock('next/navigation', () => ({ useRouter: () => router }));
+
+vi.mock('@/lib/workspace-shell/workspace-shell-registry', () => ({
+  resolveWorkspaceShellRoute: () => ({ mode: 'canvas' }),
+}));
+
+vi.mock('@ui/menus/switcher-dropdown/SwitcherDropdown', () => ({
+  default: ({
+    items,
+    onSelect,
+    renderTrigger,
+  }: {
+    items: { id: string; label: string }[];
+    onSelect: (id: string) => void;
+    renderTrigger: (state: { isOpen: boolean }) => ReactNode;
+  }) => (
+    <div>
+      {renderTrigger({ isOpen: false })}
+      {items.map((item) => (
+        <button key={item.id} onClick={() => onSelect(item.id)} type="button">
+          Select {item.label}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock('@ui/primitives/button', () => ({
+  Button: ({
+    ariaLabel,
+    children,
+    isDisabled,
+    onClick,
+  }: {
+    ariaLabel?: string;
+    children?: ReactNode;
+    isDisabled?: boolean;
+    onClick?: () => void;
+  }) => (
+    <button
+      aria-label={ariaLabel}
+      disabled={isDisabled}
+      onClick={onClick}
+      type="button"
+    >
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock('@ui/primitives/dialog', () => ({
+  Dialog: ({ children, open }: { children: ReactNode; open: boolean }) =>
+    open ? <div>{children}</div> : null,
+  DialogContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogDescription: ({ children }: { children: ReactNode }) => (
+    <p>{children}</p>
+  ),
+  DialogFooter: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogHeader: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+}));
+
+import { useConversationScopeControls } from './use-conversation-scope-controls';
+
+const activeThread = {
+  brandId: 'brand-a',
+  contextVersion: 3,
+  createdAt: '2026-07-13T00:00:00.000Z',
+  id: 'thread-1',
+  organizationId: 'org-1',
+  status: 'active',
+  updatedAt: '2026-07-13T00:00:00.000Z',
+} as const;
+
+function Harness() {
+  const state = useConversationScopeControls({
+    activeThread: activeThread as never,
+    apiService: api as never,
+    currentDraftScopeKey: 'acme:thread-1:3',
+    pathname: '/acme/brand-a/library/images',
+    searchParams: new URLSearchParams('thread=thread-1'),
+  });
+
+  return (
+    <div>
+      <span>{state.contextLabel}</span>
+      <span>{state.isConsequentiallyBlocked ? 'blocked' : 'ready'}</span>
+      {state.scopeControls}
+      {state.inspectorScope}
+    </div>
+  );
+}
+
+describe('useConversationScopeControls', () => {
+  beforeEach(() => {
+    store.activeRunStatus = 'idle';
+    store.isGenerating = false;
+    store.upsertThread.mockReset();
+    router.push.mockReset();
+    router.replace.mockReset();
+    organizationService.getMyOrganizations.mockResolvedValue([
+      { id: 'org-1', isActive: true, label: 'Acme', slug: 'acme' },
+      { id: 'org-2', isActive: false, label: 'Other', slug: 'other' },
+    ]);
+    api.updateThreadContextEffect.mockResolvedValue({
+      ...activeThread,
+      brandId: 'brand-b',
+      contextVersion: 4,
+    });
+    api.getThreadEffect.mockResolvedValue(activeThread);
+    window.sessionStorage.clear();
+    window.localStorage.clear();
+  });
+
+  it('mutates only authoritative thread context when an authorized brand is selected', async () => {
+    render(<Harness />);
+
+    expect(await screen.findByText('Acme · Brand A')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Select Brand B' }));
+
+    await waitFor(() =>
+      expect(api.updateThreadContextEffect).toHaveBeenCalledWith('thread-1', {
+        brandId: 'brand-b',
+        expectedContextVersion: 3,
+      }),
+    );
+    expect(store.upsertThread).toHaveBeenCalledWith(
+      expect.objectContaining({ brandId: 'brand-b', contextVersion: 4 }),
+    );
+    expect(router.push).toHaveBeenCalledWith(
+      '/acme/brand-b/library/images?thread=thread-1',
+    );
+  });
+
+  it('blocks consequential controls after another tab publishes a newer version', async () => {
+    api.getThreadEffect.mockResolvedValue({
+      ...activeThread,
+      brandId: 'brand-b',
+      contextVersion: 4,
+    });
+    render(<Harness />);
+
+    window.dispatchEvent(
+      new StorageEvent('storage', {
+        key: 'genfeed:agent-thread-context:v1:thread-1',
+        newValue: JSON.stringify({
+          brandId: 'brand-b',
+          contextVersion: 4,
+          organizationId: 'org-1',
+          threadId: 'thread-1',
+        }),
+      }),
+    );
+
+    expect(await screen.findByText('blocked')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Synchronize scope' }));
+
+    await waitFor(() => expect(screen.getByText('ready')).toBeInTheDocument());
+    expect(router.replace).toHaveBeenCalledWith(
+      '/acme/brand-b/library/images?thread=thread-1',
+    );
+  });
+
+  it('requires active work to stop before organization scope can change', async () => {
+    store.activeRunStatus = 'running';
+    render(<Harness />);
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Select Other' }),
+    );
+
+    expect(
+      screen.getByText('Stop active work before switching scope'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Start clean thread' }),
+    ).toBeDisabled();
+    expect(organizationService.switchOrganization).not.toHaveBeenCalled();
+  });
+});

--- a/apps/app/src/components/workspace-shell/use-conversation-scope-controls.tsx
+++ b/apps/app/src/components/workspace-shell/use-conversation-scope-controls.tsx
@@ -1,0 +1,721 @@
+'use client';
+
+import {
+  type AgentApiService,
+  type AgentThread,
+  runAgentApiEffect,
+  useAgentChatStore,
+} from '@genfeedai/agent';
+import {
+  clearConversationComposerDraft,
+  readConversationComposerDraft,
+  writeConversationComposerAttachments,
+  writeConversationComposerDocument,
+} from '@genfeedai/agent/stores/conversation-composer-draft.store';
+import { useBrand } from '@genfeedai/contexts/user/brand-context/brand-context';
+import {
+  getBrandEntityId,
+  getBrandOrganizationId,
+  getBrandOrganizationSlug,
+} from '@genfeedai/contexts/user/brand-context/brand-context.helpers';
+import { ButtonSize, ButtonVariant } from '@genfeedai/enums';
+import { useAuthedService } from '@genfeedai/hooks/auth/use-authed-service/use-authed-service';
+import type { Brand } from '@genfeedai/models/organization/brand.model';
+import { OrganizationsService } from '@genfeedai/services/organization/organizations.service';
+import { cn } from '@helpers/formatting/cn/cn.util';
+import SwitcherDropdown from '@ui/menus/switcher-dropdown/SwitcherDropdown';
+import { Button } from '@ui/primitives/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@ui/primitives/dialog';
+import { useRouter } from 'next/navigation';
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import {
+  HiChevronDown,
+  HiOutlineBuildingOffice2,
+  HiOutlineTag,
+} from 'react-icons/hi2';
+import {
+  buildConversationScopeHref,
+  buildOrganizationNewThreadHref,
+  buildScopedThreadHref,
+} from '@/lib/workspace-shell/conversation-scope-location';
+import { resolveWorkspaceShellRoute } from '@/lib/workspace-shell/workspace-shell-registry';
+
+const CONTEXT_STORAGE_PREFIX = 'genfeed:agent-thread-context:v1';
+
+interface OrganizationOption {
+  readonly id: string;
+  readonly isActive: boolean;
+  readonly label: string;
+  readonly slug: string;
+}
+
+interface AuthoritativeContextNotice {
+  readonly brandId: string | null;
+  readonly contextVersion: number;
+  readonly organizationId: string;
+  readonly threadId: string;
+}
+
+type PendingScopeChange =
+  | { readonly kind: 'brand'; readonly brand: Brand | null }
+  | {
+      readonly kind: 'organization';
+      readonly organization: OrganizationOption;
+    };
+
+interface UseConversationScopeControlsParams {
+  readonly activeThread: AgentThread | null;
+  readonly apiService: AgentApiService;
+  readonly currentDraftScopeKey: string;
+  readonly pathname: string;
+  readonly searchParams: URLSearchParams;
+}
+
+export interface ConversationScopeControlsState {
+  readonly contextLabel: string;
+  readonly inspectorScope: ReactNode;
+  readonly isConsequentiallyBlocked: boolean;
+  readonly scopeControls: ReactNode;
+}
+
+function contextStorageKey(threadId: string): string {
+  return `${CONTEXT_STORAGE_PREFIX}:${threadId}`;
+}
+
+function hasDraftContent(scopeKey: string): boolean {
+  const draft = readConversationComposerDraft(scopeKey);
+  return Boolean(draft.plainText.trim() || draft.attachments.length > 0);
+}
+
+function plainTextDocument(plainText: string) {
+  return {
+    content: [
+      {
+        content: plainText ? [{ text: plainText, type: 'text' }] : undefined,
+        type: 'paragraph',
+      },
+    ],
+    type: 'doc',
+  };
+}
+
+function preserveDraftText(
+  sourceScopeKey: string,
+  targetScopeKey: string,
+): void {
+  const draft = readConversationComposerDraft(sourceScopeKey);
+  writeConversationComposerDocument(
+    targetScopeKey,
+    plainTextDocument(draft.plainText),
+    draft.plainText,
+  );
+  writeConversationComposerAttachments(targetScopeKey, []);
+}
+
+function parseContextNotice(
+  value: string | null,
+): AuthoritativeContextNotice | null {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(value) as Partial<AuthoritativeContextNotice>;
+    if (typeof parsed.brandId !== 'string' && parsed.brandId !== null) {
+      return null;
+    }
+    if (
+      typeof parsed.contextVersion !== 'number' ||
+      typeof parsed.organizationId !== 'string' ||
+      typeof parsed.threadId !== 'string'
+    ) {
+      return null;
+    }
+    return parsed as AuthoritativeContextNotice;
+  } catch {
+    return null;
+  }
+}
+
+function publishContextNotice(thread: AgentThread): void {
+  if (!thread.organizationId) {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(
+      contextStorageKey(thread.id),
+      JSON.stringify({
+        brandId: thread.brandId ?? null,
+        contextVersion: thread.contextVersion,
+        organizationId: thread.organizationId,
+        threadId: thread.id,
+      } satisfies AuthoritativeContextNotice),
+    );
+  } catch {
+    // Focus revalidation remains the server-authoritative fallback.
+  }
+}
+
+function ScopeTrigger({
+  icon,
+  isOpen,
+  label,
+}: {
+  readonly icon: ReactNode;
+  readonly isOpen: boolean;
+  readonly label: string;
+}) {
+  return (
+    <Button
+      ariaLabel={`Change ${label} scope`}
+      className="h-7 max-w-44 gap-1.5 px-2 text-[11px]"
+      icon={icon}
+      size={ButtonSize.SM}
+      variant={ButtonVariant.GHOST}
+      withWrapper={false}
+    >
+      <span className="truncate">{label}</span>
+      <HiChevronDown
+        aria-hidden="true"
+        className={cn('size-3 transition-transform', isOpen && 'rotate-180')}
+      />
+    </Button>
+  );
+}
+
+export function useConversationScopeControls({
+  activeThread,
+  apiService,
+  currentDraftScopeKey,
+  pathname,
+  searchParams,
+}: UseConversationScopeControlsParams): ConversationScopeControlsState {
+  const { push, replace } = useRouter();
+  const {
+    brandId: globalBrandId,
+    brands,
+    organizationId: globalOrganizationId,
+  } = useBrand();
+  const getOrganizationsService = useAuthedService((token: string) =>
+    OrganizationsService.getInstance(token),
+  );
+  const activeRunStatus = useAgentChatStore((state) => state.activeRunStatus);
+  const isGenerating = useAgentChatStore((state) => state.isGenerating);
+  const resetActiveConversationState = useAgentChatStore(
+    (state) => state.resetActiveConversationState,
+  );
+  const setActiveThread = useAgentChatStore((state) => state.setActiveThread);
+  const upsertThread = useAgentChatStore((state) => state.upsertThread);
+  const [organizations, setOrganizations] = useState<OrganizationOption[]>([]);
+  const [isLoadingOrganizations, setIsLoadingOrganizations] = useState(true);
+  const [isMutating, setIsMutating] = useState(false);
+  const [pendingChange, setPendingChange] = useState<PendingScopeChange | null>(
+    null,
+  );
+  const [scopeError, setScopeError] = useState<string | null>(null);
+  const [staleContext, setStaleContext] =
+    useState<AuthoritativeContextNotice | null>(null);
+
+  const currentOrganizationId =
+    activeThread?.organizationId ?? globalOrganizationId;
+  const effectiveOrganization =
+    organizations.find(
+      (organization) => organization.id === currentOrganizationId,
+    ) ?? organizations.find((organization) => organization.isActive);
+  const organizationBrand = brands.find(
+    (brand) => getBrandOrganizationId(brand) === currentOrganizationId,
+  );
+  const currentOrganizationSlug =
+    effectiveOrganization?.slug ||
+    getBrandOrganizationSlug(organizationBrand) ||
+    pathname.split('/').filter(Boolean)[0] ||
+    '';
+  const effectiveBrandId = activeThread
+    ? (activeThread.brandId ?? null)
+    : globalBrandId || null;
+  const authorizedBrands = useMemo(
+    () =>
+      brands.filter(
+        (brand) => getBrandOrganizationId(brand) === currentOrganizationId,
+      ),
+    [brands, currentOrganizationId],
+  );
+  const effectiveBrand = authorizedBrands.find(
+    (brand) => getBrandEntityId(brand) === effectiveBrandId,
+  );
+  const isActiveWork =
+    isGenerating ||
+    activeRunStatus === 'running' ||
+    activeRunStatus === 'cancelling' ||
+    activeThread?.runStatus === 'queued' ||
+    activeThread?.runStatus === 'running' ||
+    activeThread?.runStatus === 'waiting_input';
+  const isStale = Boolean(
+    staleContext &&
+      activeThread &&
+      staleContext.contextVersion > activeThread.contextVersion,
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const service = await getOrganizationsService();
+        const nextOrganizations = await service.getMyOrganizations();
+        if (!cancelled) {
+          setOrganizations(nextOrganizations);
+          setScopeError(null);
+        }
+      } catch {
+        if (!cancelled) {
+          setScopeError('Authorized organizations could not be loaded.');
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoadingOrganizations(false);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [getOrganizationsService]);
+
+  const observeLatestThread = useCallback(async () => {
+    if (!activeThread) {
+      return null;
+    }
+    try {
+      const latest = await runAgentApiEffect(
+        apiService.getThreadEffect(activeThread.id),
+      );
+      if (latest.contextVersion > activeThread.contextVersion) {
+        setStaleContext({
+          brandId: latest.brandId ?? null,
+          contextVersion: latest.contextVersion,
+          organizationId:
+            latest.organizationId ?? activeThread.organizationId ?? '',
+          threadId: latest.id,
+        });
+      }
+      return latest;
+    } catch {
+      return null;
+    }
+  }, [activeThread, apiService]);
+
+  useEffect(() => {
+    if (!activeThread) {
+      setStaleContext(null);
+      return;
+    }
+
+    const handleStorage = (event: StorageEvent): void => {
+      if (event.key !== contextStorageKey(activeThread.id)) {
+        return;
+      }
+      const notice = parseContextNotice(event.newValue);
+      if (
+        notice &&
+        notice.threadId === activeThread.id &&
+        notice.contextVersion > activeThread.contextVersion
+      ) {
+        setStaleContext(notice);
+      }
+    };
+    const handleFocus = (): void => {
+      void observeLatestThread();
+    };
+    window.addEventListener('storage', handleStorage);
+    window.addEventListener('focus', handleFocus);
+    return () => {
+      window.removeEventListener('storage', handleStorage);
+      window.removeEventListener('focus', handleFocus);
+    };
+  }, [activeThread, observeLatestThread]);
+
+  const routeForThreadContext = useCallback(
+    (nextThread: AgentThread, history: 'push' | 'replace') => {
+      const nextBrand = authorizedBrands.find(
+        (brand) => getBrandEntityId(brand) === nextThread.brandId,
+      );
+      const nextHref = buildConversationScopeHref({
+        brandSlug: nextBrand?.slug ?? null,
+        organizationSlug: currentOrganizationSlug,
+        pathname,
+        searchParams,
+        threadId: nextThread.id,
+      });
+      const requestedPathname = nextHref.split('?')[0] ?? nextHref;
+      const authorizedHref = resolveWorkspaceShellRoute(requestedPathname)
+        ? nextHref
+        : buildScopedThreadHref(
+            currentOrganizationSlug,
+            nextBrand?.slug ?? null,
+            nextThread.id,
+          );
+      if (history === 'replace') {
+        replace(authorizedHref);
+      } else {
+        push(authorizedHref);
+      }
+    },
+    [
+      authorizedBrands,
+      currentOrganizationSlug,
+      pathname,
+      push,
+      replace,
+      searchParams,
+    ],
+  );
+
+  const synchronize = useCallback(async () => {
+    if (!activeThread || isMutating) {
+      return;
+    }
+    setIsMutating(true);
+    setScopeError(null);
+    try {
+      const latest = await runAgentApiEffect(
+        apiService.getThreadEffect(activeThread.id),
+      );
+      const nextDraftScopeKey = `${currentOrganizationSlug}:${latest.id}:${latest.contextVersion}`;
+      preserveDraftText(currentDraftScopeKey, nextDraftScopeKey);
+      upsertThread(latest);
+      routeForThreadContext(latest, 'replace');
+      setStaleContext(null);
+    } catch {
+      setScopeError('Conversation scope could not be synchronized.');
+    } finally {
+      setIsMutating(false);
+    }
+  }, [
+    activeThread,
+    apiService,
+    currentDraftScopeKey,
+    currentOrganizationSlug,
+    isMutating,
+    routeForThreadContext,
+    upsertThread,
+  ]);
+
+  const applyBrandChange = useCallback(
+    async (brand: Brand | null) => {
+      const nextBrandId = brand ? getBrandEntityId(brand) : null;
+      if (
+        nextBrandId !== null &&
+        (!nextBrandId ||
+          !authorizedBrands.some(
+            (candidate) => getBrandEntityId(candidate) === nextBrandId,
+          ))
+      ) {
+        setScopeError('That brand is not authorized for this organization.');
+        return;
+      }
+
+      setIsMutating(true);
+      setScopeError(null);
+      try {
+        if (!activeThread) {
+          const created = await runAgentApiEffect(
+            apiService.createThreadEffect({ brandId: nextBrandId }),
+          );
+          const nextDraftScopeKey = `${currentOrganizationSlug}:${created.id}:${created.contextVersion}`;
+          preserveDraftText(currentDraftScopeKey, nextDraftScopeKey);
+          upsertThread(created);
+          setActiveThread(created.id);
+          push(
+            buildScopedThreadHref(
+              currentOrganizationSlug,
+              brand?.slug ?? null,
+              created.id,
+            ),
+          );
+          publishContextNotice(created);
+          return;
+        }
+
+        const updated = await runAgentApiEffect(
+          apiService.updateThreadContextEffect(activeThread.id, {
+            brandId: nextBrandId,
+            expectedContextVersion: activeThread.contextVersion,
+          }),
+        );
+        const nextDraftScopeKey = `${currentOrganizationSlug}:${updated.id}:${updated.contextVersion}`;
+        preserveDraftText(currentDraftScopeKey, nextDraftScopeKey);
+        upsertThread(updated);
+        routeForThreadContext(updated, 'push');
+        publishContextNotice(updated);
+        setStaleContext(null);
+      } catch {
+        await observeLatestThread();
+        setScopeError(
+          'Brand scope was rejected or changed elsewhere. Synchronize before retrying.',
+        );
+      } finally {
+        setIsMutating(false);
+      }
+    },
+    [
+      activeThread,
+      apiService,
+      authorizedBrands,
+      currentDraftScopeKey,
+      currentOrganizationSlug,
+      observeLatestThread,
+      push,
+      routeForThreadContext,
+      setActiveThread,
+      upsertThread,
+    ],
+  );
+
+  const applyOrganizationChange = useCallback(
+    async (organization: OrganizationOption) => {
+      if (
+        !organizations.some((candidate) => candidate.id === organization.id)
+      ) {
+        setScopeError('That organization is not authorized.');
+        return;
+      }
+      setIsMutating(true);
+      setScopeError(null);
+      try {
+        const service = await getOrganizationsService();
+        await service.switchOrganization(organization.id);
+        clearConversationComposerDraft(currentDraftScopeKey);
+        setActiveThread(null);
+        resetActiveConversationState();
+        window.location.assign(
+          buildOrganizationNewThreadHref(organization.slug),
+        );
+      } catch {
+        setScopeError('Organization switch was rejected.');
+        setIsMutating(false);
+      }
+    },
+    [
+      currentDraftScopeKey,
+      getOrganizationsService,
+      organizations,
+      resetActiveConversationState,
+      setActiveThread,
+    ],
+  );
+
+  const requestScopeChange = useCallback(
+    (change: PendingScopeChange) => {
+      if (isStale) {
+        setScopeError('Synchronize this tab before changing scope.');
+        return;
+      }
+      if (isActiveWork || hasDraftContent(currentDraftScopeKey)) {
+        setPendingChange(change);
+        return;
+      }
+      if (change.kind === 'brand') {
+        void applyBrandChange(change.brand);
+      } else {
+        void applyOrganizationChange(change.organization);
+      }
+    },
+    [
+      applyBrandChange,
+      applyOrganizationChange,
+      currentDraftScopeKey,
+      isActiveWork,
+      isStale,
+    ],
+  );
+
+  const confirmPendingChange = useCallback(() => {
+    if (!pendingChange || isActiveWork) {
+      return;
+    }
+    const change = pendingChange;
+    setPendingChange(null);
+    if (change.kind === 'brand') {
+      void applyBrandChange(change.brand);
+    } else {
+      void applyOrganizationChange(change.organization);
+    }
+  }, [applyBrandChange, applyOrganizationChange, isActiveWork, pendingChange]);
+
+  const organizationLabel =
+    effectiveOrganization?.label ?? currentOrganizationSlug ?? 'Organization';
+  const brandLabel = effectiveBrand?.label ?? 'Organization-wide';
+  const contextLabel = `${organizationLabel} · ${brandLabel}`;
+  const scopeControls = (
+    <>
+      {isStale ? (
+        <Button
+          className="h-7 px-2 text-[11px]"
+          isDisabled={isMutating}
+          onClick={() => void synchronize()}
+          size={ButtonSize.SM}
+          variant={ButtonVariant.OUTLINE}
+          withWrapper={false}
+        >
+          Synchronize scope
+        </Button>
+      ) : null}
+      <SwitcherDropdown
+        className="w-auto"
+        emptyMessage="No authorized organizations"
+        hasSearch={organizations.length >= 5}
+        isDisabled={isMutating || isStale}
+        isLoading={isLoadingOrganizations}
+        items={organizations.map((organization) => ({
+          id: organization.id,
+          isActive: organization.id === currentOrganizationId,
+          label: organization.label,
+        }))}
+        onSelect={(id) => {
+          const organization = organizations.find((item) => item.id === id);
+          if (organization && organization.id !== currentOrganizationId) {
+            requestScopeChange({ kind: 'organization', organization });
+          }
+        }}
+        renderTrigger={({ isOpen }) => (
+          <ScopeTrigger
+            icon={<HiOutlineBuildingOffice2 className="size-3.5" />}
+            isOpen={isOpen}
+            label={organizationLabel}
+          />
+        )}
+        searchPlaceholder="Search organizations…"
+      />
+      <SwitcherDropdown
+        className="w-auto"
+        emptyMessage="No authorized brands"
+        hasSearch={authorizedBrands.length >= 5}
+        isDisabled={isMutating || isStale}
+        isLoading={false}
+        items={[
+          {
+            id: '__organization__',
+            isActive: effectiveBrandId === null,
+            label: 'Organization-wide',
+          },
+          ...authorizedBrands.map((brand) => ({
+            id: getBrandEntityId(brand),
+            imageUrl: brand.logoUrl,
+            isActive: getBrandEntityId(brand) === effectiveBrandId,
+            label: brand.label ?? 'Untitled brand',
+          })),
+        ]}
+        onSelect={(id) => {
+          if (id === '__organization__' && effectiveBrandId !== null) {
+            requestScopeChange({ brand: null, kind: 'brand' });
+            return;
+          }
+          const brand = authorizedBrands.find(
+            (item) => getBrandEntityId(item) === id,
+          );
+          if (brand && id !== effectiveBrandId) {
+            requestScopeChange({ brand, kind: 'brand' });
+          }
+        }}
+        renderTrigger={({ isOpen }) => (
+          <ScopeTrigger
+            icon={<HiOutlineTag className="size-3.5" />}
+            isOpen={isOpen}
+            label={brandLabel}
+          />
+        )}
+        searchPlaceholder="Search brands…"
+      />
+
+      <Dialog
+        open={pendingChange !== null}
+        onOpenChange={(open) => {
+          if (!open) {
+            setPendingChange(null);
+          }
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {isActiveWork
+                ? 'Stop active work before switching scope'
+                : pendingChange?.kind === 'organization'
+                  ? 'Start a clean organization thread?'
+                  : 'Change the thread brand?'}
+            </DialogTitle>
+            <DialogDescription>
+              {isActiveWork
+                ? 'The current run must be stopped from the prompt bar before its organization or brand can change.'
+                : pendingChange?.kind === 'organization'
+                  ? 'The unsent draft, attachments, transcript, artifact references, and open organization surfaces will not carry to the new thread.'
+                  : 'Your unsent text will remain. Attachments and structured references are cleared so resources from the previous brand cannot execute in the new scope.'}
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              onClick={() => setPendingChange(null)}
+              variant={ButtonVariant.GHOST}
+              withWrapper={false}
+            >
+              Cancel
+            </Button>
+            <Button
+              isDisabled={isActiveWork || isMutating}
+              onClick={confirmPendingChange}
+              variant={ButtonVariant.DEFAULT}
+              withWrapper={false}
+            >
+              {pendingChange?.kind === 'organization'
+                ? 'Start clean thread'
+                : 'Change brand'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+
+  const inspectorScope = (
+    <div
+      aria-live="polite"
+      className="rounded-lg border border-border bg-background px-3 py-2"
+      data-testid="workspace-effective-scope"
+    >
+      <p className="text-xs font-medium text-foreground">{organizationLabel}</p>
+      <p className="mt-1 text-xs text-muted-foreground">{brandLabel}</p>
+      <p className="mt-1 text-[11px] text-muted-foreground">
+        {activeThread
+          ? `Thread context v${activeThread.contextVersion}`
+          : 'New thread scope'}
+        {isStale ? ' · synchronization required' : ''}
+      </p>
+      {scopeError ? (
+        <p className="mt-2 text-xs text-destructive" role="alert">
+          {scopeError}
+        </p>
+      ) : null}
+    </div>
+  );
+
+  return {
+    contextLabel,
+    inspectorScope,
+    isConsequentiallyBlocked: isStale,
+    scopeControls,
+  };
+}

--- a/apps/app/src/lib/workspace-shell/conversation-scope-location.spec.ts
+++ b/apps/app/src/lib/workspace-shell/conversation-scope-location.spec.ts
@@ -1,0 +1,42 @@
+import {
+  buildConversationScopeHref,
+  buildOrganizationNewThreadHref,
+  buildScopedThreadHref,
+} from './conversation-scope-location';
+
+describe('conversation scope location', () => {
+  it('rewrites the brand while preserving the connected thread and canvas route', () => {
+    expect(
+      buildConversationScopeHref({
+        brandSlug: 'brand-b',
+        organizationSlug: 'acme',
+        pathname: '/acme/brand-a/library/images',
+        searchParams: new URLSearchParams(
+          'thread=thread-1&overlay=asset&overlayRef=asset%3A1&filter=recent',
+        ),
+        threadId: 'thread-1',
+      }),
+    ).toBe('/acme/brand-b/library/images?thread=thread-1&filter=recent');
+  });
+
+  it('keeps thread ids in conversation paths instead of duplicating query state', () => {
+    expect(
+      buildConversationScopeHref({
+        brandSlug: 'brand-b',
+        organizationSlug: 'acme',
+        pathname: '/acme/~/agent/thread-1',
+        searchParams: new URLSearchParams('thread=thread-1'),
+        threadId: 'thread-1',
+      }),
+    ).toBe('/acme/brand-b/agent/thread-1');
+  });
+
+  it('builds zero-carry organization and scoped-thread destinations', () => {
+    expect(buildOrganizationNewThreadHref('other-org')).toBe(
+      '/other-org/~/agent/new',
+    );
+    expect(buildScopedThreadHref('acme', 'brand-a', 'thread-1')).toBe(
+      '/acme/brand-a/agent/thread-1',
+    );
+  });
+});

--- a/apps/app/src/lib/workspace-shell/conversation-scope-location.ts
+++ b/apps/app/src/lib/workspace-shell/conversation-scope-location.ts
@@ -1,0 +1,63 @@
+import { APP_ROUTES } from '@genfeedai/constants';
+import { appendSearchParamsToHref } from '@/lib/navigation/operator-shell';
+
+interface BuildConversationScopeHrefParams {
+  readonly brandSlug: string | null;
+  readonly organizationSlug: string;
+  readonly pathname: string;
+  readonly searchParams: URLSearchParams;
+  readonly threadId: string | null;
+}
+
+function scopedPathname(
+  pathname: string,
+  organizationSlug: string,
+  brandSlug: string | null,
+): string {
+  const segments = pathname.split('/').filter(Boolean);
+  if (segments.length < 2) {
+    return `/${organizationSlug}/${brandSlug ?? '~'}${APP_ROUTES.AGENT.ROOT}`;
+  }
+
+  segments[0] = organizationSlug;
+  segments[1] = brandSlug ?? '~';
+  return `/${segments.join('/')}`;
+}
+
+export function buildConversationScopeHref({
+  brandSlug,
+  organizationSlug,
+  pathname,
+  searchParams,
+  threadId,
+}: BuildConversationScopeHrefParams): string {
+  const nextSearchParams = new URLSearchParams(searchParams);
+  nextSearchParams.delete('overlay');
+  nextSearchParams.delete('overlayRef');
+
+  const nextPathname = scopedPathname(pathname, organizationSlug, brandSlug);
+  const isConversation = /\/agent(?:\/|$)/.test(nextPathname);
+  if (isConversation) {
+    nextSearchParams.delete('thread');
+  } else if (threadId) {
+    nextSearchParams.set('thread', threadId);
+  } else {
+    nextSearchParams.delete('thread');
+  }
+
+  return appendSearchParamsToHref(nextPathname, nextSearchParams);
+}
+
+export function buildOrganizationNewThreadHref(
+  organizationSlug: string,
+): string {
+  return `/${organizationSlug}/~${APP_ROUTES.AGENT.NEW}`;
+}
+
+export function buildScopedThreadHref(
+  organizationSlug: string,
+  brandSlug: string | null,
+  threadId: string,
+): string {
+  return `/${organizationSlug}/${brandSlug ?? '~'}${APP_ROUTES.AGENT.ROOT}/${threadId}`;
+}

--- a/packages/agent/src/components/AgentChatPromptBar.tsx
+++ b/packages/agent/src/components/AgentChatPromptBar.tsx
@@ -120,9 +120,15 @@ export function AgentChatPromptBar({
     >
       <AgentChatInput
         onSend={onSend}
-        disabled={isBusy || isReadOnly}
+        disabled={
+          isBusy || isReadOnly || composerShell?.isConsequentiallyBlocked
+        }
         placeholder={
-          isReadOnly ? 'Archived threads are read-only' : placeholder
+          isReadOnly
+            ? 'Archived threads are read-only'
+            : composerShell?.isConsequentiallyBlocked
+              ? 'Synchronize the conversation scope before continuing'
+              : placeholder
         }
         onStop={onStop}
         apiService={apiService}

--- a/packages/agent/src/components/ConversationComposerShellContext.tsx
+++ b/packages/agent/src/components/ConversationComposerShellContext.tsx
@@ -20,6 +20,7 @@ export interface ConversationComposerShellContextValue {
     | ConversationComposerDispatchResult
     | Promise<ConversationComposerDispatchResult>;
   draftScopeKey: string | null;
+  isConsequentiallyBlocked?: boolean;
   portalTarget: HTMLElement | null;
   scopeControls?: ReactNode;
   shellState: 'canvas' | 'conversation' | 'overlay';
@@ -38,6 +39,7 @@ export function ConversationComposerShellProvider({
   contextLabel,
   dispatchAction,
   draftScopeKey,
+  isConsequentiallyBlocked,
   portalTarget,
   scopeControls,
   shellState,
@@ -47,6 +49,7 @@ export function ConversationComposerShellProvider({
       contextLabel,
       dispatchAction,
       draftScopeKey,
+      isConsequentiallyBlocked,
       portalTarget,
       scopeControls,
       shellState,
@@ -55,6 +58,7 @@ export function ConversationComposerShellProvider({
       contextLabel,
       dispatchAction,
       draftScopeKey,
+      isConsequentiallyBlocked,
       portalTarget,
       scopeControls,
       shellState,

--- a/packages/agent/src/hooks/use-agent-chat-container.ts
+++ b/packages/agent/src/hooks/use-agent-chat-container.ts
@@ -188,6 +188,28 @@ export function useAgentChatContainer({
     onUpload: (file, onProgress) =>
       runAgentApiEffect(apiService.uploadAttachmentEffect(file, onProgress)),
   });
+  const previousDraftScopeKeyRef = useRef(draftScopeKey);
+  useEffect(() => {
+    const previousDraftScopeKey = previousDraftScopeKeyRef.current;
+    if (previousDraftScopeKey === draftScopeKey) {
+      return;
+    }
+
+    previousDraftScopeKeyRef.current = draftScopeKey;
+    const previousVersionSeparator = previousDraftScopeKey?.lastIndexOf(':');
+    const nextVersionSeparator = draftScopeKey?.lastIndexOf(':');
+    const isSameThreadScope =
+      previousVersionSeparator !== undefined &&
+      previousVersionSeparator >= 0 &&
+      nextVersionSeparator !== undefined &&
+      nextVersionSeparator >= 0 &&
+      previousDraftScopeKey?.slice(0, previousVersionSeparator) ===
+        draftScopeKey?.slice(0, nextVersionSeparator);
+
+    if (isSameThreadScope) {
+      clearAllAttachments();
+    }
+  }, [clearAllAttachments, draftScopeKey]);
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);

--- a/packages/agent/src/models/agent-chat.model.ts
+++ b/packages/agent/src/models/agent-chat.model.ts
@@ -319,6 +319,7 @@ export interface AgentChatMessage {
 export interface AgentThread {
   id: string;
   contextVersion: number;
+  organizationId?: string;
   isPinned?: boolean;
   planModeEnabled?: boolean;
   requestedModel?: string;

--- a/packages/serializers/__tests__/agent-thread-context.test.ts
+++ b/packages/serializers/__tests__/agent-thread-context.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest';
 describe('agent thread context serialization', () => {
   it('exposes the authoritative brand and shell context version', () => {
     expect(agentThreadAttributes).toEqual(
-      expect.arrayContaining(['brandId', 'contextVersion']),
+      expect.arrayContaining(['brandId', 'contextVersion', 'organizationId']),
     );
   });
 });

--- a/packages/serializers/src/attributes/threads/agent-thread.attributes.ts
+++ b/packages/serializers/src/attributes/threads/agent-thread.attributes.ts
@@ -6,6 +6,7 @@ export const agentThreadAttributes = createEntityAttributes([
   'contextVersion',
   'lastActivityAt',
   'lastAssistantPreview',
+  'organizationId',
   'pendingInputCount',
   'runStatus',
   'organization',


### PR DESCRIPTION
## Summary

- compose authorized organization and brand controls into the existing conversation composer scope seam
- make organization changes start a zero-carry thread and make brand changes use server-authoritative compare-and-swap context without mutating the global brand default
- synchronize prompt bar, conversation, inspector, canvas route, and executor context while clearing incompatible references
- detect newer cross-tab context versions, preserve unsent text, and block consequential composer actions until explicit synchronization
- expose authoritative thread organization data and add focused scope/location/component coverage

Closes #1675
Parent epic: #1670

## Verification

- `bunx biome check` on all 12 touched files
- `git diff --check` and `git show --check`
- staged secretlint and UI/control guards from the commit hook
- Gitleaks scan of the final commit: no leaks

Tests, typechecks, builds, E2E, and CI babysitting were intentionally not run per the local MacBook and updated handoff constraints.