### PR TITLE
feat(app): embed Research work surface

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/research/layout.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/research/layout.tsx
@@ -1,8 +1,17 @@
 'use client';
 
+import ResearchWorkspaceSurfaceAdapter from '@app-components/research/work-surface/ResearchWorkspaceSurfaceAdapter';
+import { ResearchWorkSurfaceProvider } from '@pages/research/work-surface/ResearchWorkSurfaceProvider';
 import type { LayoutProps } from '@props/layout/layout.props';
 import FeatureGate from '@ui/guards/feature/FeatureGate';
 
 export default function ResearchLayout({ children }: LayoutProps) {
-  return <FeatureGate flagKey="research">{children}</FeatureGate>;
+  return (
+    <FeatureGate flagKey="research">
+      <ResearchWorkSurfaceProvider>
+        <ResearchWorkspaceSurfaceAdapter />
+        {children}
+      </ResearchWorkSurfaceProvider>
+    </FeatureGate>
+  );
 }

--- a/apps/app/packages/components/research/ads/AdsResearchAdCards.tsx
+++ b/apps/app/packages/components/research/ads/AdsResearchAdCards.tsx
@@ -40,6 +40,8 @@ export function AdGridCard({
   return (
     <Button
       type="button"
+      aria-pressed={isSelected}
+      ariaLabel={`${isSelected ? 'Selected' : 'Select'} ${item.title} for research context`}
       variant={ButtonVariant.UNSTYLED}
       onClick={() => onSelect(item)}
       className={cn(
@@ -131,11 +133,20 @@ export function AdTableRow({
 
   return (
     <TableRow
+      aria-label={`${isSelected ? 'Selected' : 'Select'} ${item.title} for research context`}
+      aria-selected={isSelected}
       className={cn(
         'cursor-pointer border-b border-white/[0.06] transition-colors hover:bg-white/[0.03]',
         isSelected && 'bg-primary/5',
       )}
       onClick={() => onSelect(item)}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          onSelect(item);
+        }
+      }}
+      tabIndex={0}
     >
       <TableCell className="px-4 py-3">
         <Badge variant="ghost">

--- a/apps/app/packages/components/research/ads/AdsResearchPageClient.tsx
+++ b/apps/app/packages/components/research/ads/AdsResearchPageClient.tsx
@@ -9,6 +9,7 @@ import {
   ViewType,
 } from '@genfeedai/enums';
 import type { AdsResearchPlatform } from '@genfeedai/interfaces';
+import { useResearchPagination } from '@pages/research/work-surface/ResearchWorkSurfaceProvider';
 import ButtonDropdown from '@ui/buttons/dropdown/button-dropdown/ButtonDropdown';
 import Alert from '@ui/feedback/alert/Alert';
 import Container from '@ui/layout/container/Container';
@@ -91,6 +92,7 @@ export default function AdsResearchPageClient({
     viewType,
     setViewType,
   } = useAdsResearchPageClient(initialPlatform);
+  const { pageItems, pagination } = useResearchPagination(allAds);
 
   return (
     <Container
@@ -282,7 +284,7 @@ export default function AdsResearchPageClient({
       {/* Card Grid / Table */}
       {viewType === ViewType.GRID ? (
         <AdsResearchAdGrid
-          ads={allAds}
+          ads={[...pageItems]}
           isLoading={isLoading}
           metric={metric}
           search={search}
@@ -291,13 +293,14 @@ export default function AdsResearchPageClient({
         />
       ) : (
         <AdsResearchAdTable
-          ads={allAds}
+          ads={[...pageItems]}
           metric={metric}
           search={search}
           selectedKey={selectedKey}
           onSelect={handleSelectAd}
         />
       )}
+      {pagination ? <div className="mt-5">{pagination}</div> : null}
 
       {/* Slide-over Detail Sidebar */}
       {selectedAd && (

--- a/apps/app/packages/components/research/ads/useAdsResearchPageClient.ts
+++ b/apps/app/packages/components/research/ads/useAdsResearchPageClient.ts
@@ -15,6 +15,16 @@ import type {
 import { useAuthedService } from '@hooks/auth/use-authed-service/use-authed-service';
 import { useOrgUrl } from '@hooks/navigation/use-org-url';
 import {
+  useOptionalResearchWorkSurface,
+  useResearchQueryState,
+  useResearchSearchParamState,
+  useRestoreResearchFinding,
+} from '@pages/research/work-surface/ResearchWorkSurfaceProvider';
+import {
+  getResearchFindingReferenceKey,
+  toAdsResearchFinding,
+} from '@pages/research/work-surface/research-work-surface.types';
+import {
   AdsResearchService,
   type UnifiedAdAccountOption,
 } from '@services/ads/ads-research.service';
@@ -53,6 +63,25 @@ type CredentialOption = {
 
 type AdSortKey = 'score' | 'ctr' | 'roas';
 
+const SOURCE_VALUES = ['all', 'my_accounts', 'public'] as const;
+const PLATFORM_VALUES = ['all', 'google', 'meta'] as const;
+const CHANNEL_VALUES = ['all', 'display', 'search', 'youtube'] as const;
+const METRIC_VALUES = [
+  'performanceScore',
+  'ctr',
+  'roas',
+  'conversions',
+  'spendEfficiency',
+] as const;
+const TIMEFRAME_VALUES = [
+  'last_7_days',
+  'last_30_days',
+  'last_90_days',
+  'all_time',
+] as const;
+const SORT_VALUES = ['score', 'ctr', 'roas'] as const;
+const VIEW_VALUES = [ViewType.GRID, ViewType.TABLE] as const;
+
 function getBrandLabel(selectedBrand?: { label?: string; name?: string }) {
   return selectedBrand?.label || selectedBrand?.name || 'Brand';
 }
@@ -61,23 +90,59 @@ export function useAdsResearchPageClient(
   initialPlatform: AdsResearchPlatform | 'all',
 ) {
   const { href } = useOrgUrl();
+  const surface = useOptionalResearchWorkSurface();
   const { brandId, credentials, isReady, selectedBrand } = useBrand();
   const getAdsResearchService = useAuthedService((token: string) =>
     AdsResearchService.getInstance(token),
   );
 
-  const [source, setSource] = useState<AdsResearchSource>('all');
-  const [platform, setPlatform] = useState<AdsResearchPlatform | 'all'>(
-    initialPlatform,
-  );
-  const [channel, setChannel] = useState<AdsChannel>('all');
-  const [metric, setMetric] = useState<AdsResearchMetric>('performanceScore');
+  const [source, setSource] = useResearchSearchParamState<AdsResearchSource>({
+    allowedValues: SOURCE_VALUES,
+    defaultValue: 'all',
+    key: 'source',
+  });
+  const [platform, setPlatform] = useResearchSearchParamState<
+    AdsResearchPlatform | 'all'
+  >({
+    allowedValues:
+      initialPlatform === 'all' ? PLATFORM_VALUES : [initialPlatform],
+    defaultValue: initialPlatform,
+    key: 'platform',
+  });
+  const [channel, setChannel] = useResearchSearchParamState<AdsChannel>({
+    allowedValues: CHANNEL_VALUES,
+    defaultValue: 'all',
+    key: 'channel',
+  });
+  const [metric, setMetric] = useResearchSearchParamState<AdsResearchMetric>({
+    allowedValues: METRIC_VALUES,
+    defaultValue: 'performanceScore',
+    key: 'metric',
+  });
   const [timeframe, setTimeframe] =
-    useState<AdsResearchTimeframe>('last_30_days');
-  const [industry, setIndustry] = useState('');
-  const [credentialId, setCredentialId] = useState('');
-  const [adAccountId, setAdAccountId] = useState('');
-  const [loginCustomerId, setLoginCustomerId] = useState('');
+    useResearchSearchParamState<AdsResearchTimeframe>({
+      allowedValues: TIMEFRAME_VALUES,
+      defaultValue: 'last_30_days',
+      key: 'timeframe',
+    });
+  const [industry, setIndustry] = useResearchSearchParamState<string>({
+    defaultValue: '',
+    key: 'industry',
+    maxLength: 120,
+  });
+  const [credentialId, setCredentialId] = useResearchSearchParamState<string>({
+    defaultValue: '',
+    key: 'credential',
+  });
+  const [adAccountId, setAdAccountId] = useResearchSearchParamState<string>({
+    defaultValue: '',
+    key: 'account',
+  });
+  const [loginCustomerId, setLoginCustomerId] =
+    useResearchSearchParamState<string>({
+      defaultValue: '',
+      key: 'loginCustomer',
+    });
   const [selectedAd, setSelectedAd] = useState<SelectedAdRef | null>(null);
   const [busyAction, setBusyAction] = useState<
     'ad_pack' | 'workflow' | 'launch_prep' | null
@@ -92,10 +157,27 @@ export function useAdsResearchPageClient(
     workflowName: string;
   } | null>(null);
 
-  const [search, setSearch] = useState('');
-  const [sortKey, setSortKey] = useState<AdSortKey>('score');
-  const [viewType, setViewType] = useState<ViewType>(ViewType.GRID);
-  const [showFilters, setShowFilters] = useState(false);
+  const [search, setSearch] = useResearchQueryState();
+  const [sortKey, setSortKey] = useResearchSearchParamState<AdSortKey>({
+    allowedValues: SORT_VALUES,
+    defaultValue: 'score',
+    key: 'sort',
+  });
+  const [viewType, setViewType] = useResearchSearchParamState<ViewType>({
+    allowedValues: VIEW_VALUES,
+    defaultValue: ViewType.GRID,
+    key: 'view',
+  });
+  const [filtersVisibility, setFiltersVisibility] = useResearchSearchParamState<
+    'hidden' | 'visible'
+  >({
+    allowedValues: ['hidden', 'visible'],
+    defaultValue: 'hidden',
+    key: 'filters',
+  });
+  const showFilters = filtersVisibility === 'visible';
+  const setShowFilters = (isVisible: boolean) =>
+    setFiltersVisibility(isVisible ? 'visible' : 'hidden');
 
   const brandLabel = getBrandLabel(selectedBrand);
   const effectivePlatform =
@@ -106,7 +188,7 @@ export function useAdsResearchPageClient(
     if (!showChannelFilter && channel !== 'all') {
       setChannel('all');
     }
-  }, [channel, showChannelFilter]);
+  }, [channel, setChannel, showChannelFilter]);
 
   useEffect(() => {
     if (!credentialId) {
@@ -115,7 +197,7 @@ export function useAdsResearchPageClient(
     }
 
     setAdAccountId('');
-  }, [credentialId]);
+  }, [credentialId, setAdAccountId]);
 
   const credentialOptions = useMemo(
     () =>
@@ -263,6 +345,49 @@ export function useAdsResearchPageClient(
 
     return filtered;
   }, [results.publicAds, results.connectedAds, search, sortKey]);
+  const findings = useMemo(() => allAds.map(toAdsResearchFinding), [allAds]);
+  const requestedReference = surface?.urlState.requestedReference ?? null;
+
+  useRestoreResearchFinding(findings, isLoading);
+
+  useEffect(() => {
+    if (!requestedReference) {
+      setSelectedAd(null);
+      return;
+    }
+
+    if (isLoading) {
+      return;
+    }
+
+    const requestedKey = getResearchFindingReferenceKey(requestedReference);
+    const item = allAds.find(
+      (candidate) =>
+        getResearchFindingReferenceKey(
+          toAdsResearchFinding(candidate).reference,
+        ) === requestedKey,
+    );
+    if (!item) {
+      return;
+    }
+
+    setSelectedAd({
+      adAccountId: item.adAccountId || adAccountId || undefined,
+      channel: item.channel,
+      credentialId: item.credentialId || credentialId || undefined,
+      id: item.source === 'my_accounts' ? item.sourceId : item.id,
+      loginCustomerId: item.loginCustomerId || loginCustomerId || undefined,
+      platform: item.platform,
+      source: item.source,
+    });
+  }, [
+    adAccountId,
+    allAds,
+    credentialId,
+    isLoading,
+    loginCustomerId,
+    requestedReference,
+  ]);
 
   const handleSelectAd = (item: AdsResearchItem) => {
     setActionError(null);
@@ -279,6 +404,7 @@ export function useAdsResearchPageClient(
       platform: item.platform,
       source: item.source,
     });
+    surface?.selectFinding(toAdsResearchFinding(item));
   };
 
   const handleCloseDetail = () => {
@@ -287,6 +413,7 @@ export function useAdsResearchPageClient(
     setAdPackResult(null);
     setLaunchPrepResult(null);
     setWorkflowResult(null);
+    surface?.clearFinding();
   };
 
   const runAction = async (action: 'ad_pack' | 'workflow' | 'launch_prep') => {

--- a/apps/app/packages/components/research/work-surface/ResearchWorkspaceSurfaceAdapter.tsx
+++ b/apps/app/packages/components/research/work-surface/ResearchWorkspaceSurfaceAdapter.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import type { ConversationComposerContextReference } from '@genfeedai/agent';
+import ResearchFindingInspector from '@pages/research/work-surface/ResearchFindingInspector';
+import { useOptionalResearchWorkSurface } from '@pages/research/work-surface/ResearchWorkSurfaceProvider';
+import { useEffect, useMemo } from 'react';
+import {
+  useRegisterResearchWorkspaceSurfaceAdapter,
+  useResearchWorkspaceSurfaceAdapterRegistrationAvailable,
+} from '@/features/research/work-surface/research-workspace-surface-adapter-context';
+
+export default function ResearchWorkspaceSurfaceAdapter() {
+  const surface = useOptionalResearchWorkSurface();
+  const isRegistrationAvailable =
+    useResearchWorkspaceSurfaceAdapterRegistrationAvailable();
+  useEffect(() => {
+    surface?.setEmbedded(isRegistrationAvailable);
+  }, [isRegistrationAvailable, surface?.setEmbedded]);
+  const references = useMemo<readonly ConversationComposerContextReference[]>(
+    () =>
+      surface?.authorizedFinding
+        ? [
+            {
+              authorization: 'authorized',
+              id: surface.authorizedFinding.reference.id,
+              kind: surface.authorizedFinding.reference.kind,
+              label: surface.authorizedFinding.title,
+            },
+          ]
+        : [],
+    [surface?.authorizedFinding],
+  );
+  const adapter = useMemo(
+    () => ({
+      inspectorContent: <ResearchFindingInspector />,
+      references,
+      surfaceKey: 'research',
+    }),
+    [references],
+  );
+
+  useRegisterResearchWorkspaceSurfaceAdapter(adapter);
+  return null;
+}

--- a/apps/app/src/components/workspace-shell/UniversalWorkspaceShell.tsx
+++ b/apps/app/src/components/workspace-shell/UniversalWorkspaceShell.tsx
@@ -42,6 +42,10 @@ import {
   HiOutlineViewColumns,
 } from 'react-icons/hi2';
 import {
+  type ResearchWorkspaceSurfaceAdapterRegistration,
+  ResearchWorkspaceSurfaceAdapterRegistrationContext,
+} from '@/features/research/work-surface/research-workspace-surface-adapter-context';
+import {
   appendSearchParamsToHref,
   normalizeProtectedPathname,
 } from '@/lib/navigation/operator-shell';
@@ -108,6 +112,10 @@ function UniversalWorkspaceShellContent({
   const [inspectorWidth, setInspectorWidth] = useState(INSPECTOR_DEFAULT_WIDTH);
   const [composerPortalTarget, setComposerPortalTarget] =
     useState<HTMLElement | null>(null);
+  const [surfaceAdapter, setSurfaceAdapter] = useState<{
+    readonly registration: ResearchWorkspaceSurfaceAdapterRegistration;
+    readonly token: symbol;
+  } | null>(null);
   const primaryRegionRef = useRef<HTMLElement>(null);
   const previousPathnameRef = useRef<string | null>(null);
   const previousStateRef = useRef<WorkspaceShellState | null>(null);
@@ -182,6 +190,28 @@ function UniversalWorkspaceShellContent({
       : state === 'overlay'
         ? 'Overlay · conversation connected'
         : `Canvas · ${shellLocation.routeKey.replace(/^canvas:/, '')}`;
+  const activeSurfaceAdapter =
+    surfaceAdapter?.registration.surfaceKey === surfaceKey
+      ? surfaceAdapter.registration
+      : null;
+
+  const registerSurfaceAdapter = useCallback(
+    (registration: ResearchWorkspaceSurfaceAdapterRegistration) => {
+      if (registration.surfaceKey !== surfaceKey) {
+        return () => undefined;
+      }
+
+      const token = Symbol(registration.surfaceKey);
+      setSurfaceAdapter({ registration, token });
+
+      return () => {
+        setSurfaceAdapter((current) =>
+          current?.token === token ? null : current,
+        );
+      };
+    },
+    [surfaceKey],
+  );
 
   useLayoutEffect(() => {
     if (!isUnthreadedConversation) {
@@ -472,15 +502,19 @@ function UniversalWorkspaceShellContent({
         />
       </div>
       <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4">
-        <div className="gen-shell-empty-state p-4">
-          <p className="text-sm font-medium text-foreground">
-            Registered {surfaceKey} adapter slot
-          </p>
-          <p className="mt-1 text-xs leading-5 text-muted-foreground">
-            Product-owned context adapters land here without changing their
-            canonical route or granting execution authority.
-          </p>
-        </div>
+        {activeSurfaceAdapter ? (
+          activeSurfaceAdapter.inspectorContent
+        ) : (
+          <div className="gen-shell-empty-state p-4">
+            <p className="text-sm font-medium text-foreground">
+              Registered {surfaceKey} adapter slot
+            </p>
+            <p className="mt-1 text-xs leading-5 text-muted-foreground">
+              Product-owned context adapters land here without changing their
+              canonical route or granting execution authority.
+            </p>
+          </div>
+        )}
         <Button
           icon={<HiOutlineEye className="size-4" />}
           onClick={handleOpenOverlay}
@@ -507,6 +541,7 @@ function UniversalWorkspaceShellContent({
       dispatchAction={handleComposerAction}
       draftScopeKey={draftScopeKey}
       portalTarget={composerPortalTarget}
+      references={activeSurfaceAdapter?.references}
       scopeControls={composerScopeControls}
       shellState={state}
     >
@@ -614,7 +649,11 @@ function UniversalWorkspaceShellContent({
                   Context
                 </Button>
               </div>
-              {baseState === 'canvas' ? children : null}
+              <ResearchWorkspaceSurfaceAdapterRegistrationContext.Provider
+                value={registerSurfaceAdapter}
+              >
+                {baseState === 'canvas' ? children : null}
+              </ResearchWorkspaceSurfaceAdapterRegistrationContext.Provider>
             </section>
 
             {state !== 'overlay' ? (

--- a/apps/app/src/features/research/work-surface/research-workspace-surface-adapter-context.tsx
+++ b/apps/app/src/features/research/work-surface/research-workspace-surface-adapter-context.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import type { ConversationComposerContextReference } from '@genfeedai/agent';
+import { createContext, type ReactNode, useContext, useEffect } from 'react';
+
+export interface ResearchWorkspaceSurfaceAdapterRegistration {
+  readonly inspectorContent: ReactNode;
+  readonly references: readonly ConversationComposerContextReference[];
+  readonly surfaceKey: 'research';
+}
+
+export type RegisterResearchWorkspaceSurfaceAdapter = (
+  adapter: ResearchWorkspaceSurfaceAdapterRegistration,
+) => () => void;
+
+export const ResearchWorkspaceSurfaceAdapterRegistrationContext =
+  createContext<RegisterResearchWorkspaceSurfaceAdapter | null>(null);
+
+export function useRegisterResearchWorkspaceSurfaceAdapter(
+  adapter: ResearchWorkspaceSurfaceAdapterRegistration,
+): void {
+  const register = useContext(
+    ResearchWorkspaceSurfaceAdapterRegistrationContext,
+  );
+
+  useEffect(() => {
+    if (!register) {
+      return;
+    }
+
+    return register(adapter);
+  }, [adapter, register]);
+}
+
+export function useResearchWorkspaceSurfaceAdapterRegistrationAvailable(): boolean {
+  return (
+    useContext(ResearchWorkspaceSurfaceAdapterRegistrationContext) !== null
+  );
+}

--- a/apps/app/src/lib/workspace-shell/workspace-shell-registry.spec.ts
+++ b/apps/app/src/lib/workspace-shell/workspace-shell-registry.spec.ts
@@ -122,6 +122,22 @@ describe('workspace shell trusted registry', () => {
     );
   });
 
+  it('registers Research as an embedded adapter with its canonical fallback', () => {
+    const route = resolveWorkspaceShellRoute(
+      '/acme/moonrise/research/ads/google',
+    );
+
+    expect(route).toMatchObject({
+      adapter: { key: 'research', status: 'embedded' },
+      mode: 'canvas',
+      safeFallback: '/:orgSlug/:brandSlug/research/discovery',
+      surfaceKey: 'research',
+    });
+    expect(route && resolveWorkspaceShellSafeFallback(route)).toBe(
+      '/acme/moonrise/research/discovery',
+    );
+  });
+
   it('keeps notifications and deployment-specific dock chrome explicit', () => {
     expect(getWorkspaceShellOverlayRegistration('notifications')).toMatchObject(
       {

--- a/apps/app/src/lib/workspace-shell/workspace-shell-registry.ts
+++ b/apps/app/src/lib/workspace-shell/workspace-shell-registry.ts
@@ -1,6 +1,7 @@
 import type {
   ResolvedWorkspaceShellRoute,
   WorkspaceShellAccessPolicy,
+  WorkspaceShellAdapterSeam,
   WorkspaceShellAuxiliaryRegistration,
   WorkspaceShellDeployment,
   WorkspaceShellOverlayRegistration,
@@ -30,6 +31,7 @@ export type {
 } from '@genfeedai/interfaces/ui/workspace-shell.interface';
 
 type RouteGroupConfig = {
+  readonly adapter?: WorkspaceShellAdapterSeam;
   readonly fallback: string;
   readonly mode: WorkspaceShellRouteMode;
   readonly scope: WorkspaceShellScopeRequirement;
@@ -102,10 +104,12 @@ function freezeRouteRegistration(
 ): WorkspaceShellRouteRegistration {
   return Object.freeze({
     accessPolicy: ACCESS_POLICY_BY_SCOPE[config.scope],
-    adapter: Object.freeze({
-      key: config.surfaceKey,
-      status: ADAPTER_STATUS_BY_MODE[config.mode],
-    }),
+    adapter: Object.freeze(
+      config.adapter ?? {
+        key: config.surfaceKey,
+        status: ADAPTER_STATUS_BY_MODE[config.mode],
+      },
+    ),
     allowedShellModes: Object.freeze([config.mode] as const),
     availability: AVAILABILITY_BY_MODE[config.mode],
     canonicalUrl,
@@ -358,6 +362,7 @@ const BRAND_ROUTE_REGISTRATIONS = [
       '/:orgSlug/:brandSlug/research/:platform',
     ],
     {
+      adapter: { key: 'research', status: 'embedded' },
       fallback: '/:orgSlug/:brandSlug/research/discovery',
       mode: 'canvas',
       scope: 'brand',

--- a/packages/agent/src/components/AgentChatInput.spec.tsx
+++ b/packages/agent/src/components/AgentChatInput.spec.tsx
@@ -135,6 +135,32 @@ describe('AgentChatInput', () => {
     expect(screen.getByText('Reattach')).toBeInTheDocument();
   });
 
+  it('renders an authorized typed surface reference without changing the draft', () => {
+    render(
+      <ConversationComposerShellProvider
+        contextLabel="Research"
+        draftScopeKey="acme:thread-1:3"
+        portalTarget={null}
+        references={[
+          {
+            authorization: 'authorized',
+            id: 'video-123',
+            kind: 'research-trend-video',
+            label: 'Three viral hook patterns',
+          },
+        ]}
+        shellState="canvas"
+      >
+        <AgentChatInput onSend={vi.fn()} />
+      </ConversationComposerShellProvider>,
+    );
+
+    expect(screen.getByText('Three viral hook patterns')).toBeInTheDocument();
+    expect(screen.getByRole('textbox')).not.toHaveTextContent(
+      'Three viral hook patterns',
+    );
+  });
+
   it('dispatches a selected trusted action without clearing or sending the draft', async () => {
     const dispatchAction = vi.fn(() => ({
       message: 'Opened Publish. Explicit approval is still required.',

--- a/packages/agent/src/components/AgentChatInputAttachmentTray.tsx
+++ b/packages/agent/src/components/AgentChatInputAttachmentTray.tsx
@@ -1,3 +1,4 @@
+import type { ConversationComposerContextReferenceKind } from '@genfeedai/agent/models/conversation-composer.model';
 import { ButtonVariant } from '@genfeedai/enums';
 import type { PromptBarAttachedAsset } from '@genfeedai/props/studio/prompt-bar.props';
 import { cn } from '@helpers/formatting/cn/cn.util';
@@ -15,7 +16,12 @@ import {
 export interface AgentChatReferenceItem {
   id: string;
   label: string;
-  type: 'brand' | 'content' | 'credential' | 'team';
+  type:
+    | 'brand'
+    | 'content'
+    | 'credential'
+    | 'team'
+    | ConversationComposerContextReferenceKind;
 }
 
 type AgentChatInputAttachmentTrayProps = {

--- a/packages/agent/src/components/ConversationComposerShellContext.tsx
+++ b/packages/agent/src/components/ConversationComposerShellContext.tsx
@@ -2,6 +2,7 @@
 
 import type {
   ConversationComposerActionInvocation,
+  ConversationComposerContextReference,
   ConversationComposerDispatchResult,
 } from '@genfeedai/agent/models/conversation-composer.model';
 import {
@@ -21,6 +22,7 @@ export interface ConversationComposerShellContextValue {
     | Promise<ConversationComposerDispatchResult>;
   draftScopeKey: string | null;
   portalTarget: HTMLElement | null;
+  references?: readonly ConversationComposerContextReference[];
   scopeControls?: ReactNode;
   shellState: 'canvas' | 'conversation' | 'overlay';
 }
@@ -39,6 +41,7 @@ export function ConversationComposerShellProvider({
   dispatchAction,
   draftScopeKey,
   portalTarget,
+  references,
   scopeControls,
   shellState,
 }: ConversationComposerShellProviderProps): ReactElement {
@@ -48,6 +51,7 @@ export function ConversationComposerShellProvider({
       dispatchAction,
       draftScopeKey,
       portalTarget,
+      references,
       scopeControls,
       shellState,
     }),
@@ -56,6 +60,7 @@ export function ConversationComposerShellProvider({
       dispatchAction,
       draftScopeKey,
       portalTarget,
+      references,
       scopeControls,
       shellState,
     ],

--- a/packages/agent/src/components/useAgentChatInput.ts
+++ b/packages/agent/src/components/useAgentChatInput.ts
@@ -253,7 +253,9 @@ export function useAgentChatInput({
 
   const [actionFeedback, setActionFeedback] = useState<string | null>(null);
   const [isEmpty, setIsEmpty] = useState(!restoredDraft.plainText.trim());
-  const [references, setReferences] = useState<AgentChatReferenceItem[]>(() =>
+  const [mentionReferences, setMentionReferences] = useState<
+    AgentChatReferenceItem[]
+  >(() =>
     restoredDraft.document
       ? extractMentions(restoredDraft.document).map((mention) => ({
           id: mention.id,
@@ -402,7 +404,7 @@ export function useAgentChatInput({
                 : `^${mention.contentTitle}`,
         type: mention.type,
       }));
-      setReferences(nextReferences);
+      setMentionReferences(nextReferences);
       writeConversationComposerDocument(
         draftScopeKey,
         document,
@@ -436,7 +438,7 @@ export function useAgentChatInput({
     const draft = readConversationComposerDraft(draftScopeKey);
     editor.commands.setContent(draft.document ?? '');
     setIsEmpty(!draft.plainText.trim());
-    setReferences(
+    setMentionReferences(
       draft.document
         ? extractMentions(draft.document).map((mention) => ({
             id: mention.id,
@@ -627,6 +629,23 @@ export function useAgentChatInput({
     },
     [removeAttachment],
   );
+
+  const references = useMemo<AgentChatReferenceItem[]>(() => {
+    const referencesByKey = new Map<string, AgentChatReferenceItem>();
+
+    for (const reference of composerShell?.references ?? []) {
+      referencesByKey.set(`${reference.kind}:${reference.id}`, {
+        id: reference.id,
+        label: reference.label,
+        type: reference.kind,
+      });
+    }
+    for (const reference of mentionReferences) {
+      referencesByKey.set(`${reference.type}:${reference.id}`, reference);
+    }
+
+    return [...referencesByKey.values()];
+  }, [composerShell?.references, mentionReferences]);
 
   const isDragActive = dragState?.isActive ?? false;
   const canSendMessage = !isEmpty || hasCompletedAttachments;

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -137,6 +137,8 @@ export type {
   ConversationComposerActionDefinition,
   ConversationComposerActionInvocation,
   ConversationComposerActionName,
+  ConversationComposerContextReference,
+  ConversationComposerContextReferenceKind,
   ConversationComposerDispatchResult,
   ConversationComposerDispatchStatus,
   ConversationComposerScope,

--- a/packages/agent/src/models/conversation-composer.model.ts
+++ b/packages/agent/src/models/conversation-composer.model.ts
@@ -12,6 +12,24 @@ export type ConversationComposerActionName =
 
 export type ConversationComposerScope = 'brand' | 'organization';
 
+export type ConversationComposerContextReferenceKind =
+  | 'research-ad-connected-google'
+  | 'research-ad-connected-meta'
+  | 'research-ad-public-google'
+  | 'research-ad-public-meta'
+  | 'research-source-post'
+  | 'research-trend-content'
+  | 'research-trend-hashtag'
+  | 'research-trend-sound'
+  | 'research-trend-video';
+
+export interface ConversationComposerContextReference {
+  authorization: 'authorized';
+  id: string;
+  kind: ConversationComposerContextReferenceKind;
+  label: string;
+}
+
 export interface ConversationComposerActionDefinition {
   description: string;
   isConsequentialProposal: boolean;

--- a/packages/interfaces/src/ui/workspace-shell.interface.ts
+++ b/packages/interfaces/src/ui/workspace-shell.interface.ts
@@ -96,7 +96,7 @@ export interface WorkspaceShellRestorationPolicy {
 
 export interface WorkspaceShellAdapterSeam {
   readonly key: string;
-  readonly status: 'dedicated-route' | 'placeholder';
+  readonly status: 'dedicated-route' | 'embedded' | 'placeholder';
 }
 
 export interface WorkspaceShellRouteRegistration {

--- a/packages/pages/research/work-surface/ResearchFindingInspector.tsx
+++ b/packages/pages/research/work-surface/ResearchFindingInspector.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { ButtonSize, ButtonVariant } from '@genfeedai/enums';
+import Card from '@ui/card/Card';
+import { Button } from '@ui/primitives/button';
+import type { ReactElement } from 'react';
+import { HiOutlineXMark } from 'react-icons/hi2';
+import { useOptionalResearchWorkSurface } from './ResearchWorkSurfaceProvider';
+
+export default function ResearchFindingInspector(): ReactElement {
+  const surface = useOptionalResearchWorkSurface();
+  const finding = surface?.authorizedFinding ?? null;
+  const isRestoring = Boolean(
+    surface?.urlState.requestedReference && !surface.authorizedFinding,
+  );
+
+  return (
+    <div className="space-y-3" data-testid="research-finding-inspector">
+      {finding ? (
+        <Card bodyClassName="gap-0">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                {finding.reference.kind.replaceAll('-', ' ')}
+              </p>
+              <h2 className="mt-2 text-sm font-semibold leading-5 text-foreground">
+                {finding.title}
+              </h2>
+            </div>
+            <Button
+              ariaLabel="Remove selected research finding"
+              className="shrink-0"
+              icon={<HiOutlineXMark className="size-4" />}
+              onClick={() => surface?.clearFinding()}
+              size={ButtonSize.ICON}
+              variant={ButtonVariant.GHOST}
+              withWrapper={false}
+            />
+          </div>
+          {finding.description ? (
+            <p className="mt-2 line-clamp-6 text-xs leading-5 text-foreground/70">
+              {finding.description}
+            </p>
+          ) : null}
+          <dl className="mt-4 space-y-2 border-t border-border pt-3">
+            {finding.metadata.map((item) => (
+              <div
+                className="flex items-start justify-between gap-3 text-xs"
+                key={`${item.label}:${item.value}`}
+              >
+                <dt className="text-muted-foreground">{item.label}</dt>
+                <dd className="text-right text-foreground/80">{item.value}</dd>
+              </div>
+            ))}
+          </dl>
+        </Card>
+      ) : isRestoring ? (
+        <div
+          aria-live="polite"
+          className="gen-shell-empty-state p-4"
+          role="status"
+        >
+          <p className="text-sm font-medium text-foreground">
+            Restoring selected finding…
+          </p>
+          <p className="mt-1 text-xs leading-5 text-muted-foreground">
+            The reference becomes available only after the scoped Research query
+            confirms access.
+          </p>
+        </div>
+      ) : (
+        <div className="gen-shell-empty-state p-4">
+          <p className="text-sm font-medium text-foreground">
+            Select a research finding
+          </p>
+          <p className="mt-1 text-xs leading-5 text-muted-foreground">
+            The inspector and composer receive only its typed canonical
+            reference. Display text never grants execution authority.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/pages/research/work-surface/ResearchWorkSurfaceProvider.tsx
+++ b/packages/pages/research/work-surface/ResearchWorkSurfaceProvider.tsx
@@ -1,0 +1,374 @@
+'use client';
+
+import Pagination from '@ui/navigation/pagination/Pagination';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import {
+  createContext,
+  type ReactElement,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {
+  type AuthorizedResearchFinding,
+  getResearchFindingReferenceKey,
+} from './research-work-surface.types';
+import {
+  buildResearchWorkSurfaceHref,
+  encodeResearchFindingReference,
+  parseResearchWorkSurfaceUrl,
+  RESEARCH_WORK_SURFACE_QUERY_KEYS,
+  type ResearchWorkSurfaceUrlState,
+} from './research-work-surface-url';
+
+const DEFAULT_RESEARCH_PAGE_SIZE = 24;
+
+type ResearchUrlHistory = 'push' | 'replace';
+
+interface UpdateResearchSearchParamsOptions {
+  readonly clearFinding?: boolean;
+  readonly history?: ResearchUrlHistory;
+  readonly resetPage?: boolean;
+}
+
+interface ResearchWorkSurfaceContextValue {
+  readonly authorizedFinding: AuthorizedResearchFinding | null;
+  readonly clearFinding: (history?: ResearchUrlHistory) => void;
+  readonly isEmbedded: boolean;
+  readonly pathname: string;
+  readonly selectFinding: (finding: AuthorizedResearchFinding) => void;
+  readonly setAuthorizedFinding: (
+    finding: AuthorizedResearchFinding | null,
+  ) => void;
+  readonly setEmbedded: (isEmbedded: boolean) => void;
+  readonly updateSearchParams: (
+    updates: Readonly<Record<string, string | null>>,
+    options?: UpdateResearchSearchParamsOptions,
+  ) => void;
+  readonly urlState: ResearchWorkSurfaceUrlState;
+}
+
+const ResearchWorkSurfaceContext =
+  createContext<ResearchWorkSurfaceContextValue | null>(null);
+
+export function ResearchWorkSurfaceProvider({
+  children,
+}: {
+  readonly children: ReactNode;
+}): ReactElement {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const searchParamsString = searchParams.toString();
+  const searchParamsStringRef = useRef(searchParamsString);
+  searchParamsStringRef.current = searchParamsString;
+  const { push, replace } = useRouter();
+  const [authorizedFinding, setAuthorizedFinding] =
+    useState<AuthorizedResearchFinding | null>(null);
+  const [isEmbedded, setEmbedded] = useState(false);
+  const urlState = useMemo(
+    () => parseResearchWorkSurfaceUrl(new URLSearchParams(searchParamsString)),
+    [searchParamsString],
+  );
+  const canonicalSearchParamsString = urlState.canonicalSearchParams.toString();
+
+  useEffect(() => {
+    if (urlState.isCanonical) {
+      return;
+    }
+
+    replace(
+      buildResearchWorkSurfaceHref(
+        pathname,
+        new URLSearchParams(canonicalSearchParamsString),
+      ),
+      { scroll: false },
+    );
+  }, [canonicalSearchParamsString, pathname, replace, urlState.isCanonical]);
+
+  const updateSearchParams = useCallback(
+    (
+      updates: Readonly<Record<string, string | null>>,
+      options: UpdateResearchSearchParamsOptions = {},
+    ) => {
+      const currentSearchParamsString = searchParamsStringRef.current;
+      const nextSearchParams = new URLSearchParams(currentSearchParamsString);
+      const shouldClearFinding = options.clearFinding ?? true;
+      const shouldResetPage = options.resetPage ?? true;
+
+      for (const [key, value] of Object.entries(updates)) {
+        if (value) {
+          nextSearchParams.set(key, value);
+        } else {
+          nextSearchParams.delete(key);
+        }
+      }
+
+      if (shouldResetPage) {
+        nextSearchParams.delete(RESEARCH_WORK_SURFACE_QUERY_KEYS.PAGE);
+      }
+      if (shouldClearFinding) {
+        nextSearchParams.delete(RESEARCH_WORK_SURFACE_QUERY_KEYS.FINDING);
+        setAuthorizedFinding(null);
+      }
+
+      const nextHref = buildResearchWorkSurfaceHref(pathname, nextSearchParams);
+      const currentHref = buildResearchWorkSurfaceHref(
+        pathname,
+        new URLSearchParams(currentSearchParamsString),
+      );
+      if (nextHref === currentHref) {
+        return;
+      }
+
+      if (options.history === 'push') {
+        push(nextHref, { scroll: false });
+      } else {
+        replace(nextHref, { scroll: false });
+      }
+    },
+    [pathname, push, replace],
+  );
+
+  const clearFinding = useCallback(
+    (history: ResearchUrlHistory = 'push') => {
+      setAuthorizedFinding(null);
+      updateSearchParams(
+        { [RESEARCH_WORK_SURFACE_QUERY_KEYS.FINDING]: null },
+        { clearFinding: false, history, resetPage: false },
+      );
+    },
+    [updateSearchParams],
+  );
+
+  const selectFinding = useCallback(
+    (finding: AuthorizedResearchFinding) => {
+      setAuthorizedFinding(finding);
+      updateSearchParams(
+        {
+          [RESEARCH_WORK_SURFACE_QUERY_KEYS.FINDING]:
+            encodeResearchFindingReference(finding.reference),
+        },
+        { clearFinding: false, history: 'push', resetPage: false },
+      );
+    },
+    [updateSearchParams],
+  );
+
+  const value = useMemo<ResearchWorkSurfaceContextValue>(
+    () => ({
+      authorizedFinding,
+      clearFinding,
+      isEmbedded,
+      pathname,
+      selectFinding,
+      setAuthorizedFinding,
+      setEmbedded,
+      updateSearchParams,
+      urlState,
+    }),
+    [
+      authorizedFinding,
+      clearFinding,
+      isEmbedded,
+      pathname,
+      selectFinding,
+      updateSearchParams,
+      urlState,
+    ],
+  );
+
+  return (
+    <ResearchWorkSurfaceContext.Provider value={value}>
+      {children}
+    </ResearchWorkSurfaceContext.Provider>
+  );
+}
+
+export function useOptionalResearchWorkSurface(): ResearchWorkSurfaceContextValue | null {
+  return useContext(ResearchWorkSurfaceContext);
+}
+
+export function useResearchQueryState(): readonly [
+  string,
+  (value: string) => void,
+] {
+  const surface = useOptionalResearchWorkSurface();
+  const updateSearchParams = surface?.updateSearchParams;
+  const [localQuery, setLocalQuery] = useState('');
+  const query = surface?.urlState.query ?? localQuery;
+  const setQuery = useCallback(
+    (value: string) => {
+      if (!updateSearchParams) {
+        setLocalQuery(value);
+        return;
+      }
+
+      updateSearchParams({
+        [RESEARCH_WORK_SURFACE_QUERY_KEYS.QUERY]: value.trim() || null,
+      });
+    },
+    [updateSearchParams],
+  );
+
+  return [query, setQuery] as const;
+}
+
+export function useResearchSearchParamState<Value extends string>({
+  allowedValues,
+  defaultValue,
+  key,
+  maxLength = 160,
+}: {
+  readonly allowedValues?: readonly Value[];
+  readonly defaultValue: Value;
+  readonly key: string;
+  readonly maxLength?: number;
+}): readonly [Value, (value: Value) => void] {
+  const surface = useOptionalResearchWorkSurface();
+  const updateSearchParams = surface?.updateSearchParams;
+  const [localValue, setLocalValue] = useState<Value>(defaultValue);
+  const rawValue = surface?.urlState.canonicalSearchParams.get(key) ?? null;
+  const isValid = Boolean(
+    rawValue !== null &&
+      rawValue.length <= maxLength &&
+      (!allowedValues || allowedValues.includes(rawValue as Value)),
+  );
+  const value = surface
+    ? isValid
+      ? (rawValue as Value)
+      : defaultValue
+    : localValue;
+
+  useEffect(() => {
+    if (!updateSearchParams || rawValue === null || isValid) {
+      return;
+    }
+
+    updateSearchParams(
+      { [key]: null },
+      { clearFinding: false, resetPage: false },
+    );
+  }, [isValid, key, rawValue, updateSearchParams]);
+
+  const setValue = useCallback(
+    (nextValue: Value) => {
+      if (!updateSearchParams) {
+        setLocalValue(nextValue);
+        return;
+      }
+
+      updateSearchParams({
+        [key]: nextValue === defaultValue ? null : nextValue,
+      });
+    },
+    [defaultValue, key, updateSearchParams],
+  );
+
+  return [value, setValue] as const;
+}
+
+export function useResearchPagination<Item>(
+  items: readonly Item[],
+  pageSize = DEFAULT_RESEARCH_PAGE_SIZE,
+): {
+  readonly currentPage: number;
+  readonly pageItems: readonly Item[];
+  readonly pagination: ReactElement | null;
+  readonly totalPages: number;
+} {
+  const surface = useOptionalResearchWorkSurface();
+  const totalPages = surface
+    ? Math.max(1, Math.ceil(items.length / pageSize))
+    : 1;
+  const currentPage = surface ? Math.min(surface.urlState.page, totalPages) : 1;
+
+  useEffect(() => {
+    if (!surface || surface.urlState.page <= totalPages) {
+      return;
+    }
+
+    surface.updateSearchParams(
+      {
+        [RESEARCH_WORK_SURFACE_QUERY_KEYS.PAGE]:
+          totalPages === 1 ? null : String(totalPages),
+      },
+      { clearFinding: false, history: 'replace', resetPage: false },
+    );
+  }, [surface, totalPages]);
+
+  const pageItems = surface
+    ? items.slice((currentPage - 1) * pageSize, currentPage * pageSize)
+    : items;
+  const pagination =
+    surface && totalPages > 1 ? (
+      <Pagination
+        currentPage={currentPage}
+        totalPages={totalPages}
+        onPageChange={(page) => {
+          surface.updateSearchParams(
+            {
+              [RESEARCH_WORK_SURFACE_QUERY_KEYS.PAGE]:
+                page === 1 ? null : String(page),
+            },
+            { history: 'replace', resetPage: false },
+          );
+        }}
+      />
+    ) : null;
+
+  return { currentPage, pageItems, pagination, totalPages };
+}
+
+export function useRestoreResearchFinding(
+  findings: readonly AuthorizedResearchFinding[],
+  isLoading: boolean,
+): void {
+  const surface = useOptionalResearchWorkSurface();
+  const clearFinding = surface?.clearFinding;
+  const setAuthorizedFinding = surface?.setAuthorizedFinding;
+  const requestedKey = surface?.urlState.requestedReference
+    ? getResearchFindingReferenceKey(surface.urlState.requestedReference)
+    : null;
+  const findingByKey = useMemo(
+    () =>
+      new Map(
+        findings.map((finding) => [
+          getResearchFindingReferenceKey(finding.reference),
+          finding,
+        ]),
+      ),
+    [findings],
+  );
+
+  useEffect(() => {
+    if (!clearFinding || !setAuthorizedFinding) {
+      return;
+    }
+    if (!requestedKey) {
+      setAuthorizedFinding(null);
+      return;
+    }
+    if (isLoading) {
+      setAuthorizedFinding(null);
+      return;
+    }
+
+    const finding = findingByKey.get(requestedKey);
+    if (finding) {
+      setAuthorizedFinding(finding);
+      return;
+    }
+
+    clearFinding('replace');
+  }, [
+    clearFinding,
+    findingByKey,
+    isLoading,
+    requestedKey,
+    setAuthorizedFinding,
+  ]);
+}

--- a/packages/pages/research/work-surface/research-work-surface-url.spec.ts
+++ b/packages/pages/research/work-surface/research-work-surface-url.spec.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildResearchWorkSurfaceHref,
+  encodeResearchFindingReference,
+  parseResearchFindingReference,
+  parseResearchWorkSurfaceUrl,
+} from './research-work-surface-url';
+
+describe('Research work surface URL contract', () => {
+  it('restores canonical filters, pagination, selection, and opaque shell state', () => {
+    const state = parseResearchWorkSurfaceUrl(
+      new URLSearchParams({
+        finding: 'research-trend-video:video-123',
+        page: '3',
+        platform: 'tiktok',
+        q: 'viral hooks',
+        thread: 'thread-1',
+      }),
+    );
+
+    expect(state).toMatchObject({
+      isCanonical: true,
+      page: 3,
+      query: 'viral hooks',
+      requestedReference: {
+        id: 'video-123',
+        kind: 'research-trend-video',
+      },
+    });
+    expect(state.canonicalSearchParams.toString()).toContain('platform=tiktok');
+    expect(state.canonicalSearchParams.toString()).toContain('thread=thread-1');
+  });
+
+  it('removes malformed owned state without dropping opaque route parameters', () => {
+    const state = parseResearchWorkSurfaceUrl(
+      new URLSearchParams({
+        finding: 'approval:grant-access',
+        page: '10001',
+        q: '   ',
+        source: 'public',
+        thread: 'thread-1',
+      }),
+    );
+
+    expect(state).toMatchObject({
+      isCanonical: false,
+      page: 1,
+      query: '',
+      requestedReference: null,
+    });
+    expect(state.canonicalSearchParams.toString()).toBe(
+      'source=public&thread=thread-1',
+    );
+  });
+
+  it('accepts only finite typed finding references with safe identifiers', () => {
+    const reference = {
+      id: 'post_123.4',
+      kind: 'research-source-post' as const,
+    };
+
+    expect(
+      parseResearchFindingReference(encodeResearchFindingReference(reference)),
+    ).toEqual(reference);
+    expect(
+      parseResearchFindingReference('research-source-post:../../admin'),
+    ).toBeNull();
+    expect(
+      buildResearchWorkSurfaceHref(
+        '/acme/moonrise/research/following',
+        new URLSearchParams({ page: '2' }),
+      ),
+    ).toBe('/acme/moonrise/research/following?page=2');
+  });
+});

--- a/packages/pages/research/work-surface/research-work-surface-url.ts
+++ b/packages/pages/research/work-surface/research-work-surface-url.ts
@@ -1,0 +1,110 @@
+import {
+  RESEARCH_FINDING_REFERENCE_KINDS,
+  type ResearchFindingReference,
+  type ResearchFindingReferenceKind,
+} from './research-work-surface.types';
+
+export const RESEARCH_WORK_SURFACE_QUERY_KEYS = {
+  FINDING: 'finding',
+  PAGE: 'page',
+  QUERY: 'q',
+} as const;
+
+const MAX_QUERY_LENGTH = 200;
+const MAX_PAGE = 10_000;
+const SAFE_FINDING_ID = /^[A-Za-z0-9._~-]{1,160}$/;
+
+export interface ResearchWorkSurfaceUrlState {
+  readonly canonicalSearchParams: URLSearchParams;
+  readonly isCanonical: boolean;
+  readonly page: number;
+  readonly query: string;
+  readonly requestedReference: ResearchFindingReference | null;
+}
+
+function isResearchFindingReferenceKind(
+  value: string,
+): value is ResearchFindingReferenceKind {
+  return RESEARCH_FINDING_REFERENCE_KINDS.includes(
+    value as ResearchFindingReferenceKind,
+  );
+}
+
+export function encodeResearchFindingReference(
+  reference: ResearchFindingReference,
+): string {
+  return `${reference.kind}:${reference.id}`;
+}
+
+export function parseResearchFindingReference(
+  value: string | null,
+): ResearchFindingReference | null {
+  if (!value) {
+    return null;
+  }
+
+  const separatorIndex = value.indexOf(':');
+  if (separatorIndex <= 0 || separatorIndex === value.length - 1) {
+    return null;
+  }
+
+  const kind = value.slice(0, separatorIndex);
+  const id = value.slice(separatorIndex + 1);
+  if (!isResearchFindingReferenceKind(kind) || !SAFE_FINDING_ID.test(id)) {
+    return null;
+  }
+
+  return { id, kind };
+}
+
+export function parseResearchWorkSurfaceUrl(
+  searchParams: URLSearchParams,
+): ResearchWorkSurfaceUrlState {
+  const canonicalSearchParams = new URLSearchParams(searchParams);
+  let isCanonical = true;
+
+  const rawQuery = searchParams.get(RESEARCH_WORK_SURFACE_QUERY_KEYS.QUERY);
+  const query = rawQuery?.trim() ?? '';
+  if (rawQuery !== null) {
+    if (!query || query.length > MAX_QUERY_LENGTH) {
+      canonicalSearchParams.delete(RESEARCH_WORK_SURFACE_QUERY_KEYS.QUERY);
+      isCanonical = false;
+    } else if (rawQuery !== query) {
+      canonicalSearchParams.set(RESEARCH_WORK_SURFACE_QUERY_KEYS.QUERY, query);
+      isCanonical = false;
+    }
+  }
+
+  const rawPage = searchParams.get(RESEARCH_WORK_SURFACE_QUERY_KEYS.PAGE);
+  const parsedPage = rawPage === null ? 1 : Number(rawPage);
+  const isValidPage =
+    Number.isInteger(parsedPage) && parsedPage >= 1 && parsedPage <= MAX_PAGE;
+  const page = isValidPage ? parsedPage : 1;
+  if (rawPage !== null && (!isValidPage || page === 1)) {
+    canonicalSearchParams.delete(RESEARCH_WORK_SURFACE_QUERY_KEYS.PAGE);
+    isCanonical = false;
+  }
+
+  const rawFinding = searchParams.get(RESEARCH_WORK_SURFACE_QUERY_KEYS.FINDING);
+  const requestedReference = parseResearchFindingReference(rawFinding);
+  if (rawFinding !== null && !requestedReference) {
+    canonicalSearchParams.delete(RESEARCH_WORK_SURFACE_QUERY_KEYS.FINDING);
+    isCanonical = false;
+  }
+
+  return {
+    canonicalSearchParams,
+    isCanonical,
+    page,
+    query: query.length <= MAX_QUERY_LENGTH ? query : '',
+    requestedReference,
+  };
+}
+
+export function buildResearchWorkSurfaceHref(
+  pathname: string,
+  searchParams: URLSearchParams,
+): string {
+  const query = searchParams.toString();
+  return query ? `${pathname}?${query}` : pathname;
+}

--- a/packages/pages/research/work-surface/research-work-surface.types.ts
+++ b/packages/pages/research/work-surface/research-work-surface.types.ts
@@ -1,0 +1,170 @@
+import type {
+  AdsResearchItem,
+  ISourcePost,
+  ITrendHashtag,
+  ITrendSound,
+  ITrendVideo,
+} from '@genfeedai/interfaces';
+import type { TrendContentItem } from '@props/trends/trends-page.props';
+
+export const RESEARCH_FINDING_REFERENCE_KINDS = [
+  'research-ad-connected-google',
+  'research-ad-connected-meta',
+  'research-ad-public-google',
+  'research-ad-public-meta',
+  'research-source-post',
+  'research-trend-content',
+  'research-trend-hashtag',
+  'research-trend-sound',
+  'research-trend-video',
+] as const;
+
+export type ResearchFindingReferenceKind =
+  (typeof RESEARCH_FINDING_REFERENCE_KINDS)[number];
+
+export interface ResearchFindingReference {
+  readonly id: string;
+  readonly kind: ResearchFindingReferenceKind;
+}
+
+export interface ResearchFindingMetadataItem {
+  readonly label: string;
+  readonly value: string;
+}
+
+export interface AuthorizedResearchFinding {
+  readonly description?: string;
+  readonly metadata: readonly ResearchFindingMetadataItem[];
+  readonly reference: ResearchFindingReference;
+  readonly title: string;
+}
+
+export function getResearchFindingReferenceKey(
+  reference: ResearchFindingReference,
+): string {
+  return `${reference.kind}:${reference.id}`;
+}
+
+export function isSameResearchFindingReference(
+  left: ResearchFindingReference | null,
+  right: ResearchFindingReference | null,
+): boolean {
+  return Boolean(
+    left && right && left.id === right.id && left.kind === right.kind,
+  );
+}
+
+export function toAdsResearchFinding(
+  item: AdsResearchItem,
+): AuthorizedResearchFinding {
+  const id = item.source === 'my_accounts' ? item.sourceId : item.id;
+  const kind: ResearchFindingReferenceKind =
+    item.source === 'my_accounts'
+      ? item.platform === 'meta'
+        ? 'research-ad-connected-meta'
+        : 'research-ad-connected-google'
+      : item.platform === 'meta'
+        ? 'research-ad-public-meta'
+        : 'research-ad-public-google';
+
+  return {
+    description:
+      item.headline || item.body || item.explanation || 'Ad research finding',
+    metadata: [
+      {
+        label: 'Platform',
+        value: item.platform === 'meta' ? 'Meta' : 'Google',
+      },
+      {
+        label: 'Source',
+        value: item.source === 'my_accounts' ? 'Connected account' : 'Public',
+      },
+      ...(item.accountName
+        ? [{ label: 'Account', value: item.accountName }]
+        : []),
+    ],
+    reference: { id, kind },
+    title: item.title,
+  };
+}
+
+export function toSourcePostFinding(
+  post: ISourcePost,
+): AuthorizedResearchFinding {
+  const title = post.text?.trim() || `${post.platform} source post`;
+
+  return {
+    description: post.text?.trim() || undefined,
+    metadata: [
+      { label: 'Platform', value: String(post.platform) },
+      ...(post.authorHandle
+        ? [{ label: 'Author', value: `@${post.authorHandle}` }]
+        : []),
+    ],
+    reference: { id: post.id, kind: 'research-source-post' },
+    title,
+  };
+}
+
+export function toTrendContentFinding(
+  item: TrendContentItem,
+): AuthorizedResearchFinding {
+  return {
+    description: item.text || item.title || item.trendTopic,
+    metadata: [
+      { label: 'Platform', value: item.platform },
+      { label: 'Trend', value: item.trendTopic },
+      { label: 'Virality', value: String(item.trendViralityScore) },
+    ],
+    reference: { id: item.id, kind: 'research-trend-content' },
+    title: item.title || item.text || item.trendTopic,
+  };
+}
+
+export function toTrendVideoFinding(
+  video: ITrendVideo,
+): AuthorizedResearchFinding {
+  return {
+    description: video.description || video.hook || video.topic,
+    metadata: [
+      { label: 'Platform', value: video.platform },
+      { label: 'Viral score', value: String(Math.round(video.viralScore)) },
+      ...(video.creatorHandle
+        ? [{ label: 'Creator', value: `@${video.creatorHandle}` }]
+        : []),
+    ],
+    reference: { id: video.id, kind: 'research-trend-video' },
+    title: video.title || video.hook || 'Untitled video',
+  };
+}
+
+export function toTrendHashtagFinding(
+  hashtag: ITrendHashtag,
+): AuthorizedResearchFinding {
+  return {
+    metadata: [
+      { label: 'Platform', value: hashtag.platform },
+      {
+        label: 'Virality',
+        value: String(Math.round(hashtag.viralityScore)),
+      },
+    ],
+    reference: { id: hashtag.id, kind: 'research-trend-hashtag' },
+    title: hashtag.hashtag,
+  };
+}
+
+export function toTrendSoundFinding(
+  sound: ITrendSound,
+): AuthorizedResearchFinding {
+  return {
+    description: sound.authorName,
+    metadata: [
+      { label: 'Platform', value: sound.platform },
+      { label: 'Uses', value: String(sound.usageCount) },
+      { label: 'Virality', value: String(Math.round(sound.viralityScore)) },
+    ],
+    reference: { id: sound.id, kind: 'research-trend-sound' },
+    title: sound.soundName || 'Untitled sound',
+  };
+}

--- a/packages/pages/trends/following/following-page.tsx
+++ b/packages/pages/trends/following/following-page.tsx
@@ -18,6 +18,18 @@ import { formatCompactNumber } from '@helpers/formatting/format/format.helper';
 import { getPlatformIcon } from '@helpers/ui/platform-icon/platform-icon.helper';
 import { useAuthedService } from '@hooks/auth/use-authed-service/use-authed-service';
 import { useDebounce } from '@hooks/utils/use-debounce/use-debounce';
+import {
+  useOptionalResearchWorkSurface,
+  useResearchPagination,
+  useResearchQueryState,
+  useResearchSearchParamState,
+  useRestoreResearchFinding,
+} from '@pages/research/work-surface/ResearchWorkSurfaceProvider';
+import {
+  type AuthorizedResearchFinding,
+  isSameResearchFindingReference,
+  toSourcePostFinding,
+} from '@pages/research/work-surface/research-work-surface.types';
 import { SocialsNavigation } from '@pages/trends/shared/socials-navigation';
 import type {
   TrendItem,
@@ -89,11 +101,16 @@ const PLATFORM_OPTIONS = [
 
 export default function FollowingPage() {
   const brandId = useBrandId();
+  const surface = useOptionalResearchWorkSurface();
   const router = useRouter();
   const queryClient = useQueryClient();
   const notifications = useMemo(() => NotificationsService.getInstance(), []);
-  const [platform, setPlatform] = useState<string>('all');
-  const [search, setSearch] = useState('');
+  const [platform, setPlatform] = useResearchSearchParamState<string>({
+    allowedValues: ['all', ...PLATFORM_OPTIONS.map((option) => option.value)],
+    defaultValue: 'all',
+    key: 'platform',
+  });
+  const [search, setSearch] = useResearchQueryState();
   const [newPlatform, setNewPlatform] = useState<SocialSourcePlatform>(
     SocialSourcePlatform.TWITTER,
   );
@@ -130,6 +147,13 @@ export default function FollowingPage() {
   });
   const isInitialFetch =
     isFetching && data.posts.length === 0 && data.sources.length === 0;
+  const findings = useMemo(
+    () => data.posts.map(toSourcePostFinding),
+    [data.posts],
+  );
+  const { pageItems, pagination } = useResearchPagination(data.posts);
+
+  useRestoreResearchFinding(findings, isInitialFetch || isError);
 
   const refreshFeed = useCallback(async () => {
     await queryClient.invalidateQueries({ queryKey: ['social-sources-feed'] });
@@ -425,19 +449,35 @@ export default function FollowingPage() {
               </div>
             </Card>
 
-            {data.posts.length ? (
-              <div className="grid grid-cols-1 gap-4 2xl:grid-cols-2">
-                {data.posts.map((post) => (
-                  <SourcePostCard
-                    key={post.id}
-                    busyId={busyId}
-                    post={post}
-                    onCreateDraft={createDraft}
-                    onOpenAgent={openAgent}
-                    onOpenRemix={openRemix}
-                  />
-                ))}
-              </div>
+            {pageItems.length ? (
+              <>
+                <div className="grid grid-cols-1 gap-4 2xl:grid-cols-2">
+                  {pageItems.map((post) => {
+                    const finding = toSourcePostFinding(post);
+                    return (
+                      <SourcePostCard
+                        key={post.id}
+                        busyId={busyId}
+                        finding={finding}
+                        isSelected={isSameResearchFindingReference(
+                          surface?.authorizedFinding?.reference ?? null,
+                          finding.reference,
+                        )}
+                        post={post}
+                        onCreateDraft={createDraft}
+                        onOpenAgent={openAgent}
+                        onOpenRemix={openRemix}
+                        onSelect={
+                          surface?.isEmbedded
+                            ? surface.selectFinding
+                            : undefined
+                        }
+                      />
+                    );
+                  })}
+                </div>
+                {pagination ? <div>{pagination}</div> : null}
+              </>
             ) : (
               <Card bodyClassName="p-10">
                 <div className="mx-auto flex max-w-md flex-col items-center text-center">
@@ -518,18 +558,24 @@ function SourceRow({
 
 function SourcePostCard({
   busyId,
+  finding,
+  isSelected = false,
   onCreateDraft,
   onOpenAgent,
   onOpenRemix,
+  onSelect,
   post,
 }: {
   busyId: string | null;
+  finding?: AuthorizedResearchFinding;
+  isSelected?: boolean;
   onCreateDraft: (
     post: ISourcePost,
     actionType: SourcePostActionType,
   ) => Promise<void>;
   onOpenAgent: (post: ISourcePost) => void;
   onOpenRemix: (post: ISourcePost) => void;
+  onSelect?: (finding: AuthorizedResearchFinding) => void;
   post: ISourcePost;
 }) {
   const title = post.text?.trim() || `${post.platform} source post`;
@@ -577,6 +623,16 @@ function SourcePostCard({
         </p>
         <MetricStrip post={post} />
         <div className="flex flex-wrap gap-2">
+          {finding && onSelect ? (
+            <Button
+              aria-pressed={isSelected}
+              label={isSelected ? 'Selected for context' : 'Use as context'}
+              onClick={() => onSelect(finding)}
+              variant={
+                isSelected ? ButtonVariant.SECONDARY : ButtonVariant.GHOST
+              }
+            />
+          ) : null}
           {post.platform === SocialSourcePlatform.TWITTER ? (
             <>
               <Button

--- a/packages/pages/trends/list/trends-list.tsx
+++ b/packages/pages/trends/list/trends-list.tsx
@@ -5,6 +5,18 @@ import { AlertCategory, ButtonSize, ButtonVariant } from '@genfeedai/enums';
 import type { ITrendVideo } from '@genfeedai/interfaces';
 import { useAuthedService } from '@hooks/auth/use-authed-service/use-authed-service';
 import { useTrendContent } from '@hooks/data/trends/use-trend-content/use-trend-content';
+import {
+  useOptionalResearchWorkSurface,
+  useResearchPagination,
+  useResearchQueryState,
+  useRestoreResearchFinding,
+} from '@pages/research/work-surface/ResearchWorkSurfaceProvider';
+import {
+  type AuthorizedResearchFinding,
+  isSameResearchFindingReference,
+  toTrendContentFinding,
+  toTrendVideoFinding,
+} from '@pages/research/work-surface/research-work-surface.types';
 import { SocialsNavigation } from '@pages/trends/shared/socials-navigation';
 import TrendContentCard from '@pages/trends/shared/trend-content-card';
 import type { TrendsSummary } from '@props/trends/trends-page.props';
@@ -26,7 +38,7 @@ import {
   TableHeader,
   TableRow,
 } from '@ui/primitives/table';
-import { type ChangeEvent, type ReactNode, useMemo, useState } from 'react';
+import { type ChangeEvent, type ReactNode, useMemo } from 'react';
 import {
   HiOutlineArrowTrendingUp,
   HiOutlineFilm,
@@ -34,7 +46,17 @@ import {
   HiOutlineSparkles,
 } from 'react-icons/hi2';
 
-function ViralVideoCard({ video }: { video: ITrendVideo }) {
+function ViralVideoCard({
+  finding,
+  isSelected,
+  onSelect,
+  video,
+}: {
+  finding: AuthorizedResearchFinding;
+  isSelected: boolean;
+  onSelect?: (finding: AuthorizedResearchFinding) => void;
+  video: ITrendVideo;
+}) {
   return (
     <Card bodyClassName="p-4">
       <div className="space-y-2">
@@ -46,6 +68,15 @@ function ViralVideoCard({ video }: { video: ITrendVideo }) {
           {video.creatorHandle ? <span>@{video.creatorHandle}</span> : null}
           <span>Score {Math.round(video.viralScore)}</span>
         </div>
+        {onSelect ? (
+          <Button
+            aria-pressed={isSelected}
+            label={isSelected ? 'Selected for context' : 'Use as context'}
+            onClick={() => onSelect(finding)}
+            size={ButtonSize.SM}
+            variant={isSelected ? ButtonVariant.SECONDARY : ButtonVariant.GHOST}
+          />
+        ) : null}
       </div>
     </Card>
   );
@@ -290,7 +321,8 @@ function ViralVideosEmptyState({ isLoading }: { isLoading: boolean }) {
 
 export default function TrendsList() {
   const brandId = useBrandId();
-  const [search, setSearch] = useState('');
+  const surface = useOptionalResearchWorkSurface();
+  const [search, setSearch] = useResearchQueryState();
   const {
     error,
     isLoading,
@@ -336,12 +368,24 @@ export default function TrendsList() {
         .some((value) => value?.toLowerCase().includes(query)),
     );
   }, [items, search]);
+  const findings = useMemo(
+    () => [
+      ...filteredItems.map(toTrendContentFinding),
+      ...viralVideos.map(toTrendVideoFinding),
+    ],
+    [filteredItems, viralVideos],
+  );
+  const { pageItems, pagination } = useResearchPagination(filteredItems);
+  const currentError = error || videosError;
+
+  useRestoreResearchFinding(
+    findings,
+    isLoading || isLoadingVideos || Boolean(currentError),
+  );
 
   const handleRefresh = async () => {
     await Promise.all([refreshTrendContent(), refetchVideos()]);
   };
-
-  const currentError = error || videosError;
 
   return (
     <>
@@ -442,11 +486,28 @@ export default function TrendsList() {
                 />
               ) : (
                 <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-                  {filteredItems.map((item) => (
-                    <TrendContentCard key={item.id} item={item} />
-                  ))}
+                  {pageItems.map((item) => {
+                    const finding = toTrendContentFinding(item);
+                    return (
+                      <TrendContentCard
+                        key={item.id}
+                        finding={finding}
+                        isSelected={isSameResearchFindingReference(
+                          surface?.authorizedFinding?.reference ?? null,
+                          finding.reference,
+                        )}
+                        item={item}
+                        onSelect={
+                          surface?.isEmbedded
+                            ? surface.selectFinding
+                            : undefined
+                        }
+                      />
+                    );
+                  })}
                 </div>
               )}
+              {pagination ? <div className="pt-2">{pagination}</div> : null}
             </section>
 
             <section className="space-y-4">
@@ -468,9 +529,25 @@ export default function TrendsList() {
                 <ViralVideosEmptyState isLoading={isLoadingVideos} />
               ) : (
                 <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
-                  {viralVideos.map((video: ITrendVideo) => (
-                    <ViralVideoCard key={video.id} video={video} />
-                  ))}
+                  {viralVideos.map((video: ITrendVideo) => {
+                    const finding = toTrendVideoFinding(video);
+                    return (
+                      <ViralVideoCard
+                        key={video.id}
+                        finding={finding}
+                        isSelected={isSameResearchFindingReference(
+                          surface?.authorizedFinding?.reference ?? null,
+                          finding.reference,
+                        )}
+                        onSelect={
+                          surface?.isEmbedded
+                            ? surface.selectFinding
+                            : undefined
+                        }
+                        video={video}
+                      />
+                    );
+                  })}
                 </div>
               )}
             </section>

--- a/packages/pages/trends/platform-detail/components/related-metric-card.tsx
+++ b/packages/pages/trends/platform-detail/components/related-metric-card.tsx
@@ -1,16 +1,25 @@
 'use client';
 
+import { ButtonSize, ButtonVariant } from '@genfeedai/enums';
+import type { AuthorizedResearchFinding } from '@pages/research/work-surface/research-work-surface.types';
 import Badge from '@ui/display/badge/Badge';
+import { Button } from '@ui/primitives/button';
 
 type RelatedMetricCardProps = {
   badgeValue: number;
   detail?: string | null;
+  finding?: AuthorizedResearchFinding;
+  isSelected?: boolean;
+  onSelect?: (finding: AuthorizedResearchFinding) => void;
   title: string;
 };
 
 export default function RelatedMetricCard({
   badgeValue,
   detail,
+  finding,
+  isSelected = false,
+  onSelect,
   title,
 }: RelatedMetricCardProps) {
   return (
@@ -23,6 +32,15 @@ export default function RelatedMetricCard({
           <Badge variant="ghost">{Math.round(badgeValue)}</Badge>
           {detail ? <span>{detail}</span> : null}
         </div>
+        {finding && onSelect ? (
+          <Button
+            aria-pressed={isSelected}
+            label={isSelected ? 'Selected for context' : 'Use as context'}
+            onClick={() => onSelect(finding)}
+            size={ButtonSize.SM}
+            variant={isSelected ? ButtonVariant.SECONDARY : ButtonVariant.GHOST}
+          />
+        ) : null}
       </div>
     </div>
   );

--- a/packages/pages/trends/platform-detail/components/trends-platform-related-sections.tsx
+++ b/packages/pages/trends/platform-detail/components/trends-platform-related-sections.tsx
@@ -5,6 +5,14 @@ import type {
   ITrendSound,
   ITrendVideo,
 } from '@genfeedai/interfaces';
+import {
+  type AuthorizedResearchFinding,
+  isSameResearchFindingReference,
+  type ResearchFindingReference,
+  toTrendHashtagFinding,
+  toTrendSoundFinding,
+  toTrendVideoFinding,
+} from '@pages/research/work-surface/research-work-surface.types';
 import { HiHashtag, HiMusicalNote, HiOutlineFilm } from 'react-icons/hi2';
 import RelatedMetricCard from './related-metric-card';
 
@@ -20,6 +28,8 @@ type TrendsPlatformRelatedSectionsProps = {
   showSounds: boolean;
   isLoadingSounds: boolean;
   sounds: ITrendSound[];
+  selectedReference?: ResearchFindingReference | null;
+  onSelect?: (finding: AuthorizedResearchFinding) => void;
 };
 
 export default function TrendsPlatformRelatedSections({
@@ -32,6 +42,8 @@ export default function TrendsPlatformRelatedSections({
   showSounds,
   isLoadingSounds,
   sounds,
+  selectedReference,
+  onSelect,
 }: TrendsPlatformRelatedSectionsProps) {
   return (
     <>
@@ -49,16 +61,25 @@ export default function TrendsPlatformRelatedSections({
             </div>
           ) : viralVideos.length > 0 ? (
             <div className="grid grid-cols-1 gap-3 xl:grid-cols-2">
-              {viralVideos.map((video: ITrendVideo) => (
-                <RelatedMetricCard
-                  badgeValue={video.viralScore}
-                  detail={
-                    video.creatorHandle ? `@${video.creatorHandle}` : null
-                  }
-                  key={video.id}
-                  title={video.title || video.hook || 'Untitled'}
-                />
-              ))}
+              {viralVideos.map((video: ITrendVideo) => {
+                const finding = toTrendVideoFinding(video);
+                return (
+                  <RelatedMetricCard
+                    badgeValue={video.viralScore}
+                    detail={
+                      video.creatorHandle ? `@${video.creatorHandle}` : null
+                    }
+                    finding={finding}
+                    isSelected={isSameResearchFindingReference(
+                      selectedReference ?? null,
+                      finding.reference,
+                    )}
+                    key={video.id}
+                    onSelect={onSelect}
+                    title={video.title || video.hook || 'Untitled'}
+                  />
+                );
+              })}
             </div>
           ) : (
             <div className="py-3 text-sm text-foreground/40">
@@ -82,16 +103,25 @@ export default function TrendsPlatformRelatedSections({
             </div>
           ) : hashtags.length > 0 ? (
             <div className="grid grid-cols-1 gap-3 xl:grid-cols-2">
-              {hashtags.map((hashtag: ITrendHashtag) => (
-                <RelatedMetricCard
-                  badgeValue={hashtag.viralityScore}
-                  detail={
-                    hashtag.platform ? hashtag.platform.toLowerCase() : null
-                  }
-                  key={hashtag.id || hashtag.hashtag}
-                  title={hashtag.hashtag}
-                />
-              ))}
+              {hashtags.map((hashtag: ITrendHashtag) => {
+                const finding = toTrendHashtagFinding(hashtag);
+                return (
+                  <RelatedMetricCard
+                    badgeValue={hashtag.viralityScore}
+                    detail={
+                      hashtag.platform ? hashtag.platform.toLowerCase() : null
+                    }
+                    finding={finding}
+                    isSelected={isSameResearchFindingReference(
+                      selectedReference ?? null,
+                      finding.reference,
+                    )}
+                    key={hashtag.id || hashtag.hashtag}
+                    onSelect={onSelect}
+                    title={hashtag.hashtag}
+                  />
+                );
+              })}
             </div>
           ) : (
             <div className="py-3 text-sm text-foreground/40">
@@ -115,14 +145,25 @@ export default function TrendsPlatformRelatedSections({
             </div>
           ) : sounds.length > 0 ? (
             <div className="grid grid-cols-1 gap-3 xl:grid-cols-2">
-              {sounds.map((sound: ITrendSound) => (
-                <RelatedMetricCard
-                  badgeValue={sound.viralityScore}
-                  detail={sound.platform ? sound.platform.toLowerCase() : null}
-                  key={sound.soundId}
-                  title={sound.soundName || 'Untitled sound'}
-                />
-              ))}
+              {sounds.map((sound: ITrendSound) => {
+                const finding = toTrendSoundFinding(sound);
+                return (
+                  <RelatedMetricCard
+                    badgeValue={sound.viralityScore}
+                    detail={
+                      sound.platform ? sound.platform.toLowerCase() : null
+                    }
+                    finding={finding}
+                    isSelected={isSameResearchFindingReference(
+                      selectedReference ?? null,
+                      finding.reference,
+                    )}
+                    key={sound.soundId}
+                    onSelect={onSelect}
+                    title={sound.soundName || 'Untitled sound'}
+                  />
+                );
+              })}
             </div>
           ) : (
             <div className="py-3 text-sm text-foreground/40">

--- a/packages/pages/trends/platform-detail/trends-platform-detail.tsx
+++ b/packages/pages/trends/platform-detail/trends-platform-detail.tsx
@@ -10,6 +10,18 @@ import type {
 import { useAuthedService } from '@hooks/auth/use-authed-service/use-authed-service';
 import { useTrendContent } from '@hooks/data/trends/use-trend-content/use-trend-content';
 import {
+  useOptionalResearchWorkSurface,
+  useResearchPagination,
+  useRestoreResearchFinding,
+} from '@pages/research/work-surface/ResearchWorkSurfaceProvider';
+import {
+  isSameResearchFindingReference,
+  toTrendContentFinding,
+  toTrendHashtagFinding,
+  toTrendSoundFinding,
+  toTrendVideoFinding,
+} from '@pages/research/work-surface/research-work-surface.types';
+import {
   SocialsNavigation,
   type SocialsNavigationBasePath,
 } from '@pages/trends/shared/socials-navigation';
@@ -40,6 +52,7 @@ export default function TrendsPlatformDetail({
   basePath?: SocialsNavigationBasePath;
 }) {
   const brandId = useBrandId();
+  const surface = useOptionalResearchWorkSurface();
   const label = getTrendPlatformLabel(platform);
   const relatedContent = PLATFORM_RELATED_CONTENT[platform];
   const unsupportedContentFeed = ![
@@ -125,6 +138,21 @@ export default function TrendsPlatformDetail({
 
     return 'Public references';
   }, [unsupportedContentFeed]);
+  const findings = useMemo(
+    () => [
+      ...items.map(toTrendContentFinding),
+      ...viralVideos.map(toTrendVideoFinding),
+      ...hashtags.map(toTrendHashtagFinding),
+      ...sounds.map(toTrendSoundFinding),
+    ],
+    [hashtags, items, sounds, viralVideos],
+  );
+  const { pageItems, pagination } = useResearchPagination(items);
+
+  useRestoreResearchFinding(
+    findings,
+    isLoading || isLoadingVideos || isLoadingHashtags || isLoadingSounds,
+  );
 
   const handleRefresh = async () => {
     await refreshTrendContent();
@@ -212,11 +240,27 @@ export default function TrendsPlatformDetail({
                 <div className="py-3 text-sm text-foreground/40">
                   Loading content feed…
                 </div>
-              ) : items.length > 0 ? (
+              ) : pageItems.length > 0 ? (
                 <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
-                  {items.map((item) => (
-                    <TrendContentCard key={item.id} item={item} />
-                  ))}
+                  {pageItems.map((item) => {
+                    const finding = toTrendContentFinding(item);
+                    return (
+                      <TrendContentCard
+                        key={item.id}
+                        finding={finding}
+                        isSelected={isSameResearchFindingReference(
+                          surface?.authorizedFinding?.reference ?? null,
+                          finding.reference,
+                        )}
+                        item={item}
+                        onSelect={
+                          surface?.isEmbedded
+                            ? surface.selectFinding
+                            : undefined
+                        }
+                      />
+                    );
+                  })}
                 </div>
               ) : (
                 <div className="py-3 text-sm text-foreground/40">
@@ -224,6 +268,7 @@ export default function TrendsPlatformDetail({
                   right now.
                 </div>
               )}
+              {pagination ? <div className="pt-2">{pagination}</div> : null}
             </section>
 
             <TrendsPlatformRelatedSections
@@ -236,6 +281,8 @@ export default function TrendsPlatformDetail({
               showVideos={relatedContent.videos}
               sounds={sounds}
               viralVideos={viralVideos}
+              selectedReference={surface?.authorizedFinding?.reference ?? null}
+              onSelect={surface?.isEmbedded ? surface.selectFinding : undefined}
             />
           </div>
         ) : null}

--- a/packages/pages/trends/shared/trend-content-card.tsx
+++ b/packages/pages/trends/shared/trend-content-card.tsx
@@ -6,6 +6,7 @@ import { getRelativeTime } from '@helpers/formatting/date/date.helper';
 import { formatCompactNumber } from '@helpers/formatting/format/format.helper';
 import { getPlatformIcon } from '@helpers/ui/platform-icon/platform-icon.helper';
 import { useAuthedService } from '@hooks/auth/use-authed-service/use-authed-service';
+import type { AuthorizedResearchFinding } from '@pages/research/work-surface/research-work-surface.types';
 import type {
   TrendContentItem,
   TrendItem,
@@ -87,7 +88,17 @@ function toSourceItem(item: TrendContentItem): TrendSourceItem {
   };
 }
 
-export default function TrendContentCard({ item }: { item: TrendContentItem }) {
+export default function TrendContentCard({
+  finding,
+  isSelected = false,
+  item,
+  onSelect,
+}: {
+  finding?: AuthorizedResearchFinding;
+  isSelected?: boolean;
+  item: TrendContentItem;
+  onSelect?: (finding: AuthorizedResearchFinding) => void;
+}) {
   const brandId = useBrandId();
   const router = useRouter();
   const [isSavingBrief, setIsSavingBrief] = useState(false);
@@ -256,6 +267,16 @@ export default function TrendContentCard({ item }: { item: TrendContentItem }) {
         </div>
 
         <div className="flex flex-wrap gap-2 pt-1">
+          {finding && onSelect ? (
+            <Button
+              aria-pressed={isSelected}
+              label={isSelected ? 'Selected for context' : 'Use as context'}
+              onClick={() => onSelect(finding)}
+              variant={
+                isSelected ? ButtonVariant.SECONDARY : ButtonVariant.GHOST
+              }
+            />
+          ) : null}
           <Button
             icon={<HiOutlineSparkles className="size-3.5" />}
             label="Remix"


### PR DESCRIPTION
## Summary

- embed every canonical Research route as a focused canvas while preserving existing providers, algorithms, actions, and route behavior
- restore query, filters, pagination, and typed finding selection from canonical URLs; authorize restored selections only from the current scoped result set
- add the Research inspector and typed composer context references, bounded 24-item rendering, keyboard-accessible selection, and safe canonical fallback when the adapter is unavailable

## Parallel coordination

- rebased onto current master at e493c271b after the task started
- inspected open PRs #1699 and #1700; the shared registry configuration matches #1700's additive adapter shape, while substantive runtime code remains under the Research feature/domain
- expected future overlap is limited to the universal shell and composer seam; resolution must retain #1699 scope controls, #1700 artifact references/provider, and this PR's Research inspector/context references

## Verification

- Biome check passed for all 27 changed files
- design-system boundaries, app UI boundaries, raw-control guard, bespoke-card guard, and packages/pages boundary passed
- staged secretlint passed; Gitleaks scanned the rebased commit with no leaks
- git diff/show whitespace checks passed
- focused tests were added for URL restoration, malformed-state fallback, embedded registry metadata, and typed composer references

Tests, typechecks, builds, E2E, and GitHub Actions babysitting were intentionally not run per the local MacBook policy and task handoff. The aggregate UI-guard runner also hits the repository's existing TypeScript-loader crash in the nested-card check; the relevant guards above were run individually.

Closes #1686
Part of #1670