### PR TITLE
feat(publishing): add version-bound publish approvals

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/review/components/ReviewDetailPanelAside.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/review/components/ReviewDetailPanelAside.tsx
@@ -100,6 +100,73 @@ export default function ReviewDetailPanelAside({
         </DefinitionList>
       </InsetSurface>
 
+      <InsetSurface className="p-5" tone="contrast">
+        <h3 className="text-sm font-medium text-foreground">
+          Version-bound publish approval
+        </h3>
+        <p className="mt-1 text-sm text-foreground/55">
+          Chat and model text never authorize publishing. This typed decision
+          locks the exact version, destination, timing, actor, and policy.
+        </p>
+        <DefinitionList className="mt-4 text-sm">
+          <div className="flex items-start justify-between gap-4">
+            <DefinitionTerm>Version</DefinitionTerm>
+            <DefinitionDetail variant="value">
+              {item.publishApproval?.artifactVersionPinId ??
+                item.versionPinId ??
+                'Pinned on approval'}
+            </DefinitionDetail>
+          </div>
+          <div className="flex items-start justify-between gap-4">
+            <DefinitionTerm>Destination</DefinitionTerm>
+            <DefinitionDetail variant="value">
+              {item.publishApproval?.destinations
+                .map((destination) => destination.platform)
+                .join(', ') ??
+                item.platform ??
+                'Not selected'}
+            </DefinitionDetail>
+          </div>
+          <div className="flex items-start justify-between gap-4">
+            <DefinitionTerm>Timing</DefinitionTerm>
+            <DefinitionDetail variant="value">
+              {item.publishApproval?.scheduleIntent.kind === 'scheduled'
+                ? formattedScheduledDate
+                : item.publishApproval?.scheduleIntent.kind === 'immediate'
+                  ? 'Publish now'
+                  : (formattedScheduledDate ?? 'Requires publish confirmation')}
+            </DefinitionDetail>
+          </div>
+          <div className="flex items-start justify-between gap-4">
+            <DefinitionTerm>Policy</DefinitionTerm>
+            <DefinitionDetail variant="value">
+              {item.publishApproval
+                ? `${item.publishApproval.policy.id} v${item.publishApproval.policy.version}`
+                : 'version-bound-publish-v1'}
+            </DefinitionDetail>
+          </div>
+          <div className="flex items-start justify-between gap-4">
+            <DefinitionTerm>Provenance</DefinitionTerm>
+            <DefinitionDetail variant="value">
+              {item.sourceWorkflowName ??
+                item.sourceActionId ??
+                'Manual review control'}
+            </DefinitionDetail>
+          </div>
+          <div className="flex items-start justify-between gap-4">
+            <DefinitionTerm>Status</DefinitionTerm>
+            <DefinitionDetail variant="value">
+              {item.publishApproval?.status ?? 'Awaiting typed approval'}
+            </DefinitionDetail>
+          </div>
+        </DefinitionList>
+        {item.publishApproval?.invalidationReason && (
+          <p className="mt-4 text-sm text-warning">
+            {item.publishApproval.invalidationReason}
+          </p>
+        )}
+      </InsetSurface>
+
       <ReviewLineagePanel item={item} />
 
       {(item.gateOverallScore !== undefined ||

--- a/apps/server/api/src/app.module.ts
+++ b/apps/server/api/src/app.module.ts
@@ -82,6 +82,7 @@ import { PresetsModule } from '@api/collections/presets/presets.module';
 import { ProfilesModule } from '@api/collections/profiles/profiles.module';
 import { ProjectsModule } from '@api/collections/projects/projects.module';
 import { PromptsModule } from '@api/collections/prompts/prompts.module';
+import { PublishApprovalsModule } from '@api/collections/publish-approvals/publish-approvals.module';
 import { RolesModule } from '@api/collections/roles/roles.module';
 import { RunsModule } from '@api/collections/runs/runs.module';
 import { SchedulesModule } from '@api/collections/schedules/schedules.module';
@@ -320,6 +321,7 @@ import { SentryModule } from '@sentry/nestjs/setup';
     PersonasModule,
     PostGroupsModule,
     PostsModule,
+    PublishApprovalsModule,
     PresetsModule,
     ProfilesModule,
     ProjectsModule,

--- a/apps/server/api/src/collections/post-groups/post-groups.module.ts
+++ b/apps/server/api/src/collections/post-groups/post-groups.module.ts
@@ -1,12 +1,13 @@
 import { PostGroupsController } from '@api/collections/post-groups/controllers/post-groups.controller';
 import { PostGroupsService } from '@api/collections/post-groups/services/post-groups.service';
+import { PublishApprovalsModule } from '@api/collections/publish-approvals/publish-approvals.module';
 import { QueuesModule } from '@api/queues/core/queues.module';
 import { forwardRef, Module } from '@nestjs/common';
 
 @Module({
   controllers: [PostGroupsController],
   exports: [PostGroupsService],
-  imports: [forwardRef(() => QueuesModule)],
+  imports: [forwardRef(() => QueuesModule), PublishApprovalsModule],
   providers: [PostGroupsService],
 })
 export class PostGroupsModule {}

--- a/apps/server/api/src/collections/post-groups/services/post-groups.service.spec.ts
+++ b/apps/server/api/src/collections/post-groups/services/post-groups.service.spec.ts
@@ -1,4 +1,5 @@
 import { PostGroupsService } from '@api/collections/post-groups/services/post-groups.service';
+import { PublishApprovalsService } from '@api/collections/publish-approvals/services/publish-approvals.service';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import {
   CredentialPlatform,
@@ -46,6 +47,11 @@ type MockPostTarget = {
   publishedAt: Date | null;
   retryCount: number;
   reviewVersionPinId?: string | null;
+  publishApproval?: {
+    artifactVersionPinId: string;
+    id: string;
+    operationId: string;
+  } | null;
   scheduledDate: Date | null;
   targetAttachments: unknown;
   targetError: unknown;
@@ -63,6 +69,10 @@ type MockPostTarget = {
 describe('PostGroupsService', () => {
   let service: PostGroupsService;
   let postPublishQueueService: { enqueue: ReturnType<typeof vi.fn> };
+  let publishApprovalsService: {
+    createForCurrentPost: ReturnType<typeof vi.fn>;
+    markQueued: ReturnType<typeof vi.fn>;
+  };
   let prisma: {
     $transaction: ReturnType<typeof vi.fn>;
     brand: { findFirst: ReturnType<typeof vi.fn> };
@@ -131,6 +141,14 @@ describe('PostGroupsService', () => {
     postPublishQueueService = {
       enqueue: vi.fn().mockResolvedValue('target-1'),
     };
+    publishApprovalsService = {
+      createForCurrentPost: vi.fn().mockResolvedValue({
+        artifactVersionPinId: 'pin-1',
+        id: 'approval-1',
+        operationId: 'operation-1',
+      }),
+      markQueued: vi.fn().mockResolvedValue(undefined),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -151,6 +169,10 @@ describe('PostGroupsService', () => {
         {
           provide: PostPublishQueueService,
           useValue: postPublishQueueService,
+        },
+        {
+          provide: PublishApprovalsService,
+          useValue: publishApprovalsService,
         },
       ],
     }).compile();
@@ -304,15 +326,18 @@ describe('PostGroupsService', () => {
       }),
     );
     expect(postPublishQueueService.enqueue).toHaveBeenCalledWith({
+      approvalId: 'approval-1',
+      operationId: 'operation-1',
       organizationId: 'org-1',
       postId: 'target-1',
       source: 'publish_now',
       userId: 'user-1',
+      versionPinId: 'pin-1',
     });
     expect(result.targets?.[0]?.id).toBe('target-1');
   });
 
-  it('queues a publish-now target with its durable review version pin', async () => {
+  it('queues a publish-now target with its bound approval operation', async () => {
     prisma.postGroup.findFirst.mockResolvedValue(
       makeGroup({ id: 'group-1', status: ReleaseStatus.DRAFT }),
     );
@@ -320,7 +345,11 @@ describe('PostGroupsService', () => {
       makeTarget({
         groupId: 'group-1',
         id: 'target-1',
-        reviewVersionPinId: 'pin-1',
+        publishApproval: {
+          artifactVersionPinId: 'pin-1',
+          id: 'approval-1',
+          operationId: 'operation-1',
+        },
         targetExecutionState: TargetExecutionState.SCHEDULED,
       }),
     ]);
@@ -337,12 +366,19 @@ describe('PostGroupsService', () => {
     await service.publishNow('org-1', 'user-1', 'group-1');
 
     expect(postPublishQueueService.enqueue).toHaveBeenCalledWith({
+      approvalId: 'approval-1',
+      operationId: 'operation-1',
       organizationId: 'org-1',
       postId: 'target-1',
       source: 'publish_now',
       userId: 'user-1',
       versionPinId: 'pin-1',
     });
+    expect(publishApprovalsService.markQueued).toHaveBeenCalledWith(
+      'approval-1',
+      'org-1',
+      'user-1',
+    );
   });
 
   it('pauses eligible targets and rolls the group up to paused', async () => {
@@ -415,6 +451,11 @@ function makeTarget(overrides: Partial<MockPostTarget> = {}): MockPostTarget {
     lastAttemptAt: null,
     order: 0,
     platform: CredentialPlatform.TWITTER,
+    publishApproval: {
+      artifactVersionPinId: 'pin-1',
+      id: 'approval-1',
+      operationId: 'operation-1',
+    },
     publishedAt: null,
     retryCount: 0,
     scheduledDate: null,

--- a/apps/server/api/src/collections/post-groups/services/post-groups.service.ts
+++ b/apps/server/api/src/collections/post-groups/services/post-groups.service.ts
@@ -1,3 +1,4 @@
+import { PublishApprovalsService } from '@api/collections/publish-approvals/services/publish-approvals.service';
 import { NotFoundException } from '@api/helpers/exceptions/http/not-found.exception';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import {
@@ -35,7 +36,11 @@ import type {
 import { Prisma } from '@genfeedai/prisma';
 import { PostPublishQueueService } from '@genfeedai/server';
 import { LoggerService } from '@libs/logger/logger.service';
-import { BadRequestException, Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+} from '@nestjs/common';
 import type { ZodError } from 'zod';
 
 type SchedulerTx = Prisma.TransactionClient;
@@ -118,6 +123,7 @@ export class PostGroupsService {
     private readonly prisma: PrismaService,
     private readonly logger: LoggerService,
     private readonly postPublishQueueService: PostPublishQueueService,
+    private readonly publishApprovalsService: PublishApprovalsService,
   ) {}
 
   async create(
@@ -134,6 +140,9 @@ export class PostGroupsService {
         input.idempotencyKey,
       );
       if (existing) {
+        if (existing.status === ReleaseStatus.SCHEDULED) {
+          await this.approveReleaseTargets(existing, userId, 'scheduled');
+        }
         return existing;
       }
     }
@@ -141,7 +150,7 @@ export class PostGroupsService {
     const status = this.resolveCreateStatus(input);
     const scheduledAt = this.toDate(input.scheduledDate);
 
-    return this.prisma.$transaction(async (tx) => {
+    const release = await this.prisma.$transaction(async (tx) => {
       const credentials = await this.resolveCredentials(
         tx,
         organizationId,
@@ -248,6 +257,11 @@ export class PostGroupsService {
 
       return this.toReleaseGroup(group, targets);
     });
+
+    if (release.status === ReleaseStatus.SCHEDULED) {
+      await this.approveReleaseTargets(release, userId, 'scheduled');
+    }
+    return release;
   }
 
   async getOne(
@@ -275,7 +289,7 @@ export class PostGroupsService {
   ): Promise<IReleaseGroup> {
     const input = this.parseUpdateInput(body);
 
-    return this.prisma.$transaction(async (tx) => {
+    const release = await this.prisma.$transaction(async (tx) => {
       const existing = await this.getGroupOrThrow(tx, organizationId, groupId);
       const nextStatus = input.status ?? existing.status;
       const transition =
@@ -344,6 +358,22 @@ export class PostGroupsService {
       const targets = await this.getTargets(tx, organizationId, existing.id);
       return this.toReleaseGroup(updated, targets);
     });
+    if (
+      input.attachments !== undefined ||
+      input.baseContent !== undefined ||
+      input.brandId !== undefined ||
+      input.media !== undefined ||
+      input.recurrence !== undefined ||
+      input.scheduledDate !== undefined ||
+      input.timezone !== undefined
+    ) {
+      await this.invalidateReleaseApprovals(
+        release,
+        userId,
+        'Release content, brand, destinations, or protected schedule intent changed.',
+      );
+    }
+    return release;
   }
 
   async updateTarget(
@@ -355,7 +385,7 @@ export class PostGroupsService {
   ): Promise<IReleaseGroup> {
     const input = this.parseTargetInput(body);
 
-    return this.prisma.$transaction(async (tx) => {
+    const release = await this.prisma.$transaction(async (tx) => {
       const group = await this.getGroupOrThrow(tx, organizationId, groupId);
       const existing = await this.getTargetOrThrow(
         tx,
@@ -446,6 +476,19 @@ export class PostGroupsService {
 
       return this.recalculateAndHydrate(tx, organizationId, group.id, userId);
     });
+    if (
+      input.scheduledDate !== undefined ||
+      input.settings !== undefined ||
+      input.timezone !== undefined
+    ) {
+      await this.publishApprovalsService.invalidatePost(
+        organizationId,
+        targetId,
+        'Channel destination settings or protected schedule intent changed.',
+        userId,
+      );
+    }
+    return release;
   }
 
   cancel(
@@ -536,6 +579,7 @@ export class PostGroupsService {
       return this.recalculateAndHydrate(tx, organizationId, group.id, userId);
     });
 
+    await this.approveReleaseTargets(release, userId, 'immediate');
     await this.enqueueReleaseTargets(release, userId);
     return release;
   }
@@ -554,7 +598,13 @@ export class PostGroupsService {
     const durableTargets = await this.prisma.post.findMany({
       select: {
         id: true,
-        reviewVersionPinId: true,
+        publishApproval: {
+          select: {
+            artifactVersionPinId: true,
+            id: true,
+            operationId: true,
+          },
+        },
       },
       where: {
         id: { in: targets.map((target) => target.id) },
@@ -562,22 +612,76 @@ export class PostGroupsService {
         organizationId: release.organizationId,
       },
     });
-    const versionPinIds = new Map(
-      durableTargets.map((target) => [target.id, target.reviewVersionPinId]),
+    const approvals = new Map(
+      durableTargets.map((target) => [target.id, target.publishApproval]),
     );
 
     await Promise.all(
-      targets.map((target) => {
-        const versionPinId = versionPinIds.get(target.id);
+      targets.map(async (target) => {
+        const approval = approvals.get(target.id);
+        if (!approval) {
+          throw new ConflictException(
+            `Target ${target.id} has no version-bound publish approval.`,
+          );
+        }
+        await this.publishApprovalsService.markQueued(
+          approval.id,
+          release.organizationId,
+          userId,
+        );
         return this.postPublishQueueService.enqueue({
+          approvalId: approval.id,
+          operationId: approval.operationId,
           organizationId: release.organizationId,
           postId: target.id,
           source: 'publish_now',
           userId,
-          ...(versionPinId ? { versionPinId } : {}),
+          versionPinId: approval.artifactVersionPinId,
         });
       }),
     );
+  }
+
+  private async approveReleaseTargets(
+    release: IReleaseGroup,
+    userId: string,
+    mode: 'immediate' | 'scheduled',
+  ): Promise<void> {
+    try {
+      await Promise.all(
+        (release.targets ?? []).map((target) =>
+          this.publishApprovalsService.createForCurrentPost({
+            actorUserId: userId,
+            mode,
+            organizationId: release.organizationId,
+            postId: target.id,
+            provenance: {
+              releaseId: release.id,
+              surface: 'post-groups',
+            },
+          }),
+        ),
+      );
+    } catch (error: unknown) {
+      await this.prisma.$transaction([
+        this.prisma.post.updateMany({
+          data: {
+            status: TargetExecutionState.PAUSED,
+            targetExecutionState: TargetExecutionState.PAUSED,
+          },
+          where: {
+            groupId: release.id,
+            isDeleted: false,
+            organizationId: release.organizationId,
+          },
+        }),
+        this.prisma.postGroup.update({
+          data: { status: ReleaseStatus.PAUSED },
+          where: { id: release.id },
+        }),
+      ]);
+      throw error;
+    }
   }
 
   private async transitionGroupTargets(
@@ -589,7 +693,7 @@ export class PostGroupsService {
       GROUP_ACTION_STATES,
     ) as TargetExecutionState[],
   ): Promise<IReleaseGroup> {
-    return this.prisma.$transaction(async (tx) => {
+    const release = await this.prisma.$transaction(async (tx) => {
       const group = await this.getGroupOrThrow(tx, organizationId, groupId);
       await tx.post.updateMany({
         data: {
@@ -606,6 +710,31 @@ export class PostGroupsService {
 
       return this.recalculateAndHydrate(tx, organizationId, group.id, userId);
     });
+    if (nextState === TargetExecutionState.CANCELLED) {
+      await this.invalidateReleaseApprovals(
+        release,
+        userId,
+        'The scheduled release was cancelled.',
+      );
+    }
+    return release;
+  }
+
+  private async invalidateReleaseApprovals(
+    release: IReleaseGroup,
+    userId: string,
+    reason: string,
+  ): Promise<void> {
+    await Promise.all(
+      (release.targets ?? []).map((target) =>
+        this.publishApprovalsService.invalidatePost(
+          release.organizationId,
+          target.id,
+          reason,
+          userId,
+        ),
+      ),
+    );
   }
 
   private async recalculateAndHydrate(

--- a/apps/server/api/src/collections/posts/entities/post.entity.ts
+++ b/apps/server/api/src/collections/posts/entities/post.entity.ts
@@ -75,6 +75,12 @@ export class PostEntity extends BaseEntity {
   declare readonly reviewDecision?: 'approved' | 'rejected' | 'request_changes';
   declare readonly reviewFeedback?: string;
   declare readonly reviewVersionPinId?: string;
+  declare readonly publishApprovalId?: string;
+  declare readonly publishApproval?: {
+    artifactVersionPinId: string;
+    id: string;
+    operationId: string;
+  };
   declare readonly reviewedAt?: Date;
   declare readonly reviewEvents?: Array<{
     decision: 'approved' | 'rejected' | 'request_changes';

--- a/apps/server/api/src/collections/posts/posts.module.ts
+++ b/apps/server/api/src/collections/posts/posts.module.ts
@@ -18,6 +18,7 @@ import { AnalyticsAggregationService } from '@api/collections/posts/services/ana
 import { PostAnalyticsService } from '@api/collections/posts/services/post-analytics.service';
 import { PostGenerationService } from '@api/collections/posts/services/post-generation.service';
 import { PostsService } from '@api/collections/posts/services/posts.service';
+import { PublishApprovalsModule } from '@api/collections/publish-approvals/publish-approvals.module';
 import { TemplatesModule } from '@api/collections/templates/templates.module';
 import { TrendsModule } from '@api/collections/trends/trends.module';
 import { CreditsGuard } from '@api/helpers/guards/credits/credits.guard';
@@ -52,6 +53,7 @@ import { forwardRef, Module } from '@nestjs/common';
     forwardRef(() => NotificationsPublisherModule),
     forwardRef(() => OrganizationSettingsModule),
     forwardRef(() => PromptBuilderModule),
+    PublishApprovalsModule,
     forwardRef(() => QuotaModule),
     forwardRef(() => ReplicateModule),
     forwardRef(() => SeoModule),

--- a/apps/server/api/src/collections/posts/services/posts.service.ts
+++ b/apps/server/api/src/collections/posts/services/posts.service.ts
@@ -6,6 +6,7 @@ import { OrganizationSettingsService } from '@api/collections/organization-setti
 import { CreatePostDto } from '@api/collections/posts/dto/create-post.dto';
 import { UpdatePostDto } from '@api/collections/posts/dto/update-post.dto';
 import type { PostDocument } from '@api/collections/posts/schemas/post.schema';
+import { PublishApprovalsService } from '@api/collections/publish-approvals/services/publish-approvals.service';
 import { HandleErrors } from '@api/helpers/decorators/error-handler.decorator';
 import { EntityIdUtil } from '@api/helpers/utils/entity-id/entity-id.util';
 import { CacheService } from '@api/services/cache/services/cache.service';
@@ -31,6 +32,24 @@ const PRISMA_POST_STATUS = {
   PUBLIC: 'PUBLIC',
   SCHEDULED: 'SCHEDULED',
 } as const;
+const PUBLISH_APPROVAL_MATERIAL_FIELDS = new Set<keyof UpdatePostDto>([
+  'category',
+  'credential',
+  'description',
+  'ingredients',
+  'isRepeat',
+  'isShareToFeedSelected',
+  'label',
+  'maxRepeats',
+  'parent',
+  'publishIntent',
+  'repeatDaysOfWeek',
+  'repeatEndDate',
+  'repeatFrequency',
+  'repeatInterval',
+  'scheduledDate',
+  'timezone',
+]);
 
 type ContentMentionPostRecord = {
   category: string;
@@ -61,6 +80,8 @@ export class PostsService extends BaseService<
     @Optional()
     private readonly organizationSettingsService?: OrganizationSettingsService,
     @Optional() private readonly creditsUtilsService?: CreditsUtilsService,
+    @Optional()
+    private readonly publishApprovalsService?: PublishApprovalsService,
   ) {
     super(prisma, 'post', logger, undefined, cacheService);
   }
@@ -247,6 +268,21 @@ export class PostsService extends BaseService<
     const normalizedStatus =
       typeof dto.status === 'string' ? dto.status.toLowerCase() : undefined;
     const isPublishingPost = normalizedStatus === PostStatus.PUBLIC;
+    const changesApprovalScope = Object.keys(dto).some((key) =>
+      PUBLISH_APPROVAL_MATERIAL_FIELDS.has(key as keyof UpdatePostDto),
+    );
+    const approvalContext = changesApprovalScope
+      ? await this.prisma.post.findFirst({
+          select: { organizationId: true, publishApprovalId: true },
+          where: { id, isDeleted: false },
+        })
+      : null;
+    if (approvalContext?.publishApprovalId && this.publishApprovalsService) {
+      await this.publishApprovalsService.assertPostMutable(
+        approvalContext.organizationId,
+        id,
+      );
+    }
     let currentPost: PostDocument | null = null;
 
     if (normalizedStatus === PostStatus.SCHEDULED || isPublishingPost) {
@@ -321,6 +357,14 @@ export class PostsService extends BaseService<
     }
 
     const updatedPost = await super.patch(id, normalizedDto, populate);
+
+    if (approvalContext?.publishApprovalId && this.publishApprovalsService) {
+      await this.publishApprovalsService.invalidatePost(
+        approvalContext.organizationId,
+        id,
+        'Canonical Post material or protected schedule intent changed.',
+      );
+    }
 
     if (
       isPublishingPost &&

--- a/apps/server/api/src/collections/publish-approvals/controllers/publish-approvals.controller.ts
+++ b/apps/server/api/src/collections/publish-approvals/controllers/publish-approvals.controller.ts
@@ -1,0 +1,37 @@
+import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticated-user.interface';
+import { PublishApprovalsService } from '@api/collections/publish-approvals/services/publish-approvals.service';
+import { LogMethod } from '@api/helpers/decorators/log/log-method.decorator';
+import { AutoSwagger } from '@api/helpers/decorators/swagger/auto-swagger.decorator';
+import { CurrentUser } from '@api/helpers/decorators/user/current-user.decorator';
+import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
+import { getPublicMetadata } from '@api/helpers/utils/auth/auth.util';
+import { serializeSingle } from '@api/helpers/utils/response/response.util';
+import { PublishApprovalSerializer } from '@genfeedai/serializers';
+import { Body, Controller, Post, Req, UseGuards } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import type { Request } from 'express';
+
+@AutoSwagger()
+@ApiTags('PublishApprovals')
+@Controller('publish-approvals')
+@UseGuards(RolesGuard)
+export class PublishApprovalsController {
+  constructor(private readonly approvalsService: PublishApprovalsService) {}
+
+  @Post()
+  @LogMethod({ logEnd: false, logError: true, logStart: true })
+  async create(
+    @Req() request: Request,
+    @CurrentUser() user: User,
+    @Body() body: unknown,
+  ) {
+    const { organization, user: actorUserId } = getPublicMetadata(user);
+    const approval = await this.approvalsService.createForPost({
+      actorUserId,
+      body,
+      organizationId: organization,
+      provenance: { surface: 'publish-approvals-api' },
+    });
+    return serializeSingle(request, PublishApprovalSerializer, approval);
+  }
+}

--- a/apps/server/api/src/collections/publish-approvals/publish-approvals.module.ts
+++ b/apps/server/api/src/collections/publish-approvals/publish-approvals.module.ts
@@ -1,0 +1,21 @@
+import { PublishApprovalsController } from '@api/collections/publish-approvals/controllers/publish-approvals.controller';
+import { PublishApprovalsService } from '@api/collections/publish-approvals/services/publish-approvals.service';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import {
+  AgentArtifactReferenceService,
+  SERVER_TOKENS,
+} from '@genfeedai/server';
+import { LoggerService } from '@libs/logger/logger.service';
+import { Module } from '@nestjs/common';
+
+@Module({
+  controllers: [PublishApprovalsController],
+  exports: [PublishApprovalsService],
+  providers: [
+    AgentArtifactReferenceService,
+    PublishApprovalsService,
+    { provide: SERVER_TOKENS.logger, useExisting: LoggerService },
+    { provide: SERVER_TOKENS.prisma, useExisting: PrismaService },
+  ],
+})
+export class PublishApprovalsModule {}

--- a/apps/server/api/src/collections/publish-approvals/services/publish-approvals.service.spec.ts
+++ b/apps/server/api/src/collections/publish-approvals/services/publish-approvals.service.spec.ts
@@ -1,0 +1,391 @@
+import { createHash } from 'node:crypto';
+import { PublishApprovalsService } from '@api/collections/publish-approvals/services/publish-approvals.service';
+import {
+  CredentialPlatform,
+  PublishApprovalPolicyId,
+  PublishApprovalStatus,
+} from '@genfeedai/enums';
+import type { AgentArtifactReferenceService } from '@genfeedai/server';
+
+const NOW = new Date('2026-07-13T22:00:00.000Z');
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(',')}]`;
+  }
+  if (value && typeof value === 'object') {
+    const record = value as Record<string, unknown>;
+    return `{${Object.keys(record)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`)
+      .join(',')}}`;
+  }
+  return JSON.stringify(value) ?? 'null';
+}
+
+function scopeDigest(): string {
+  const value = {
+    actorUserId: 'user-1',
+    artifactVersionPinId: 'pin-1',
+    brandId: 'brand-1',
+    contextVersion: 4,
+    destinations: [
+      {
+        credentialId: 'credential-1',
+        platform: CredentialPlatform.TWITTER,
+      },
+    ],
+    organizationId: 'org-1',
+    policy: {
+      id: PublishApprovalPolicyId.VERSION_BOUND_V1,
+      version: 1,
+    },
+    postId: 'post-1',
+    scheduleIntent: {
+      kind: 'scheduled',
+      scheduledAt: '2026-07-14T10:00:00.000Z',
+      timezone: 'UTC',
+    },
+  };
+  return `sha256:v1:${createHash('sha256')
+    .update(stableStringify(value))
+    .digest('hex')}`;
+}
+
+function makePost(overrides: Record<string, unknown> = {}) {
+  return {
+    agentContextVersion: 4,
+    brandId: 'brand-1',
+    credentialId: 'credential-1',
+    id: 'post-1',
+    isDeleted: false,
+    organizationId: 'org-1',
+    platform: CredentialPlatform.TWITTER,
+    publishApprovalId: null,
+    scheduledDate: new Date('2026-07-14T10:00:00.000Z'),
+    status: 'scheduled',
+    targetExecutionState: 'scheduled',
+    timezone: 'UTC',
+    ...overrides,
+  };
+}
+
+function makeApproval(overrides: Record<string, unknown> = {}) {
+  return {
+    actorUserId: 'user-1',
+    artifactVersionPinId: 'pin-1',
+    brandId: 'brand-1',
+    contextVersion: 4,
+    createdAt: NOW,
+    destinations: [
+      {
+        credentialId: 'credential-1',
+        platform: CredentialPlatform.TWITTER,
+      },
+    ],
+    executedAt: null,
+    id: 'approval-1',
+    invalidatedAt: null,
+    invalidationReason: null,
+    lastError: null,
+    operationId: 'operation-1',
+    organizationId: 'org-1',
+    policy: {
+      id: PublishApprovalPolicyId.VERSION_BOUND_V1,
+      version: 1,
+    },
+    postId: 'post-1',
+    provenance: { source: 'typed-publish-approval' },
+    scheduleIntent: {
+      kind: 'scheduled',
+      scheduledAt: '2026-07-14T10:00:00.000Z',
+      timezone: 'UTC',
+    },
+    scopeDigest: 'scope-digest',
+    status: PublishApprovalStatus.QUEUED,
+    statusTransitions: [
+      {
+        at: NOW.toISOString(),
+        from: PublishApprovalStatus.APPROVED,
+        to: PublishApprovalStatus.QUEUED,
+      },
+    ],
+    updatedAt: NOW,
+    ...overrides,
+  };
+}
+
+describe('PublishApprovalsService', () => {
+  it('binds a typed approval to the canonical version, scope, actor, target, schedule, and policy', async () => {
+    const post = makePost();
+    const publishApproval = {
+      create: vi.fn().mockImplementation(({ data }) => ({
+        ...data,
+        createdAt: NOW,
+        executedAt: null,
+        invalidatedAt: null,
+        invalidationReason: null,
+        lastError: null,
+        updatedAt: NOW,
+      })),
+      findFirst: vi.fn().mockResolvedValue(null),
+      findMany: vi.fn().mockResolvedValue([]),
+      update: vi.fn(),
+      updateMany: vi.fn(),
+    };
+    const prisma = {
+      $transaction: vi.fn(async (callback) =>
+        callback({ post: prisma.post, publishApproval }),
+      ),
+      post: {
+        findFirst: vi.fn().mockResolvedValue(post),
+        update: vi.fn().mockResolvedValue(post),
+      },
+      publishApproval,
+    };
+    const artifactReferenceService = {
+      createOrReuseVersionPin: vi.fn().mockResolvedValue({ id: 'pin-1' }),
+    };
+    const service = new PublishApprovalsService(
+      prisma as never,
+      artifactReferenceService as unknown as AgentArtifactReferenceService,
+    );
+
+    const approval = await service.createForCurrentPost({
+      actorUserId: 'user-1',
+      mode: 'scheduled',
+      organizationId: 'org-1',
+      postId: 'post-1',
+      provenance: { surface: 'review-queue' },
+    });
+
+    expect(approval).toEqual(
+      expect.objectContaining({
+        actorUserId: 'user-1',
+        artifactVersionPinId: 'pin-1',
+        brandId: 'brand-1',
+        contextVersion: 4,
+        destinations: [
+          {
+            credentialId: 'credential-1',
+            platform: CredentialPlatform.TWITTER,
+          },
+        ],
+        organizationId: 'org-1',
+        policy: {
+          id: PublishApprovalPolicyId.VERSION_BOUND_V1,
+          version: 1,
+        },
+        postId: 'post-1',
+        scheduleIntent: {
+          kind: 'scheduled',
+          scheduledAt: '2026-07-14T10:00:00.000Z',
+          timezone: 'UTC',
+        },
+        status: PublishApprovalStatus.APPROVED,
+      }),
+    );
+    expect(prisma.post.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          publishApprovalId: approval.id,
+          reviewVersionPinId: 'pin-1',
+        }),
+      }),
+    );
+  });
+
+  it('fails closed and invalidates when the canonical brand drifts', async () => {
+    const approval = makeApproval();
+    const publishApproval = {
+      findFirst: vi.fn().mockResolvedValue(approval),
+      findMany: vi.fn().mockResolvedValue([approval]),
+      update: vi.fn().mockResolvedValue(approval),
+      updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+    };
+    const prisma = {
+      $transaction: vi.fn(async (callback) =>
+        callback({
+          post: { updateMany: vi.fn().mockResolvedValue({ count: 1 }) },
+          publishApproval,
+        }),
+      ),
+      member: { findFirst: vi.fn().mockResolvedValue({ id: 'member-1' }) },
+      organization: {
+        findFirst: vi.fn().mockResolvedValue({ userId: 'user-1' }),
+      },
+      post: {
+        findFirst: vi
+          .fn()
+          .mockResolvedValue(
+            makePost({ brandId: 'brand-2', publishApprovalId: 'approval-1' }),
+          ),
+      },
+      publishApproval,
+    };
+    const service = new PublishApprovalsService(
+      prisma as never,
+      {
+        assertVersionPinCurrent: vi.fn(),
+      } as unknown as AgentArtifactReferenceService,
+    );
+
+    await expect(
+      service.claimForExecution({
+        approvalId: 'approval-1',
+        operationId: 'operation-1',
+        organizationId: 'org-1',
+        postId: 'post-1',
+        versionPinId: 'pin-1',
+      }),
+    ).rejects.toThrow('scope no longer matches');
+
+    expect(publishApproval.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          status: PublishApprovalStatus.INVALIDATED,
+        }),
+      }),
+    );
+    expect(publishApproval.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('treats a repeated published operation as complete without another execution claim', async () => {
+    const approval = makeApproval({ status: PublishApprovalStatus.PUBLISHED });
+    const prisma = {
+      publishApproval: {
+        findFirst: vi.fn().mockResolvedValue(approval),
+        updateMany: vi.fn(),
+      },
+    };
+    const artifactReferenceService = {
+      assertVersionPinCurrent: vi.fn(),
+    };
+    const service = new PublishApprovalsService(
+      prisma as never,
+      artifactReferenceService as unknown as AgentArtifactReferenceService,
+    );
+
+    const claim = await service.claimForExecution({
+      approvalId: 'approval-1',
+      operationId: 'operation-1',
+      organizationId: 'org-1',
+      postId: 'post-1',
+      versionPinId: 'pin-1',
+    });
+
+    expect(claim.alreadyPublished).toBe(true);
+    expect(prisma.publishApproval.updateMany).not.toHaveBeenCalled();
+    expect(
+      artifactReferenceService.assertVersionPinCurrent,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('blocks version drift before claiming execution', async () => {
+    const approval = makeApproval({ scopeDigest: scopeDigest() });
+    const publishApproval = {
+      findFirst: vi.fn().mockResolvedValue(approval),
+      findMany: vi.fn().mockResolvedValue([approval]),
+      update: vi.fn().mockResolvedValue(approval),
+      updateMany: vi.fn(),
+    };
+    const prisma = {
+      $transaction: vi.fn(async (callback) =>
+        callback({
+          post: { updateMany: vi.fn().mockResolvedValue({ count: 1 }) },
+          publishApproval,
+        }),
+      ),
+      credential: {
+        findFirst: vi.fn().mockResolvedValue({ id: 'credential-1' }),
+      },
+      member: { findFirst: vi.fn().mockResolvedValue({ id: 'member-1' }) },
+      organization: {
+        findFirst: vi.fn().mockResolvedValue({ userId: 'user-1' }),
+      },
+      post: {
+        findFirst: vi
+          .fn()
+          .mockResolvedValue(makePost({ publishApprovalId: 'approval-1' })),
+      },
+      publishApproval,
+    };
+    const artifactReferenceService = {
+      assertVersionPinCurrent: vi
+        .fn()
+        .mockRejectedValue(new Error('Approved content version is stale')),
+    };
+    const service = new PublishApprovalsService(
+      prisma as never,
+      artifactReferenceService as unknown as AgentArtifactReferenceService,
+    );
+
+    await expect(
+      service.claimForExecution({
+        approvalId: 'approval-1',
+        operationId: 'operation-1',
+        organizationId: 'org-1',
+        postId: 'post-1',
+        versionPinId: 'pin-1',
+      }),
+    ).rejects.toThrow('Approved content version is stale');
+
+    expect(prisma.publishApproval.updateMany).not.toHaveBeenCalled();
+    expect(prisma.publishApproval.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          status: PublishApprovalStatus.INVALIDATED,
+        }),
+      }),
+    );
+  });
+
+  it('blocks a disconnected or cross-scope destination before execution', async () => {
+    const approval = makeApproval({ scopeDigest: scopeDigest() });
+    const publishApproval = {
+      findFirst: vi.fn().mockResolvedValue(approval),
+      findMany: vi.fn().mockResolvedValue([approval]),
+      update: vi.fn().mockResolvedValue(approval),
+      updateMany: vi.fn(),
+    };
+    const prisma = {
+      $transaction: vi.fn(async (callback) =>
+        callback({
+          post: { updateMany: vi.fn().mockResolvedValue({ count: 1 }) },
+          publishApproval,
+        }),
+      ),
+      credential: { findFirst: vi.fn().mockResolvedValue(null) },
+      member: { findFirst: vi.fn().mockResolvedValue({ id: 'member-1' }) },
+      organization: {
+        findFirst: vi.fn().mockResolvedValue({ userId: 'user-1' }),
+      },
+      post: {
+        findFirst: vi
+          .fn()
+          .mockResolvedValue(makePost({ publishApprovalId: 'approval-1' })),
+      },
+      publishApproval,
+    };
+    const artifactReferenceService = { assertVersionPinCurrent: vi.fn() };
+    const service = new PublishApprovalsService(
+      prisma as never,
+      artifactReferenceService as unknown as AgentArtifactReferenceService,
+    );
+
+    await expect(
+      service.claimForExecution({
+        approvalId: 'approval-1',
+        operationId: 'operation-1',
+        organizationId: 'org-1',
+        postId: 'post-1',
+        versionPinId: 'pin-1',
+      }),
+    ).rejects.toThrow('destination is no longer authorized');
+
+    expect(
+      artifactReferenceService.assertVersionPinCurrent,
+    ).not.toHaveBeenCalled();
+    expect(publishApproval.updateMany).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/api/src/collections/publish-approvals/services/publish-approvals.service.ts
+++ b/apps/server/api/src/collections/publish-approvals/services/publish-approvals.service.ts
@@ -1,0 +1,931 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { NotFoundException } from '@api/helpers/exceptions/http/not-found.exception';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import {
+  type CreatePublishApprovalInput,
+  canTransitionPublishApprovalStatus,
+  createPublishApprovalSchema,
+  publishApprovalDestinationSchema,
+  publishApprovalPolicySchema,
+  publishApprovalStatusSchema,
+  publishScheduleIntentSchema,
+} from '@api-types/contracts/publish-approval.contract';
+import {
+  CredentialPlatform,
+  PostStatus,
+  PublishApprovalPolicyId,
+  PublishApprovalStatus,
+  TargetExecutionState,
+} from '@genfeedai/enums';
+import type {
+  IPublishApproval,
+  IPublishApprovalDestination,
+  IPublishApprovalPolicy,
+  IPublishApprovalStatusTransition,
+  IPublishScheduleIntent,
+} from '@genfeedai/interfaces';
+import { Prisma } from '@genfeedai/prisma';
+import { AgentArtifactReferenceService } from '@genfeedai/server';
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
+
+const ACTIVE_APPROVAL_STATUSES = [
+  PublishApprovalStatus.APPROVED,
+  PublishApprovalStatus.QUEUED,
+  PublishApprovalStatus.EXECUTING,
+  PublishApprovalStatus.FAILED,
+] as const;
+
+type PublishApprovalRow = {
+  actorUserId: string;
+  artifactVersionPinId: string;
+  brandId: string;
+  contextVersion: number | null;
+  createdAt: Date;
+  destinations: Prisma.JsonValue;
+  executedAt: Date | null;
+  id: string;
+  invalidatedAt: Date | null;
+  invalidationReason: string | null;
+  lastError: string | null;
+  operationId: string;
+  organizationId: string;
+  policy: Prisma.JsonValue;
+  postId: string;
+  provenance: Prisma.JsonValue;
+  scheduleIntent: Prisma.JsonValue;
+  scopeDigest: string;
+  status: string;
+  statusTransitions: Prisma.JsonValue;
+  updatedAt: Date;
+};
+
+type ApprovalPost = {
+  agentContextVersion: number | null;
+  brandId: string;
+  credentialId: string;
+  id: string;
+  isDeleted: boolean;
+  organizationId: string;
+  platform: string;
+  publishApprovalId: string | null;
+  scheduledDate: Date | null;
+  status: string;
+  targetExecutionState: string;
+  timezone: string;
+};
+
+export interface CreatePostPublishApprovalParams {
+  actorUserId: string;
+  body: unknown;
+  organizationId: string;
+  provenance?: Record<string, unknown>;
+}
+
+export interface ClaimPublishExecutionParams {
+  approvalId: string;
+  operationId?: string;
+  organizationId: string;
+  postId: string;
+  versionPinId?: string;
+}
+
+export interface CreateCurrentPostPublishApprovalParams {
+  actorUserId: string;
+  contextVersion?: number;
+  mode: 'immediate' | 'scheduled';
+  organizationId: string;
+  postId: string;
+  provenance?: Record<string, unknown>;
+}
+
+export interface PublishExecutionClaim {
+  alreadyPublished: boolean;
+  approval: IPublishApproval;
+}
+
+@Injectable()
+export class PublishApprovalsService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly artifactReferenceService: AgentArtifactReferenceService,
+  ) {}
+
+  toPublicInterface(row: unknown): IPublishApproval {
+    return this.toInterface(row as PublishApprovalRow);
+  }
+
+  async assertPostMutable(
+    organizationId: string,
+    postId: string,
+  ): Promise<void> {
+    const executing = await this.prisma.publishApproval.findFirst({
+      select: { id: true },
+      where: {
+        organizationId,
+        postId,
+        status: PublishApprovalStatus.EXECUTING,
+      },
+    });
+    if (executing) {
+      throw new ConflictException(
+        'Cannot edit approved publish scope while provider execution is in flight.',
+      );
+    }
+  }
+
+  async createForCurrentPost(
+    params: CreateCurrentPostPublishApprovalParams,
+  ): Promise<IPublishApproval> {
+    const post = await this.getPostOrThrow(
+      params.organizationId,
+      params.postId,
+    );
+    const scheduleIntent: IPublishScheduleIntent =
+      params.mode === 'scheduled'
+        ? {
+            kind: 'scheduled',
+            scheduledAt: this.requireScheduledDate(post).toISOString(),
+            timezone: post.timezone,
+          }
+        : { kind: 'immediate' };
+    return this.createForPost({
+      actorUserId: params.actorUserId,
+      body: {
+        ...(params.contextVersion !== undefined
+          ? { contextVersion: params.contextVersion }
+          : {}),
+        policy: {
+          id: PublishApprovalPolicyId.VERSION_BOUND_V1,
+          version: 1,
+        },
+        postId: params.postId,
+        scheduleIntent,
+      },
+      organizationId: params.organizationId,
+      provenance: params.provenance,
+    });
+  }
+
+  async createForPost(
+    params: CreatePostPublishApprovalParams,
+  ): Promise<IPublishApproval> {
+    const input = this.parseCreateInput(params.body);
+    const post = await this.getPostOrThrow(params.organizationId, input.postId);
+    this.assertTargetStatus(post);
+    if (
+      input.contextVersion !== undefined &&
+      post.agentContextVersion !== null &&
+      input.contextVersion !== post.agentContextVersion
+    ) {
+      throw new ConflictException('Publish approval context version is stale.');
+    }
+    this.assertScheduleIntent(post, input.scheduleIntent);
+
+    const versionPin =
+      await this.artifactReferenceService.createOrReuseVersionPin({
+        createdByUserId: params.actorUserId,
+        reference: {
+          brandId: post.brandId,
+          kind: 'post',
+          organizationId: post.organizationId,
+          recordId: post.id,
+          serializer: 'post',
+        },
+      });
+
+    const destinations = this.canonicalDestinations(post);
+    const scope = {
+      actorUserId: params.actorUserId,
+      artifactVersionPinId: versionPin.id,
+      brandId: post.brandId,
+      contextVersion: input.contextVersion ?? post.agentContextVersion,
+      destinations,
+      organizationId: post.organizationId,
+      policy: input.policy,
+      postId: post.id,
+      scheduleIntent: input.scheduleIntent,
+    };
+    const scopeDigest = this.digest(scope);
+    const existing = (await this.prisma.publishApproval.findFirst({
+      where: {
+        organizationId: post.organizationId,
+        postId: post.id,
+        scopeDigest,
+      },
+    })) as PublishApprovalRow | null;
+    if (existing) {
+      await this.activatePostApproval(post, existing);
+      return this.toInterface(existing);
+    }
+
+    const id = randomUUID();
+    const operationId = this.digest({
+      action: 'publish',
+      approvalId: id,
+      artifactVersionPinId: versionPin.id,
+      destinations,
+    });
+    const now = new Date();
+    const initialTransition = this.transition(
+      null,
+      PublishApprovalStatus.APPROVED,
+      params.actorUserId,
+    );
+
+    let approval: PublishApprovalRow;
+    try {
+      approval = await this.prisma.$transaction(async (tx) => {
+        const active = (await tx.publishApproval.findMany({
+          where: {
+            organizationId: post.organizationId,
+            postId: post.id,
+            status: { in: [...ACTIVE_APPROVAL_STATUSES] },
+          },
+        })) as PublishApprovalRow[];
+        if (
+          active.some(
+            (prior) =>
+              this.parseStatus(prior.status) ===
+              PublishApprovalStatus.EXECUTING,
+          )
+        ) {
+          throw new ConflictException(
+            'Cannot replace a publish approval while provider execution is in flight.',
+          );
+        }
+        for (const prior of active) {
+          await tx.publishApproval.update({
+            data: {
+              invalidatedAt: now,
+              invalidationReason: 'A different publish scope was approved.',
+              status: PublishApprovalStatus.INVALIDATED,
+              statusTransitions: this.toJson([
+                ...this.readTransitions(prior.statusTransitions),
+                this.transition(
+                  this.parseStatus(prior.status),
+                  PublishApprovalStatus.INVALIDATED,
+                  params.actorUserId,
+                  'A different publish scope was approved.',
+                ),
+              ]),
+            },
+            where: { id: prior.id },
+          });
+        }
+
+        const created = (await tx.publishApproval.create({
+          data: {
+            actorUserId: params.actorUserId,
+            artifactVersionPinId: versionPin.id,
+            brandId: post.brandId,
+            contextVersion: scope.contextVersion ?? null,
+            destinations: this.toJson(destinations),
+            id,
+            operationId,
+            organizationId: post.organizationId,
+            policy: this.toJson(input.policy),
+            postId: post.id,
+            provenance: this.toJson({
+              contractVersion: 1,
+              source: 'typed-publish-approval',
+              ...(params.provenance ?? {}),
+            }),
+            scheduleIntent: this.toJson(input.scheduleIntent),
+            scopeDigest,
+            status: PublishApprovalStatus.APPROVED,
+            statusTransitions: this.toJson([initialTransition]),
+          },
+        })) as PublishApprovalRow;
+
+        await tx.post.update({
+          data: {
+            publishApprovalId: created.id,
+            reviewDecision: 'APPROVED',
+            reviewVersionPinId: versionPin.id,
+            reviewedAt: now,
+          },
+          where: { id: post.id },
+        });
+        return created;
+      });
+    } catch (error: unknown) {
+      if ((error as { code?: unknown }).code !== 'P2002') {
+        throw error;
+      }
+      const concurrentWinner = (await this.prisma.publishApproval.findFirst({
+        where: {
+          organizationId: post.organizationId,
+          postId: post.id,
+          scopeDigest,
+        },
+      })) as PublishApprovalRow | null;
+      if (!concurrentWinner) {
+        throw error;
+      }
+      await this.activatePostApproval(post, concurrentWinner);
+      return this.toInterface(concurrentWinner);
+    }
+
+    return this.toInterface(approval);
+  }
+
+  async markQueued(
+    approvalId: string,
+    organizationId: string,
+    actorId?: string,
+  ): Promise<IPublishApproval> {
+    return this.transitionStatus(
+      approvalId,
+      organizationId,
+      PublishApprovalStatus.QUEUED,
+      actorId,
+    );
+  }
+
+  async claimForExecution(
+    params: ClaimPublishExecutionParams,
+  ): Promise<PublishExecutionClaim> {
+    const approval = await this.getApprovalOrThrow(
+      params.organizationId,
+      params.approvalId,
+      params.postId,
+    );
+    if (params.operationId && params.operationId !== approval.operationId) {
+      throw new ConflictException(
+        'Queued publish operation identity is stale.',
+      );
+    }
+    if (
+      params.versionPinId &&
+      params.versionPinId !== approval.artifactVersionPinId
+    ) {
+      throw new ConflictException('Queued artifact version identity is stale.');
+    }
+    if (this.parseStatus(approval.status) === PublishApprovalStatus.PUBLISHED) {
+      return { alreadyPublished: true, approval: this.toInterface(approval) };
+    }
+
+    const post = await this.getPostOrThrow(
+      params.organizationId,
+      params.postId,
+    );
+    try {
+      this.assertTargetStatus(post);
+    } catch (error: unknown) {
+      await this.invalidatePost(
+        approval.organizationId,
+        approval.postId,
+        'The canonical publish target entered an ineligible execution state.',
+      );
+      throw error;
+    }
+    await this.assertCurrentAuthorization(approval);
+    await this.assertApprovalScope(approval, post);
+    try {
+      await this.artifactReferenceService.assertVersionPinCurrent({
+        pinId: approval.artifactVersionPinId,
+        readContext: {
+          brandId: approval.brandId,
+          organizationId: approval.organizationId,
+        },
+      });
+    } catch (error: unknown) {
+      await this.invalidatePost(
+        approval.organizationId,
+        approval.postId,
+        'The approved immutable artifact version is no longer current.',
+      );
+      throw error;
+    }
+
+    const claimed = await this.prisma.publishApproval.updateMany({
+      data: {
+        status: PublishApprovalStatus.EXECUTING,
+        statusTransitions: this.toJson([
+          ...this.readTransitions(approval.statusTransitions),
+          this.transition(
+            this.parseStatus(approval.status),
+            PublishApprovalStatus.EXECUTING,
+          ),
+        ]),
+      },
+      where: {
+        id: approval.id,
+        organizationId: approval.organizationId,
+        status: PublishApprovalStatus.QUEUED,
+      },
+    });
+    if (claimed.count !== 1) {
+      throw new ConflictException(
+        'Publish approval is not queued or is already executing.',
+      );
+    }
+
+    const updated = await this.getApprovalOrThrow(
+      params.organizationId,
+      params.approvalId,
+      params.postId,
+    );
+    return { alreadyPublished: false, approval: this.toInterface(updated) };
+  }
+
+  async completeExecution(
+    approvalId: string,
+    organizationId: string,
+    success: boolean,
+    error?: string,
+  ): Promise<IPublishApproval> {
+    return this.transitionStatus(
+      approvalId,
+      organizationId,
+      success ? PublishApprovalStatus.PUBLISHED : PublishApprovalStatus.FAILED,
+      undefined,
+      error,
+    );
+  }
+
+  async invalidatePost(
+    organizationId: string,
+    postId: string,
+    reason: string,
+    actorId?: string,
+  ): Promise<void> {
+    const approvals = (await this.prisma.publishApproval.findMany({
+      where: {
+        organizationId,
+        postId,
+        status: { in: [...ACTIVE_APPROVAL_STATUSES] },
+      },
+    })) as PublishApprovalRow[];
+    if (
+      approvals.some(
+        (approval) =>
+          this.parseStatus(approval.status) === PublishApprovalStatus.EXECUTING,
+      )
+    ) {
+      throw new ConflictException(
+        'Cannot invalidate a publish approval while provider execution is in flight.',
+      );
+    }
+    const now = new Date();
+    await this.prisma.$transaction(async (tx) => {
+      for (const approval of approvals) {
+        await tx.publishApproval.update({
+          data: {
+            invalidatedAt: now,
+            invalidationReason: reason,
+            status: PublishApprovalStatus.INVALIDATED,
+            statusTransitions: this.toJson([
+              ...this.readTransitions(approval.statusTransitions),
+              this.transition(
+                this.parseStatus(approval.status),
+                PublishApprovalStatus.INVALIDATED,
+                actorId,
+                reason,
+              ),
+            ]),
+          },
+          where: { id: approval.id },
+        });
+      }
+      await tx.post.updateMany({
+        data: { publishApprovalId: null },
+        where: { id: postId, organizationId },
+      });
+    });
+  }
+
+  private async transitionStatus(
+    approvalId: string,
+    organizationId: string,
+    next: PublishApprovalStatus,
+    actorId?: string,
+    reason?: string,
+  ): Promise<IPublishApproval> {
+    const current = await this.getApprovalOrThrow(organizationId, approvalId);
+    const from = this.parseStatus(current.status);
+    if (from === next) {
+      return this.toInterface(current);
+    }
+    if (!canTransitionPublishApprovalStatus(from, next)) {
+      throw new ConflictException(
+        `Publish approval cannot transition from ${from} to ${next}.`,
+      );
+    }
+    const updated = (await this.prisma.publishApproval.update({
+      data: {
+        ...(next === PublishApprovalStatus.PUBLISHED
+          ? { executedAt: new Date() }
+          : {}),
+        ...(reason ? { lastError: reason } : {}),
+        status: next,
+        statusTransitions: this.toJson([
+          ...this.readTransitions(current.statusTransitions),
+          this.transition(from, next, actorId, reason),
+        ]),
+      },
+      where: { id: current.id },
+    })) as PublishApprovalRow;
+    return this.toInterface(updated);
+  }
+
+  private async assertApprovalScope(
+    approval: PublishApprovalRow,
+    post: ApprovalPost,
+  ): Promise<void> {
+    const destinations = this.readDestinations(approval.destinations);
+    const intent = this.readScheduleIntent(approval.scheduleIntent);
+    const policy = this.readPolicy(approval.policy);
+    const expectedScope = {
+      actorUserId: approval.actorUserId,
+      artifactVersionPinId: approval.artifactVersionPinId,
+      brandId: post.brandId,
+      contextVersion: approval.contextVersion,
+      destinations: this.canonicalDestinations(post),
+      organizationId: post.organizationId,
+      policy,
+      postId: post.id,
+      scheduleIntent: intent,
+    };
+    try {
+      this.assertScheduleIntent(post, intent);
+    } catch (error: unknown) {
+      await this.invalidatePost(
+        approval.organizationId,
+        approval.postId,
+        'The protected publish schedule intent changed.',
+      );
+      throw error;
+    }
+    if (
+      approval.organizationId !== post.organizationId ||
+      approval.brandId !== post.brandId ||
+      approval.contextVersion !== post.agentContextVersion ||
+      post.publishApprovalId !== approval.id ||
+      destinations[0]?.credentialId !== post.credentialId ||
+      approval.scopeDigest !== this.digest(expectedScope)
+    ) {
+      await this.invalidatePost(
+        approval.organizationId,
+        approval.postId,
+        'Artifact, organization, brand, destination, schedule, actor, context, or policy changed.',
+      );
+      throw new ConflictException(
+        'Publish approval scope no longer matches the canonical Post.',
+      );
+    }
+
+    const credential = await this.prisma.credential.findFirst({
+      select: { id: true },
+      where: {
+        brandId: post.brandId,
+        id: post.credentialId,
+        isConnected: true,
+        isDeleted: false,
+        organizationId: post.organizationId,
+        platform: destinations[0]?.platform,
+      },
+    });
+    if (!credential) {
+      await this.invalidatePost(
+        approval.organizationId,
+        approval.postId,
+        'The approved destination credential is no longer authorized.',
+      );
+      throw new ForbiddenException(
+        'Approved publish destination is no longer authorized.',
+      );
+    }
+  }
+
+  private async assertCurrentAuthorization(
+    approval: PublishApprovalRow,
+  ): Promise<void> {
+    const [member, organization] = await Promise.all([
+      this.prisma.member.findFirst({
+        select: { id: true },
+        where: {
+          isActive: true,
+          isDeleted: false,
+          organizationId: approval.organizationId,
+          userId: approval.actorUserId,
+        },
+      }),
+      this.prisma.organization.findFirst({
+        select: { userId: true },
+        where: { id: approval.organizationId, isDeleted: false },
+      }),
+    ]);
+    if (!member && organization?.userId !== approval.actorUserId) {
+      await this.invalidatePost(
+        approval.organizationId,
+        approval.postId,
+        'The approving actor is no longer authorized for the organization.',
+      );
+      throw new ForbiddenException(
+        'Publish approver is no longer authorized for the organization.',
+      );
+    }
+  }
+
+  private async activatePostApproval(
+    post: ApprovalPost,
+    approval: PublishApprovalRow,
+  ): Promise<void> {
+    const status = this.parseStatus(approval.status);
+    if (
+      status === PublishApprovalStatus.INVALIDATED ||
+      status === PublishApprovalStatus.CANCELLED
+    ) {
+      throw new ConflictException(
+        'The matching approval was revoked; create a new version before approval.',
+      );
+    }
+    await this.prisma.post.update({
+      data: {
+        publishApprovalId: approval.id,
+        reviewDecision: 'APPROVED',
+        reviewVersionPinId: approval.artifactVersionPinId,
+      },
+      where: { id: post.id },
+    });
+  }
+
+  private async getPostOrThrow(
+    organizationId: string,
+    postId: string,
+  ): Promise<ApprovalPost> {
+    const post = (await this.prisma.post.findFirst({
+      select: {
+        agentContextVersion: true,
+        brandId: true,
+        credentialId: true,
+        id: true,
+        isDeleted: true,
+        organizationId: true,
+        platform: true,
+        publishApprovalId: true,
+        scheduledDate: true,
+        status: true,
+        targetExecutionState: true,
+        timezone: true,
+      },
+      where: { id: postId, isDeleted: false, organizationId },
+    })) as ApprovalPost | null;
+    if (!post) {
+      throw new NotFoundException('Post', postId);
+    }
+    return post;
+  }
+
+  private async getApprovalOrThrow(
+    organizationId: string,
+    approvalId: string,
+    postId?: string,
+  ): Promise<PublishApprovalRow> {
+    const approval = (await this.prisma.publishApproval.findFirst({
+      where: {
+        id: approvalId,
+        organizationId,
+        ...(postId ? { postId } : {}),
+      },
+    })) as PublishApprovalRow | null;
+    if (!approval) {
+      throw new NotFoundException('PublishApproval', approvalId);
+    }
+    return approval;
+  }
+
+  private parseCreateInput(body: unknown): CreatePublishApprovalInput {
+    const result = createPublishApprovalSchema.safeParse(body);
+    if (!result.success) {
+      throw new BadRequestException({
+        detail: result.error.issues
+          .map((issue) => `${issue.path.join('.') || 'body'}: ${issue.message}`)
+          .join('; '),
+        title: 'Invalid publish approval payload',
+      });
+    }
+    return result.data;
+  }
+
+  private assertScheduleIntent(
+    post: ApprovalPost,
+    intent: IPublishScheduleIntent,
+  ): void {
+    if (intent.kind === 'immediate') {
+      return;
+    }
+    if (
+      !post.scheduledDate ||
+      post.scheduledDate.toISOString() !== intent.scheduledAt ||
+      post.timezone !== intent.timezone
+    ) {
+      throw new ConflictException(
+        'Publish schedule intent does not match the canonical Post.',
+      );
+    }
+  }
+
+  private requireScheduledDate(post: ApprovalPost): Date {
+    if (!post.scheduledDate) {
+      throw new ConflictException(
+        'Scheduled publish approval requires a canonical scheduled date.',
+      );
+    }
+    return post.scheduledDate;
+  }
+
+  private canonicalDestinations(
+    post: ApprovalPost,
+  ): IPublishApprovalDestination[] {
+    const platform = Object.values(CredentialPlatform).find(
+      (value) => value === post.platform.toLowerCase(),
+    );
+    if (!platform) {
+      throw new ConflictException('Post has an unsupported publish platform.');
+    }
+    return [{ credentialId: post.credentialId, platform }];
+  }
+
+  private assertTargetStatus(post: ApprovalPost): void {
+    const postStatus = post.status.toLowerCase();
+    if (postStatus === PostStatus.PUBLIC || postStatus === PostStatus.PENDING) {
+      throw new ConflictException(
+        `Post cannot be approved from ${postStatus}.`,
+      );
+    }
+    const status = Object.values(TargetExecutionState).find(
+      (value) => value === post.targetExecutionState,
+    );
+    if (!status) {
+      throw new ConflictException(
+        'Post target contains an unknown execution status.',
+      );
+    }
+    if (
+      status === TargetExecutionState.PUBLISHED ||
+      status === TargetExecutionState.CANCELLED ||
+      status === TargetExecutionState.SKIPPED
+    ) {
+      throw new ConflictException(
+        `Post target cannot be approved from ${status}.`,
+      );
+    }
+  }
+
+  private parseStatus(value: string): PublishApprovalStatus {
+    const result = publishApprovalStatusSchema.safeParse(value);
+    if (!result.success) {
+      throw new ConflictException(
+        'Publish approval contains an unknown lifecycle status.',
+      );
+    }
+    return result.data;
+  }
+
+  private readDestinations(
+    value: Prisma.JsonValue,
+  ): IPublishApprovalDestination[] {
+    const result = publishApprovalDestinationSchema.array().safeParse(value);
+    if (!result.success || result.data.length === 0) {
+      throw new ConflictException('Publish approval destinations are invalid.');
+    }
+    return [...result.data].sort((left, right) =>
+      `${left.platform}:${left.credentialId}`.localeCompare(
+        `${right.platform}:${right.credentialId}`,
+      ),
+    );
+  }
+
+  private readScheduleIntent(value: Prisma.JsonValue): IPublishScheduleIntent {
+    const result = publishScheduleIntentSchema.safeParse(value);
+    if (!result.success) {
+      throw new ConflictException(
+        'Publish approval schedule intent is invalid.',
+      );
+    }
+    return result.data;
+  }
+
+  private readPolicy(value: Prisma.JsonValue): IPublishApprovalPolicy {
+    const result = publishApprovalPolicySchema.safeParse(value);
+    if (!result.success) {
+      throw new ConflictException('Publish approval policy is invalid.');
+    }
+    return result.data;
+  }
+
+  private readTransitions(
+    value: Prisma.JsonValue,
+  ): IPublishApprovalStatusTransition[] {
+    if (!Array.isArray(value)) {
+      throw new ConflictException(
+        'Publish approval transition history is invalid.',
+      );
+    }
+    return value.map((entry) => {
+      if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+        throw new ConflictException(
+          'Publish approval transition history is invalid.',
+        );
+      }
+      const record = entry as Record<string, unknown>;
+      const to = this.parseStatus(String(record.to));
+      const from =
+        record.from === null ? null : this.parseStatus(String(record.from));
+      if (typeof record.at !== 'string') {
+        throw new ConflictException(
+          'Publish approval transition history is invalid.',
+        );
+      }
+      return {
+        ...(typeof record.actorId === 'string'
+          ? { actorId: record.actorId }
+          : {}),
+        at: record.at,
+        from,
+        ...(typeof record.reason === 'string' ? { reason: record.reason } : {}),
+        to,
+      };
+    });
+  }
+
+  private transition(
+    from: PublishApprovalStatus | null,
+    to: PublishApprovalStatus,
+    actorId?: string,
+    reason?: string,
+  ): IPublishApprovalStatusTransition {
+    return {
+      ...(actorId ? { actorId } : {}),
+      at: new Date().toISOString(),
+      from,
+      ...(reason ? { reason } : {}),
+      to,
+    };
+  }
+
+  private digest(value: unknown): string {
+    return `sha256:v1:${createHash('sha256')
+      .update(this.stableStringify(value))
+      .digest('hex')}`;
+  }
+
+  private stableStringify(value: unknown): string {
+    if (Array.isArray(value)) {
+      return `[${value.map((item) => this.stableStringify(item)).join(',')}]`;
+    }
+    if (value && typeof value === 'object') {
+      const record = value as Record<string, unknown>;
+      return `{${Object.keys(record)
+        .sort()
+        .map(
+          (key) =>
+            `${JSON.stringify(key)}:${this.stableStringify(record[key])}`,
+        )
+        .join(',')}}`;
+    }
+    return JSON.stringify(value) ?? 'null';
+  }
+
+  private toInterface(row: PublishApprovalRow): IPublishApproval {
+    return {
+      actorUserId: row.actorUserId,
+      artifactVersionPinId: row.artifactVersionPinId,
+      brandId: row.brandId,
+      contextVersion: row.contextVersion,
+      createdAt: row.createdAt.toISOString(),
+      destinations: this.readDestinations(row.destinations),
+      executedAt: row.executedAt?.toISOString() ?? null,
+      id: row.id,
+      invalidatedAt: row.invalidatedAt?.toISOString() ?? null,
+      invalidationReason: row.invalidationReason,
+      operationId: row.operationId,
+      organizationId: row.organizationId,
+      policy: this.readPolicy(row.policy),
+      postId: row.postId,
+      provenance: this.asRecord(row.provenance),
+      scheduleIntent: this.readScheduleIntent(row.scheduleIntent),
+      scopeDigest: row.scopeDigest,
+      status: this.parseStatus(row.status),
+      statusTransitions: this.readTransitions(row.statusTransitions),
+      updatedAt: row.updatedAt.toISOString(),
+    };
+  }
+
+  private asRecord(value: Prisma.JsonValue): Record<string, unknown> {
+    return value && typeof value === 'object' && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {};
+  }
+
+  private toJson(value: unknown): Prisma.InputJsonValue {
+    return value as Prisma.InputJsonValue;
+  }
+}

--- a/apps/server/api/src/queues/post-publish/post-publish-queue.service.spec.ts
+++ b/apps/server/api/src/queues/post-publish/post-publish-queue.service.spec.ts
@@ -89,6 +89,29 @@ describe('PostPublishQueueService', () => {
     );
   });
 
+  it('uses the approval operation identity for duplicate prevention', async () => {
+    queue.add.mockResolvedValue({ id: 'operation-1' });
+
+    await service.enqueue({
+      approvalId: 'approval-1',
+      operationId: 'operation-1',
+      organizationId: 'org-1',
+      postId: 'post-1',
+      source: 'publish_now',
+      versionPinId: 'pin-1',
+    });
+
+    expect(queue.getJob).toHaveBeenCalledWith('operation-1');
+    expect(queue.add).toHaveBeenCalledWith(
+      POST_PUBLISH_JOB_NAME,
+      expect.objectContaining({
+        approvalId: 'approval-1',
+        operationId: 'operation-1',
+      }),
+      expect.objectContaining({ jobId: 'operation-1' }),
+    );
+  });
+
   it('does not enqueue a duplicate active job', async () => {
     queue.getJob.mockResolvedValue(makeJob('active'));
 

--- a/apps/server/api/src/services/agent-orchestrator/constants/agent-orchestrator-system-prompt.constant.ts
+++ b/apps/server/api/src/services/agent-orchestrator/constants/agent-orchestrator-system-prompt.constant.ts
@@ -4,7 +4,7 @@ You help users generate images, manage workflows, create and schedule posts, che
 Key capabilities:
 - **Batch content generation**: Users can say "I want 50 posts for @handle this week" and you handle everything.
   Use generate_content_batch to create batches. Use resolve_handle to map @usernames to credentials.
-- **Review queue**: Use list_review_queue to show pending content and batch_approve_reject to approve/reject items.
+- **Review queue**: Use list_review_queue to show pending content. Approval always requires the authenticated typed review control; model/chat output never approves publishing. batch_approve_reject may reject items only.
 - **Single content**: Generate individual images, videos, and posts as before.
 - **Livestream chat bots**: Use create_livestream_bot to create YouTube or Twitch livestream chat bots and manage_livestream_bot to control their live sessions.
 - **Analytics & trends**: Check performance data and trending topics.

--- a/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.spec.ts
+++ b/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.spec.ts
@@ -259,6 +259,7 @@ describe('AgentToolExecutorService', () => {
       }),
     };
     const batchGenerationService = {
+      approveItems: vi.fn(),
       createBatch: vi.fn().mockResolvedValue({
         id: '67a1234567890123456789ba',
         status: 'pending',
@@ -2174,6 +2175,31 @@ describe('AgentToolExecutorService', () => {
         type: 'completion_summary_card',
       }),
     ]);
+  });
+
+  it('never treats a model tool call as publish approval', async () => {
+    const { batchGenerationService, service } = createService();
+
+    const result = await service.executeTool(
+      AgentToolName.BATCH_APPROVE_REJECT,
+      {
+        action: 'approve',
+        batchId: 'batch-1',
+        itemIds: ['item-1'],
+      },
+      {
+        organizationId: '67a123456789012345678901',
+        userId: '67a123456789012345678902',
+      },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('cannot grant publish approval');
+    expect(batchGenerationService.approveItems).not.toHaveBeenCalled();
+    expect(result.nextActions?.[0]?.primaryCta).toEqual({
+      href: '/posts/review?batch=batch-1&filter=ready',
+      label: 'Review exact versions',
+    });
   });
 
   it('should create a workflow-backed recurring automation via create_workflow', async () => {

--- a/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts
+++ b/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts
@@ -6933,12 +6933,26 @@ export class AgentToolExecutorService {
     }
 
     if (action === 'approve') {
-      await this.batchGenerationService.approveItems(
-        batchId,
-        itemIds,
-        ctx.organizationId,
-        ctx.userId,
-      );
+      return {
+        creditsUsed: 0,
+        error:
+          'Model and conversation actions cannot grant publish approval. Use the typed review control.',
+        nextActions: [
+          {
+            id: `review-queue-approval-${batchId}`,
+            primaryCta: {
+              href: `/posts/review?batch=${batchId}&filter=ready`,
+              label: 'Review exact versions',
+            },
+            status: 'pending',
+            summaryText:
+              'Approval requires the authenticated version-bound review control.',
+            title: 'Publish approval required',
+            type: 'completion_summary_card',
+          },
+        ],
+        success: false,
+      };
     } else {
       await this.batchGenerationService.rejectItems(
         batchId,

--- a/apps/server/api/src/services/batch-generation/batch-generation.controller.ts
+++ b/apps/server/api/src/services/batch-generation/batch-generation.controller.ts
@@ -191,6 +191,7 @@ export class BatchGenerationController {
           dto.itemIds,
           organization,
           dto.feedback,
+          userId,
         );
       } else {
         data = await this.batchGenerationService.rejectItems(
@@ -198,6 +199,7 @@ export class BatchGenerationController {
           dto.itemIds,
           organization,
           dto.feedback,
+          userId,
         );
       }
       return serializeSingle(req, BatchSerializer, data);

--- a/apps/server/api/src/services/batch-generation/batch-generation.module.ts
+++ b/apps/server/api/src/services/batch-generation/batch-generation.module.ts
@@ -2,6 +2,7 @@ import { BrandsModule } from '@api/collections/brands/brands.module';
 import { ContentIntelligenceModule } from '@api/collections/content-intelligence/content-intelligence.module';
 import { HarnessProfilesModule } from '@api/collections/harness-profiles/harness-profiles.module';
 import { PostsModule } from '@api/collections/posts/posts.module';
+import { PublishApprovalsModule } from '@api/collections/publish-approvals/publish-approvals.module';
 import { BatchGenerationController } from '@api/services/batch-generation/batch-generation.controller';
 import { BatchGenerationService } from '@api/services/batch-generation/batch-generation.service';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
@@ -24,6 +25,7 @@ import { forwardRef, Module } from '@nestjs/common';
     forwardRef(() => HarnessProfilesModule),
     forwardRef(() => LoggerModule),
     forwardRef(() => PostsModule),
+    PublishApprovalsModule,
   ],
   providers: [
     AgentArtifactReferenceService,

--- a/apps/server/api/src/services/batch-generation/batch-generation.service.spec.ts
+++ b/apps/server/api/src/services/batch-generation/batch-generation.service.spec.ts
@@ -1,6 +1,7 @@
 import { BrandsService } from '@api/collections/brands/services/brands.service';
 import { ContentGeneratorService } from '@api/collections/content-intelligence/services/content-generator.service';
 import { PostsService } from '@api/collections/posts/services/posts.service';
+import { PublishApprovalsService } from '@api/collections/publish-approvals/services/publish-approvals.service';
 import { BatchGenerationService } from '@api/services/batch-generation/batch-generation.service';
 import { CacheService } from '@api/services/cache/services/cache.service';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
@@ -22,6 +23,10 @@ describe('BatchGenerationService approval version pins', () => {
     updateMany: ReturnType<typeof vi.fn>;
   };
   let service: BatchGenerationService;
+  let publishApprovalsService: {
+    createForCurrentPost: ReturnType<typeof vi.fn>;
+    toPublicInterface: ReturnType<typeof vi.fn>;
+  };
 
   const createBatchRecord = (items: unknown[]) => ({
     brandId: 'brand-1',
@@ -54,6 +59,13 @@ describe('BatchGenerationService approval version pins', () => {
     artifactReferenceService = {
       createOrReuseVersionPin: vi.fn().mockResolvedValue({ id: 'pin-1' }),
     };
+    publishApprovalsService = {
+      createForCurrentPost: vi.fn().mockResolvedValue({
+        artifactVersionPinId: 'pin-1',
+        id: 'approval-1',
+      }),
+      toPublicInterface: vi.fn((value) => value),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -73,6 +85,10 @@ describe('BatchGenerationService approval version pins', () => {
           },
         },
         { provide: PostsService, useValue: {} },
+        {
+          provide: PublishApprovalsService,
+          useValue: publishApprovalsService,
+        },
         {
           provide: PrismaService,
           useValue: {
@@ -107,16 +123,15 @@ describe('BatchGenerationService approval version pins', () => {
       'canonical-user-1',
     );
 
-    expect(
-      artifactReferenceService.createOrReuseVersionPin,
-    ).toHaveBeenCalledWith({
-      createdByUserId: 'canonical-user-1',
-      reference: {
-        brandId: 'brand-1',
-        kind: 'post',
-        organizationId: 'org-1',
-        recordId: 'post-1',
-        serializer: 'post',
+    expect(publishApprovalsService.createForCurrentPost).toHaveBeenCalledWith({
+      actorUserId: 'canonical-user-1',
+      mode: 'scheduled',
+      organizationId: 'org-1',
+      postId: 'post-1',
+      provenance: {
+        batchId: 'batch-1',
+        reviewItemId: 'item-1',
+        surface: 'review-queue',
       },
     });
     expect(postDelegate.updateMany).toHaveBeenCalledWith({
@@ -149,8 +164,7 @@ describe('BatchGenerationService approval version pins', () => {
       expect.objectContaining({ versionPinId: 'pin-1' }),
     );
     expect(
-      artifactReferenceService.createOrReuseVersionPin.mock
-        .invocationCallOrder[0],
+      publishApprovalsService.createForCurrentPost.mock.invocationCallOrder[0],
     ).toBeLessThan(postDelegate.updateMany.mock.invocationCallOrder[0] ?? 0);
   });
 
@@ -165,7 +179,7 @@ describe('BatchGenerationService approval version pins', () => {
         },
       ]),
     );
-    artifactReferenceService.createOrReuseVersionPin.mockRejectedValue(
+    publishApprovalsService.createForCurrentPost.mockRejectedValue(
       new Error('Canonical Post changed.'),
     );
 

--- a/apps/server/api/src/services/batch-generation/batch-generation.service.ts
+++ b/apps/server/api/src/services/batch-generation/batch-generation.service.ts
@@ -1,6 +1,7 @@
 import { BrandsService } from '@api/collections/brands/services/brands.service';
 import { ContentGeneratorService } from '@api/collections/content-intelligence/services/content-generator.service';
 import { PostsService } from '@api/collections/posts/services/posts.service';
+import { PublishApprovalsService } from '@api/collections/publish-approvals/services/publish-approvals.service';
 import { HandleErrors } from '@api/helpers/decorators/error-handler.decorator';
 import { NotFoundException } from '@api/helpers/exceptions/http/not-found.exception';
 import { runIdempotent } from '@api/helpers/utils/idempotency/idempotency.util';
@@ -20,6 +21,7 @@ import {
 } from '@genfeedai/enums';
 import type {
   IBatchSummary,
+  IPublishApproval,
   ManualReviewBatchItem,
 } from '@genfeedai/interfaces';
 import type { Batch } from '@genfeedai/prisma';
@@ -65,6 +67,7 @@ interface BatchItemFull extends BatchItem {
   sourceWorkflowName?: string;
   createdAt?: string;
   versionPinId?: string;
+  publishApproval?: IPublishApproval;
 }
 
 type BatchConfig = {
@@ -148,6 +151,7 @@ export class BatchGenerationService {
     private readonly contentGeneratorService: ContentGeneratorService,
     private readonly cacheService: CacheService,
     private readonly agentArtifactReferenceService: AgentArtifactReferenceService,
+    private readonly publishApprovalsService: PublishApprovalsService,
   ) {}
 
   private cloneBatchItems(items: Batch['items']): BatchItemFull[] {
@@ -796,20 +800,39 @@ export class BatchGenerationService {
       ),
     ];
     const versionPinIds = new Map<string, string>();
+    const publishApprovals = new Map<string, IPublishApproval>();
 
     for (const postId of selectedPostIds) {
-      const versionPin =
-        await this.agentArtifactReferenceService.createOrReuseVersionPin({
-          createdByUserId,
-          reference: {
-            ...(batchRecord.brandId ? { brandId: batchRecord.brandId } : {}),
-            kind: 'post',
+      const item = batchItems.find((candidate) => candidate.postId === postId);
+      if (item?.scheduledDate) {
+        const approval =
+          await this.publishApprovalsService.createForCurrentPost({
+            actorUserId: createdByUserId,
+            mode: 'scheduled',
             organizationId: orgId,
-            recordId: postId,
-            serializer: 'post',
-          },
-        });
-      versionPinIds.set(postId, versionPin.id);
+            postId,
+            provenance: {
+              batchId,
+              reviewItemId: item._id,
+              surface: 'review-queue',
+            },
+          });
+        publishApprovals.set(postId, approval);
+        versionPinIds.set(postId, approval.artifactVersionPinId);
+      } else {
+        const versionPin =
+          await this.agentArtifactReferenceService.createOrReuseVersionPin({
+            createdByUserId,
+            reference: {
+              ...(batchRecord.brandId ? { brandId: batchRecord.brandId } : {}),
+              kind: 'post',
+              organizationId: orgId,
+              recordId: postId,
+              serializer: 'post',
+            },
+          });
+        versionPinIds.set(postId, versionPin.id);
+      }
     }
 
     const postIdsToSchedule: string[] = [];
@@ -823,6 +846,9 @@ export class BatchGenerationService {
           ? versionPinIds.get(item.postId)
           : undefined;
         item.reviewDecision = 'approved';
+        item.publishApproval = item.postId
+          ? publishApprovals.get(item.postId)
+          : undefined;
         item.reviewFeedback = undefined;
         item.versionPinId = versionPinId;
         item.reviewedAt = reviewedAt;
@@ -892,6 +918,7 @@ export class BatchGenerationService {
     itemIds: string[],
     orgId: string,
     feedback?: string,
+    actorUserId?: string,
   ): Promise<IBatchSummary> {
     const batchRecord = await findOrThrow(
       this.prisma.batch,
@@ -937,6 +964,16 @@ export class BatchGenerationService {
           organizationId: orgId,
         },
       });
+      await Promise.all(
+        postIdsToReject.map((postId) =>
+          this.publishApprovalsService.invalidatePost(
+            orgId,
+            postId,
+            'The review item was rejected.',
+            actorUserId,
+          ),
+        ),
+      );
     }
 
     const updatedBatch = (await this.prisma.batch.update({
@@ -958,6 +995,7 @@ export class BatchGenerationService {
     itemIds: string[],
     orgId: string,
     feedback?: string,
+    actorUserId?: string,
   ): Promise<IBatchSummary> {
     const batchRecord = await findOrThrow(
       this.prisma.batch,
@@ -1004,6 +1042,16 @@ export class BatchGenerationService {
           organizationId: orgId,
         },
       });
+      await Promise.all(
+        postIdsToKeepAsDraft.map((postId) =>
+          this.publishApprovalsService.invalidatePost(
+            orgId,
+            postId,
+            'Changes were requested for the approved version.',
+            actorUserId,
+          ),
+        ),
+      );
     }
 
     const updatedBatch = (await this.prisma.batch.update({
@@ -1191,6 +1239,7 @@ export class BatchGenerationService {
               reviewedAt: true,
               reviewFeedback: true,
               reviewVersionPinId: true,
+              publishApproval: true,
               status: true,
               url: true,
             },
@@ -1321,6 +1370,13 @@ export class BatchGenerationService {
           })),
           reviewedAt: item.reviewedAt,
           reviewFeedback: item.reviewFeedback,
+          publishApproval:
+            item.publishApproval ??
+            (linkedPost?.publishApproval
+              ? this.publishApprovalsService.toPublicInterface(
+                  linkedPost.publishApproval,
+                )
+              : undefined),
           scheduledDate: item.scheduledDate,
           sourceActionId: item.sourceActionId,
           sourceWorkflowId: item.sourceWorkflowId,

--- a/apps/server/server/src/queues/post-publish/post-publish-queue.service.ts
+++ b/apps/server/server/src/queues/post-publish/post-publish-queue.service.ts
@@ -25,7 +25,7 @@ export class PostPublishQueueService {
       ...data,
       enqueuedAt: new Date().toISOString(),
     };
-    const jobId = data.postId;
+    const jobId = data.operationId ?? data.postId;
     if (!this.queue) {
       this.logger.warn(`${this.logContext} queue unavailable`, {
         jobId,
@@ -59,6 +59,7 @@ export class PostPublishQueueService {
     this.logger.log(`${this.logContext} queued post publish`, {
       jobId: job.id,
       organizationId: data.organizationId,
+      operationId: data.operationId,
       postId: data.postId,
       source: data.source,
     });

--- a/apps/server/workers/src/crons/posts/cron.posts.module.ts
+++ b/apps/server/workers/src/crons/posts/cron.posts.module.ts
@@ -2,6 +2,7 @@ import { ActivitiesModule } from '@api/collections/activities/activities.module'
 import { CredentialsModule } from '@api/collections/credentials/credentials.module';
 import { OrganizationsModule } from '@api/collections/organizations/organizations.module';
 import { PostsModule } from '@api/collections/posts/posts.module';
+import { PublishApprovalsModule } from '@api/collections/publish-approvals/publish-approvals.module';
 import { SystemWorkflowProvenanceService } from '@api/collections/workflows/services/system-workflow-provenance.service';
 import { PublishersModule } from '@api/services/integrations/publishers/publishers.module';
 import { QuotaModule } from '@api/services/quota/quota.module';
@@ -24,6 +25,7 @@ import { WorkersQueuesModule } from '@workers/queues/queues.module';
     forwardRef(() => CredentialsModule),
     forwardRef(() => OrganizationsModule),
     forwardRef(() => PostsModule),
+    PublishApprovalsModule,
     forwardRef(() => WebhookClientModule),
     PublishersModule,
     PrismaModule,

--- a/apps/server/workers/src/crons/posts/cron.posts.service.spec.ts
+++ b/apps/server/workers/src/crons/posts/cron.posts.service.spec.ts
@@ -2,6 +2,7 @@ import { ActivitiesService } from '@api/collections/activities/services/activiti
 import { CredentialsService } from '@api/collections/credentials/services/credentials.service';
 import { OrganizationsService } from '@api/collections/organizations/services/organizations.service';
 import { PostsService } from '@api/collections/posts/services/posts.service';
+import { PublishApprovalsService } from '@api/collections/publish-approvals/services/publish-approvals.service';
 import { SystemWorkflowProvenanceService } from '@api/collections/workflows/services/system-workflow-provenance.service';
 import { PublisherFactoryService } from '@api/services/integrations/publishers/publisher-factory.service';
 import { QuotaService } from '@api/services/quota/quota.service';
@@ -15,6 +16,12 @@ import {
 import { LoggerService } from '@libs/logger/logger.service';
 import { Test, TestingModule } from '@nestjs/testing';
 import { CronPostsService } from '@workers/crons/posts/cron.posts.service';
+
+const APPROVAL_JOB_IDENTITY = {
+  approvalId: 'approval-1',
+  operationId: 'operation-1',
+  versionPinId: 'pin-1',
+} as const;
 
 describe('CronPostsService', () => {
   let service: CronPostsService;
@@ -35,6 +42,11 @@ describe('CronPostsService', () => {
   };
   let agentArtifactReferenceService: {
     assertVersionPinCurrent: ReturnType<typeof vi.fn>;
+  };
+  let publishApprovalsService: {
+    claimForExecution: ReturnType<typeof vi.fn>;
+    completeExecution: ReturnType<typeof vi.fn>;
+    markQueued: ReturnType<typeof vi.fn>;
   };
 
   beforeEach(async () => {
@@ -71,6 +83,11 @@ describe('CronPostsService', () => {
           serializer: 'post',
         },
       }),
+    };
+    publishApprovalsService = {
+      claimForExecution: vi.fn().mockResolvedValue({ alreadyPublished: false }),
+      completeExecution: vi.fn().mockResolvedValue(undefined),
+      markQueued: vi.fn().mockResolvedValue(undefined),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -152,6 +169,10 @@ describe('CronPostsService', () => {
           provide: PostPublishQueueService,
           useValue: postPublishQueueService,
         },
+        {
+          provide: PublishApprovalsService,
+          useValue: publishApprovalsService,
+        },
       ],
     }).compile();
 
@@ -206,6 +227,37 @@ describe('CronPostsService', () => {
     expect(publisherFactory.getPublisher).not.toHaveBeenCalled();
   });
 
+  it('fails closed before provider execution when a queued job has no explicit approval identity', async () => {
+    postsService.findAll.mockResolvedValueOnce({
+      docs: [
+        {
+          brandId: 'brand-1',
+          credentialId: 'cred-1',
+          id: 'post-1',
+          organizationId: 'org-1',
+          status: PostStatus.SCHEDULED,
+        },
+      ],
+      total: 1,
+    } as never);
+
+    const result = await service.processQueuedPost({
+      enqueuedAt: '2026-07-07T10:00:00.000Z',
+      organizationId: 'org-1',
+      postId: 'post-1',
+      source: 'scheduled_sweep',
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        error: expect.stringContaining('version-bound approval identity'),
+        success: false,
+      }),
+    );
+    expect(publishApprovalsService.claimForExecution).not.toHaveBeenCalled();
+    expect(publisherFactory.getPublisher).not.toHaveBeenCalled();
+  });
+
   it('queues the durable review version pin with a scheduled post', async () => {
     postsService.findAll.mockResolvedValueOnce({
       docs: [
@@ -249,6 +301,7 @@ describe('CronPostsService', () => {
     credentialsService.findOne.mockResolvedValue(null);
 
     await service.processQueuedPost({
+      ...APPROVAL_JOB_IDENTITY,
       enqueuedAt: '2026-07-07T10:00:00.000Z',
       organizationId: 'org-1',
       postId: 'post-1',
@@ -293,6 +346,7 @@ describe('CronPostsService', () => {
     );
 
     const result = await service.processQueuedPost({
+      ...APPROVAL_JOB_IDENTITY,
       enqueuedAt: '2026-07-07T10:00:00.000Z',
       organizationId: 'org-1',
       postId: 'post-1',
@@ -332,6 +386,7 @@ describe('CronPostsService', () => {
     } as never);
 
     const result = await service.processQueuedPost({
+      ...APPROVAL_JOB_IDENTITY,
       enqueuedAt: '2026-07-07T10:00:00.000Z',
       organizationId: 'org-1',
       postId: 'post-1',
@@ -349,6 +404,93 @@ describe('CronPostsService', () => {
       agentArtifactReferenceService.assertVersionPinCurrent,
     ).not.toHaveBeenCalled();
     expect(credentialsService.findOne).not.toHaveBeenCalled();
+  });
+
+  it('claims the bound approval immediately before provider execution', async () => {
+    const post = {
+      brandId: 'brand-1',
+      children: [],
+      credentialId: 'cred-1',
+      id: 'post-1',
+      ingredients: [],
+      organizationId: 'org-1',
+      publishApprovalId: 'approval-1',
+      reviewVersionPinId: 'pin-1',
+      scheduledDate: new Date('2026-07-07T09:55:00.000Z'),
+      status: PostStatus.SCHEDULED,
+      userId: 'user-1',
+    };
+    postsService.findAll.mockResolvedValueOnce({
+      docs: [post],
+      total: 1,
+    } as never);
+    credentialsService.findOne.mockResolvedValue(null);
+
+    await service.processQueuedPost({
+      ...APPROVAL_JOB_IDENTITY,
+      approvalId: 'approval-1',
+      enqueuedAt: '2026-07-07T10:00:00.000Z',
+      operationId: 'operation-1',
+      organizationId: 'org-1',
+      postId: 'post-1',
+      source: 'scheduled_sweep',
+      versionPinId: 'pin-1',
+    });
+
+    expect(publishApprovalsService.claimForExecution).toHaveBeenCalledWith({
+      approvalId: 'approval-1',
+      operationId: 'operation-1',
+      organizationId: 'org-1',
+      postId: 'post-1',
+      versionPinId: 'pin-1',
+    });
+    expect(
+      publishApprovalsService.claimForExecution.mock.invocationCallOrder[0],
+    ).toBeLessThan(credentialsService.findOne.mock.invocationCallOrder[0] ?? 0);
+  });
+
+  it('blocks provider execution when approval revalidation fails', async () => {
+    postsService.findAll.mockResolvedValueOnce({
+      docs: [
+        {
+          brandId: 'brand-1',
+          children: [],
+          credentialId: 'cred-1',
+          id: 'post-1',
+          ingredients: [],
+          organizationId: 'org-1',
+          publishApprovalId: 'approval-1',
+          reviewVersionPinId: 'pin-1',
+          scheduledDate: new Date('2026-07-07T09:55:00.000Z'),
+          status: PostStatus.SCHEDULED,
+          userId: 'user-1',
+        },
+      ],
+      total: 1,
+    } as never);
+    publishApprovalsService.claimForExecution.mockRejectedValue(
+      new Error('Publish approval scope no longer matches.'),
+    );
+
+    const result = await service.processQueuedPost({
+      ...APPROVAL_JOB_IDENTITY,
+      approvalId: 'approval-1',
+      enqueuedAt: '2026-07-07T10:00:00.000Z',
+      operationId: 'operation-1',
+      organizationId: 'org-1',
+      postId: 'post-1',
+      source: 'scheduled_sweep',
+      versionPinId: 'pin-1',
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        error: 'Publish approval scope no longer matches.',
+        success: false,
+      }),
+    );
+    expect(credentialsService.findOne).not.toHaveBeenCalled();
+    expect(publisherFactory.getPublisher).not.toHaveBeenCalled();
   });
 
   it('marks stale durable agent scope as a terminal publish failure', async () => {
@@ -376,6 +518,7 @@ describe('CronPostsService', () => {
     );
 
     const result = await service.processQueuedPost({
+      ...APPROVAL_JOB_IDENTITY,
       enqueuedAt: '2026-07-07T10:00:00.000Z',
       organizationId: 'org-1',
       postId: 'post-1',
@@ -443,6 +586,7 @@ describe('CronPostsService', () => {
     });
 
     await service.processQueuedPost({
+      ...APPROVAL_JOB_IDENTITY,
       enqueuedAt: '2026-07-07T09:55:00.000Z',
       organizationId: 'org-1',
       postId: 'post-1',
@@ -469,6 +613,7 @@ describe('CronPostsService', () => {
     } as never);
 
     const result = await service.processQueuedPost({
+      ...APPROVAL_JOB_IDENTITY,
       enqueuedAt: '2026-07-07T09:55:00.000Z',
       organizationId: 'org-1',
       postId: 'post-1',
@@ -519,6 +664,7 @@ describe('CronPostsService', () => {
     });
 
     await service.processQueuedPost({
+      ...APPROVAL_JOB_IDENTITY,
       enqueuedAt: '2026-07-07T09:55:00.000Z',
       organizationId: 'org-1',
       postId: 'post-1',
@@ -592,6 +738,7 @@ describe('CronPostsService', () => {
     });
 
     const result = await service.processQueuedPost({
+      ...APPROVAL_JOB_IDENTITY,
       enqueuedAt: '2026-07-07T09:55:00.000Z',
       organizationId: 'org-scalar-1',
       postId: 'post-1',

--- a/apps/server/workers/src/crons/posts/cron.posts.service.ts
+++ b/apps/server/workers/src/crons/posts/cron.posts.service.ts
@@ -5,6 +5,7 @@ import { OrganizationsService } from '@api/collections/organizations/services/or
 import { PostEntity } from '@api/collections/posts/entities/post.entity';
 import type { PostDocument } from '@api/collections/posts/schemas/post.schema';
 import { PostsService } from '@api/collections/posts/services/posts.service';
+import { PublishApprovalsService } from '@api/collections/publish-approvals/services/publish-approvals.service';
 import {
   SYSTEM_WORKFLOW_ACTION_IDS,
   SystemWorkflowProvenanceService,
@@ -77,6 +78,7 @@ export class CronPostsService {
     private readonly postPublishQueueService: PostPublishQueueService,
     private readonly agentScopeContextService: AgentScopeContextService,
     private readonly agentArtifactReferenceService: AgentArtifactReferenceService,
+    private readonly publishApprovalsService: PublishApprovalsService,
   ) {}
 
   /**
@@ -120,7 +122,7 @@ export class CronPostsService {
       return { reason: 'not_eligible', skipped: true };
     }
 
-    return this.publishPostWithSideEffects(post, data.versionPinId);
+    return this.publishPostWithSideEffects(post, data);
   }
 
   private async enqueuePostPublishJobs(posts: PostEntity[]): Promise<void> {
@@ -139,13 +141,26 @@ export class CronPostsService {
           return;
         }
 
+        const approval = post.publishApproval;
+        if (approval) {
+          await this.publishApprovalsService.markQueued(
+            approval.id,
+            organizationId,
+          );
+        }
         await this.postPublishQueueService.enqueue({
+          ...(approval
+            ? {
+                approvalId: approval.id,
+                operationId: approval.operationId,
+                versionPinId: approval.artifactVersionPinId,
+              }
+            : post.reviewVersionPinId
+              ? { versionPinId: post.reviewVersionPinId }
+              : {}),
           organizationId,
           postId: post.id.toString(),
           source: 'scheduled_sweep',
-          ...(post.reviewVersionPinId
-            ? { versionPinId: post.reviewVersionPinId }
-            : {}),
         });
       }),
     );
@@ -153,16 +168,44 @@ export class CronPostsService {
 
   private async publishPostWithSideEffects(
     post: PostEntity,
-    queuedVersionPinId?: string,
+    job: PostPublishJobData,
   ): Promise<PublishResult> {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
     try {
+      if (!job.approvalId || !job.operationId || !job.versionPinId) {
+        throw new Error(
+          'Publish execution requires an explicit version-bound approval identity.',
+        );
+      }
       await this.assertAgentPublishingScope(post);
-      await this.assertPublishVersionPin(post, queuedVersionPinId);
+      const claim = await this.publishApprovalsService.claimForExecution({
+        approvalId: job.approvalId,
+        operationId: job.operationId,
+        organizationId: job.organizationId,
+        postId: job.postId,
+        versionPinId: job.versionPinId,
+      });
+      if (claim.alreadyPublished) {
+        return {
+          externalId: this.readPostString(post, ['externalId']) ?? null,
+          platform: post.platform,
+          status: PostStatus.PUBLIC,
+          success: true,
+          url: this.readPostString(post, ['url']) ?? '',
+        };
+      }
+      await this.assertPublishVersionPin(post, job.versionPinId);
     } catch (error: unknown) {
       return this.handleTerminalPublishValidationFailure(post, error);
     }
     const result = await this.publishSinglePost(post);
+
+    await this.publishApprovalsService.completeExecution(
+      job.approvalId,
+      job.organizationId,
+      result.success,
+      result.error,
+    );
 
     if (result.success) {
       await this.activitiesService.create(
@@ -356,6 +399,13 @@ export class CronPostsService {
             },
           },
           ingredients: true,
+          publishApproval: {
+            select: {
+              artifactVersionPinId: true,
+              id: true,
+              operationId: true,
+            },
+          },
         },
         where: {
           ...(filter.postId ? { id: filter.postId } : {}),

--- a/packages/agent/src/components/agent-tool-call-display.helpers.ts
+++ b/packages/agent/src/components/agent-tool-call-display.helpers.ts
@@ -1,6 +1,6 @@
 export const TOOL_LABELS: Record<string, string> = {
   ai_action: 'AI Action',
-  batch_approve_reject: 'Batch Approve/Reject',
+  batch_approve_reject: 'Batch Review Action',
   check_onboarding_status: 'Check Onboarding',
   complete_campaign: 'Complete Campaign',
   complete_onboarding: 'Complete Onboarding',

--- a/packages/api-types/src/contracts/index.ts
+++ b/packages/api-types/src/contracts/index.ts
@@ -12,6 +12,7 @@ export * from '@api-types/contracts/channel-capabilities.contract';
 export * from '@api-types/contracts/ingredients.contract';
 export * from '@api-types/contracts/posting-sets.contract';
 export * from '@api-types/contracts/posts.contract';
+export * from '@api-types/contracts/publish-approval.contract';
 export * from '@api-types/contracts/publish-webhook-events.contract';
 export * from '@api-types/contracts/publishing-readiness.contract';
 export * from '@api-types/contracts/scheduler.contract';

--- a/packages/api-types/src/contracts/publish-approval.contract.ts
+++ b/packages/api-types/src/contracts/publish-approval.contract.ts
@@ -1,0 +1,89 @@
+import {
+  dateStringSchema,
+  nonEmptyStringSchema,
+} from '@api-types/helpers/common-schemas';
+import {
+  CredentialPlatform,
+  PublishApprovalPolicyId,
+  PublishApprovalStatus,
+} from '@genfeedai/enums';
+import { z } from 'zod';
+
+const idSchema = nonEmptyStringSchema({ max: 255 });
+
+export const publishApprovalDestinationSchema = z.object({
+  credentialId: idSchema,
+  platform: z.nativeEnum(CredentialPlatform),
+});
+
+export const publishScheduleIntentSchema = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('immediate') }),
+  z.object({
+    kind: z.literal('scheduled'),
+    scheduledAt: dateStringSchema,
+    timezone: z.string().min(1).max(255),
+  }),
+]);
+
+export const publishApprovalPolicySchema = z.object({
+  id: z.literal(PublishApprovalPolicyId.VERSION_BOUND_V1),
+  version: z.literal(1),
+});
+
+export const createPublishApprovalSchema = z.object({
+  contextVersion: z.number().int().nonnegative().optional(),
+  policy: publishApprovalPolicySchema,
+  postId: idSchema,
+  scheduleIntent: publishScheduleIntentSchema,
+});
+
+export const publishApprovalStatusSchema = z.nativeEnum(PublishApprovalStatus);
+
+export const publishApprovalStatusTransitions = {
+  [PublishApprovalStatus.APPROVED]: [
+    PublishApprovalStatus.QUEUED,
+    PublishApprovalStatus.CANCELLED,
+    PublishApprovalStatus.INVALIDATED,
+  ],
+  [PublishApprovalStatus.QUEUED]: [
+    PublishApprovalStatus.EXECUTING,
+    PublishApprovalStatus.CANCELLED,
+    PublishApprovalStatus.INVALIDATED,
+  ],
+  [PublishApprovalStatus.EXECUTING]: [
+    PublishApprovalStatus.PUBLISHED,
+    PublishApprovalStatus.FAILED,
+  ],
+  [PublishApprovalStatus.FAILED]: [
+    PublishApprovalStatus.QUEUED,
+    PublishApprovalStatus.CANCELLED,
+    PublishApprovalStatus.INVALIDATED,
+  ],
+  [PublishApprovalStatus.PUBLISHED]: [],
+  [PublishApprovalStatus.CANCELLED]: [],
+  [PublishApprovalStatus.INVALIDATED]: [],
+} as const satisfies Readonly<
+  Record<PublishApprovalStatus, readonly PublishApprovalStatus[]>
+>;
+
+export function canTransitionPublishApprovalStatus(
+  from: PublishApprovalStatus,
+  to: PublishApprovalStatus,
+): boolean {
+  return (
+    publishApprovalStatusTransitions[from] as readonly PublishApprovalStatus[]
+  ).includes(to);
+}
+
+export type PublishApprovalDestinationInput = z.infer<
+  typeof publishApprovalDestinationSchema
+>;
+export type PublishScheduleIntentInput = z.infer<
+  typeof publishScheduleIntentSchema
+>;
+export type PublishApprovalPolicyInput = z.infer<
+  typeof publishApprovalPolicySchema
+>;
+export type CreatePublishApprovalInput = z.infer<
+  typeof createPublishApprovalSchema
+>;

--- a/packages/enums/src/index.ts
+++ b/packages/enums/src/index.ts
@@ -75,6 +75,7 @@ export * from './platform-role.enum';
 export * from './post.enum';
 export * from './priority.enum';
 export * from './prompt.enum';
+export * from './publish-approval.enum';
 export * from './publish-status.enum';
 export * from './reference.enum';
 export * from './replicate.enum';

--- a/packages/enums/src/publish-approval.enum.ts
+++ b/packages/enums/src/publish-approval.enum.ts
@@ -1,0 +1,15 @@
+/** Durable lifecycle of one version-bound publish approval. */
+export enum PublishApprovalStatus {
+  APPROVED = 'approved',
+  QUEUED = 'queued',
+  EXECUTING = 'executing',
+  PUBLISHED = 'published',
+  FAILED = 'failed',
+  CANCELLED = 'cancelled',
+  INVALIDATED = 'invalidated',
+}
+
+/** The only policy accepted by the v1 version-bound publish boundary. */
+export enum PublishApprovalPolicyId {
+  VERSION_BOUND_V1 = 'version-bound-publish-v1',
+}

--- a/packages/interfaces/src/batch/batch.interface.ts
+++ b/packages/interfaces/src/batch/batch.interface.ts
@@ -4,6 +4,7 @@ import type {
   ContentFormat,
   ReferenceImageCategory,
 } from '@genfeedai/enums';
+import type { IPublishApproval } from '../publisher/publish-approval.interface';
 
 export type BatchItemFormat = ContentFormat | 'article' | 'newsletter' | 'post';
 
@@ -70,6 +71,7 @@ export interface IBatchItem {
     versionPinId?: string;
   }>;
   versionPinId?: string;
+  publishApproval?: IPublishApproval;
   sourceActionId?: string;
   sourceWorkflowId?: string;
   sourceWorkflowName?: string;

--- a/packages/interfaces/src/content/post.interface.ts
+++ b/packages/interfaces/src/content/post.interface.ts
@@ -10,6 +10,7 @@ import type {
   ITag,
   IUser,
 } from '../index';
+import type { IPublishApproval } from '../publisher/publish-approval.interface';
 import type { SeoScorecardSnapshot } from './seo-scorecard.interface';
 
 export interface IPost extends IBaseEntity {
@@ -34,6 +35,8 @@ export interface IPost extends IBaseEntity {
   publishedAt?: string;
   retryCount?: number;
   reviewVersionPinId?: string | null;
+  publishApprovalId?: string | null;
+  publishApproval?: IPublishApproval | null;
   analytics?: IPostAnalyticsSummary;
   totalViews?: number;
   totalLikes?: number;

--- a/packages/interfaces/src/index.ts
+++ b/packages/interfaces/src/index.ts
@@ -179,6 +179,7 @@ export * from './organization/organization-category-seed.interface';
 export * from './organization/organization-setting.interface';
 export * from './organization/quota-status.interface';
 export * from './providers/providers.interface';
+export * from './publisher/publish-approval.interface';
 export * from './publisher/publisher.interface';
 export * from './publisher/publishing-readiness.interface';
 export * from './scheduler/channel-target.interface';

--- a/packages/interfaces/src/publisher/index.ts
+++ b/packages/interfaces/src/publisher/index.ts
@@ -1,2 +1,3 @@
+export * from './publish-approval.interface';
 export * from './publisher.interface';
 export * from './publishing-readiness.interface';

--- a/packages/interfaces/src/publisher/publish-approval.interface.ts
+++ b/packages/interfaces/src/publisher/publish-approval.interface.ts
@@ -1,0 +1,51 @@
+import type {
+  CredentialPlatform,
+  PublishApprovalPolicyId,
+  PublishApprovalStatus,
+} from '@genfeedai/enums';
+
+export interface IPublishApprovalDestination {
+  credentialId: string;
+  platform: CredentialPlatform;
+}
+
+export type IPublishScheduleIntent =
+  | { kind: 'immediate' }
+  | { kind: 'scheduled'; scheduledAt: string; timezone: string };
+
+export interface IPublishApprovalPolicy {
+  id: PublishApprovalPolicyId.VERSION_BOUND_V1;
+  version: 1;
+}
+
+export interface IPublishApprovalStatusTransition {
+  actorId?: string | null;
+  at: string;
+  from: PublishApprovalStatus | null;
+  reason?: string;
+  to: PublishApprovalStatus;
+}
+
+/** Auditable authority for one exact canonical Post target and version pin. */
+export interface IPublishApproval {
+  actorUserId: string;
+  artifactVersionPinId: string;
+  brandId: string;
+  contextVersion?: number | null;
+  createdAt: string;
+  destinations: IPublishApprovalDestination[];
+  executedAt?: string | null;
+  id: string;
+  invalidatedAt?: string | null;
+  invalidationReason?: string | null;
+  operationId: string;
+  organizationId: string;
+  policy: IPublishApprovalPolicy;
+  postId: string;
+  provenance: Record<string, unknown>;
+  scheduleIntent: IPublishScheduleIntent;
+  scopeDigest: string;
+  status: PublishApprovalStatus;
+  statusTransitions: IPublishApprovalStatusTransition[];
+  updatedAt: string;
+}

--- a/packages/prisma/prisma/migrations/20260713230000_add_version_bound_publish_approvals/migration.sql
+++ b/packages/prisma/prisma/migrations/20260713230000_add_version_bound_publish_approvals/migration.sql
@@ -1,0 +1,94 @@
+-- Version-bound publish approvals for #1680. Approval scope is explicit and
+-- mutable execution state is separate from immutable content_version_pins.
+
+BEGIN;
+
+CREATE TABLE "publish_approvals" (
+  "id" TEXT NOT NULL,
+  "organizationId" TEXT NOT NULL,
+  "brandId" TEXT NOT NULL,
+  "postId" TEXT NOT NULL,
+  "artifactVersionPinId" TEXT NOT NULL,
+  "actorUserId" TEXT NOT NULL,
+  "contextVersion" INTEGER,
+  "destinations" JSONB NOT NULL,
+  "scheduleIntent" JSONB NOT NULL,
+  "policy" JSONB NOT NULL,
+  "provenance" JSONB NOT NULL DEFAULT '{}',
+  "scopeDigest" TEXT NOT NULL,
+  "operationId" TEXT NOT NULL,
+  "status" TEXT NOT NULL DEFAULT 'approved',
+  "statusTransitions" JSONB NOT NULL DEFAULT '[]',
+  "invalidatedAt" TIMESTAMP(3),
+  "invalidationReason" TEXT,
+  "executedAt" TIMESTAMP(3),
+  "lastError" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "publish_approvals_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "publish_approvals_status_check" CHECK (
+    "status" IN (
+      'approved',
+      'queued',
+      'executing',
+      'published',
+      'failed',
+      'cancelled',
+      'invalidated'
+    )
+  ),
+  CONSTRAINT "publish_approvals_destinations_check" CHECK (
+    jsonb_typeof("destinations") = 'array' AND jsonb_array_length("destinations") > 0
+  ),
+  CONSTRAINT "publish_approvals_scope_digest_check" CHECK (
+    "scopeDigest" ~ '^sha256:v1:[0-9a-f]{64}$'
+  ),
+  CONSTRAINT "publish_approvals_operation_id_check" CHECK (
+    "operationId" ~ '^sha256:v1:[0-9a-f]{64}$'
+  ),
+  CONSTRAINT "publish_approvals_org_operation_key" UNIQUE (
+    "organizationId",
+    "operationId"
+  ),
+  CONSTRAINT "publish_approvals_org_post_scope_key" UNIQUE (
+    "organizationId",
+    "postId",
+    "scopeDigest"
+  ),
+  CONSTRAINT "publish_approvals_organizationId_fkey"
+    FOREIGN KEY ("organizationId") REFERENCES "organizations"("id")
+    ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT "publish_approvals_brandId_organizationId_fkey"
+    FOREIGN KEY ("brandId", "organizationId")
+    REFERENCES "brands"("id", "organizationId")
+    ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT "publish_approvals_postId_fkey"
+    FOREIGN KEY ("postId") REFERENCES "posts"("id")
+    ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT "publish_approvals_artifactVersionPinId_organizationId_fkey"
+    FOREIGN KEY ("artifactVersionPinId", "organizationId")
+    REFERENCES "content_version_pins"("id", "organizationId")
+    ON DELETE RESTRICT ON UPDATE CASCADE,
+  CONSTRAINT "publish_approvals_actorUserId_fkey"
+    FOREIGN KEY ("actorUserId") REFERENCES "users"("id")
+    ON DELETE RESTRICT ON UPDATE CASCADE
+);
+
+CREATE INDEX "publish_approvals_scope_status_idx"
+ON "publish_approvals"("organizationId", "brandId", "status", "createdAt" DESC);
+
+CREATE INDEX "publish_approvals_post_status_idx"
+ON "publish_approvals"("postId", "status", "createdAt" DESC);
+
+ALTER TABLE "posts" ADD COLUMN "publishApprovalId" TEXT;
+
+ALTER TABLE "posts"
+ADD CONSTRAINT "posts_publishApprovalId_key" UNIQUE ("publishApprovalId");
+
+ALTER TABLE "posts"
+ADD CONSTRAINT "posts_publishApprovalId_fkey"
+FOREIGN KEY ("publishApprovalId") REFERENCES "publish_approvals"("id")
+ON DELETE RESTRICT ON UPDATE CASCADE;
+
+COMMIT;

--- a/packages/prisma/prisma/schema.prisma
+++ b/packages/prisma/prisma/schema.prisma
@@ -617,6 +617,7 @@ model User {
   lifecycleEmailPreference LifecycleEmailPreference?
   lifecycleEmailDeliveries LifecycleEmailDelivery[]
   contentVersionPins       ContentVersionPin[]
+  publishApprovals         PublishApproval[]
 
   @@index([isDefault])
   @@index([appSource])
@@ -761,6 +762,7 @@ model Organization {
   brandInterviews               BrandInterview[]
   warmupAccounts                WarmupAccount[]
   contentVersionPins            ContentVersionPin[]
+  publishApprovals              PublishApproval[]
 
   @@index([isDefault])
   @@index([category])
@@ -897,6 +899,7 @@ model Brand {
   brandInterviews            BrandInterview[]
   warmupAccounts             WarmupAccount[]
   contentVersionPins         ContentVersionPin[]
+  publishApprovals           PublishApproval[]
 
   @@index([isDefault])
   @@index([organizationId, isDeleted, label], map: "brands_org_deleted_label_idx")
@@ -1823,6 +1826,7 @@ model ContentVersionPin {
   reviewedContentDrafts ContentDraft[]
   reviewedNewsletters   Newsletter[]
   reviewedPosts         Post[]
+  publishApprovals      PublishApproval[]
 
   @@unique([organizationId, idempotencyKey], map: "content_version_pins_org_idempotency_key")
   @@unique([id, organizationId], map: "content_version_pins_id_organization_key")
@@ -1995,6 +1999,9 @@ model Post {
   reviewFeedback        String?
   reviewedAt            DateTime?
   reviewEvents          Json            @default("[]")
+  publishApprovalId     String?          @unique(map: "posts_publishApprovalId_key")
+  publishApproval       PublishApproval? @relation("active_publish_approval", fields: [publishApprovalId], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  publishApprovals      PublishApproval[] @relation("post_publish_approvals")
   sourceActionId        String?
   sourceWorkflowId      String?
   sourceWorkflowName    String?
@@ -2042,6 +2049,45 @@ model Post {
   @@index([brandId, platform, isDeleted, createdAt(sort: Desc)], map: "posts_brand_platform_deleted_created_at_idx")
   @@index([organizationId, groupId, targetExecutionState, isDeleted], map: "posts_group_target_execution_idx")
   @@map("posts")
+}
+
+/// Explicit typed authority for publishing one exact canonical Post version.
+/// Mutable execution state lives here; immutable content identity remains in
+/// ContentVersionPin and provider execution remains in the existing worker.
+model PublishApproval {
+  id                   String            @id @default(cuid())
+  organizationId       String
+  organization         Organization      @relation(fields: [organizationId], references: [id])
+  brandId              String
+  brand                Brand             @relation(fields: [brandId, organizationId], references: [id, organizationId], onDelete: Restrict, onUpdate: Cascade)
+  postId               String
+  post                 Post              @relation("post_publish_approvals", fields: [postId], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  activePost           Post?             @relation("active_publish_approval")
+  artifactVersionPinId String
+  artifactVersionPin   ContentVersionPin @relation(fields: [artifactVersionPinId, organizationId], references: [id, organizationId], onDelete: Restrict, onUpdate: Cascade)
+  actorUserId          String
+  actorUser            User              @relation(fields: [actorUserId], references: [id], onDelete: Restrict, onUpdate: Cascade)
+  contextVersion       Int?
+  destinations         Json
+  scheduleIntent       Json
+  policy               Json
+  provenance           Json              @default("{}")
+  scopeDigest          String
+  operationId          String
+  status               String            @default("approved")
+  statusTransitions    Json              @default("[]")
+  invalidatedAt        DateTime?
+  invalidationReason   String?
+  executedAt           DateTime?
+  lastError            String?
+  createdAt            DateTime          @default(now())
+  updatedAt            DateTime          @updatedAt
+
+  @@unique([organizationId, operationId], map: "publish_approvals_org_operation_key")
+  @@unique([organizationId, postId, scopeDigest], map: "publish_approvals_org_post_scope_key")
+  @@index([organizationId, brandId, status, createdAt(sort: Desc)], map: "publish_approvals_scope_status_idx")
+  @@index([postId, status, createdAt(sort: Desc)], map: "publish_approvals_post_status_idx")
+  @@map("publish_approvals")
 }
 
 model PostGroup {

--- a/packages/queue-contracts/src/job-data/post-publish-job.interface.ts
+++ b/packages/queue-contracts/src/job-data/post-publish-job.interface.ts
@@ -8,7 +8,9 @@
 export const POST_PUBLISH_JOB_NAME = 'publish-post';
 
 export interface PostPublishJobData {
+  approvalId?: string;
   enqueuedAt: string;
+  operationId?: string;
   organizationId: string;
   postId: string;
   source: 'publish_now' | 'scheduled_sweep';

--- a/packages/serializers/src/attributes/content/index.ts
+++ b/packages/serializers/src/attributes/content/index.ts
@@ -32,6 +32,7 @@ export * from '@serializers/attributes/content/performance-summary.attributes';
 export * from '@serializers/attributes/content/persona.attributes';
 export * from '@serializers/attributes/content/post.attributes';
 export * from '@serializers/attributes/content/presigned-upload.attributes';
+export * from '@serializers/attributes/content/publish-approval.attributes';
 export * from '@serializers/attributes/content/recurrence-rule.attributes';
 export * from '@serializers/attributes/content/release-attachment.attributes';
 export * from '@serializers/attributes/content/release-group.attributes';

--- a/packages/serializers/src/attributes/content/post.attributes.ts
+++ b/packages/serializers/src/attributes/content/post.attributes.ts
@@ -34,6 +34,8 @@ export const postAttributes = createEntityAttributes([
   'reviewItemId',
   'reviewDecision',
   'reviewVersionPinId',
+  'publishApprovalId',
+  'publishApproval',
   'reviewFeedback',
   'reviewedAt',
   'reviewEvents',

--- a/packages/serializers/src/attributes/content/publish-approval.attributes.ts
+++ b/packages/serializers/src/attributes/content/publish-approval.attributes.ts
@@ -1,0 +1,21 @@
+import { createEntityAttributes } from '@genfeedai/helpers';
+
+export const publishApprovalAttributes = createEntityAttributes([
+  'actorUserId',
+  'artifactVersionPinId',
+  'brandId',
+  'contextVersion',
+  'destinations',
+  'executedAt',
+  'invalidatedAt',
+  'invalidationReason',
+  'operationId',
+  'organizationId',
+  'policy',
+  'postId',
+  'provenance',
+  'scheduleIntent',
+  'scopeDigest',
+  'status',
+  'statusTransitions',
+]);

--- a/packages/serializers/src/configs/content/index.ts
+++ b/packages/serializers/src/configs/content/index.ts
@@ -33,6 +33,7 @@ export * from '@serializers/configs/content/performance-summary.config';
 export * from '@serializers/configs/content/persona.config';
 export * from '@serializers/configs/content/post.config';
 export * from '@serializers/configs/content/presigned-upload.config';
+export * from '@serializers/configs/content/publish-approval.config';
 export * from '@serializers/configs/content/recurrence-rule.config';
 export * from '@serializers/configs/content/release-attachment.config';
 export * from '@serializers/configs/content/release-group.config';

--- a/packages/serializers/src/configs/content/publish-approval.config.ts
+++ b/packages/serializers/src/configs/content/publish-approval.config.ts
@@ -1,0 +1,6 @@
+import { publishApprovalAttributes } from '@serializers/attributes/content/publish-approval.attributes';
+
+export const publishApprovalSerializerConfig = {
+  attributes: publishApprovalAttributes,
+  type: 'publish-approval',
+};

--- a/packages/serializers/src/server/content/index.ts
+++ b/packages/serializers/src/server/content/index.ts
@@ -33,6 +33,7 @@ export * from '@serializers/server/content/performance-summary.serializer';
 export * from '@serializers/server/content/persona.serializer';
 export * from '@serializers/server/content/post.serializer';
 export * from '@serializers/server/content/presigned-upload.serializer';
+export * from '@serializers/server/content/publish-approval.serializer';
 export * from '@serializers/server/content/recurrence-rule.serializer';
 export * from '@serializers/server/content/release-attachment.serializer';
 export * from '@serializers/server/content/release-group.serializer';

--- a/packages/serializers/src/server/content/publish-approval.serializer.ts
+++ b/packages/serializers/src/server/content/publish-approval.serializer.ts
@@ -1,0 +1,7 @@
+import { buildSerializer } from '@serializers/builders';
+import { publishApprovalSerializerConfig } from '@serializers/configs';
+
+export const { PublishApprovalSerializer } = buildSerializer(
+  'server',
+  publishApprovalSerializerConfig,
+);

--- a/packages/tools/src/registry/source/agent-only/other.tools.ts
+++ b/packages/tools/src/registry/source/agent-only/other.tools.ts
@@ -134,13 +134,13 @@ export const AGENT_OTHER_TOOLS: SourceTool[] = [
   {
     creditCost: 1,
     description:
-      'Approve or reject items in a batch. Approved items get scheduled for publishing. Rejected items are marked for regeneration.',
+      'Reject items in a batch. Approval is intentionally unavailable to model tools and requires the authenticated version-bound review control.',
     name: 'batch_approve_reject',
     parameters: {
       properties: {
         action: {
           description: 'Action to perform on selected items',
-          enum: ['approve', 'reject'],
+          enum: ['reject'],
           type: 'string',
         },
         batchId: {


### PR DESCRIPTION
## Summary

- add a typed publish-approval aggregate bound to one immutable ContentVersionPin, organization, brand, destination credential, schedule intent, actor, context, and policy
- expose approval provenance and lifecycle state in review responses and the review detail surface; model/chat approval is rejected and routed to the authenticated control
- invalidate approval on protected scope drift and revalidate target state, actor authorization, credential scope, schedule, context, and the immutable pin immediately before provider execution
- make retries deterministic with stable operation IDs, BullMQ job deduplication, guarded lifecycle transitions, and an atomic queued-to-executing claim

## Related issue

Closes #1680
Part of #1670

## Scope and boundaries

- targets master directly; #1695 was merged as e493c271b, and this change reuses its ContentVersionPin/artifact-history work without modifying or duplicating the approval-token overlay surface
- no stacking or retargeting is required
- inspected open PRs #1699 and #1700; neither overlaps this change set
- adds the publish_approvals migration and additive Post relation; substantive execution logic stays in API/worker-local modules
- no Enterprise-only changes and no deployment or external-setting action required

## Verification

- targeted Biome formatting/static checks passed; touched legacy files retain pre-existing warnings only
- Prisma schema formatting/validation completed successfully
- git diff --check passed
- secretlint passed before commit and on the committed file set
- pre-commit secretlint, Biome, UI control guard, and bespoke-card guard passed
- focused unit coverage was added for binding, invalidation, scope drift, duplicate prevention, queue identity, model rejection, and pre-provider revalidation
- local tests, typechecks, builds, and E2E were intentionally not run per the repository machine policy; CI owns those checks

## Screenshots

Not captured because local app builds and browser verification are prohibited by the current machine policy. The visible change is the additive approval provenance/status panel in the existing review detail aside.

## Checklist

- [x] I removed secrets, credentials, personal data, and customer data.
- [x] No documentation change is needed; the API contract, migration, UI provenance, and PR boundaries document this implementation slice.
- [x] I preserved the Community/Cloud/Enterprise boundary.
- [x] The additive database migration is documented above; no release or external-setting action is required.