### PR TITLE
feat(app): embed Workspace overview surfaces

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/overview/page.spec.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/overview/page.spec.tsx
@@ -1,4 +1,16 @@
 import { runPageModuleTests } from '@shared/pages/pageTestUtils';
+import type { ReactNode } from 'react';
 import * as PageModule from './page';
+
+vi.mock(
+  '@/features/workspace-overview/workspace-overview-surface-adapters',
+  () => ({
+    BrandWorkspaceOverviewSurfaceAdapter: ({
+      children,
+    }: {
+      children: ReactNode;
+    }) => children,
+  }),
+);
 
 runPageModuleTests('app/(protected)/workspace/overview/page', PageModule);

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/overview/page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/overview/page.tsx
@@ -1,13 +1,16 @@
 import { createPageMetadata } from '@helpers/media/metadata/page-metadata.helper';
 import ErrorBoundary from '@ui/display/error-boundary/ErrorBoundary';
+import { BrandWorkspaceOverviewSurfaceAdapter } from '@/features/workspace-overview/workspace-overview-surface-adapters';
 import WorkspaceOverviewContent from './content';
 
 export const generateMetadata = createPageMetadata('Workspace Dashboard');
 
 export default function WorkspaceOverviewPage() {
   return (
-    <ErrorBoundary>
-      <WorkspaceOverviewContent />
-    </ErrorBoundary>
+    <BrandWorkspaceOverviewSurfaceAdapter>
+      <ErrorBoundary>
+        <WorkspaceOverviewContent />
+      </ErrorBoundary>
+    </BrandWorkspaceOverviewSurfaceAdapter>
   );
 }

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useBrand } from '@contexts/user/brand-context/brand-context';
 import { AlertCategory, ButtonSize, ButtonVariant } from '@genfeedai/enums';
 import type { IAgentRun, IAnalytics } from '@genfeedai/interfaces';
 import type { AgentRunStats } from '@genfeedai/types';
@@ -16,8 +17,10 @@ import LazyLoadingFallback from '@ui/loading/fallback/LazyLoadingFallback';
 import { WorkspaceSurface } from '@ui/overview/WorkspaceSurface';
 import { Button } from '@ui/primitives/button';
 import dynamic from 'next/dynamic';
-import { Suspense, startTransition, useMemo } from 'react';
+import { Suspense, startTransition, useEffect, useMemo } from 'react';
 import { HiOutlineSquares2X2 } from 'react-icons/hi2';
+import { useWorkspaceSurfaceSelection } from '@/components/workspace-shell/WorkspaceSurfaceAdapterContext';
+import { getWorkspaceOverviewArtifactReferences } from '@/features/workspace-overview/workspace-overview-artifact-references';
 import { useWorkspacePageContent } from './use-workspace-page-content';
 import { WorkspaceDashboard } from './workspace-dashboard';
 import { workspaceInboxTableColumns } from './workspace-inbox-columns';
@@ -64,7 +67,9 @@ function WorkspacePageContentContent({
   initialTimeSeriesData,
   section = 'overview',
 }: WorkspacePageContentProps) {
+  const { brandId, organizationId } = useBrand();
   const { href } = useOrgUrl();
+  const surfaceSelection = useWorkspaceSurfaceSelection();
   const { trends: trendItems, isLoading: isTrendsLoading } = useTrends();
   const {
     activityItems,
@@ -109,6 +114,25 @@ function WorkspacePageContentContent({
     initialTimeSeriesData,
     section,
   });
+  const selectedArtifactReferences = useMemo(
+    () =>
+      getWorkspaceOverviewArtifactReferences(selectedTask, {
+        brandId,
+        organizationId,
+      }),
+    [brandId, organizationId, selectedTask],
+  );
+
+  useEffect(() => {
+    if (!surfaceSelection || !isOverviewSection) {
+      return;
+    }
+
+    surfaceSelection.setArtifactReferences(selectedArtifactReferences);
+    return () => {
+      surfaceSelection.setArtifactReferences([]);
+    };
+  }, [isOverviewSection, selectedArtifactReferences, surfaceSelection]);
 
   const workspaceHeaderActions = useMemo(
     () => (

--- a/apps/app/app/(protected)/[orgSlug]/~/overview/page.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/overview/page.test.tsx
@@ -1,6 +1,18 @@
 import { runPageModuleTests } from '@shared/pages/pageTestUtils';
 import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
 import OrgOverviewPage, * as PageModule from './page';
+
+vi.mock(
+  '@/features/workspace-overview/workspace-overview-surface-adapters',
+  () => ({
+    OrganizationWorkspaceOverviewSurfaceAdapter: ({
+      children,
+    }: {
+      children: ReactNode;
+    }) => <div data-testid="organization-overview-adapter">{children}</div>,
+  }),
+);
 
 vi.mock(
   '@pages/analytics/organization-overview/analytics-organization-overview',
@@ -16,5 +28,8 @@ describe('OrgOverviewPage', () => {
     render(<OrgOverviewPage />);
 
     expect(screen.getByTestId('organization-overview')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('organization-overview-adapter'),
+    ).toBeInTheDocument();
   });
 });

--- a/apps/app/app/(protected)/[orgSlug]/~/overview/page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/overview/page.tsx
@@ -1,8 +1,13 @@
 import { createPageMetadata } from '@helpers/media/metadata/page-metadata.helper';
 import AnalyticsOrganizationOverview from '@pages/analytics/organization-overview/analytics-organization-overview';
+import { OrganizationWorkspaceOverviewSurfaceAdapter } from '@/features/workspace-overview/workspace-overview-surface-adapters';
 
 export const generateMetadata = createPageMetadata('Organization Overview');
 
 export default function OrgOverviewPage() {
-  return <AnalyticsOrganizationOverview />;
+  return (
+    <OrganizationWorkspaceOverviewSurfaceAdapter>
+      <AnalyticsOrganizationOverview />
+    </OrganizationWorkspaceOverviewSurfaceAdapter>
+  );
 }

--- a/apps/app/src/components/workspace-shell/UniversalWorkspaceShell.test.tsx
+++ b/apps/app/src/components/workspace-shell/UniversalWorkspaceShell.test.tsx
@@ -133,6 +133,13 @@ vi.mock('@hooks/navigation/use-org-url', () => ({
   }),
 }));
 
+vi.mock('@contexts/user/brand-context/brand-context', () => ({
+  useBrand: () => ({
+    brandId: navigation.pathname.includes('/moonrise/') ? 'brand-1' : '',
+    organizationId: 'org-1',
+  }),
+}));
+
 vi.mock('next/navigation', () => ({
   usePathname: () => navigation.pathname,
   useRouter: () => router,
@@ -206,6 +213,7 @@ vi.mock('@/lib/workspace-shell/workspace-shell-telemetry', () => ({
   captureWorkspaceShellTransition: vi.fn(),
 }));
 
+import { BrandWorkspaceOverviewSurfaceAdapter } from '@/features/workspace-overview/workspace-overview-surface-adapters';
 import UniversalWorkspaceShell from './UniversalWorkspaceShell';
 
 describe('UniversalWorkspaceShell', () => {
@@ -262,13 +270,69 @@ describe('UniversalWorkspaceShell', () => {
     ).toHaveTextContent('thread-1');
     expect(screen.getByTestId('universal-workspace-shell')).toHaveAttribute(
       'data-workspace-surface',
-      'workspace',
+      'workspace-overview',
     );
     expect(
       screen.getByTestId('universal-workspace-shell').parentElement,
     ).toHaveAttribute('data-draft-scope', 'acme:thread-1:3');
     expect(pageShellMount).toHaveBeenCalledTimes(1);
     expect(router.replace).toHaveBeenCalledWith(
+      '/acme/moonrise/workspace/overview?thread=thread-1',
+    );
+  });
+
+  it('mounts the brand overview registration in the harness inspector', async () => {
+    navigation.pathname = '/acme/moonrise/workspace/overview';
+
+    render(
+      <UniversalWorkspaceShell agentApiService={agentApiService}>
+        <BrandWorkspaceOverviewSurfaceAdapter>
+          <div data-testid="canonical-brand-overview">Workspace overview</div>
+        </BrandWorkspaceOverviewSurfaceAdapter>
+      </UniversalWorkspaceShell>,
+    );
+
+    expect(
+      await screen.findByTestId('workspace-surface-adapter-inspector'),
+    ).toHaveTextContent('Brand Workspace overview');
+    expect(screen.getByTestId('canonical-brand-overview')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Registered workspace-overview adapter slot'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('launches the organization overview from organization conversation scope', () => {
+    navigation.pathname = '/acme/~/agent/thread-1';
+
+    render(
+      <UniversalWorkspaceShell agentApiService={agentApiService}>
+        <div>Conversation</div>
+      </UniversalWorkspaceShell>,
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Open workspace canvas' }),
+    );
+
+    expect(router.push).toHaveBeenCalledWith(
+      '/acme/~/overview?thread=thread-1',
+    );
+  });
+
+  it('launches the brand overview from brand conversation scope', () => {
+    navigation.pathname = '/acme/moonrise/agent/thread-1';
+
+    render(
+      <UniversalWorkspaceShell agentApiService={agentApiService}>
+        <div>Conversation</div>
+      </UniversalWorkspaceShell>,
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Open workspace canvas' }),
+    );
+
+    expect(router.push).toHaveBeenCalledWith(
       '/acme/moonrise/workspace/overview?thread=thread-1',
     );
   });

--- a/apps/app/src/components/workspace-shell/UniversalWorkspaceShell.tsx
+++ b/apps/app/src/components/workspace-shell/UniversalWorkspaceShell.tsx
@@ -53,13 +53,20 @@ import {
   type WorkspaceShellLocation,
   type WorkspaceShellState,
 } from '@/lib/workspace-shell/workspace-shell-location';
-import { getWorkspaceShellOverlayRegistration } from '@/lib/workspace-shell/workspace-shell-registry';
+import {
+  getWorkspaceShellOverlayRegistration,
+  resolveWorkspaceShellRoute,
+} from '@/lib/workspace-shell/workspace-shell-registry';
 import {
   captureWorkspaceShellRestorationFailure,
   captureWorkspaceShellTransition,
 } from '@/lib/workspace-shell/workspace-shell-telemetry';
 import { resolveWorkspaceSurfaceLaunch } from '@/lib/workspace-shell/workspace-surface-launcher';
 import WorkspaceOverlayHost from './WorkspaceOverlayHost';
+import {
+  useActiveWorkspaceSurfaceAdapter,
+  WorkspaceSurfaceAdapterProvider,
+} from './WorkspaceSurfaceAdapterContext';
 
 const INSPECTOR_DEFAULT_WIDTH = 320;
 const INSPECTOR_MIN_WIDTH = 256;
@@ -103,6 +110,7 @@ function UniversalWorkspaceShellContent({
   const { brandSlug, href, orgHref, orgSlug } = useOrgUrl();
   const activeThreadId = useAgentChatStore((state) => state.activeThreadId);
   const threads = useAgentChatStore((state) => state.threads);
+  const activeSurfaceAdapter = useActiveWorkspaceSurfaceAdapter();
   const [isInspectorOpen, setIsInspectorOpen] = useState(true);
   const [isMobileInspectorOpen, setIsMobileInspectorOpen] = useState(false);
   const [inspectorWidth, setInspectorWidth] = useState(INSPECTOR_DEFAULT_WIDTH);
@@ -153,6 +161,16 @@ function UniversalWorkspaceShellContent({
     () => (overlay ? getWorkspaceShellOverlayRegistration(overlay.key) : null),
     [overlay],
   );
+  const routeRegistration = useMemo(
+    () => resolveWorkspaceShellRoute(normalizedPathname),
+    [normalizedPathname],
+  );
+  const resolvedSurfaceAdapter =
+    routeRegistration?.adapter.status === 'embedded' &&
+    activeSurfaceAdapter?.registration.key === routeRegistration.adapter.key &&
+    activeSurfaceAdapter.registration.scope === routeRegistration.scope
+      ? activeSurfaceAdapter
+      : null;
   const canonicalSearchParamsString = canonicalSearchParams.toString();
   const isUnthreadedConversation =
     baseState === 'conversation' &&
@@ -286,13 +304,28 @@ function UniversalWorkspaceShellContent({
   }, [normalizedPathname, state]);
 
   const handleOpenCanvas = useCallback(() => {
+    const launch = resolveWorkspaceSurfaceLaunch({
+      currentHref,
+      destinationHref: brandSlug
+        ? href(APP_ROUTES.WORKSPACE.OVERVIEW)
+        : orgHref('/overview'),
+      threadId: effectiveThreadId ?? activeThreadId,
+    });
+    if (launch.history !== 'push' || launch.mode !== 'canvas') {
+      return;
+    }
+
     pendingTransitionRef.current = 'canvas_launch';
-    push(
-      buildWorkspaceShellHref(orgHref(APP_ROUTES.WORKSPACE.OVERVIEW), {
-        threadId: effectiveThreadId ?? activeThreadId,
-      }),
-    );
-  }, [activeThreadId, effectiveThreadId, orgHref, push]);
+    push(launch.href);
+  }, [
+    activeThreadId,
+    brandSlug,
+    currentHref,
+    effectiveThreadId,
+    href,
+    orgHref,
+    push,
+  ]);
 
   const handleReturnToConversation = useCallback(() => {
     pendingTransitionRef.current = 'conversation_return';
@@ -472,14 +505,29 @@ function UniversalWorkspaceShellContent({
         />
       </div>
       <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4">
-        <div className="gen-shell-empty-state p-4">
+        <div
+          className="gen-shell-empty-state p-4"
+          data-testid={
+            resolvedSurfaceAdapter
+              ? 'workspace-surface-adapter-inspector'
+              : undefined
+          }
+        >
           <p className="text-sm font-medium text-foreground">
-            Registered {surfaceKey} adapter slot
+            {resolvedSurfaceAdapter
+              ? resolvedSurfaceAdapter.registration.title
+              : `Registered ${surfaceKey} adapter slot`}
           </p>
           <p className="mt-1 text-xs leading-5 text-muted-foreground">
-            Product-owned context adapters land here without changing their
-            canonical route or granting execution authority.
+            {resolvedSurfaceAdapter
+              ? resolvedSurfaceAdapter.registration.description
+              : 'Product-owned context adapters land here without changing their canonical route or granting execution authority.'}
           </p>
+          {resolvedSurfaceAdapter ? (
+            <p className="mt-3 text-xs leading-5 text-muted-foreground">
+              Full management remains available on this canonical route.
+            </p>
+          ) : null}
         </div>
         <Button
           icon={<HiOutlineEye className="size-4" />}
@@ -503,6 +551,7 @@ function UniversalWorkspaceShellContent({
 
   return (
     <ConversationComposerShellProvider
+      artifactReferences={resolvedSurfaceAdapter?.artifactReferences}
       contextLabel={composerContextLabel}
       dispatchAction={handleComposerAction}
       draftScopeKey={draftScopeKey}
@@ -700,11 +749,13 @@ export default function UniversalWorkspaceShell({
 }: UniversalWorkspaceShellProps) {
   return (
     <AgentWorkspaceLayoutClient agentApiService={agentApiService}>
-      <UniversalWorkspaceShellContent
-        composerScopeControls={composerScopeControls}
-      >
-        {children}
-      </UniversalWorkspaceShellContent>
+      <WorkspaceSurfaceAdapterProvider>
+        <UniversalWorkspaceShellContent
+          composerScopeControls={composerScopeControls}
+        >
+          {children}
+        </UniversalWorkspaceShellContent>
+      </WorkspaceSurfaceAdapterProvider>
     </AgentWorkspaceLayoutClient>
   );
 }

--- a/apps/app/src/components/workspace-shell/WorkspaceSurfaceAdapterContext.test.tsx
+++ b/apps/app/src/components/workspace-shell/WorkspaceSurfaceAdapterContext.test.tsx
@@ -1,0 +1,114 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { type ReactElement, useEffect } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  useActiveWorkspaceSurfaceAdapter,
+  useWorkspaceSurfaceSelection,
+  WorkspaceSurfaceAdapterProvider,
+  WorkspaceSurfaceAdapterRegistration,
+  type WorkspaceSurfaceAdapterRegistration as WorkspaceSurfaceAdapterRegistrationContract,
+} from './WorkspaceSurfaceAdapterContext';
+
+const scope = vi.hoisted(() => ({
+  brandId: 'brand-1',
+  organizationId: 'org-1',
+}));
+
+vi.mock('@contexts/user/brand-context/brand-context', () => ({
+  useBrand: () => scope,
+}));
+
+const REGISTRATION = Object.freeze({
+  canonicalFallback: 'same-route',
+  description: 'Existing dashboard',
+  key: 'brand-workspace-overview',
+  managementMode: 'canonical-route',
+  scope: 'brand',
+  supportedReferenceKinds: Object.freeze(['post']),
+  title: 'Brand Workspace overview',
+} as const satisfies WorkspaceSurfaceAdapterRegistrationContract);
+
+function AdapterProbe(): ReactElement {
+  const adapter = useActiveWorkspaceSurfaceAdapter();
+  return (
+    <output data-testid="active-adapter">
+      {adapter
+        ? `${adapter.registration.key}:${adapter.organizationId}:${adapter.brandId}:${adapter.artifactReferences.length}`
+        : 'none'}
+    </output>
+  );
+}
+
+function SelectionProbe(): null {
+  const selection = useWorkspaceSurfaceSelection();
+
+  useEffect(() => {
+    selection?.setArtifactReferences([
+      {
+        brandId: 'brand-1',
+        kind: 'post',
+        organizationId: 'org-1',
+        recordId: 'post-1',
+        serializer: 'post',
+      },
+      {
+        brandId: 'brand-forged',
+        kind: 'post',
+        organizationId: 'org-1',
+        recordId: 'post-forged',
+        serializer: 'post',
+      },
+      {
+        brandId: 'brand-1',
+        kind: 'asset',
+        organizationId: 'org-1',
+        recordId: 'asset-not-supported',
+        serializer: 'asset',
+      },
+    ]);
+  }, [selection]);
+
+  return null;
+}
+
+describe('WorkspaceSurfaceAdapterContext', () => {
+  beforeEach(() => {
+    scope.brandId = 'brand-1';
+    scope.organizationId = 'org-1';
+  });
+
+  it('registers a route-owned adapter and keeps only in-scope supported references', async () => {
+    render(
+      <WorkspaceSurfaceAdapterProvider>
+        <AdapterProbe />
+        <WorkspaceSurfaceAdapterRegistration registration={REGISTRATION}>
+          <SelectionProbe />
+        </WorkspaceSurfaceAdapterRegistration>
+      </WorkspaceSurfaceAdapterProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('active-adapter')).toHaveTextContent(
+        'brand-workspace-overview:org-1:brand-1:1',
+      );
+    });
+  });
+
+  it('does not activate a brand adapter without canonical brand scope', () => {
+    scope.brandId = '';
+
+    render(
+      <WorkspaceSurfaceAdapterProvider>
+        <AdapterProbe />
+        <WorkspaceSurfaceAdapterRegistration registration={REGISTRATION}>
+          <div>Canonical dashboard remains rendered</div>
+        </WorkspaceSurfaceAdapterRegistration>
+      </WorkspaceSurfaceAdapterProvider>,
+    );
+
+    expect(screen.getByTestId('active-adapter')).toHaveTextContent('none');
+    expect(
+      screen.getByText('Canonical dashboard remains rendered'),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/app/src/components/workspace-shell/WorkspaceSurfaceAdapterContext.tsx
+++ b/apps/app/src/components/workspace-shell/WorkspaceSurfaceAdapterContext.tsx
@@ -1,0 +1,236 @@
+'use client';
+
+import { useBrand } from '@contexts/user/brand-context/brand-context';
+import type {
+  AgentArtifactRecordKind,
+  AgentArtifactReference,
+} from '@genfeedai/interfaces';
+import {
+  createContext,
+  type ReactElement,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useLayoutEffect,
+  useMemo,
+  useState,
+} from 'react';
+
+export interface WorkspaceSurfaceAdapterRegistration {
+  readonly canonicalFallback: 'same-route';
+  readonly description: string;
+  readonly key: string;
+  readonly managementMode: 'canonical-route';
+  readonly scope: 'brand' | 'organization';
+  readonly supportedReferenceKinds: readonly AgentArtifactRecordKind[];
+  readonly title: string;
+}
+
+export interface ActiveWorkspaceSurfaceAdapter {
+  readonly artifactReferences: readonly AgentArtifactReference[];
+  readonly brandId?: string;
+  readonly organizationId: string;
+  readonly registration: WorkspaceSurfaceAdapterRegistration;
+}
+
+interface WorkspaceSurfaceAdapterContextValue {
+  readonly activeAdapter: ActiveWorkspaceSurfaceAdapter | null;
+  readonly activateAdapter: (
+    registration: WorkspaceSurfaceAdapterRegistration,
+    organizationId: string,
+    brandId?: string,
+  ) => void;
+  readonly deactivateAdapter: (key: string) => void;
+  readonly setArtifactReferences: (
+    key: string,
+    references: readonly AgentArtifactReference[],
+  ) => void;
+}
+
+interface WorkspaceSurfaceAdapterProviderProps {
+  readonly children: ReactNode;
+}
+
+interface WorkspaceSurfaceAdapterRegistrationProps {
+  readonly children: ReactNode;
+  readonly registration: WorkspaceSurfaceAdapterRegistration;
+}
+
+interface WorkspaceSurfaceSelectionContextValue {
+  readonly adapterKey: string;
+  readonly setArtifactReferences: (
+    references: readonly AgentArtifactReference[],
+  ) => void;
+}
+
+const WorkspaceSurfaceAdapterContext =
+  createContext<WorkspaceSurfaceAdapterContextValue | null>(null);
+
+const WorkspaceSurfaceSelectionContext =
+  createContext<WorkspaceSurfaceSelectionContextValue | null>(null);
+
+function areScopesEqual(
+  adapter: ActiveWorkspaceSurfaceAdapter,
+  organizationId: string,
+  brandId?: string,
+): boolean {
+  return (
+    adapter.organizationId === organizationId && adapter.brandId === brandId
+  );
+}
+
+function scopeEligibleReferences(
+  adapter: ActiveWorkspaceSurfaceAdapter,
+  references: readonly AgentArtifactReference[],
+): readonly AgentArtifactReference[] {
+  const allowedKinds = new Set(adapter.registration.supportedReferenceKinds);
+  const uniqueReferences = new Map<string, AgentArtifactReference>();
+
+  for (const reference of references) {
+    const isBrandAuthorized =
+      adapter.registration.scope === 'organization'
+        ? reference.brandId === undefined
+        : Boolean(adapter.brandId && reference.brandId === adapter.brandId);
+
+    if (
+      reference.organizationId !== adapter.organizationId ||
+      !isBrandAuthorized ||
+      !allowedKinds.has(reference.kind)
+    ) {
+      continue;
+    }
+
+    uniqueReferences.set(`${reference.kind}:${reference.recordId}`, reference);
+  }
+
+  return Object.freeze([...uniqueReferences.values()]);
+}
+
+export function WorkspaceSurfaceAdapterProvider({
+  children,
+}: WorkspaceSurfaceAdapterProviderProps): ReactElement {
+  const [activeAdapter, setActiveAdapter] =
+    useState<ActiveWorkspaceSurfaceAdapter | null>(null);
+
+  const activateAdapter = useCallback(
+    (
+      registration: WorkspaceSurfaceAdapterRegistration,
+      organizationId: string,
+      brandId?: string,
+    ) => {
+      setActiveAdapter((current) => {
+        if (
+          current?.registration.key === registration.key &&
+          areScopesEqual(current, organizationId, brandId)
+        ) {
+          return current;
+        }
+
+        return {
+          artifactReferences: Object.freeze([]),
+          ...(brandId ? { brandId } : {}),
+          organizationId,
+          registration,
+        };
+      });
+    },
+    [],
+  );
+
+  const deactivateAdapter = useCallback((key: string) => {
+    setActiveAdapter((current) =>
+      current?.registration.key === key ? null : current,
+    );
+  }, []);
+
+  const setArtifactReferences = useCallback(
+    (key: string, references: readonly AgentArtifactReference[]) => {
+      setActiveAdapter((current) => {
+        if (!current || current.registration.key !== key) {
+          return current;
+        }
+
+        return {
+          ...current,
+          artifactReferences: scopeEligibleReferences(current, references),
+        };
+      });
+    },
+    [],
+  );
+
+  const value = useMemo<WorkspaceSurfaceAdapterContextValue>(
+    () => ({
+      activeAdapter,
+      activateAdapter,
+      deactivateAdapter,
+      setArtifactReferences,
+    }),
+    [activeAdapter, activateAdapter, deactivateAdapter, setArtifactReferences],
+  );
+
+  return (
+    <WorkspaceSurfaceAdapterContext.Provider value={value}>
+      {children}
+    </WorkspaceSurfaceAdapterContext.Provider>
+  );
+}
+
+export function WorkspaceSurfaceAdapterRegistration({
+  children,
+  registration,
+}: WorkspaceSurfaceAdapterRegistrationProps): ReactElement {
+  const adapterContext = useContext(WorkspaceSurfaceAdapterContext);
+  const activateAdapter = adapterContext?.activateAdapter;
+  const deactivateAdapter = adapterContext?.deactivateAdapter;
+  const updateArtifactReferences = adapterContext?.setArtifactReferences;
+  const { brandId, organizationId } = useBrand();
+  const scopedBrandId = registration.scope === 'brand' ? brandId : undefined;
+
+  useLayoutEffect(() => {
+    if (
+      !activateAdapter ||
+      !deactivateAdapter ||
+      !organizationId ||
+      (registration.scope === 'brand' && !scopedBrandId)
+    ) {
+      return;
+    }
+
+    activateAdapter(registration, organizationId, scopedBrandId);
+
+    return () => {
+      deactivateAdapter(registration.key);
+    };
+  }, [
+    activateAdapter,
+    deactivateAdapter,
+    organizationId,
+    registration,
+    scopedBrandId,
+  ]);
+
+  const selectionValue = useMemo<WorkspaceSurfaceSelectionContextValue>(
+    () => ({
+      adapterKey: registration.key,
+      setArtifactReferences: (references) => {
+        updateArtifactReferences?.(registration.key, references);
+      },
+    }),
+    [registration.key, updateArtifactReferences],
+  );
+
+  return (
+    <WorkspaceSurfaceSelectionContext.Provider value={selectionValue}>
+      {children}
+    </WorkspaceSurfaceSelectionContext.Provider>
+  );
+}
+
+export function useActiveWorkspaceSurfaceAdapter(): ActiveWorkspaceSurfaceAdapter | null {
+  return useContext(WorkspaceSurfaceAdapterContext)?.activeAdapter ?? null;
+}
+
+export function useWorkspaceSurfaceSelection(): WorkspaceSurfaceSelectionContextValue | null {
+  return useContext(WorkspaceSurfaceSelectionContext);
+}

--- a/apps/app/src/features/workspace-overview/workspace-overview-artifact-references.spec.ts
+++ b/apps/app/src/features/workspace-overview/workspace-overview-artifact-references.spec.ts
@@ -1,0 +1,65 @@
+import { Task } from '@services/management/tasks.service';
+import { describe, expect, it } from 'vitest';
+import { getWorkspaceOverviewArtifactReferences } from './workspace-overview-artifact-references';
+
+describe('getWorkspaceOverviewArtifactReferences', () => {
+  it('maps supported linked content to scoped canonical references', () => {
+    const task = new Task({
+      id: 'task-1',
+      linkedEntities: [
+        { entityId: 'post-1', entityModel: 'Post' },
+        { entityId: 'article-1', entityModel: 'Article' },
+        { entityId: 'ingredient-1', entityModel: 'Ingredient' },
+        { entityId: 'evaluation-1', entityModel: 'Evaluation' },
+        { entityId: 'post-1', entityModel: 'Post' },
+      ],
+    });
+
+    expect(
+      getWorkspaceOverviewArtifactReferences(task, {
+        brandId: 'brand-1',
+        organizationId: 'org-1',
+      }),
+    ).toEqual([
+      {
+        brandId: 'brand-1',
+        kind: 'post',
+        organizationId: 'org-1',
+        recordId: 'post-1',
+        serializer: 'post',
+      },
+      {
+        brandId: 'brand-1',
+        kind: 'article',
+        organizationId: 'org-1',
+        recordId: 'article-1',
+        serializer: 'article',
+      },
+      {
+        brandId: 'brand-1',
+        kind: 'ingredient',
+        organizationId: 'org-1',
+        recordId: 'ingredient-1',
+        serializer: 'ingredient',
+      },
+    ]);
+  });
+
+  it('returns no references without an authorized task and scope', () => {
+    expect(
+      getWorkspaceOverviewArtifactReferences(null, {
+        brandId: 'brand-1',
+        organizationId: 'org-1',
+      }),
+    ).toEqual([]);
+    expect(
+      getWorkspaceOverviewArtifactReferences(
+        new Task({
+          id: 'task-1',
+          linkedEntities: [{ entityId: 'post-1', entityModel: 'Post' }],
+        }),
+        { brandId: '', organizationId: 'org-1' },
+      ),
+    ).toEqual([]);
+  });
+});

--- a/apps/app/src/features/workspace-overview/workspace-overview-artifact-references.ts
+++ b/apps/app/src/features/workspace-overview/workspace-overview-artifact-references.ts
@@ -1,0 +1,49 @@
+import {
+  AGENT_ARTIFACT_SERIALIZER_BY_KIND,
+  type AgentArtifactRecordKind,
+  type AgentArtifactReference,
+} from '@genfeedai/interfaces';
+import type {
+  Task,
+  TaskLinkedEntityModel,
+} from '@services/management/tasks.service';
+
+interface WorkspaceOverviewArtifactScope {
+  readonly brandId: string;
+  readonly organizationId: string;
+}
+
+const ARTIFACT_KIND_BY_TASK_ENTITY = Object.freeze({
+  Article: 'article',
+  Ingredient: 'ingredient',
+  Post: 'post',
+} as const satisfies Partial<
+  Record<TaskLinkedEntityModel, AgentArtifactRecordKind>
+>);
+
+export function getWorkspaceOverviewArtifactReferences(
+  task: Task | null,
+  scope: WorkspaceOverviewArtifactScope,
+): readonly AgentArtifactReference[] {
+  if (!task || !scope.brandId || !scope.organizationId) {
+    return Object.freeze([]);
+  }
+
+  const references = new Map<string, AgentArtifactReference>();
+  for (const entity of task.linkedEntities ?? []) {
+    const kind = ARTIFACT_KIND_BY_TASK_ENTITY[entity.entityModel];
+    if (!kind || !entity.entityId) {
+      continue;
+    }
+
+    references.set(`${kind}:${entity.entityId}`, {
+      brandId: scope.brandId,
+      kind,
+      organizationId: scope.organizationId,
+      recordId: entity.entityId,
+      serializer: AGENT_ARTIFACT_SERIALIZER_BY_KIND[kind],
+    });
+  }
+
+  return Object.freeze([...references.values()]);
+}

--- a/apps/app/src/features/workspace-overview/workspace-overview-surface-adapters.tsx
+++ b/apps/app/src/features/workspace-overview/workspace-overview-surface-adapters.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import type { ReactElement, ReactNode } from 'react';
+import {
+  WorkspaceSurfaceAdapterRegistration,
+  type WorkspaceSurfaceAdapterRegistration as WorkspaceSurfaceAdapterRegistrationContract,
+} from '@/components/workspace-shell/WorkspaceSurfaceAdapterContext';
+
+interface WorkspaceOverviewSurfaceAdapterProps {
+  readonly children: ReactNode;
+}
+
+export const ORGANIZATION_WORKSPACE_OVERVIEW_ADAPTER = Object.freeze({
+  canonicalFallback: 'same-route',
+  description:
+    'Organization metrics and brand performance from the existing overview dashboard.',
+  key: 'organization-workspace-overview',
+  managementMode: 'canonical-route',
+  scope: 'organization',
+  supportedReferenceKinds: Object.freeze([]),
+  title: 'Organization Workspace overview',
+} as const satisfies WorkspaceSurfaceAdapterRegistrationContract);
+
+export const BRAND_WORKSPACE_OVERVIEW_ADAPTER = Object.freeze({
+  canonicalFallback: 'same-route',
+  description:
+    'Brand tasks, runs, inbox, trends, and persisted OpenUI dashboard blocks.',
+  key: 'brand-workspace-overview',
+  managementMode: 'canonical-route',
+  scope: 'brand',
+  supportedReferenceKinds: Object.freeze(['article', 'ingredient', 'post']),
+  title: 'Brand Workspace overview',
+} as const satisfies WorkspaceSurfaceAdapterRegistrationContract);
+
+export function OrganizationWorkspaceOverviewSurfaceAdapter({
+  children,
+}: WorkspaceOverviewSurfaceAdapterProps): ReactElement {
+  return (
+    <WorkspaceSurfaceAdapterRegistration
+      registration={ORGANIZATION_WORKSPACE_OVERVIEW_ADAPTER}
+    >
+      {children}
+    </WorkspaceSurfaceAdapterRegistration>
+  );
+}
+
+export function BrandWorkspaceOverviewSurfaceAdapter({
+  children,
+}: WorkspaceOverviewSurfaceAdapterProps): ReactElement {
+  return (
+    <WorkspaceSurfaceAdapterRegistration
+      registration={BRAND_WORKSPACE_OVERVIEW_ADAPTER}
+    >
+      {children}
+    </WorkspaceSurfaceAdapterRegistration>
+  );
+}

--- a/apps/app/src/lib/workspace-shell/workspace-shell-registry.spec.ts
+++ b/apps/app/src/lib/workspace-shell/workspace-shell-registry.spec.ts
@@ -101,6 +101,36 @@ describe('workspace shell trusted registry', () => {
     ).toBeNull();
   });
 
+  it('registers organization and brand Workspace overviews independently', () => {
+    expect(resolveWorkspaceShellRoute('/acme/~/overview')).toMatchObject({
+      adapter: {
+        key: 'organization-workspace-overview',
+        status: 'embedded',
+      },
+      safeFallback: '/:orgSlug/~/overview',
+      scope: 'organization',
+      surfaceKey: 'organization-overview',
+    });
+    expect(
+      resolveWorkspaceShellRoute('/acme/moonrise/workspace/overview'),
+    ).toMatchObject({
+      adapter: {
+        key: 'brand-workspace-overview',
+        status: 'embedded',
+      },
+      safeFallback: '/:orgSlug/:brandSlug/workspace/overview',
+      scope: 'brand',
+      surfaceKey: 'workspace-overview',
+    });
+    expect(
+      resolveWorkspaceShellRoute('/acme/~/analytics/overview')?.adapter.status,
+    ).toBe('placeholder');
+    expect(
+      resolveWorkspaceShellRoute('/acme/moonrise/workspace/inbox/all')?.adapter
+        .status,
+    ).toBe('placeholder');
+  });
+
   it('does not treat reserved application prefixes as scoped routes', () => {
     expect(resolveWorkspaceShellRoute('/settings/~/overview')).toBeNull();
     expect(resolveWorkspaceShellRoute('/settings/example/posts')).toBeNull();

--- a/apps/app/src/lib/workspace-shell/workspace-shell-registry.ts
+++ b/apps/app/src/lib/workspace-shell/workspace-shell-registry.ts
@@ -1,6 +1,7 @@
 import type {
   ResolvedWorkspaceShellRoute,
   WorkspaceShellAccessPolicy,
+  WorkspaceShellAdapterSeam,
   WorkspaceShellAuxiliaryRegistration,
   WorkspaceShellDeployment,
   WorkspaceShellOverlayRegistration,
@@ -30,6 +31,7 @@ export type {
 } from '@genfeedai/interfaces/ui/workspace-shell.interface';
 
 type RouteGroupConfig = {
+  readonly adapter?: WorkspaceShellAdapterSeam;
   readonly fallback: string;
   readonly mode: WorkspaceShellRouteMode;
   readonly scope: WorkspaceShellScopeRequirement;
@@ -102,10 +104,12 @@ function freezeRouteRegistration(
 ): WorkspaceShellRouteRegistration {
   return Object.freeze({
     accessPolicy: ACCESS_POLICY_BY_SCOPE[config.scope],
-    adapter: Object.freeze({
-      key: config.surfaceKey,
-      status: ADAPTER_STATUS_BY_MODE[config.mode],
-    }),
+    adapter: Object.freeze(
+      config.adapter ?? {
+        key: config.surfaceKey,
+        status: ADAPTER_STATUS_BY_MODE[config.mode],
+      },
+    ),
     allowedShellModes: Object.freeze([config.mode] as const),
     availability: AVAILABILITY_BY_MODE[config.mode],
     canonicalUrl,
@@ -150,17 +154,32 @@ const PERSONAL_ROUTE_REGISTRATIONS = [
 ] as const;
 
 const ORGANIZATION_ROUTE_REGISTRATIONS = [
-  ...registerRoutes(
-    ['/:orgSlug', '/:orgSlug/~/overview', '/:orgSlug/~/analytics/overview'],
-    {
-      fallback: '/:orgSlug/~/overview',
-      mode: 'canvas',
-      scope: 'organization',
-      surfaceKey: 'organization-overview',
-      switcherItems: ['workspace', 'messages', 'research'],
-      telemetryClass: 'product',
+  ...registerRoutes(['/:orgSlug/~/overview'], {
+    adapter: {
+      key: 'organization-workspace-overview',
+      status: 'embedded',
     },
-  ),
+    fallback: '/:orgSlug/~/overview',
+    mode: 'canvas',
+    scope: 'organization',
+    surfaceKey: 'organization-overview',
+    switcherItems: ['workspace', 'messages', 'research'],
+    telemetryClass: 'product',
+  }),
+  ...registerRoutes(['/:orgSlug'], {
+    fallback: '/:orgSlug/~/overview',
+    mode: 'canvas',
+    scope: 'organization',
+    surfaceKey: 'organization-landing',
+    telemetryClass: 'product',
+  }),
+  ...registerRoutes(['/:orgSlug/~/analytics/overview'], {
+    fallback: '/:orgSlug/~/overview',
+    mode: 'canvas',
+    scope: 'organization',
+    surfaceKey: 'analytics',
+    telemetryClass: 'product',
+  }),
   ...registerRoutes(
     ['/:orgSlug/~/agent', '/:orgSlug/~/agent/new', '/:orgSlug/~/agent/:id'],
     {
@@ -295,6 +314,22 @@ const BRAND_ROUTE_REGISTRATIONS = [
     [
       '/:orgSlug/:brandSlug/workspace',
       '/:orgSlug/:brandSlug/workspace/overview',
+    ],
+    {
+      adapter: {
+        key: 'brand-workspace-overview',
+        status: 'embedded',
+      },
+      fallback: '/:orgSlug/:brandSlug/workspace/overview',
+      mode: 'canvas',
+      scope: 'brand',
+      surfaceKey: 'workspace-overview',
+      switcherItems: ['workspace'],
+      telemetryClass: 'product',
+    },
+  ),
+  ...registerRoutes(
+    [
       '/:orgSlug/:brandSlug/workspace/inbox/:view',
       '/:orgSlug/:brandSlug/workspace/activity',
       '/:orgSlug/:brandSlug/tasks',

--- a/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.controller.spec.ts
+++ b/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.controller.spec.ts
@@ -4,6 +4,7 @@ import type { CreditsUtilsService } from '@api/collections/credits/services/cred
 import type { UsersService } from '@api/collections/users/services/users.service';
 import { AgentOrchestratorController } from '@api/services/agent-orchestrator/agent-orchestrator.controller';
 import type { AgentOrchestratorService } from '@api/services/agent-orchestrator/agent-orchestrator.service';
+import type { AgentArtifactReference } from '@genfeedai/interfaces';
 import type { LoggerService } from '@libs/logger/logger.service';
 
 vi.mock('@genfeedai/tools', () => ({
@@ -101,6 +102,41 @@ describe('AgentOrchestratorController', () => {
         expect.objectContaining({
           authToken: 'token123',
           userId: expect.any(String),
+        }),
+      );
+    });
+
+    it('passes typed selected artifact references to the scoped turn', async () => {
+      const user = {
+        id: 'authProvider_123',
+        publicMetadata: { organization: 'org', user: 'usr' },
+      } as unknown as User;
+      const reference = {
+        brandId: 'brand-1',
+        kind: 'post',
+        organizationId: '507f191e810c19729de860ea',
+        recordId: 'post-1',
+        serializer: 'post',
+      } satisfies AgentArtifactReference;
+      usersService.findOne.mockResolvedValue({
+        id: '507f191e810c19729de860ea',
+      });
+      service.chat.mockResolvedValue({} as never);
+
+      await controller.createTurn(
+        {
+          artifactReferences: [reference],
+          content: 'Review the selected post',
+          threadId: 'conv-1',
+        },
+        user,
+        'Bearer token123',
+      );
+
+      expect(service.chat).toHaveBeenCalledWith(
+        expect.objectContaining({ artifactReferences: [reference] }),
+        expect.objectContaining({
+          organizationId: '507f191e810c19729de860ea',
         }),
       );
     });

--- a/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.controller.ts
+++ b/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.controller.ts
@@ -10,6 +10,7 @@ import { ErrorResponse } from '@api/helpers/utils/error-response/error-response.
 import { AgentOrchestratorService } from '@api/services/agent-orchestrator/agent-orchestrator.service';
 import { AGENT_MODEL_TURN_COSTS } from '@api/services/agent-orchestrator/constants/agent-credit-costs.constant';
 import type { AgentPageContext } from '@api/services/agent-orchestrator/interfaces/agent-chat.interface';
+import type { AgentArtifactReference } from '@genfeedai/interfaces';
 import { LoggerService } from '@libs/logger/logger.service';
 import {
   BadRequestException,
@@ -33,6 +34,7 @@ interface AgentChatAttachment {
 }
 
 interface AgentChatBody {
+  artifactReferences?: AgentArtifactReference[];
   brandId?: string | null;
   content: string;
   expectedContextVersion?: number;
@@ -158,6 +160,7 @@ export class AgentOrchestratorController {
     }
 
     return {
+      artifactReferences: body.artifactReferences,
       attachments: body.attachments,
       brandId: body.brandId,
       content: body.content,

--- a/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.spec.ts
+++ b/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.spec.ts
@@ -20,7 +20,10 @@ import { AgentRuntimeSessionService } from '@api/services/agent-threading/servic
 import { AgentThreadEngineService } from '@api/services/agent-threading/services/agent-thread-engine.service';
 import { LlmDispatcherService } from '@api/services/integrations/llm/llm-dispatcher.service';
 import { AgentAutonomyMode, AgentType } from '@genfeedai/enums';
-import { AgentToolName } from '@genfeedai/interfaces';
+import {
+  type AgentArtifactReference,
+  AgentToolName,
+} from '@genfeedai/interfaces';
 import { AgentScopeContextService } from '@genfeedai/server';
 import { ConfigService } from '@libs/config/config.service';
 import { LoggerService } from '@libs/logger/logger.service';
@@ -44,6 +47,7 @@ describe('AgentOrchestratorService', () => {
   let agentStrategiesService: vi.Mocked<AgentStrategiesService>;
   let agentRunsService: vi.Mocked<AgentRunsService>;
   let agentMemoriesService: vi.Mocked<AgentMemoriesService>;
+  let agentMessagesService: vi.Mocked<AgentMessagesService>;
   let creditsUtilsService: vi.Mocked<CreditsUtilsService>;
   let toolExecutorService: vi.Mocked<AgentToolExecutorService>;
   let streamPublisher: vi.Mocked<AgentStreamPublisherService>;
@@ -513,6 +517,7 @@ describe('AgentOrchestratorService', () => {
     configService = module.get(ConfigService);
     agentThreadsService = module.get(AgentThreadsService);
     agentMemoriesService = module.get(AgentMemoriesService);
+    agentMessagesService = module.get(AgentMessagesService);
     llmDispatcher = module.get(LlmDispatcherService);
     creditsUtilsService = module.get(CreditsUtilsService);
     organizationsService = module.get(OrganizationsService);
@@ -563,6 +568,37 @@ describe('AgentOrchestratorService', () => {
         actualModel: 'google/gemini-2.5-flash',
         model: 'google/gemini-2.5-flash',
         requestedModel: 'openrouter/auto',
+      }),
+    );
+  });
+
+  it('persists selected artifact references on the scoped user message', async () => {
+    organizationsService.findOne.mockResolvedValue({
+      onboardingCompleted: true,
+    } as never);
+    const reference = {
+      brandId: 'brand-1',
+      kind: 'post',
+      organizationId: ORG_ID,
+      recordId: 'post-1',
+      serializer: 'post',
+    } satisfies AgentArtifactReference;
+
+    await service.chat(
+      {
+        artifactReferences: [reference],
+        brandId: 'brand-1',
+        content: 'Review the selected post',
+      },
+      { organizationId: ORG_ID, userId: USER_ID },
+    );
+
+    expect(agentMessagesService.addMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        artifactReferences: [reference],
+        brandId: 'brand-1',
+        organizationId: ORG_ID,
+        role: 'user',
       }),
     );
   });

--- a/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.ts
+++ b/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.ts
@@ -346,6 +346,7 @@ export class AgentOrchestratorService {
 
       // Save user message
       await this.agentMessagesService.addMessage({
+        artifactReferences: request.artifactReferences,
         brandId: scope.brandId,
         content: request.content,
         metadata: {
@@ -1268,6 +1269,7 @@ export class AgentOrchestratorService {
 
     // Save user message
     await this.agentMessagesService.addMessage({
+      artifactReferences: request.artifactReferences,
       brandId: scope.brandId,
       content: request.content,
       metadata: {

--- a/apps/server/api/src/services/agent-orchestrator/interfaces/agent-chat.interface.ts
+++ b/apps/server/api/src/services/agent-orchestrator/interfaces/agent-chat.interface.ts
@@ -1,5 +1,8 @@
 import type { AgentType } from '@genfeedai/enums';
-import type { ValidatedAgentScope } from '@genfeedai/interfaces';
+import type {
+  AgentArtifactReference,
+  ValidatedAgentScope,
+} from '@genfeedai/interfaces';
 import type { ResolvedRuntimeSkill } from '@genfeedai/interfaces/ai';
 
 export interface AgentChatAttachment {
@@ -25,6 +28,7 @@ export interface AgentPageContext {
 
 export interface AgentChatRequest {
   agentType?: AgentType;
+  artifactReferences?: AgentArtifactReference[];
   attachments?: AgentChatAttachment[];
   brandId?: string | null;
   content: string;

--- a/packages/agent/src/components/AgentChatInput.spec.tsx
+++ b/packages/agent/src/components/AgentChatInput.spec.tsx
@@ -171,4 +171,29 @@ describe('AgentChatInput', () => {
       screen.getByText('Opened Publish. Explicit approval is still required.'),
     ).toBeInTheDocument();
   });
+
+  it('exposes selected surface artifact references in the composer context', () => {
+    render(
+      <ConversationComposerShellProvider
+        artifactReferences={[
+          {
+            brandId: 'brand-1',
+            kind: 'post',
+            organizationId: 'org-1',
+            recordId: 'post-1',
+            serializer: 'post',
+          },
+        ]}
+        contextLabel="Brand Workspace overview"
+        draftScopeKey="acme:thread-1:3"
+        portalTarget={null}
+        shellState="canvas"
+      >
+        <AgentChatInput onSend={vi.fn()} />
+      </ConversationComposerShellProvider>,
+    );
+
+    expect(screen.getByText('1 reference')).toBeInTheDocument();
+    expect(screen.getByText('^post:post-1')).toBeInTheDocument();
+  });
 });

--- a/packages/agent/src/components/AgentChatInput.tsx
+++ b/packages/agent/src/components/AgentChatInput.tsx
@@ -3,6 +3,7 @@ import { AgentChatInputStyles } from '@genfeedai/agent/components/AgentChatInput
 import { AgentChatInputToolbar } from '@genfeedai/agent/components/AgentChatInputToolbar';
 import { AgentComposerContextRail } from '@genfeedai/agent/components/AgentComposerContextRail';
 import { useAgentChatInput } from '@genfeedai/agent/components/useAgentChatInput';
+import type { ConversationComposerSendOptions } from '@genfeedai/agent/models/conversation-composer.model';
 import type { AgentApiService } from '@genfeedai/agent/services/agent-api.service';
 import type { PromptBarAttachedAsset } from '@genfeedai/props/studio/prompt-bar.props';
 import type {
@@ -33,9 +34,7 @@ interface AgentChatInputProps {
     content: string,
     mentions?: ExtractedMention[],
     attachments?: ChatAttachment[],
-    options?: {
-      planModeEnabled?: boolean;
-    },
+    options?: ConversationComposerSendOptions,
   ) => void;
   onStop?: () => void | Promise<void>;
   disabled?: boolean;

--- a/packages/agent/src/components/ConversationComposerShellContext.tsx
+++ b/packages/agent/src/components/ConversationComposerShellContext.tsx
@@ -4,6 +4,7 @@ import type {
   ConversationComposerActionInvocation,
   ConversationComposerDispatchResult,
 } from '@genfeedai/agent/models/conversation-composer.model';
+import type { AgentArtifactReference } from '@genfeedai/interfaces';
 import {
   createContext,
   type ReactElement,
@@ -13,6 +14,7 @@ import {
 } from 'react';
 
 export interface ConversationComposerShellContextValue {
+  artifactReferences?: readonly AgentArtifactReference[];
   contextLabel: string;
   dispatchAction?: (
     invocation: ConversationComposerActionInvocation,
@@ -34,6 +36,7 @@ const ConversationComposerShellContext =
   createContext<ConversationComposerShellContextValue | null>(null);
 
 export function ConversationComposerShellProvider({
+  artifactReferences,
   children,
   contextLabel,
   dispatchAction,
@@ -44,6 +47,7 @@ export function ConversationComposerShellProvider({
 }: ConversationComposerShellProviderProps): ReactElement {
   const value = useMemo<ConversationComposerShellContextValue>(
     () => ({
+      artifactReferences,
       contextLabel,
       dispatchAction,
       draftScopeKey,
@@ -52,6 +56,7 @@ export function ConversationComposerShellProvider({
       shellState,
     }),
     [
+      artifactReferences,
       contextLabel,
       dispatchAction,
       draftScopeKey,

--- a/packages/agent/src/components/useAgentChatInput.ts
+++ b/packages/agent/src/components/useAgentChatInput.ts
@@ -15,7 +15,10 @@ import { useContentMentions } from '@genfeedai/agent/hooks/use-content-mentions'
 import { useCredentialMentions } from '@genfeedai/agent/hooks/use-credential-mentions';
 import { useMicrophoneInput } from '@genfeedai/agent/hooks/use-microphone-input';
 import { useTeamMentions } from '@genfeedai/agent/hooks/use-team-mentions';
-import type { ConversationComposerActionName } from '@genfeedai/agent/models/conversation-composer.model';
+import type {
+  ConversationComposerActionName,
+  ConversationComposerSendOptions,
+} from '@genfeedai/agent/models/conversation-composer.model';
 import type { AgentApiService } from '@genfeedai/agent/services/agent-api.service';
 import { useAgentChatStore } from '@genfeedai/agent/stores/agent-chat.store';
 import {
@@ -201,7 +204,7 @@ interface UseAgentChatInputParams {
     content: string,
     mentions?: ExtractedMention[],
     attachments?: ChatAttachment[],
-    options?: { planModeEnabled?: boolean },
+    options?: ConversationComposerSendOptions,
   ) => void;
   onStop?: () => void | Promise<void>;
   disabled?: boolean;
@@ -268,6 +271,17 @@ export function useAgentChatInput({
           type: mention.type,
         }))
       : [],
+  );
+  const displayedReferences = useMemo<AgentChatReferenceItem[]>(
+    () => [
+      ...references,
+      ...(composerShell?.artifactReferences ?? []).map((reference) => ({
+        id: reference.recordId,
+        label: `^${reference.kind}:${reference.recordId}`,
+        type: 'content' as const,
+      })),
+    ],
+    [composerShell?.artifactReferences, references],
   );
   const editorRef = useRef<Editor | null>(null);
 
@@ -533,7 +547,12 @@ export function useAgentChatInput({
       text,
       mentionData.length > 0 ? mentionData : undefined,
       completed && completed.length > 0 ? completed : undefined,
-      { planModeEnabled: false },
+      {
+        artifactReferences: composerShell?.artifactReferences
+          ? [...composerShell.artifactReferences]
+          : undefined,
+        planModeEnabled: false,
+      },
     );
     editor.commands.clearContent();
     clearAllAttachments?.();
@@ -657,7 +676,7 @@ export function useAgentChatInput({
     isDragActive,
     isListening,
     isTranscribing,
-    references,
+    references: displayedReferences,
     shouldShowSendButton,
     shouldShowVoiceInput,
     startListening,

--- a/packages/agent/src/hooks/use-agent-chat-container.ts
+++ b/packages/agent/src/hooks/use-agent-chat-container.ts
@@ -15,7 +15,10 @@ import {
   AgentWorkEventStatus,
   AgentWorkEventType,
 } from '@genfeedai/agent/models/agent-chat.model';
-import type { PersistedConversationComposerAttachment } from '@genfeedai/agent/models/conversation-composer.model';
+import type {
+  ConversationComposerSendOptions,
+  PersistedConversationComposerAttachment,
+} from '@genfeedai/agent/models/conversation-composer.model';
 import type { AgentApiService } from '@genfeedai/agent/services/agent-api.service';
 import { runAgentApiEffect } from '@genfeedai/agent/services/agent-base-api.service';
 import { useAgentChatStore } from '@genfeedai/agent/stores/agent-chat.store';
@@ -305,9 +308,7 @@ export function useAgentChatContainer({
       content: string,
       _mentions?: ExtractedMention[],
       attachments?: ChatAttachment[],
-      options?: {
-        planModeEnabled?: boolean;
-      },
+      options?: ConversationComposerSendOptions,
     ) => {
       if (isReadOnly) {
         setError('Archived threads are read-only.');
@@ -315,6 +316,7 @@ export function useAgentChatContainer({
       }
       followLatestTurn('smooth');
       sendMessage(content, {
+        artifactReferences: options?.artifactReferences,
         attachments,
         planModeEnabled: options?.planModeEnabled ?? false,
       });

--- a/packages/agent/src/hooks/use-agent-chat-stream.spec.tsx
+++ b/packages/agent/src/hooks/use-agent-chat-stream.spec.tsx
@@ -184,6 +184,36 @@ describe('useAgentChatStream', () => {
     );
   });
 
+  it('sends selected canonical artifact references with a streaming turn', async () => {
+    const chatStream = vi.fn().mockResolvedValue({
+      brandId: 'brand-1',
+      contextVersion: 1,
+      runId: 'run-reference',
+      startedAt: '2026-07-13T00:00:00.000Z',
+      threadId: 'thread-reference',
+    });
+    const apiService = createApiService({ chatStream });
+    const reference = {
+      brandId: 'brand-1',
+      kind: 'post' as const,
+      organizationId: 'org-1',
+      recordId: 'post-1',
+      serializer: 'post' as const,
+    };
+    const { result } = renderHook(() => useAgentChatStream({ apiService }));
+
+    await act(async () => {
+      await result.current.sendMessage('Review this post', {
+        artifactReferences: [reference],
+      });
+    });
+
+    expect(chatStream).toHaveBeenCalledWith(
+      expect.objectContaining({ artifactReferences: [reference] }),
+      expect.any(AbortSignal),
+    );
+  });
+
   it('falls back to non-streaming chat when the socket is not ready', async () => {
     socketReady = false;
     socketConnected = false;

--- a/packages/agent/src/hooks/use-agent-chat-stream.ts
+++ b/packages/agent/src/hooks/use-agent-chat-stream.ts
@@ -33,6 +33,7 @@ import {
 import { applyDashboardOperation } from '@genfeedai/agent/utils/apply-dashboard-operation';
 import { mapToolCallResponse } from '@genfeedai/agent/utils/map-tool-call-response';
 import { AgentThreadStatus } from '@genfeedai/enums';
+import type { AgentArtifactReference } from '@genfeedai/interfaces';
 import type { ChatAttachment } from '@genfeedai/props/ui/attachments.props';
 import { useSocketManager } from '@hooks/utils/use-socket-manager/use-socket-manager';
 import { useCallback, useEffect, useRef } from 'react';
@@ -44,6 +45,7 @@ interface UseAgentChatStreamOptions {
 }
 
 interface SendStreamMessageOptions {
+  artifactReferences?: AgentArtifactReference[];
   forceNewThread?: boolean;
   source?: 'agent' | 'proactive' | 'onboarding';
   signal?: AbortSignal;
@@ -380,6 +382,7 @@ export function useAgentChatStream(
         const response = await runAgentApiEffect(
           apiService.chatEffect(
             {
+              artifactReferences: sendOptions?.artifactReferences,
               attachments: sendOptions?.attachments,
               brandId: currentThread?.brandId ?? null,
               content,
@@ -632,9 +635,18 @@ export function useAgentChatStream(
         content,
         createdAt: new Date().toISOString(),
         id: `user-${Date.now()}`,
-        metadata: sendOptions?.attachments?.length
-          ? { attachments: sendOptions.attachments }
-          : undefined,
+        metadata:
+          sendOptions?.attachments?.length ||
+          sendOptions?.artifactReferences?.length
+            ? {
+                ...(sendOptions.attachments?.length
+                  ? { attachments: sendOptions.attachments }
+                  : {}),
+                ...(sendOptions.artifactReferences?.length
+                  ? { artifactReferences: sendOptions.artifactReferences }
+                  : {}),
+              }
+            : undefined,
         role: 'user',
         threadId: currentActiveThreadId ?? '',
       };
@@ -1018,6 +1030,7 @@ export function useAgentChatStream(
         const response = await runAgentApiEffect(
           apiService.chatStreamEffect(
             {
+              artifactReferences: sendOptions?.artifactReferences,
               attachments: sendOptions?.attachments,
               brandId: currentThread?.brandId ?? null,
               content,

--- a/packages/agent/src/hooks/use-agent-chat.spec.tsx
+++ b/packages/agent/src/hooks/use-agent-chat.spec.tsx
@@ -162,4 +162,40 @@ describe('useAgentChat', () => {
     expect(payload?.pageContext).not.toHaveProperty('suggestedActions');
     expect(() => JSON.stringify(payload)).not.toThrow();
   });
+
+  it('sends selected canonical artifact references with the turn', async () => {
+    const chat = vi.fn().mockResolvedValue({
+      contextVersion: 1,
+      creditsRemaining: 95,
+      creditsUsed: 5,
+      message: { content: 'Reviewed', metadata: {}, role: 'assistant' },
+      threadId: 'thread-reference',
+      toolCalls: [],
+    });
+    const apiService = {
+      chat,
+      chatEffect: vi.fn((...args: Parameters<typeof chat>) =>
+        Effect.promise(() => chat(...args)),
+      ),
+    } as unknown as AgentApiService;
+    const reference = {
+      brandId: 'brand-1',
+      kind: 'post' as const,
+      organizationId: 'org-1',
+      recordId: 'post-1',
+      serializer: 'post' as const,
+    };
+    const { result } = renderHook(() => useAgentChat({ apiService }));
+
+    await act(async () => {
+      await result.current.sendMessage('Review this post', {
+        artifactReferences: [reference],
+      });
+    });
+
+    expect(chat).toHaveBeenCalledWith(
+      expect.objectContaining({ artifactReferences: [reference] }),
+      expect.any(AbortSignal),
+    );
+  });
 });

--- a/packages/agent/src/hooks/use-agent-chat.ts
+++ b/packages/agent/src/hooks/use-agent-chat.ts
@@ -7,6 +7,7 @@ import { toAgentRequestPageContext } from '@genfeedai/agent/utils/agent-page-con
 import { applyDashboardOperation } from '@genfeedai/agent/utils/apply-dashboard-operation';
 import { mapToolCallResponse } from '@genfeedai/agent/utils/map-tool-call-response';
 import { AgentThreadStatus } from '@genfeedai/enums';
+import type { AgentArtifactReference } from '@genfeedai/interfaces';
 import type { ChatAttachment } from '@genfeedai/props/ui/attachments.props';
 import { useCallback, useRef } from 'react';
 
@@ -17,6 +18,7 @@ interface UseAgentChatOptions {
 }
 
 interface SendMessageOptions {
+  artifactReferences?: AgentArtifactReference[];
   source?: 'agent' | 'proactive' | 'onboarding';
   signal?: AbortSignal;
   attachments?: ChatAttachment[];
@@ -53,9 +55,18 @@ export function useAgentChat(options: UseAgentChatOptions): UseAgentChatReturn {
         content,
         createdAt: new Date().toISOString(),
         id: `user-${Date.now()}`,
-        metadata: sendOptions?.attachments?.length
-          ? { attachments: sendOptions.attachments }
-          : undefined,
+        metadata:
+          sendOptions?.attachments?.length ||
+          sendOptions?.artifactReferences?.length
+            ? {
+                ...(sendOptions.attachments?.length
+                  ? { attachments: sendOptions.attachments }
+                  : {}),
+                ...(sendOptions.artifactReferences?.length
+                  ? { artifactReferences: sendOptions.artifactReferences }
+                  : {}),
+              }
+            : undefined,
         role: 'user',
         threadId: activeThreadId ?? '',
       };
@@ -78,6 +89,7 @@ export function useAgentChat(options: UseAgentChatOptions): UseAgentChatReturn {
         const response = await runAgentApiEffect(
           apiService.chatEffect(
             {
+              artifactReferences: sendOptions?.artifactReferences,
               attachments: sendOptions?.attachments,
               brandId: currentThread?.brandId ?? null,
               content,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -140,6 +140,7 @@ export type {
   ConversationComposerDispatchResult,
   ConversationComposerDispatchStatus,
   ConversationComposerScope,
+  ConversationComposerSendOptions,
   ParsedConversationComposerCommand,
   PersistedConversationComposerAttachment,
   PersistedConversationComposerDraft,

--- a/packages/agent/src/models/agent-chat.model.ts
+++ b/packages/agent/src/models/agent-chat.model.ts
@@ -2,6 +2,7 @@ import type { SuggestedAction } from '@genfeedai/agent/models/agent-suggested-ac
 import type { ClipRunCardState } from '@genfeedai/agent/models/clip-run-card.model';
 import type { AgentThreadStatus } from '@genfeedai/enums';
 import type {
+  AgentArtifactReference,
   AgentClipRunIdentity,
   AgentDashboardOperation,
   AgentUIBlock,
@@ -10,6 +11,7 @@ import type { ChatAttachment } from '@genfeedai/props/ui/attachments.props';
 import type { StructuredProgressDebugPayload } from '@genfeedai/utils/progress/structured-progress-event.util';
 
 export interface AgentChatMessageMetadata {
+  artifactReferences?: AgentArtifactReference[];
   generatedContent?: string;
   isFallbackContent?: boolean;
   model?: string;
@@ -476,6 +478,7 @@ export interface AgentToolCallSummary {
 }
 
 export interface AgentChatPayload {
+  artifactReferences?: AgentArtifactReference[];
   threadId?: string;
   brandId?: string | null;
   expectedContextVersion?: number;

--- a/packages/agent/src/models/conversation-composer.model.ts
+++ b/packages/agent/src/models/conversation-composer.model.ts
@@ -1,3 +1,4 @@
+import type { AgentArtifactReference } from '@genfeedai/interfaces';
 import type { JSONContent } from '@tiptap/core';
 
 export type ConversationComposerActionName =
@@ -34,6 +35,11 @@ export interface ConversationComposerDispatchResult {
 export interface ConversationComposerActionInvocation {
   action: ConversationComposerActionDefinition;
   arguments: string;
+}
+
+export interface ConversationComposerSendOptions {
+  artifactReferences?: AgentArtifactReference[];
+  planModeEnabled?: boolean;
 }
 
 export interface UnknownConversationComposerCommand {

--- a/packages/interfaces/src/ui/workspace-shell.interface.ts
+++ b/packages/interfaces/src/ui/workspace-shell.interface.ts
@@ -96,7 +96,7 @@ export interface WorkspaceShellRestorationPolicy {
 
 export interface WorkspaceShellAdapterSeam {
   readonly key: string;
-  readonly status: 'dedicated-route' | 'placeholder';
+  readonly status: 'dedicated-route' | 'embedded' | 'placeholder';
 }
 
 export interface WorkspaceShellRouteRegistration {


### PR DESCRIPTION
## Summary

- register organization and brand Workspace overview routes independently as embedded harness surfaces while retaining their canonical URLs and same-route fallback
- wrap the existing dashboard trees in app-local adapters so current blocks, actions, loading/error states, data providers, and persisted OpenUI layouts remain unchanged
- expose selected task-linked content as scoped typed artifact references in the composer and persist only server-authorized references on the user message
- keep organization and brand canvas launches on their canonical overview routes with connected thread state preserved

## Parallel coordination

- inspected open PR #1699; its scope-control work is additive to this adapter slice
- the only textual overlap is the universal shell and its test; resolution should retain both scope-control props/inspector content and the WorkspaceSurfaceAdapterProvider/overview inspector content

## Verification

- Biome staged-file check passed for all 32 changed files
- UI control guard passed
- no-bespoke-card guard passed
- design-system check passed
- git diff/show checks passed
- staged secretlint passed
- Gitleaks passed for the staged diff and final commit
- focused tests were added for routes, adapters, scope filtering, canonical launches, composer propagation, API handoff, and server persistence

Tests, typechecks, builds, E2E, and GitHub Actions babysitting were intentionally not run per the local MacBook policy and task handoff.

Closes #1684
Part of #1670
Parent #1681