### PR TITLE
feat(workflows): embed workflow work surfaces

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/[id]/WorkflowDetailPageClient.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/[id]/WorkflowDetailPageClient.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useAgentChatStore } from '@genfeedai/agent';
 import { ButtonSize, ButtonVariant } from '@genfeedai/enums';
 import {
   buildWorkflowEtaSnapshot,
@@ -79,6 +80,10 @@ export default function WorkflowDetailPageClient({
     string | null
   >(null);
   const getWorkflowService = useAuthedService(createWorkflowApiService);
+  const activeThreadId = useAgentChatStore((state) => state.activeThreadId);
+  const activeThread = useAgentChatStore((state) =>
+    state.threads.find((thread) => thread.id === state.activeThreadId),
+  );
 
   const {
     isLoading,
@@ -210,8 +215,10 @@ export default function WorkflowDetailPageClient({
         }
 
         const execution = await service.execute(runnableWorkflowId, {
+          expectedContextVersion: activeThread?.contextVersion,
           inputValues,
           metadata: { source: 'workflow-editor-run-panel' },
+          threadId: activeThreadId ?? undefined,
         });
         setActiveExecutionId(execution._id);
         setShowRunPanel(false);
@@ -225,7 +232,14 @@ export default function WorkflowDetailPageClient({
         setIsRunning(false);
       }
     },
-    [currentWorkflowId, getWorkflowService, saveInputDefaults, workflowId],
+    [
+      activeThread?.contextVersion,
+      activeThreadId,
+      currentWorkflowId,
+      getWorkflowService,
+      saveInputDefaults,
+      workflowId,
+    ],
   );
 
   const handleRunButtonClick = useCallback(() => {
@@ -251,7 +265,7 @@ export default function WorkflowDetailPageClient({
   return (
     <WorkflowUIProvider config={workflowUiConfig}>
       <ReactFlowProvider>
-        <div className="workflow-scope workflow-editor-shell flex h-screen flex-col bg-[var(--background)] text-[var(--foreground)]">
+        <div className="workflow-scope workflow-editor-shell flex h-full min-h-[32rem] flex-col bg-[var(--background)] text-[var(--foreground)]">
           {cloudError && (
             <div className="border-b border-[var(--destructive)]/20 bg-[var(--destructive)]/10 px-4 py-2 text-xs text-[var(--destructive)]">
               {cloudError}

--- a/apps/app/app/(protected)/[orgSlug]/~/[orgRootApp]/[[...segments]]/page.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/[orgRootApp]/[[...segments]]/page.test.tsx
@@ -60,6 +60,12 @@ vi.mock('@/features/workflows/pages/executions/WorkflowExecutionsPage', () => ({
   default: () => <div data-testid="workflow-executions-page" />,
 }));
 
+vi.mock('@/features/workflows/pages/executions/ExecutionDetailPage', () => ({
+  default: ({ executionId }: { executionId: string }) => (
+    <div data-execution-id={executionId} data-testid="execution-detail-page" />
+  ),
+}));
+
 vi.mock('@/features/workflows/pages/library/WorkflowLibraryPage', () => ({
   default: () => <div data-testid="workflow-library-page" />,
 }));
@@ -291,6 +297,23 @@ describe('OrgRootAppPage', () => {
     render(executionsElement);
 
     expect(screen.getByTestId('workflow-executions-page')).toBeInTheDocument();
+  });
+
+  it('restores an org workflow execution detail route', async () => {
+    const element = await OrgRootAppPage({
+      params: Promise.resolve({
+        orgRootApp: 'workflows',
+        orgSlug: 'acme',
+        segments: ['executions', 'execution-1'],
+      }),
+    });
+
+    render(element);
+
+    expect(screen.getByTestId('execution-detail-page')).toHaveAttribute(
+      'data-execution-id',
+      'execution-1',
+    );
   });
 
   it('renders org workflow new and detail pages', async () => {

--- a/apps/app/app/(protected)/[orgSlug]/~/[orgRootApp]/[[...segments]]/page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/[orgRootApp]/[[...segments]]/page.tsx
@@ -5,6 +5,7 @@ import LazyLoadingFallback from '@ui/loading/fallback/LazyLoadingFallback';
 import { SkeletonLoadingFallback } from '@ui/loading/skeleton/SkeletonFallbacks';
 import { notFound } from 'next/navigation';
 import { Suspense } from 'react';
+import ExecutionDetailPage from '@/features/workflows/pages/executions/ExecutionDetailPage';
 import WorkflowExecutionsPage from '@/features/workflows/pages/executions/WorkflowExecutionsPage';
 import WorkflowLibraryPage from '@/features/workflows/pages/library/WorkflowLibraryPage';
 import WorkflowTemplatesPage from '@/features/workflows/pages/templates/WorkflowTemplatesPage';
@@ -108,6 +109,15 @@ function OrgWorkflowsPage({
   }
 
   if (section === 'executions') {
+    const executionId = segments?.[1];
+    if (executionId) {
+      return (
+        <Suspense fallback={<LazyLoadingFallback variant="grid" />}>
+          <ExecutionDetailPage executionId={executionId} />
+        </Suspense>
+      );
+    }
+
     return (
       <Suspense fallback={<LazyLoadingFallback variant="grid" />}>
         <WorkflowExecutionsPage />

--- a/apps/app/src/components/workspace-shell/UniversalWorkspaceShell.test.tsx
+++ b/apps/app/src/components/workspace-shell/UniversalWorkspaceShell.test.tsx
@@ -14,8 +14,10 @@ const router = vi.hoisted(() => ({
 }));
 const agentState = vi.hoisted(() => ({
   activeThreadId: 'thread-1' as string | null,
+  seedComposer: vi.fn(),
   threads: [
     {
+      brandId: 'brand-1',
       contextVersion: 3,
       id: 'thread-1',
     },
@@ -69,6 +71,22 @@ vi.mock('@genfeedai/agent', () => ({
         type="button"
       />
       <button
+        aria-label="Dispatch workflow action"
+        onClick={() =>
+          dispatchAction({
+            action: {
+              isConsequentialProposal: false,
+              label: 'Workflow',
+              name: 'workflow',
+              requiredScope: 'brand',
+              route: '/workflows',
+            },
+            arguments: '',
+          })
+        }
+        type="button"
+      />
+      <button
         aria-label="Dispatch forged publish action"
         onClick={() =>
           dispatchAction({
@@ -86,16 +104,27 @@ vi.mock('@genfeedai/agent', () => ({
       />
     </div>
   ),
-  getConversationComposerAction: (name: string) =>
-    name === 'publish'
-      ? {
-          isConsequentialProposal: true,
-          label: 'Publish',
-          name: 'publish',
-          requiredScope: 'brand',
-          route: '/posts/review',
-        }
-      : null,
+  getConversationComposerAction: (name: string) => {
+    if (name === 'publish') {
+      return {
+        isConsequentialProposal: true,
+        label: 'Publish',
+        name: 'publish',
+        requiredScope: 'brand',
+        route: '/posts/review',
+      };
+    }
+    if (name === 'workflow') {
+      return {
+        isConsequentialProposal: false,
+        label: 'Workflow',
+        name: 'workflow',
+        requiredScope: 'brand',
+        route: '/workflows',
+      };
+    }
+    return null;
+  },
   useAgentChatStore: Object.assign(
     (selector: (state: typeof agentState) => unknown) => selector(agentState),
     {
@@ -206,6 +235,30 @@ vi.mock('@/lib/workspace-shell/workspace-shell-telemetry', () => ({
   captureWorkspaceShellTransition: vi.fn(),
 }));
 
+vi.mock('@/features/workflows/workspace/WorkflowSurfaceInspector', () => ({
+  WorkflowSurfaceInspector: () => <div>Workflow surface inspector</div>,
+}));
+
+vi.mock('@/features/workflows/workspace/WorkflowPickerOverlay', () => ({
+  WorkflowPickerOverlay: ({
+    onAttachWorkflow,
+  }: {
+    onAttachWorkflow: (workflow: { _id: string; name: string }) => void;
+  }) => (
+    <div>
+      <p>Authorized workflow picker</p>
+      <button
+        onClick={() =>
+          onAttachWorkflow({ _id: 'workflow-1', name: 'Launch brief' })
+        }
+        type="button"
+      >
+        Attach Launch brief
+      </button>
+    </div>
+  ),
+}));
+
 import UniversalWorkspaceShell from './UniversalWorkspaceShell';
 
 describe('UniversalWorkspaceShell', () => {
@@ -216,6 +269,7 @@ describe('UniversalWorkspaceShell', () => {
     pageShellMount.mockClear();
     agentActions.resetActiveConversationState.mockClear();
     agentActions.setActiveThread.mockClear();
+    agentState.seedComposer.mockClear();
     router.back.mockClear();
     router.push.mockClear();
     router.replace.mockClear();
@@ -345,6 +399,65 @@ describe('UniversalWorkspaceShell', () => {
     expect(router.push).toHaveBeenCalledWith(
       '/acme/moonrise/posts/review?thread=thread-1',
     );
+  });
+
+  it('opens and restores the trusted workflow picker without dialog graph UI', () => {
+    navigation.pathname = '/acme/~/workflows';
+    navigation.searchParams = new URLSearchParams({ thread: 'thread-1' });
+
+    const view = render(
+      <UniversalWorkspaceShell agentApiService={agentApiService}>
+        <div>Workspace</div>
+      </UniversalWorkspaceShell>,
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Dispatch workflow action' }),
+    );
+    expect(router.push).toHaveBeenCalledWith(
+      '/acme/~/workflows?thread=thread-1&overlay=workflow-picker',
+    );
+
+    navigation.searchParams = new URLSearchParams({
+      overlay: 'workflow-picker',
+      thread: 'thread-1',
+    });
+    view.rerender(
+      <UniversalWorkspaceShell agentApiService={agentApiService}>
+        <div>Workspace</div>
+      </UniversalWorkspaceShell>,
+    );
+
+    expect(screen.getByText('Authorized workflow picker')).toBeInTheDocument();
+    expect(screen.queryByText(/graph editor/i)).not.toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Attach Launch brief' }),
+    );
+    expect(agentState.seedComposer).toHaveBeenCalledWith(
+      'Use the deterministic workflow “Launch brief” (workflow ID: workflow-1) for this request: ',
+      'thread-1',
+    );
+    expect(router.replace).toHaveBeenCalledWith(
+      '/acme/~/workflows?thread=thread-1',
+    );
+  });
+
+  it('gives canonical workflow editors focused canvas overflow ownership', () => {
+    navigation.pathname = '/acme/moonrise/workflows/workflow-1';
+    navigation.searchParams = new URLSearchParams({ thread: 'thread-1' });
+
+    render(
+      <UniversalWorkspaceShell agentApiService={agentApiService}>
+        <div>Workflow graph editor</div>
+      </UniversalWorkspaceShell>,
+    );
+
+    expect(screen.getByTestId('workspace-canvas-layout')).toHaveClass(
+      'overflow-hidden',
+    );
+    expect(screen.getByText('Workflow graph editor')).toBeInTheDocument();
+    expect(screen.queryByTestId('workspace-dialog')).not.toBeInTheDocument();
   });
 
   it('exposes the optional scope-control composition slot without owning it', () => {

--- a/apps/app/src/components/workspace-shell/UniversalWorkspaceShell.tsx
+++ b/apps/app/src/components/workspace-shell/UniversalWorkspaceShell.tsx
@@ -36,11 +36,16 @@ import {
 } from 'react';
 import {
   HiOutlineArrowLeft,
+  HiOutlineBolt,
   HiOutlineChatBubbleLeftRight,
   HiOutlineEye,
   HiOutlineSquares2X2,
   HiOutlineViewColumns,
 } from 'react-icons/hi2';
+import type { WorkflowSummary } from '@/features/workflows/services/workflow-api';
+import { WorkflowPickerOverlay } from '@/features/workflows/workspace/WorkflowPickerOverlay';
+import { WorkflowSurfaceInspector } from '@/features/workflows/workspace/WorkflowSurfaceInspector';
+import { resolveWorkflowSurfaceRoute } from '@/features/workflows/workspace/workflow-surface-routing';
 import {
   appendSearchParamsToHref,
   normalizeProtectedPathname,
@@ -103,6 +108,7 @@ function UniversalWorkspaceShellContent({
   const { brandSlug, href, orgHref, orgSlug } = useOrgUrl();
   const activeThreadId = useAgentChatStore((state) => state.activeThreadId);
   const threads = useAgentChatStore((state) => state.threads);
+  const seedComposer = useAgentChatStore((state) => state.seedComposer);
   const [isInspectorOpen, setIsInspectorOpen] = useState(true);
   const [isMobileInspectorOpen, setIsMobileInspectorOpen] = useState(false);
   const [inspectorWidth, setInspectorWidth] = useState(INSPECTOR_DEFAULT_WIDTH);
@@ -174,6 +180,14 @@ function UniversalWorkspaceShellContent({
   const activeThread = useMemo(
     () => threads.find((thread) => thread.id === effectiveThreadId) ?? null,
     [effectiveThreadId, threads],
+  );
+  const workflowSurfaceRoute = useMemo(
+    () =>
+      resolveWorkflowSurfaceRoute(
+        rawPathname,
+        new URLSearchParams(searchParamsString),
+      ),
+    [rawPathname, searchParamsString],
   );
   const draftScopeKey = `${orgSlug || 'unknown'}:${effectiveThreadId ?? 'new'}:${activeThread?.contextVersion ?? 0}`;
   const composerContextLabel =
@@ -334,6 +348,36 @@ function UniversalWorkspaceShellContent({
     push(launch.href);
   }, [currentHref, push, replace]);
 
+  const handleOpenWorkflowPicker = useCallback((): boolean => {
+    const launch = resolveWorkspaceOverlayLaunch({
+      currentHref,
+      invocation: 'user',
+      overlay: {
+        key: 'workflow-picker',
+        parameters: {},
+      },
+    });
+    if (launch.history === 'none') {
+      return false;
+    }
+
+    pendingTransitionRef.current = 'overlay_open';
+    overlayReturnFocusRef.current =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+    hasOverlayReturnFocusRef.current = Boolean(overlayReturnFocusRef.current);
+
+    if (launch.history === 'replace') {
+      replace(launch.href);
+      return true;
+    }
+
+    isOwnedOverlayEntryRef.current = true;
+    push(launch.href);
+    return true;
+  }, [currentHref, push, replace]);
+
   const handleComposerAction = useCallback(
     (
       invocation: ConversationComposerActionInvocation,
@@ -351,6 +395,28 @@ function UniversalWorkspaceShellContent({
             'That action is not registered. Your draft and references are unchanged.',
           status: 'unavailable',
         };
+      }
+
+      if (trustedAction.name === 'workflow') {
+        if (!activeThread?.brandId) {
+          return {
+            message:
+              '/workflow needs an active thread brand. Select a brand through the scoped controls; your draft has been preserved.',
+            status: 'unauthorized',
+          };
+        }
+
+        return handleOpenWorkflowPicker()
+          ? {
+              message:
+                'Opened the authorized workflow picker. Choose a workflow to attach it or open its focused editor.',
+              status: 'dispatched',
+            }
+          : {
+              message:
+                'The workflow picker is unavailable. Your draft and references are unchanged.',
+              status: 'unavailable',
+            };
       }
 
       if (trustedAction.requiredScope === 'brand' && !brandSlug) {
@@ -389,10 +455,12 @@ function UniversalWorkspaceShellContent({
     },
     [
       activeThreadId,
+      activeThread?.brandId,
       brandSlug,
       currentHref,
       effectiveThreadId,
       href,
+      handleOpenWorkflowPicker,
       orgHref,
       push,
     ],
@@ -412,6 +480,37 @@ function UniversalWorkspaceShellContent({
       ),
     );
   }, [back, rawPathname, replace, searchParamsString]);
+
+  const openWorkflowCanvas = useCallback(
+    (workflow?: WorkflowSummary) => {
+      const destinationHref = href(
+        workflow ? `/workflows/${workflow._id}` : '/workflows',
+      );
+      const launch = resolveWorkspaceSurfaceLaunch({
+        currentHref,
+        destinationHref,
+        threadId: effectiveThreadId ?? activeThreadId,
+      });
+      if (launch.history !== 'push' || launch.mode !== 'canvas') {
+        return;
+      }
+
+      pendingTransitionRef.current = 'canvas_launch';
+      push(launch.href);
+    },
+    [activeThreadId, currentHref, effectiveThreadId, href, push],
+  );
+
+  const handleAttachWorkflow = useCallback(
+    (workflow: WorkflowSummary) => {
+      seedComposer(
+        `Use the deterministic workflow “${workflow.name}” (workflow ID: ${workflow._id}) for this request: `,
+        effectiveThreadId ?? activeThreadId,
+      );
+      handleDismissOverlay();
+    },
+    [activeThreadId, effectiveThreadId, handleDismissOverlay, seedComposer],
+  );
 
   const handleInspectorResizeStart = useCallback(
     (event: ReactMouseEvent<HTMLButtonElement>) => {
@@ -472,15 +571,32 @@ function UniversalWorkspaceShellContent({
         />
       </div>
       <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4">
-        <div className="gen-shell-empty-state p-4">
-          <p className="text-sm font-medium text-foreground">
-            Registered {surfaceKey} adapter slot
-          </p>
-          <p className="mt-1 text-xs leading-5 text-muted-foreground">
-            Product-owned context adapters land here without changing their
-            canonical route or granting execution authority.
-          </p>
-        </div>
+        {surfaceKey === 'workflows' ? (
+          <WorkflowSurfaceInspector
+            contextVersion={activeThread?.contextVersion}
+            pathname={rawPathname}
+            searchParams={new URLSearchParams(searchParamsString)}
+            threadId={effectiveThreadId}
+          />
+        ) : (
+          <div className="gen-shell-empty-state p-4">
+            <p className="text-sm font-medium text-foreground">
+              Registered {surfaceKey} adapter slot
+            </p>
+            <p className="mt-1 text-xs leading-5 text-muted-foreground">
+              Product-owned context adapters land here without changing their
+              canonical route or granting execution authority.
+            </p>
+          </div>
+        )}
+        <Button
+          icon={<HiOutlineBolt className="size-4" />}
+          onClick={handleOpenWorkflowPicker}
+          variant={ButtonVariant.OUTLINE}
+          withWrapper={false}
+        >
+          Choose workflow
+        </Button>
         <Button
           icon={<HiOutlineEye className="size-4" />}
           onClick={handleOpenOverlay}
@@ -586,7 +702,10 @@ function UniversalWorkspaceShellContent({
               aria-hidden={baseState !== 'canvas'}
               aria-label="Primary workspace canvas"
               className={cn(
-                'gen-workspace-shell-region-emphasis h-full min-w-0 overflow-auto bg-background pb-48 shadow-border md:pb-56',
+                'gen-workspace-shell-region-emphasis h-full min-w-0 bg-background shadow-border',
+                workflowSurfaceRoute.isGraphCanvas
+                  ? 'overflow-hidden'
+                  : 'overflow-auto pb-48 md:pb-56',
                 baseState !== 'canvas' && 'hidden',
               )}
               data-testid="workspace-canvas-layout"
@@ -681,6 +800,16 @@ function UniversalWorkspaceShellContent({
 
         <WorkspaceOverlayHost
           composerPortalRef={setComposerPortalTarget}
+          content={
+            overlay?.key === 'workflow-picker' ? (
+              <WorkflowPickerOverlay
+                activeBrandId={activeThread?.brandId}
+                onAttachWorkflow={handleAttachWorkflow}
+                onOpenLibrary={() => openWorkflowCanvas()}
+                onOpenWorkflow={openWorkflowCanvas}
+              />
+            ) : undefined
+          }
           fallbackFocusRef={primaryRegionRef}
           isOpen={state === 'overlay'}
           onDismiss={handleDismissOverlay}

--- a/apps/app/src/components/workspace-shell/WorkspaceOverlayHost.test.tsx
+++ b/apps/app/src/components/workspace-shell/WorkspaceOverlayHost.test.tsx
@@ -168,4 +168,22 @@ describe('WorkspaceOverlayHost', () => {
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
+
+  it('renders product-owned content inside the trusted host boundary', () => {
+    render(
+      <WorkspaceOverlayHost
+        content={<div>Authorized workflow choices</div>}
+        fallbackFocusRef={createRef<HTMLElement>()}
+        isOpen
+        onDismiss={vi.fn()}
+        overlay={{ key: 'workflow-picker', parameters: {} }}
+        registration={getWorkspaceShellOverlayRegistration('workflow-picker')}
+        returnFocusRef={createRef<HTMLElement>()}
+      />,
+    );
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Authorized workflow choices')).toBeVisible();
+    expect(screen.queryByText('No resource reference selected')).toBeNull();
+  });
 });

--- a/apps/app/src/components/workspace-shell/WorkspaceOverlayHost.tsx
+++ b/apps/app/src/components/workspace-shell/WorkspaceOverlayHost.tsx
@@ -26,6 +26,7 @@ function formatOverlayParameters(
  */
 export default function WorkspaceOverlayHost({
   composerPortalRef,
+  content,
   fallbackFocusRef,
   isOpen,
   onDismiss,
@@ -70,9 +71,11 @@ export default function WorkspaceOverlayHost({
               {registration.presentation.description}
             </DialogDescription>
           </DialogHeader>
-          <div className="p-5 pb-2 text-sm text-muted-foreground">
-            {formatOverlayParameters(overlay)}
-          </div>
+          {content ?? (
+            <div className="p-5 pb-2 text-sm text-muted-foreground">
+              {formatOverlayParameters(overlay)}
+            </div>
+          )}
           <div
             className="border-t border-border p-3"
             data-testid="workspace-overlay-composer-slot"

--- a/apps/app/src/features/workflows/services/workflow-api.test.ts
+++ b/apps/app/src/features/workflows/services/workflow-api.test.ts
@@ -344,8 +344,10 @@ describe('WorkflowApiService', () => {
     });
     await expect(
       service().execute('workflow-1', {
+        expectedContextVersion: 4,
         inputValues: { topic: 'launch' },
         metadata: { source: 'test' },
+        threadId: 'thread-1',
       }),
     ).resolves.toMatchObject({ _id: 'execution-1' });
     await expect(
@@ -371,8 +373,10 @@ describe('WorkflowApiService', () => {
       2,
       'https://api.test/v1/workflow-executions',
       {
+        expectedContextVersion: 4,
         inputValues: { topic: 'launch' },
         metadata: { source: 'test' },
+        threadId: 'thread-1',
         workflow: 'workflow-1',
       },
     );
@@ -391,6 +395,30 @@ describe('WorkflowApiService', () => {
     expect(mocks.get).toHaveBeenNthCalledWith(
       2,
       'https://api.test/v1/workflow-executions/execution-1',
+    );
+  });
+
+  it('resumes a failed execution with connected thread authority', async () => {
+    mocks.post.mockResolvedValueOnce({
+      data: {
+        data: {
+          message: 'Partial execution started',
+          runId: 'execution-2',
+          status: 'pending',
+        },
+      },
+    });
+
+    await expect(
+      service().resumeExecution('workflow-1', 'execution-1', {
+        expectedContextVersion: 4,
+        threadId: 'thread-1',
+      }),
+    ).resolves.toMatchObject({ runId: 'execution-2' });
+
+    expect(mocks.post).toHaveBeenCalledWith(
+      '/workflow-1/execute/resume/execution-1',
+      { expectedContextVersion: 4, threadId: 'thread-1' },
     );
   });
 
@@ -470,8 +498,26 @@ describe('WorkflowApiService', () => {
     });
     await service().deleteWebhook('workflow-1');
     await expect(
-      service().submitApproval('workflow-1', 'execution-1', 'review-1', true),
+      service().submitApproval(
+        'workflow-1',
+        'execution-1',
+        'review-1',
+        true,
+        undefined,
+        { expectedContextVersion: 4, threadId: 'thread-1' },
+      ),
     ).resolves.toMatchObject({ status: 'approved' });
+    expect(mocks.post).toHaveBeenNthCalledWith(
+      2,
+      '/workflow-1/executions/execution-1/approve',
+      {
+        approved: true,
+        expectedContextVersion: 4,
+        nodeId: 'review-1',
+        rejectionReason: undefined,
+        threadId: 'thread-1',
+      },
+    );
     await expect(service().listTemplates()).resolves.toEqual([
       {
         id: 'template-1',

--- a/apps/app/src/features/workflows/services/workflow-api.ts
+++ b/apps/app/src/features/workflows/services/workflow-api.ts
@@ -136,8 +136,21 @@ export interface UpdateWorkflowInput {
 
 /** Options for executing a workflow */
 export interface ExecuteOptions {
+  expectedContextVersion?: number;
   inputValues?: Record<string, unknown>;
   metadata?: Record<string, unknown>;
+  threadId?: string;
+}
+
+export interface WorkflowActionContext {
+  expectedContextVersion: number;
+  threadId: string;
+}
+
+export interface ResumeExecutionResult {
+  message: string;
+  runId: string;
+  status: string;
 }
 
 /** Node-level result within an execution */
@@ -175,6 +188,7 @@ export interface ExecutionResult {
   workflow: string | { _id: string; label?: string; description?: string };
   status: string;
   trigger: string;
+  inputValues?: Record<string, unknown>;
   nodeResults: ExecutionNodeResult[];
   progress: number;
   startedAt?: string;
@@ -589,6 +603,12 @@ export class WorkflowApiService extends HTTPBaseService {
       const response = await this.instance.post<unknown>(execBaseURL, {
         inputValues: options?.inputValues ?? {},
         metadata: options?.metadata,
+        ...(options?.threadId && options.expectedContextVersion !== undefined
+          ? {
+              expectedContextVersion: options.expectedContextVersion,
+              threadId: options.threadId,
+            }
+          : {}),
         workflow: id,
       });
 
@@ -742,11 +762,17 @@ export class WorkflowApiService extends HTTPBaseService {
     nodeId: string,
     approved: boolean,
     rejectionReason?: string,
+    context?: WorkflowActionContext,
   ): Promise<ApprovalResponse> {
     try {
       const response = await this.instance.post<{ data: ApprovalResponse }>(
         `/${workflowId}/executions/${executionId}/approve`,
-        { approved, nodeId, rejectionReason },
+        {
+          approved,
+          ...(context ?? {}),
+          nodeId,
+          rejectionReason,
+        },
       );
       return response.data.data;
     } catch (error) {
@@ -754,6 +780,27 @@ export class WorkflowApiService extends HTTPBaseService {
         error,
         executionId,
         nodeId,
+        workflowId,
+      });
+      throw error;
+    }
+  }
+
+  /** Resume a failed workflow through the canonical deterministic run path. */
+  async resumeExecution(
+    workflowId: string,
+    executionId: string,
+    context?: WorkflowActionContext,
+  ): Promise<ResumeExecutionResult> {
+    try {
+      const response = await this.instance.post<{
+        data: ResumeExecutionResult;
+      }>(`/${workflowId}/execute/resume/${executionId}`, context ?? {});
+      return response.data.data;
+    } catch (error) {
+      logger.error('Failed to resume workflow execution', {
+        error,
+        executionId,
         workflowId,
       });
       throw error;

--- a/apps/app/src/features/workflows/workspace/WorkflowPickerOverlay.test.tsx
+++ b/apps/app/src/features/workflows/workspace/WorkflowPickerOverlay.test.tsx
@@ -1,0 +1,99 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { ChangeEvent, ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+
+const picker = vi.hoisted(() => ({
+  error: null,
+  hasNextPage: false,
+  isLoading: false,
+  page: 1,
+  retry: vi.fn(),
+  search: '',
+  setPage: vi.fn(),
+  setSearch: vi.fn(),
+  visibleWorkflows: [
+    {
+      _id: 'workflow-1',
+      brandId: 'brand-1',
+      createdAt: '2026-07-13T08:00:00.000Z',
+      lifecycle: 'published',
+      name: 'Launch brief',
+      nodeCount: 3,
+      updatedAt: '2026-07-13T08:00:00.000Z',
+    },
+  ],
+}));
+
+vi.mock('./useWorkflowPicker', () => ({
+  useWorkflowPicker: () => picker,
+}));
+
+vi.mock('@ui/primitives/button', () => ({
+  Button: ({
+    ariaLabel,
+    children,
+    disabled,
+    onClick,
+  }: {
+    ariaLabel?: string;
+    children?: ReactNode;
+    disabled?: boolean;
+    onClick?: () => void;
+  }) => (
+    <button
+      aria-label={ariaLabel}
+      disabled={disabled}
+      onClick={onClick}
+      type="button"
+    >
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock('@ui/primitives/input', () => ({
+  Input: ({
+    onChange,
+    value,
+    ...props
+  }: {
+    onChange: (event: ChangeEvent<HTMLInputElement>) => void;
+    value: string;
+  }) => <input {...props} onChange={onChange} value={value} />,
+}));
+
+import { WorkflowPickerOverlay } from './WorkflowPickerOverlay';
+
+describe('WorkflowPickerOverlay', () => {
+  it('keeps compact selection separate from editor and request intents', () => {
+    const onAttachWorkflow = vi.fn();
+    const onOpenLibrary = vi.fn();
+    const onOpenWorkflow = vi.fn();
+
+    render(
+      <WorkflowPickerOverlay
+        activeBrandId="brand-1"
+        onAttachWorkflow={onAttachWorkflow}
+        onOpenLibrary={onOpenLibrary}
+        onOpenWorkflow={onOpenWorkflow}
+      />,
+    );
+
+    expect(screen.getByText('Launch brief')).toBeInTheDocument();
+    fireEvent.change(
+      screen.getByRole('textbox', { name: 'Search authorized workflows' }),
+      { target: { value: 'launch' } },
+    );
+    expect(picker.setSearch).toHaveBeenCalledWith('launch');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Use in request' }));
+    expect(onAttachWorkflow).toHaveBeenCalledWith(picker.visibleWorkflows[0]);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open editor' }));
+    expect(onOpenWorkflow).toHaveBeenCalledWith(picker.visibleWorkflows[0]);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Full library' }));
+    expect(onOpenLibrary).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/app/src/features/workflows/workspace/WorkflowPickerOverlay.tsx
+++ b/apps/app/src/features/workflows/workspace/WorkflowPickerOverlay.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+import { ButtonSize, ButtonVariant } from '@genfeedai/enums';
+import Card from '@ui/card/Card';
+import { Button } from '@ui/primitives/button';
+import { Input } from '@ui/primitives/input';
+import {
+  HiOutlineArrowLeft,
+  HiOutlineArrowRight,
+  HiOutlineArrowTopRightOnSquare,
+  HiOutlineBolt,
+  HiOutlineMagnifyingGlass,
+  HiOutlinePaperClip,
+} from 'react-icons/hi2';
+import type { WorkflowSummary } from '@/features/workflows/services/workflow-api';
+import { useWorkflowPicker } from './useWorkflowPicker';
+
+interface WorkflowPickerOverlayProps {
+  readonly activeBrandId?: string | null;
+  readonly onAttachWorkflow: (workflow: WorkflowSummary) => void;
+  readonly onOpenLibrary: () => void;
+  readonly onOpenWorkflow: (workflow: WorkflowSummary) => void;
+}
+
+export function WorkflowPickerOverlay({
+  activeBrandId,
+  onAttachWorkflow,
+  onOpenLibrary,
+  onOpenWorkflow,
+}: WorkflowPickerOverlayProps) {
+  const {
+    error,
+    hasNextPage,
+    isLoading,
+    page,
+    retry,
+    search,
+    setPage,
+    setSearch,
+    visibleWorkflows,
+  } = useWorkflowPicker({ activeBrandId });
+
+  return (
+    <div className="flex max-h-[min(62vh,36rem)] min-h-0 flex-col">
+      <div className="border-b border-border p-4">
+        <div className="relative">
+          <HiOutlineMagnifyingGlass className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            aria-label="Search authorized workflows"
+            className="pl-9"
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder="Search this page"
+            value={search}
+          />
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto p-4">
+        {!activeBrandId ? (
+          <div className="gen-shell-empty-state p-4 text-sm text-muted-foreground">
+            Select a brand in the scoped controls before choosing a workflow.
+          </div>
+        ) : isLoading ? (
+          <div
+            aria-live="polite"
+            className="animate-pulse p-6 text-center text-sm text-muted-foreground"
+          >
+            Loading authorized workflows…
+          </div>
+        ) : error ? (
+          <div className="gen-shell-empty-state space-y-3 p-4 text-sm">
+            <p className="text-destructive">{error}</p>
+            <Button
+              onClick={retry}
+              size={ButtonSize.SM}
+              variant={ButtonVariant.OUTLINE}
+              withWrapper={false}
+            >
+              Retry
+            </Button>
+          </div>
+        ) : visibleWorkflows.length === 0 ? (
+          <div className="gen-shell-empty-state p-4 text-sm text-muted-foreground">
+            No authorized workflows match this selection.
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {visibleWorkflows.map((workflow) => (
+              <Card bodyClassName="gap-0 p-3" key={workflow._id}>
+                <div className="flex items-start gap-3">
+                  <div className="flex size-9 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
+                    <HiOutlineBolt className="size-5" />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <h3 className="truncate text-sm font-medium text-foreground">
+                        {workflow.name}
+                      </h3>
+                      <span className="rounded-full bg-muted px-2 py-0.5 text-[11px] capitalize text-muted-foreground">
+                        {workflow.lifecycle}
+                      </span>
+                    </div>
+                    <p className="mt-1 line-clamp-2 text-xs leading-5 text-muted-foreground">
+                      {workflow.description ??
+                        'Deterministic reusable automation workflow.'}
+                    </p>
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      <Button
+                        icon={<HiOutlinePaperClip className="size-4" />}
+                        onClick={() => onAttachWorkflow(workflow)}
+                        size={ButtonSize.SM}
+                        variant={ButtonVariant.DEFAULT}
+                        withWrapper={false}
+                      >
+                        Use in request
+                      </Button>
+                      <Button
+                        icon={
+                          <HiOutlineArrowTopRightOnSquare className="size-4" />
+                        }
+                        onClick={() => onOpenWorkflow(workflow)}
+                        size={ButtonSize.SM}
+                        variant={ButtonVariant.OUTLINE}
+                        withWrapper={false}
+                      >
+                        Open editor
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              </Card>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center justify-between border-t border-border px-4 py-3">
+        <Button
+          onClick={onOpenLibrary}
+          size={ButtonSize.SM}
+          variant={ButtonVariant.GHOST}
+          withWrapper={false}
+        >
+          Full library
+        </Button>
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-muted-foreground">Page {page}</span>
+          <Button
+            ariaLabel="Previous workflow page"
+            disabled={page === 1 || isLoading}
+            icon={<HiOutlineArrowLeft className="size-4" />}
+            onClick={() => setPage((current) => Math.max(1, current - 1))}
+            size={ButtonSize.ICON}
+            variant={ButtonVariant.GHOST}
+            withWrapper={false}
+          />
+          <Button
+            ariaLabel="Next workflow page"
+            disabled={!hasNextPage || isLoading}
+            icon={<HiOutlineArrowRight className="size-4" />}
+            onClick={() => setPage((current) => current + 1)}
+            size={ButtonSize.ICON}
+            variant={ButtonVariant.GHOST}
+            withWrapper={false}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/features/workflows/workspace/WorkflowSurfaceInspector.test.tsx
+++ b/apps/app/src/features/workflows/workspace/WorkflowSurfaceInspector.test.tsx
@@ -1,0 +1,175 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+
+const service = vi.hoisted(() => ({
+  get: vi.fn(),
+  getExecution: vi.fn(),
+  resumeExecution: vi.fn(),
+  submitApproval: vi.fn(),
+}));
+const router = vi.hoisted(() => ({ push: vi.fn() }));
+
+vi.mock('@hooks/auth/use-authed-service/use-authed-service', () => ({
+  useAuthedService: () => async () => service,
+}));
+
+vi.mock('@services/core/logger.service', () => ({
+  logger: { error: vi.fn() },
+}));
+
+vi.mock('@ui/primitives/button', () => ({
+  Button: ({
+    children,
+    disabled,
+    onClick,
+  }: {
+    children?: ReactNode;
+    disabled?: boolean;
+    onClick?: () => void;
+  }) => (
+    <button disabled={disabled} onClick={onClick} type="button">
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => router,
+}));
+
+import { WorkflowSurfaceInspector } from './WorkflowSurfaceInspector';
+
+describe('WorkflowSurfaceInspector', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service.get.mockResolvedValue({
+      _id: 'workflow-1',
+      createdAt: '2026-07-13T08:00:00.000Z',
+      edgeStyle: 'bezier',
+      edges: [],
+      inputVariables: [
+        {
+          key: 'topic',
+          label: 'Topic',
+          required: true,
+          type: 'text',
+        },
+      ],
+      isScheduleEnabled: true,
+      lifecycle: 'published',
+      name: 'Launch brief',
+      nodes: [],
+      organization: 'organization-1',
+      schedule: '0 9 * * *',
+      timezone: 'Europe/Malta',
+      updatedAt: '2026-07-13T08:00:00.000Z',
+    });
+    service.getExecution.mockResolvedValue({
+      _id: 'run-1',
+      createdAt: '2026-07-13T08:00:00.000Z',
+      inputValues: { topic: 'Product launch' },
+      metadata: {
+        agentScope: {
+          contextVersion: 4,
+          source: 'agent',
+          threadId: 'thread-1',
+        },
+        pendingApproval: {
+          nodeId: 'review-1',
+          requestedAt: '2026-07-13T08:01:00.000Z',
+        },
+        source: 'conversation',
+      },
+      nodeResults: [],
+      progress: 60,
+      status: 'waiting_approval',
+      trigger: 'agent',
+      updatedAt: '2026-07-13T08:01:00.000Z',
+      workflow: 'workflow-1',
+    });
+    service.submitApproval.mockResolvedValue({ status: 'approved' });
+    service.resumeExecution.mockResolvedValue({
+      message: 'Partial execution started',
+      runId: 'run-2',
+      status: 'pending',
+    });
+  });
+
+  it('shows run context and submits scoped approvals', async () => {
+    render(
+      <WorkflowSurfaceInspector
+        contextVersion={4}
+        pathname="/acme/moonrise/workflows/executions/run-1"
+        searchParams={new URLSearchParams({ thread: 'thread-1' })}
+        threadId="thread-1"
+      />,
+    );
+
+    expect(await screen.findByText('Launch brief')).toBeInTheDocument();
+    expect(screen.getByText('60%')).toBeInTheDocument();
+    expect(screen.getByText('Provided for this run')).toBeInTheDocument();
+    expect(screen.getByText('conversation')).toBeInTheDocument();
+    expect(screen.getByText('v4 · agent')).toBeInTheDocument();
+    expect(screen.getByText('Review required')).toBeInTheDocument();
+    expect(screen.getByText(/Enabled · 0 9 \* \* \*/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }));
+
+    await waitFor(() => {
+      expect(service.submitApproval).toHaveBeenCalledWith(
+        'workflow-1',
+        'run-1',
+        'review-1',
+        true,
+        undefined,
+        { expectedContextVersion: 4, threadId: 'thread-1' },
+      );
+    });
+  });
+
+  it('resumes failed runs through the canonical scoped route', async () => {
+    service.getExecution.mockResolvedValueOnce({
+      _id: 'run-1',
+      createdAt: '2026-07-13T08:00:00.000Z',
+      metadata: { source: 'conversation' },
+      nodeResults: [],
+      progress: 100,
+      status: 'failed',
+      trigger: 'agent',
+      updatedAt: '2026-07-13T08:01:00.000Z',
+      workflow: 'workflow-1',
+    });
+
+    render(
+      <WorkflowSurfaceInspector
+        contextVersion={4}
+        pathname="/acme/moonrise/workflows/executions/run-1"
+        searchParams={new URLSearchParams({ thread: 'thread-1' })}
+        threadId="thread-1"
+      />,
+    );
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Resume failed run' }),
+    );
+
+    await waitFor(() => {
+      expect(service.resumeExecution).toHaveBeenCalledWith(
+        'workflow-1',
+        'run-1',
+        { expectedContextVersion: 4, threadId: 'thread-1' },
+      );
+      expect(router.push).toHaveBeenCalledWith(
+        '/acme/moonrise/workflows/executions/run-2?thread=thread-1',
+      );
+    });
+  });
+});

--- a/apps/app/src/features/workflows/workspace/WorkflowSurfaceInspector.tsx
+++ b/apps/app/src/features/workflows/workspace/WorkflowSurfaceInspector.tsx
@@ -1,0 +1,553 @@
+'use client';
+
+import { ButtonSize, ButtonVariant } from '@genfeedai/enums';
+import { useAuthedService } from '@hooks/auth/use-authed-service/use-authed-service';
+import { logger } from '@services/core/logger.service';
+import { Button } from '@ui/primitives/button';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  HiOutlineArrowPath,
+  HiOutlineArrowTopRightOnSquare,
+  HiOutlineCheck,
+  HiOutlineClock,
+  HiOutlineExclamationTriangle,
+  HiOutlineShieldCheck,
+  HiOutlineXMark,
+} from 'react-icons/hi2';
+import {
+  type CloudWorkflowData,
+  createWorkflowApiService,
+  type ExecutionResult,
+  type WorkflowInputVariable,
+} from '@/features/workflows/services/workflow-api';
+import {
+  appendWorkflowThread,
+  resolveWorkflowSurfaceRoute,
+} from './workflow-surface-routing';
+
+const ACTIVE_RUN_POLL_MS = 2500;
+const TERMINAL_RUN_STATUSES = new Set(['cancelled', 'completed', 'failed']);
+
+interface WorkflowAgentScopeMetadata {
+  readonly brandId?: string;
+  readonly contextVersion?: number;
+  readonly source?: string;
+  readonly threadId?: string;
+}
+
+interface WorkflowPendingApproval {
+  readonly nodeId?: string;
+  readonly requestedAt?: string;
+  readonly timeoutHours?: number;
+}
+
+interface WorkflowLastApproval {
+  readonly approved?: boolean;
+  readonly approvedAt?: string;
+  readonly approvedBy?: string;
+  readonly nodeId?: string;
+}
+
+interface WorkflowInspectorMetadata extends Record<string, unknown> {
+  readonly agentScope?: WorkflowAgentScopeMetadata;
+  readonly lastApproval?: WorkflowLastApproval;
+  readonly pendingApproval?: WorkflowPendingApproval | null;
+  readonly source?: string;
+}
+
+interface WorkflowSurfaceInspectorProps {
+  readonly contextVersion?: number;
+  readonly pathname: string;
+  readonly searchParams: URLSearchParams;
+  readonly threadId: string | null;
+}
+
+function getWorkflowId(execution: ExecutionResult): string {
+  return typeof execution.workflow === 'string'
+    ? execution.workflow
+    : execution.workflow._id;
+}
+
+function hasInputValue(value: unknown): boolean {
+  return !(
+    value === undefined ||
+    value === null ||
+    (typeof value === 'string' && value.trim().length === 0)
+  );
+}
+
+function describeRequiredInput(
+  variable: WorkflowInputVariable,
+  execution: ExecutionResult | null,
+): string {
+  const value = execution?.inputValues?.[variable.key];
+  if (hasInputValue(value)) {
+    return 'Provided for this run';
+  }
+  if (hasInputValue(variable.defaultValue)) {
+    return 'Using saved default';
+  }
+  return variable.required ? 'Required before run' : 'Optional';
+}
+
+function formatTimestamp(value?: string): string | null {
+  if (!value) {
+    return null;
+  }
+
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date.toLocaleString();
+}
+
+export function WorkflowSurfaceInspector({
+  contextVersion,
+  pathname,
+  searchParams,
+  threadId,
+}: WorkflowSurfaceInspectorProps) {
+  const selection = useMemo(
+    () => resolveWorkflowSurfaceRoute(pathname, searchParams),
+    [pathname, searchParams],
+  );
+  const [workflow, setWorkflow] = useState<CloudWorkflowData | null>(null);
+  const [execution, setExecution] = useState<ExecutionResult | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isResuming, setIsResuming] = useState(false);
+  const [isSubmittingApproval, setIsSubmittingApproval] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+  const getService = useAuthedService(createWorkflowApiService);
+  const { push } = useRouter();
+
+  useEffect(() => {
+    void reloadKey;
+    const controller = new AbortController();
+    let pollTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const load = async (): Promise<void> => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const service = await getService();
+        if (controller.signal.aborted) {
+          return;
+        }
+
+        const nextExecution = selection.executionId
+          ? await service.getExecution(selection.executionId)
+          : null;
+        if (controller.signal.aborted) {
+          return;
+        }
+
+        const nextWorkflowId =
+          selection.workflowId ??
+          (nextExecution ? getWorkflowId(nextExecution) : null);
+        const nextWorkflow = nextWorkflowId
+          ? await service.get(nextWorkflowId)
+          : null;
+        if (controller.signal.aborted) {
+          return;
+        }
+
+        setExecution(nextExecution);
+        setWorkflow(nextWorkflow);
+
+        if (nextExecution && !TERMINAL_RUN_STATUSES.has(nextExecution.status)) {
+          pollTimer = setTimeout(() => {
+            setReloadKey((current) => current + 1);
+          }, ACTIVE_RUN_POLL_MS);
+        }
+      } catch (cause) {
+        if (!controller.signal.aborted) {
+          logger.error('Failed to load workflow inspector', {
+            cause,
+            executionId: selection.executionId,
+            workflowId: selection.workflowId,
+          });
+          setError(
+            cause instanceof Error
+              ? cause.message
+              : 'Failed to load workflow context',
+          );
+        }
+      } finally {
+        if (!controller.signal.aborted) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void load();
+    return () => {
+      controller.abort();
+      if (pollTimer) {
+        clearTimeout(pollTimer);
+      }
+    };
+  }, [getService, reloadKey, selection.executionId, selection.workflowId]);
+
+  const metadata = (execution?.metadata ?? {}) as WorkflowInspectorMetadata;
+  const pendingApproval = metadata.pendingApproval ?? null;
+  const requiredInputs =
+    workflow?.inputVariables?.filter((variable) => variable.required) ?? [];
+  const workflowId =
+    workflow?._id ??
+    (execution ? getWorkflowId(execution) : selection.workflowId);
+  const workflowHref =
+    selection.workflowBaseHref && workflowId
+      ? appendWorkflowThread(
+          `${selection.workflowBaseHref}/${encodeURIComponent(workflowId)}${
+            execution ? `?execution=${encodeURIComponent(execution._id)}` : ''
+          }`,
+          threadId,
+        )
+      : null;
+  const executionHref =
+    selection.workflowBaseHref && execution
+      ? appendWorkflowThread(
+          `${selection.workflowBaseHref}/executions/${encodeURIComponent(
+            execution._id,
+          )}`,
+          threadId,
+        )
+      : null;
+
+  const submitApproval = useCallback(
+    async (approved: boolean): Promise<void> => {
+      if (!workflowId || !execution || !pendingApproval?.nodeId) {
+        return;
+      }
+
+      setIsSubmittingApproval(true);
+      setError(null);
+      try {
+        const service = await getService();
+        await service.submitApproval(
+          workflowId,
+          execution._id,
+          pendingApproval.nodeId,
+          approved,
+          approved ? undefined : 'Rejected from workflow run inspector',
+          threadId && contextVersion !== undefined
+            ? { expectedContextVersion: contextVersion, threadId }
+            : undefined,
+        );
+        setReloadKey((current) => current + 1);
+      } catch (cause) {
+        logger.error('Failed to submit workflow inspector approval', {
+          approved,
+          cause,
+          executionId: execution._id,
+          workflowId,
+        });
+        setError(
+          cause instanceof Error
+            ? cause.message
+            : 'Failed to submit workflow approval',
+        );
+      } finally {
+        setIsSubmittingApproval(false);
+      }
+    },
+    [
+      contextVersion,
+      execution,
+      getService,
+      pendingApproval?.nodeId,
+      threadId,
+      workflowId,
+    ],
+  );
+
+  const resumeExecution = useCallback(async (): Promise<void> => {
+    if (!workflowId || !execution || !selection.workflowBaseHref) {
+      return;
+    }
+
+    setIsResuming(true);
+    setError(null);
+    try {
+      const service = await getService();
+      const resumed = await service.resumeExecution(
+        workflowId,
+        execution._id,
+        threadId && contextVersion !== undefined
+          ? { expectedContextVersion: contextVersion, threadId }
+          : undefined,
+      );
+      push(
+        appendWorkflowThread(
+          `${selection.workflowBaseHref}/executions/${encodeURIComponent(
+            resumed.runId,
+          )}`,
+          threadId,
+        ),
+      );
+    } catch (cause) {
+      logger.error('Failed to resume workflow inspector execution', {
+        cause,
+        executionId: execution._id,
+        workflowId,
+      });
+      setError(
+        cause instanceof Error
+          ? cause.message
+          : 'Failed to resume workflow execution',
+      );
+    } finally {
+      setIsResuming(false);
+    }
+  }, [
+    contextVersion,
+    execution,
+    getService,
+    push,
+    selection.workflowBaseHref,
+    threadId,
+    workflowId,
+  ]);
+
+  if (!selection.workflowBaseHref) {
+    return null;
+  }
+
+  if (!selection.workflowId && !selection.executionId) {
+    return (
+      <div className="gen-shell-empty-state p-4">
+        <p className="text-sm font-medium text-foreground">Workflow library</p>
+        <p className="mt-1 text-xs leading-5 text-muted-foreground">
+          Select an authorized workflow to inspect its inputs, schedule, runs,
+          provenance, and approvals.
+        </p>
+      </div>
+    );
+  }
+
+  if (isLoading && !workflow && !execution) {
+    return (
+      <div
+        aria-live="polite"
+        className="animate-pulse p-4 text-sm text-muted-foreground"
+      >
+        Loading workflow context…
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {error ? (
+        <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-xs text-destructive">
+          <div className="flex items-start gap-2">
+            <HiOutlineExclamationTriangle className="mt-0.5 size-4 shrink-0" />
+            <p>{error}</p>
+          </div>
+          <Button
+            className="mt-3"
+            icon={<HiOutlineArrowPath className="size-4" />}
+            onClick={() => setReloadKey((current) => current + 1)}
+            size={ButtonSize.SM}
+            variant={ButtonVariant.OUTLINE}
+            withWrapper={false}
+          >
+            Retry
+          </Button>
+        </div>
+      ) : null}
+
+      <section className="rounded-lg border border-border bg-background p-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <p className="truncate text-sm font-medium text-foreground">
+              {workflow?.name ?? 'Workflow run'}
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Deterministic workflow engine
+            </p>
+          </div>
+          {execution ? (
+            <span className="rounded-full bg-muted px-2 py-0.5 text-[11px] capitalize text-foreground">
+              {execution.status}
+            </span>
+          ) : null}
+        </div>
+
+        {execution ? (
+          <div className="mt-3 space-y-2 text-xs">
+            <div className="flex items-center justify-between gap-3">
+              <span className="text-muted-foreground">Progress</span>
+              <span className="font-medium text-foreground">
+                {execution.progress}%
+              </span>
+            </div>
+            <div className="h-1.5 overflow-hidden rounded-full bg-muted">
+              <div
+                className="h-full rounded-full bg-primary transition-[width]"
+                style={{
+                  width: `${Math.max(0, Math.min(100, execution.progress))}%`,
+                }}
+              />
+            </div>
+          </div>
+        ) : null}
+      </section>
+
+      <section className="rounded-lg border border-border bg-background p-3">
+        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          Required input
+        </p>
+        {requiredInputs.length === 0 ? (
+          <p className="mt-2 text-xs text-muted-foreground">
+            No required inputs.
+          </p>
+        ) : (
+          <ul className="mt-2 space-y-2">
+            {requiredInputs.map((variable) => (
+              <li className="text-xs" key={variable.key}>
+                <div className="flex items-center justify-between gap-2">
+                  <span className="font-medium text-foreground">
+                    {variable.label}
+                  </span>
+                  <span className="text-right text-muted-foreground">
+                    {describeRequiredInput(variable, execution)}
+                  </span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section className="rounded-lg border border-border bg-background p-3">
+        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          Provenance
+        </p>
+        <dl className="mt-2 space-y-2 text-xs">
+          <div className="flex items-center justify-between gap-3">
+            <dt className="text-muted-foreground">Trigger</dt>
+            <dd className="capitalize text-foreground">
+              {execution?.trigger ?? 'Not running'}
+            </dd>
+          </div>
+          {metadata.source ? (
+            <div className="flex items-center justify-between gap-3">
+              <dt className="text-muted-foreground">Source</dt>
+              <dd className="text-right text-foreground">{metadata.source}</dd>
+            </div>
+          ) : null}
+          {metadata.agentScope?.threadId ? (
+            <div className="flex items-center justify-between gap-3">
+              <dt className="text-muted-foreground">Thread context</dt>
+              <dd className="text-right text-foreground">
+                v{metadata.agentScope.contextVersion ?? '—'} ·{' '}
+                {metadata.agentScope.source ?? 'validated'}
+              </dd>
+            </div>
+          ) : null}
+        </dl>
+      </section>
+
+      <section className="rounded-lg border border-border bg-background p-3">
+        <div className="flex items-center gap-2">
+          <HiOutlineShieldCheck className="size-4 text-muted-foreground" />
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Approvals
+          </p>
+        </div>
+        {pendingApproval?.nodeId ? (
+          <div className="mt-3 space-y-3">
+            <div className="rounded-md bg-warning/10 p-2 text-xs text-foreground">
+              <p className="font-medium">Review required</p>
+              <p className="mt-1 text-muted-foreground">
+                Node {pendingApproval.nodeId}
+                {formatTimestamp(pendingApproval.requestedAt)
+                  ? ` · ${formatTimestamp(pendingApproval.requestedAt)}`
+                  : ''}
+              </p>
+            </div>
+            <div className="grid grid-cols-2 gap-2">
+              <Button
+                disabled={isSubmittingApproval}
+                icon={<HiOutlineCheck className="size-4" />}
+                onClick={() => void submitApproval(true)}
+                size={ButtonSize.SM}
+                variant={ButtonVariant.DEFAULT}
+                withWrapper={false}
+              >
+                Approve
+              </Button>
+              <Button
+                disabled={isSubmittingApproval}
+                icon={<HiOutlineXMark className="size-4" />}
+                onClick={() => void submitApproval(false)}
+                size={ButtonSize.SM}
+                variant={ButtonVariant.OUTLINE}
+                withWrapper={false}
+              >
+                Reject
+              </Button>
+            </div>
+          </div>
+        ) : metadata.lastApproval ? (
+          <p className="mt-2 text-xs text-muted-foreground">
+            Last decision:{' '}
+            {metadata.lastApproval.approved ? 'approved' : 'rejected'}
+            {formatTimestamp(metadata.lastApproval.approvedAt)
+              ? ` · ${formatTimestamp(metadata.lastApproval.approvedAt)}`
+              : ''}
+          </p>
+        ) : (
+          <p className="mt-2 text-xs text-muted-foreground">
+            No approval is currently required.
+          </p>
+        )}
+      </section>
+
+      {workflow?.schedule ? (
+        <section className="rounded-lg border border-border bg-background p-3">
+          <div className="flex items-center gap-2">
+            <HiOutlineClock className="size-4 text-muted-foreground" />
+            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Schedule
+            </p>
+          </div>
+          <p className="mt-2 text-xs text-foreground">
+            {workflow.isScheduleEnabled ? 'Enabled' : 'Disabled'} ·{' '}
+            {workflow.schedule} · {workflow.timezone ?? 'UTC'}
+          </p>
+        </section>
+      ) : null}
+
+      <div className="space-y-2">
+        {execution?.status === 'failed' ? (
+          <Button
+            disabled={isResuming}
+            icon={<HiOutlineArrowPath className="size-4" />}
+            onClick={() => void resumeExecution()}
+            variant={ButtonVariant.DEFAULT}
+            withWrapper={false}
+          >
+            Resume failed run
+          </Button>
+        ) : null}
+        {workflowHref ? (
+          <Button asChild variant={ButtonVariant.OUTLINE} withWrapper={false}>
+            <Link href={workflowHref}>
+              <HiOutlineArrowTopRightOnSquare className="size-4" />
+              Open workflow editor
+            </Link>
+          </Button>
+        ) : null}
+        {executionHref ? (
+          <Button asChild variant={ButtonVariant.GHOST} withWrapper={false}>
+            <Link href={executionHref}>Inspect canonical run</Link>
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/features/workflows/workspace/useWorkflowPicker.ts
+++ b/apps/app/src/features/workflows/workspace/useWorkflowPicker.ts
@@ -1,0 +1,115 @@
+'use client';
+
+import { useAuthedService } from '@hooks/auth/use-authed-service/use-authed-service';
+import { logger } from '@services/core/logger.service';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  createWorkflowApiService,
+  type WorkflowSummary,
+} from '@/features/workflows/services/workflow-api';
+
+const WORKFLOW_PICKER_PAGE_SIZE = 12;
+
+interface UseWorkflowPickerOptions {
+  readonly activeBrandId?: string | null;
+}
+
+export function useWorkflowPicker({ activeBrandId }: UseWorkflowPickerOptions) {
+  const [workflows, setWorkflows] = useState<WorkflowSummary[]>([]);
+  const [page, setPage] = useState(1);
+  const [search, setSearch] = useState('');
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+  const getService = useAuthedService(createWorkflowApiService);
+
+  useEffect(() => {
+    void reloadKey;
+    if (!activeBrandId) {
+      setError(null);
+      setIsLoading(false);
+      setWorkflows([]);
+      return;
+    }
+
+    const controller = new AbortController();
+
+    const load = async (): Promise<void> => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const service = await getService();
+        if (controller.signal.aborted) {
+          return;
+        }
+
+        const data = await service.list({
+          brandId: activeBrandId,
+          limit: WORKFLOW_PICKER_PAGE_SIZE,
+          page,
+          sort: 'updatedAt: -1',
+        });
+        if (!controller.signal.aborted) {
+          setWorkflows(data);
+        }
+      } catch (cause) {
+        if (controller.signal.aborted) {
+          return;
+        }
+        logger.error('Failed to load workflow picker', { cause, page });
+        setError(
+          cause instanceof Error
+            ? cause.message
+            : 'Failed to load authorized workflows',
+        );
+      } finally {
+        if (!controller.signal.aborted) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void load();
+    return () => controller.abort();
+  }, [activeBrandId, getService, page, reloadKey]);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: brand changes must reset server pagination before the next request.
+  useEffect(() => {
+    setPage(1);
+  }, [activeBrandId]);
+
+  const visibleWorkflows = useMemo(() => {
+    const normalizedSearch = search.trim().toLowerCase();
+
+    return workflows.filter((workflow) => {
+      if (activeBrandId && workflow.brandId !== activeBrandId) {
+        return false;
+      }
+
+      if (!normalizedSearch) {
+        return true;
+      }
+
+      return `${workflow.name} ${workflow.description ?? ''}`
+        .toLowerCase()
+        .includes(normalizedSearch);
+    });
+  }, [activeBrandId, search, workflows]);
+
+  const retry = useCallback(() => {
+    setReloadKey((current) => current + 1);
+  }, []);
+
+  return {
+    error,
+    hasNextPage: workflows.length === WORKFLOW_PICKER_PAGE_SIZE,
+    isLoading,
+    page,
+    retry,
+    search,
+    setPage,
+    setSearch,
+    visibleWorkflows,
+  };
+}

--- a/apps/app/src/features/workflows/workspace/workflow-surface-routing.spec.ts
+++ b/apps/app/src/features/workflows/workspace/workflow-surface-routing.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import {
+  appendWorkflowThread,
+  resolveWorkflowSurfaceRoute,
+} from './workflow-surface-routing';
+
+describe('workflow surface routing', () => {
+  it('resolves focused graph editors without inventing dialog routes', () => {
+    expect(
+      resolveWorkflowSurfaceRoute(
+        '/acme/moonrise/workflows/workflow-1',
+        new URLSearchParams({ execution: 'run-1', thread: 'thread-1' }),
+      ),
+    ).toEqual({
+      executionId: 'run-1',
+      isGraphCanvas: true,
+      workflowBaseHref: '/acme/moonrise/workflows',
+      workflowId: 'workflow-1',
+    });
+  });
+
+  it('resolves brand and organization run inspection canvases', () => {
+    expect(
+      resolveWorkflowSurfaceRoute(
+        '/acme/~/workflows/executions/run-1',
+        new URLSearchParams(),
+      ),
+    ).toEqual({
+      executionId: 'run-1',
+      isGraphCanvas: false,
+      workflowBaseHref: '/acme/~/workflows',
+      workflowId: null,
+    });
+  });
+
+  it('preserves opaque queries while restoring the connected thread', () => {
+    expect(
+      appendWorkflowThread(
+        '/acme/moonrise/workflows/workflow-1?execution=run-1',
+        'thread-1',
+      ),
+    ).toBe(
+      '/acme/moonrise/workflows/workflow-1?execution=run-1&thread=thread-1',
+    );
+  });
+});

--- a/apps/app/src/features/workflows/workspace/workflow-surface-routing.ts
+++ b/apps/app/src/features/workflows/workspace/workflow-surface-routing.ts
@@ -1,0 +1,68 @@
+const WORKFLOW_RESERVED_SEGMENTS = new Set([
+  'executions',
+  'library',
+  'templates',
+]);
+
+export interface WorkflowSurfaceRouteSelection {
+  readonly executionId: string | null;
+  readonly isGraphCanvas: boolean;
+  readonly workflowBaseHref: string | null;
+  readonly workflowId: string | null;
+}
+
+export function resolveWorkflowSurfaceRoute(
+  pathname: string,
+  searchParams: URLSearchParams,
+): WorkflowSurfaceRouteSelection {
+  const segments = pathname.split('/').filter(Boolean);
+  const workflowsIndex = segments.indexOf('workflows');
+  if (workflowsIndex < 0) {
+    return {
+      executionId: null,
+      isGraphCanvas: false,
+      workflowBaseHref: null,
+      workflowId: null,
+    };
+  }
+
+  const workflowBaseHref = `/${segments
+    .slice(0, workflowsIndex + 1)
+    .join('/')}`;
+  const section = segments[workflowsIndex + 1];
+  const detailId = segments[workflowsIndex + 2];
+
+  if (section === 'executions') {
+    return {
+      executionId: detailId ?? null,
+      isGraphCanvas: false,
+      workflowBaseHref,
+      workflowId: null,
+    };
+  }
+
+  const workflowId =
+    section && section !== 'new' && !WORKFLOW_RESERVED_SEGMENTS.has(section)
+      ? section
+      : null;
+
+  return {
+    executionId: searchParams.get('execution'),
+    isGraphCanvas: section === 'new' || Boolean(workflowId),
+    workflowBaseHref,
+    workflowId,
+  };
+}
+
+export function appendWorkflowThread(
+  href: string,
+  threadId: string | null,
+): string {
+  if (!threadId) {
+    return href;
+  }
+
+  const url = new URL(href, 'https://workspace.genfeed.invalid');
+  url.searchParams.set('thread', threadId);
+  return `${url.pathname}${url.search}${url.hash}`;
+}

--- a/apps/app/src/lib/workspace-shell/workspace-overlay-launcher.spec.ts
+++ b/apps/app/src/lib/workspace-shell/workspace-overlay-launcher.spec.ts
@@ -8,6 +8,25 @@ const SHELL_PREVIEW_OVERLAY = {
 } as const satisfies WorkspaceShellOverlayRequest;
 
 describe('workspace overlay launcher', () => {
+  it('opens the parameter-free workflow picker through the trusted host', () => {
+    const overlay = {
+      key: 'workflow-picker',
+      parameters: {},
+    } as const satisfies WorkspaceShellOverlayRequest;
+
+    expect(
+      resolveWorkspaceOverlayLaunch({
+        currentHref: '/acme/moonrise/workflows?thread=thread-1',
+        invocation: 'user',
+        overlay,
+      }),
+    ).toMatchObject({
+      history: 'push',
+      href: '/acme/moonrise/workflows?thread=thread-1&overlay=workflow-picker',
+      overlay,
+    });
+  });
+
   it('pushes one trusted overlay over the complete underlying URL', () => {
     expect(
       resolveWorkspaceOverlayLaunch({

--- a/apps/app/src/lib/workspace-shell/workspace-overlay-launcher.ts
+++ b/apps/app/src/lib/workspace-shell/workspace-overlay-launcher.ts
@@ -55,7 +55,7 @@ function encodeOverlayReference(
     return undefined;
   }
 
-  if (overlay.key === 'notifications') {
+  if (overlay.key === 'notifications' || overlay.key === 'workflow-picker') {
     return Object.keys(overlay.parameters).length === 0 ? null : undefined;
   }
 

--- a/apps/app/src/lib/workspace-shell/workspace-shell-location.spec.ts
+++ b/apps/app/src/lib/workspace-shell/workspace-shell-location.spec.ts
@@ -80,6 +80,25 @@ describe('workspace shell URL restoration', () => {
     });
   });
 
+  it('restores the workflow picker and canonical organization run URL', () => {
+    expect(
+      restoreWorkspaceShellLocation({
+        normalizedPathname: '/workflows/executions/run-1',
+        pathname: '/acme/~/workflows/executions/run-1',
+        searchParams: new URLSearchParams({
+          overlay: 'workflow-picker',
+          thread: 'thread-1',
+        }),
+      }),
+    ).toMatchObject({
+      baseState: 'canvas',
+      overlay: { key: 'workflow-picker', parameters: {} },
+      routeKey: 'route:/:orgSlug/~/workflows/executions/:id',
+      state: 'overlay',
+      threadId: 'thread-1',
+    });
+  });
+
   it('removes invalid overlay state without changing scope or opaque queries', () => {
     const restored = restoreWorkspaceShellLocation({
       normalizedPathname: '/posts/calendar',

--- a/apps/app/src/lib/workspace-shell/workspace-shell-location.ts
+++ b/apps/app/src/lib/workspace-shell/workspace-shell-location.ts
@@ -77,6 +77,10 @@ function createOverlayRequest(
         key: 'shell-preview',
         parameters: { reference },
       };
+    case 'workflow-picker':
+      return reference
+        ? null
+        : { key: 'workflow-picker', parameters: Object.freeze({}) };
   }
 }
 

--- a/apps/app/src/lib/workspace-shell/workspace-shell-registry.spec.ts
+++ b/apps/app/src/lib/workspace-shell/workspace-shell-registry.spec.ts
@@ -31,11 +31,11 @@ function materializeRoutePattern(pattern: string): string {
 
 describe('workspace shell trusted registry', () => {
   it('owns the complete accepted protected-route denominator', () => {
-    expect(PROTECTED_ROUTE_INVENTORY).toHaveLength(206);
+    expect(PROTECTED_ROUTE_INVENTORY).toHaveLength(207);
     expect(
       new Set(PROTECTED_ROUTE_INVENTORY.map((route) => route.canonicalUrl))
         .size,
-    ).toBe(206);
+    ).toBe(207);
 
     for (const route of PROTECTED_ROUTE_INVENTORY) {
       expect(route.accessPolicy).toMatch(
@@ -142,6 +142,13 @@ describe('workspace shell trusted registry', () => {
         presentation: { title: 'Temporary workspace overlay' },
       },
     );
+    expect(
+      getWorkspaceShellOverlayRegistration('workflow-picker'),
+    ).toMatchObject({
+      parameterContract: { kind: 'none' },
+      presentation: { title: 'Choose a workflow' },
+      telemetryClass: 'workflow_picker',
+    });
     expect(
       WORKSPACE_SHELL_AUXILIARY_REGISTRY.find(
         (registration) => registration.key === 'terminal-dock',

--- a/apps/app/src/lib/workspace-shell/workspace-shell-registry.ts
+++ b/apps/app/src/lib/workspace-shell/workspace-shell-registry.ts
@@ -262,6 +262,7 @@ const ORGANIZATION_ROUTE_REGISTRATIONS = [
       '/:orgSlug/~/workflows/library',
       '/:orgSlug/~/workflows/templates',
       '/:orgSlug/~/workflows/executions',
+      '/:orgSlug/~/workflows/executions/:id',
       '/:orgSlug/~/workflows/new',
       '/:orgSlug/~/workflows/:id',
     ],
@@ -651,9 +652,9 @@ const ADMIN_ROUTE_REGISTRATIONS = registerRoutes(ADMIN_ROUTE_PATTERNS, {
 });
 
 /**
- * Canonical application-owned inventory for the 206 protected route patterns
- * accepted in ADR-CONVERSATION-SHELL-CONTRACTS v1.0.0. The two intentional hard
- * cuts (`/:orgSlug/~/workspace/*` and
+ * Canonical application-owned inventory for the protected route patterns
+ * accepted in ADR-CONVERSATION-SHELL-CONTRACTS v1.0.0 plus routes added after
+ * its 206-route snapshot. The two intentional hard cuts (`/:orgSlug/~/workspace/*` and
  * `/:orgSlug/~/settings/organization/*`) are deliberately absent.
  */
 export const PROTECTED_ROUTE_INVENTORY = Object.freeze([
@@ -711,6 +712,28 @@ export const WORKSPACE_SHELL_AUXILIARY_REGISTRY = Object.freeze([
     safeFallback: 'same-canonical-url',
     scope: 'organization',
     telemetryClass: 'shell_preview',
+  }),
+  Object.freeze({
+    accessPolicy: 'organization-member',
+    adapter: Object.freeze({ key: 'workflow-picker', status: 'placeholder' }),
+    allowedShellModes: Object.freeze(['overlay'] as const),
+    availability: 'conversation-shell',
+    canonicalUrl: null,
+    deployments: ALL_DEPLOYMENTS,
+    key: 'workflow-picker',
+    kind: 'overlay',
+    launchTarget: 'overlay',
+    parameterContract: Object.freeze({ kind: 'none' } as const),
+    presentation: Object.freeze({
+      description:
+        'Choose an authorized deterministic workflow without leaving the active conversation or canvas.',
+      openAnnouncement: 'Workflow picker opened.',
+      title: 'Choose a workflow',
+    }),
+    restoration: URL_RESTORATION_POLICY,
+    safeFallback: 'same-canonical-url',
+    scope: 'organization',
+    telemetryClass: 'workflow_picker',
   }),
   Object.freeze({
     accessPolicy: 'organization-member',

--- a/apps/server/api/openapi/openapi.json
+++ b/apps/server/api/openapi/openapi.json
@@ -5434,6 +5434,10 @@
       },
       "CreateWorkflowExecutionDto": {
         "properties": {
+          "expectedContextVersion": {
+            "minimum": 1,
+            "type": "number"
+          },
           "inputValues": {
             "description": "Input values for workflow variables",
             "type": "object"
@@ -5441,6 +5445,10 @@
           "metadata": {
             "description": "Additional metadata",
             "type": "object"
+          },
+          "threadId": {
+            "description": "Active agent thread ID",
+            "type": "string"
           },
           "trigger": {
             "allOf": [
@@ -8542,10 +8550,18 @@
       },
       "ResumeExecutionDto": {
         "properties": {
+          "expectedContextVersion": {
+            "minimum": 1,
+            "type": "number"
+          },
           "respectLocks": {
             "default": true,
             "description": "Whether to skip locked nodes",
             "type": "boolean"
+          },
+          "threadId": {
+            "description": "Active agent thread ID",
+            "type": "string"
           }
         },
         "type": "object"
@@ -9369,6 +9385,10 @@
             "example": true,
             "type": "boolean"
           },
+          "expectedContextVersion": {
+            "minimum": 1,
+            "type": "number"
+          },
           "nodeId": {
             "description": "Review gate node ID awaiting approval",
             "example": "review-gate-1",
@@ -9377,6 +9397,10 @@
           "rejectionReason": {
             "description": "Optional rejection reason when approval is denied",
             "example": "Rejected by reviewer",
+            "type": "string"
+          },
+          "threadId": {
+            "description": "Active agent thread ID",
             "type": "string"
           }
         },
@@ -17987,6 +18011,15 @@
             "schema": {
               "default": true,
               "type": "boolean"
+            }
+          },
+          {
+            "description": "Restrict visible workflows to the active brand for an authorized picker.",
+            "in": "query",
+            "name": "brandId",
+            "required": false,
+            "schema": {
+              "type": "string"
             }
           },
           {

--- a/apps/server/api/src/collections/workflow-executions/controllers/workflow-executions.controller.spec.ts
+++ b/apps/server/api/src/collections/workflow-executions/controllers/workflow-executions.controller.spec.ts
@@ -5,6 +5,7 @@ vi.mock('@api/helpers/utils/response/response.util', () => ({
 
 import { WorkflowExecutionsController } from '@api/collections/workflow-executions/controllers/workflow-executions.controller';
 import { WorkflowExecutionsService } from '@api/collections/workflow-executions/services/workflow-executions.service';
+import { WorkflowExecutionAuthorizationService } from '@api/collections/workflows/services/workflow-execution-authorization.service';
 import { WorkflowExecutorService } from '@api/collections/workflows/services/workflow-executor.service';
 import { NotFoundException } from '@api/helpers/exceptions/http/not-found.exception';
 import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
@@ -34,6 +35,9 @@ describe('WorkflowExecutionsController', () => {
   const mockWorkflowExecutorService = {
     executeManualWorkflow: vi.fn(),
   };
+  const mockWorkflowExecutionAuthorizationService = {
+    authorize: vi.fn().mockResolvedValue(undefined),
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -42,6 +46,10 @@ describe('WorkflowExecutionsController', () => {
         {
           provide: WorkflowExecutionsService,
           useValue: mockService,
+        },
+        {
+          provide: WorkflowExecutionAuthorizationService,
+          useValue: mockWorkflowExecutionAuthorizationService,
         },
         {
           provide: WorkflowExecutorService,
@@ -174,7 +182,18 @@ describe('WorkflowExecutionsController', () => {
         { prompt: 'hello' },
         { source: 'builder' },
         'api',
+        undefined,
       );
+      expect(
+        mockWorkflowExecutionAuthorizationService.authorize,
+      ).toHaveBeenCalledWith({
+        expectedContextVersion: undefined,
+        organizationId: '507f1f77bcf86cd799439011',
+        requestedBrandId: undefined,
+        threadId: undefined,
+        userId: 'user-123',
+        workflowId: 'wf-1',
+      });
       expect(mockService.findOne).toHaveBeenCalledWith({
         _id: 'exec-new',
         isDeleted: false,
@@ -182,6 +201,57 @@ describe('WorkflowExecutionsController', () => {
       });
       expect(mockService.createExecution).not.toHaveBeenCalled();
       expect(result).toEqual(mockExecution);
+    });
+
+    it('passes validated shell scope to the canonical workflow executor', async () => {
+      const scope = {
+        brandId: 'brand-1',
+        contextVersion: 4,
+        threadId: 'thread-1',
+      };
+      mockWorkflowExecutionAuthorizationService.authorize.mockResolvedValueOnce(
+        scope,
+      );
+      mockWorkflowExecutorService.executeManualWorkflow.mockResolvedValue({
+        executionId: 'exec-scoped',
+      });
+      mockService.findOne.mockResolvedValue({ _id: 'exec-scoped' });
+
+      await controller.create(mockRequest, mockUser, {
+        expectedContextVersion: 4,
+        threadId: 'thread-1',
+        workflow: 'wf-1',
+      } as never);
+
+      expect(
+        mockWorkflowExecutorService.executeManualWorkflow,
+      ).toHaveBeenCalledWith(
+        'wf-1',
+        'user-123',
+        '507f1f77bcf86cd799439011',
+        {},
+        undefined,
+        undefined,
+        scope,
+      );
+    });
+
+    it('rejects invalid shell authority before the workflow engine executes', async () => {
+      mockWorkflowExecutionAuthorizationService.authorize.mockRejectedValueOnce(
+        new BadRequestException('stale workflow context'),
+      );
+
+      await expect(
+        controller.create(mockRequest, mockUser, {
+          expectedContextVersion: 2,
+          threadId: 'thread-1',
+          workflow: 'wf-1',
+        } as never),
+      ).rejects.toBeInstanceOf(BadRequestException);
+
+      expect(
+        mockWorkflowExecutorService.executeManualWorkflow,
+      ).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/server/api/src/collections/workflow-executions/controllers/workflow-executions.controller.ts
+++ b/apps/server/api/src/collections/workflow-executions/controllers/workflow-executions.controller.ts
@@ -5,6 +5,7 @@ import {
   WorkflowExecutionQueryDto,
 } from '@api/collections/workflow-executions/dto/create-workflow-execution.dto';
 import { WorkflowExecutionsService } from '@api/collections/workflow-executions/services/workflow-executions.service';
+import { WorkflowExecutionAuthorizationService } from '@api/collections/workflows/services/workflow-execution-authorization.service';
 import { WorkflowExecutorService } from '@api/collections/workflows/services/workflow-executor.service';
 import { RolesDecorator } from '@api/helpers/decorators/roles/roles.decorator';
 import { CurrentUser } from '@api/helpers/decorators/user/current-user.decorator';
@@ -50,6 +51,7 @@ import type { Request } from 'express';
 export class WorkflowExecutionsController {
   constructor(
     private readonly workflowExecutionsService: WorkflowExecutionsService,
+    private readonly workflowExecutionAuthorizationService: WorkflowExecutionAuthorizationService,
     private readonly workflowExecutorService: WorkflowExecutorService,
   ) {}
 
@@ -171,6 +173,14 @@ export class WorkflowExecutionsController {
     @Body() dto: CreateWorkflowExecutionDto,
   ) {
     const publicMetadata = getPublicMetadata(user);
+    const scope = await this.workflowExecutionAuthorizationService.authorize({
+      expectedContextVersion: dto.expectedContextVersion,
+      organizationId: publicMetadata.organization,
+      requestedBrandId: publicMetadata.brand || undefined,
+      threadId: dto.threadId,
+      userId: publicMetadata.user,
+      workflowId: dto.workflow.toString(),
+    });
     const result = await this.workflowExecutorService.executeManualWorkflow(
       dto.workflow.toString(),
       publicMetadata.user,
@@ -178,6 +188,7 @@ export class WorkflowExecutionsController {
       dto.inputValues ?? {},
       dto.metadata,
       dto.trigger,
+      scope,
     );
     const execution = await this.workflowExecutionsService.findOne({
       _id: result.executionId,

--- a/apps/server/api/src/collections/workflow-executions/dto/create-workflow-execution.dto.ts
+++ b/apps/server/api/src/collections/workflow-executions/dto/create-workflow-execution.dto.ts
@@ -1,3 +1,4 @@
+import { WorkflowActionContextDto } from '@api/collections/workflows/dto/workflow-action-context.dto';
 import { BaseQueryDto } from '@api/helpers/dto/base-query.dto';
 import { IsEntityId } from '@api/helpers/validation/entity-id.validator';
 import {
@@ -7,7 +8,7 @@ import {
 import { ApiProperty } from '@nestjs/swagger';
 import { IsEnum, IsObject, IsOptional, IsString } from 'class-validator';
 
-export class CreateWorkflowExecutionDto {
+export class CreateWorkflowExecutionDto extends WorkflowActionContextDto {
   @IsEntityId()
   @ApiProperty({ description: 'Workflow ID to execute' })
   readonly workflow!: string;

--- a/apps/server/api/src/collections/workflows/controllers/workflow-crud.controller.spec.ts
+++ b/apps/server/api/src/collections/workflows/controllers/workflow-crud.controller.spec.ts
@@ -159,6 +159,25 @@ describe('WorkflowCrudController', () => {
       ]);
       expect(result).toBeDefined();
     });
+
+    it('should restrict the visible list to the requested brand', async () => {
+      const brandId = '507f1f77bcf86cd799439099';
+      mockWorkflowsService.findAll.mockResolvedValue({
+        docs: [],
+        totalDocs: 0,
+      });
+
+      await controller.findAll(mockRequest, mockUser, { brandId });
+
+      const [aggregateArg] =
+        mockWorkflowsService.findAll.mock.calls[
+          mockWorkflowsService.findAll.mock.calls.length - 1
+        ];
+      expect(aggregateArg.where).toMatchObject({
+        brandId,
+        organization: mockUser.publicMetadata.organization,
+      });
+    });
   });
 
   describe('getStatistics', () => {

--- a/apps/server/api/src/collections/workflows/controllers/workflow-crud.controller.ts
+++ b/apps/server/api/src/collections/workflows/controllers/workflow-crud.controller.ts
@@ -112,10 +112,12 @@ export class WorkflowCrudController {
     // `GET /workflows/referencable` route (#1354).
     const where = query.referencable
       ? {
+          ...(query.brandId ? { brandId: query.brandId } : {}),
           isDeleted,
           organization: publicMetadata.organization,
         }
       : {
+          ...(query.brandId ? { brandId: query.brandId } : {}),
           isDeleted,
           organization: publicMetadata.organization,
           OR: [

--- a/apps/server/api/src/collections/workflows/controllers/workflow-execution.controller.spec.ts
+++ b/apps/server/api/src/collections/workflows/controllers/workflow-execution.controller.spec.ts
@@ -1,5 +1,6 @@
 import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticated-user.interface';
 import { WorkflowExecutionController } from '@api/collections/workflows/controllers/workflow-execution.controller';
+import { WorkflowExecutionAuthorizationService } from '@api/collections/workflows/services/workflow-execution-authorization.service';
 import { WorkflowExecutorService } from '@api/collections/workflows/services/workflow-executor.service';
 import { WorkflowRunControlService } from '@api/collections/workflows/services/workflow-run-control.service';
 import { WorkflowsService } from '@api/collections/workflows/services/workflows.service';
@@ -39,6 +40,10 @@ describe('WorkflowExecutionController', () => {
     submitReviewGateApproval: vi.fn(),
   };
 
+  const mockWorkflowExecutionAuthorizationService = {
+    authorize: vi.fn().mockResolvedValue(undefined),
+  };
+
   const mockLoggerService = {
     debug: vi.fn(),
     error: vi.fn(),
@@ -54,6 +59,10 @@ describe('WorkflowExecutionController', () => {
         {
           provide: WorkflowRunControlService,
           useValue: mockWorkflowRunControlService,
+        },
+        {
+          provide: WorkflowExecutionAuthorizationService,
+          useValue: mockWorkflowExecutionAuthorizationService,
         },
         {
           provide: WorkflowExecutorService,
@@ -147,6 +156,43 @@ describe('WorkflowExecutionController', () => {
     });
   });
 
+  describe('resumeExecution', () => {
+    it('authorizes the connected thread before resuming a failed run', async () => {
+      mockWorkflowRunControlService.resumeFromFailed.mockResolvedValue({
+        message: 'Partial execution started',
+        runId: 'exec-2',
+        status: 'pending',
+      });
+
+      const result = await controller.resumeExecution(
+        '507f1f77bcf86cd799439014',
+        'exec-1',
+        { expectedContextVersion: 4, threadId: 'thread-1' },
+        mockUser,
+      );
+
+      expect(
+        mockWorkflowExecutionAuthorizationService.authorize,
+      ).toHaveBeenCalledWith({
+        expectedContextVersion: 4,
+        organizationId: mockUser.publicMetadata.organization,
+        requestedBrandId: undefined,
+        threadId: 'thread-1',
+        userId: mockUser.publicMetadata.user,
+        workflowId: '507f1f77bcf86cd799439014',
+      });
+      expect(
+        mockWorkflowRunControlService.resumeFromFailed,
+      ).toHaveBeenCalledWith(
+        '507f1f77bcf86cd799439014',
+        'exec-1',
+        mockUser.publicMetadata.user,
+        mockUser.publicMetadata.organization,
+      );
+      expect(result.data.runId).toBe('exec-2');
+    });
+  });
+
   describe('submitApproval', () => {
     it('should submit a review gate approval for the current org', async () => {
       mockWorkflowExecutorService.submitReviewGateApproval.mockResolvedValue({
@@ -175,6 +221,16 @@ describe('WorkflowExecutionController', () => {
         true,
         undefined,
       );
+      expect(
+        mockWorkflowExecutionAuthorizationService.authorize,
+      ).toHaveBeenCalledWith({
+        expectedContextVersion: undefined,
+        organizationId: mockUser.publicMetadata.organization,
+        requestedBrandId: undefined,
+        threadId: undefined,
+        userId: mockUser.publicMetadata.user,
+        workflowId: '507f1f77bcf86cd799439014',
+      });
       expect(result).toEqual({
         data: {
           approvedAt: '2026-01-01T00:00:00.000Z',

--- a/apps/server/api/src/collections/workflows/controllers/workflow-execution.controller.ts
+++ b/apps/server/api/src/collections/workflows/controllers/workflow-execution.controller.ts
@@ -6,6 +6,7 @@ import {
   ResumeExecutionDto,
   SubmitApprovalDto,
 } from '@api/collections/workflows/dto/execute-workflow.dto';
+import { WorkflowExecutionAuthorizationService } from '@api/collections/workflows/services/workflow-execution-authorization.service';
 import { WorkflowExecutorService } from '@api/collections/workflows/services/workflow-executor.service';
 import { WorkflowRunControlService } from '@api/collections/workflows/services/workflow-run-control.service';
 import { WorkflowsService } from '@api/collections/workflows/services/workflows.service';
@@ -53,6 +54,7 @@ export class WorkflowExecutionController {
   constructor(
     private readonly workflowsService: WorkflowsService,
     private readonly workflowRunControlService: WorkflowRunControlService,
+    private readonly workflowExecutionAuthorizationService: WorkflowExecutionAuthorizationService,
     private readonly workflowExecutorService: WorkflowExecutorService,
     readonly _loggerService: LoggerService,
   ) {}
@@ -95,11 +97,19 @@ export class WorkflowExecutionController {
   async resumeExecution(
     @Param('workflowId') workflowId: string,
     @Param('runId') runId: string,
-    @Body() _dto: ResumeExecutionDto,
+    @Body() dto: ResumeExecutionDto,
     @CurrentUser() user: User,
   ): Promise<{ data: { runId: string; status: string; message: string } }> {
     return wrapError(async () => {
       const publicMetadata = getPublicMetadata(user);
+      await this.workflowExecutionAuthorizationService.authorize({
+        expectedContextVersion: dto.expectedContextVersion,
+        organizationId: publicMetadata.organization,
+        requestedBrandId: publicMetadata.brand || undefined,
+        threadId: dto.threadId,
+        userId: publicMetadata.user,
+        workflowId,
+      });
       const result = await this.workflowRunControlService.resumeFromFailed(
         workflowId,
         runId,
@@ -169,6 +179,14 @@ export class WorkflowExecutionController {
   }> {
     return wrapError(async () => {
       const publicMetadata = getPublicMetadata(user);
+      await this.workflowExecutionAuthorizationService.authorize({
+        expectedContextVersion: dto.expectedContextVersion,
+        organizationId: publicMetadata.organization,
+        requestedBrandId: publicMetadata.brand || undefined,
+        threadId: dto.threadId,
+        userId: publicMetadata.user,
+        workflowId,
+      });
       const result =
         await this.workflowExecutorService.submitReviewGateApproval(
           workflowId,

--- a/apps/server/api/src/collections/workflows/dto/execute-workflow.dto.ts
+++ b/apps/server/api/src/collections/workflows/dto/execute-workflow.dto.ts
@@ -1,3 +1,4 @@
+import { WorkflowActionContextDto } from '@api/collections/workflows/dto/workflow-action-context.dto';
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import {
@@ -43,7 +44,7 @@ export class ExecutePartialDto {
 /**
  * DTO for resuming workflow from a failed run
  */
-export class ResumeExecutionDto {
+export class ResumeExecutionDto extends WorkflowActionContextDto {
   @IsBoolean()
   @IsOptional()
   @ApiProperty({
@@ -57,7 +58,7 @@ export class ResumeExecutionDto {
 /**
  * DTO for approving or rejecting a review-gate pause
  */
-export class SubmitApprovalDto {
+export class SubmitApprovalDto extends WorkflowActionContextDto {
   @IsString()
   @ApiProperty({
     description: 'Review gate node ID awaiting approval',

--- a/apps/server/api/src/collections/workflows/dto/query-workflow.dto.ts
+++ b/apps/server/api/src/collections/workflows/dto/query-workflow.dto.ts
@@ -1,4 +1,5 @@
 import { BaseQueryDto } from '@api/helpers/dto/base-query.dto';
+import { IsEntityId } from '@api/helpers/validation/entity-id.validator';
 import { ApiProperty } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
 import { IsBoolean, IsOptional } from 'class-validator';
@@ -12,6 +13,15 @@ import { IsBoolean, IsOptional } from 'class-validator';
  * RPC route (#1354).
  */
 export class WorkflowQueryDto extends BaseQueryDto {
+  @IsEntityId()
+  @IsOptional()
+  @ApiProperty({
+    description:
+      'Restrict visible workflows to the active brand for an authorized picker.',
+    required: false,
+  })
+  readonly brandId?: string;
+
   @IsBoolean()
   @IsOptional()
   @Transform(({ value }) =>

--- a/apps/server/api/src/collections/workflows/dto/workflow-action-context.dto.ts
+++ b/apps/server/api/src/collections/workflows/dto/workflow-action-context.dto.ts
@@ -1,0 +1,22 @@
+import { IsEntityId } from '@api/helpers/validation/entity-id.validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsInt, IsOptional, Min } from 'class-validator';
+
+/**
+ * Optional conversation-shell authority for a consequential workflow action.
+ * Direct routed actions keep their existing session/RBAC path; when either
+ * field is supplied the authorization adapter requires both and revalidates
+ * the server-owned thread scope before the workflow engine is reached.
+ */
+export class WorkflowActionContextDto {
+  @ApiPropertyOptional({ minimum: 1 })
+  @IsInt()
+  @IsOptional()
+  @Min(1)
+  readonly expectedContextVersion?: number;
+
+  @ApiPropertyOptional({ description: 'Active agent thread ID' })
+  @IsEntityId()
+  @IsOptional()
+  readonly threadId?: string;
+}

--- a/apps/server/api/src/collections/workflows/services/workflow-execution-authorization.service.spec.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-execution-authorization.service.spec.ts
@@ -1,0 +1,120 @@
+import { WorkflowExecutionAuthorizationService } from '@api/collections/workflows/services/workflow-execution-authorization.service';
+import { BadRequestException, ForbiddenException } from '@nestjs/common';
+
+const scope = {
+  brandId: 'brand-1',
+  contextVersion: 3,
+  isLegacyFallback: false,
+  isVersionExplicit: true,
+  organizationId: 'org-1',
+  source: 'explicit',
+  threadId: 'thread-1',
+  userId: 'user-1',
+} as const;
+
+describe('WorkflowExecutionAuthorizationService', () => {
+  const prisma = {
+    workflow: {
+      findFirst: vi.fn(),
+    },
+  };
+  const agentScopeContextService = {
+    assertConsequentialBoundary: vi.fn(),
+    assertResourceBrand: vi.fn(),
+    prepareForTurn: vi.fn(),
+  };
+  const service = new WorkflowExecutionAuthorizationService(
+    prisma as never,
+    agentScopeContextService as never,
+  );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    agentScopeContextService.prepareForTurn.mockResolvedValue({
+      existingScope: scope,
+    });
+    prisma.workflow.findFirst.mockResolvedValue({
+      brandId: 'brand-1',
+      id: 'workflow-1',
+    });
+  });
+
+  it('preserves the existing direct-route authorization path without shell state', async () => {
+    await expect(
+      service.authorize({
+        organizationId: 'org-1',
+        userId: 'user-1',
+        workflowId: 'workflow-1',
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(agentScopeContextService.prepareForTurn).not.toHaveBeenCalled();
+    expect(prisma.workflow.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('requires the thread and context version as one authorization unit', async () => {
+    await expect(
+      service.authorize({
+        organizationId: 'org-1',
+        threadId: 'thread-1',
+        userId: 'user-1',
+        workflowId: 'workflow-1',
+      }),
+    ).rejects.toBeInstanceOf(BadRequestException);
+
+    expect(agentScopeContextService.prepareForTurn).not.toHaveBeenCalled();
+  });
+
+  it('validates stale context and exact workflow brand before execution', async () => {
+    await expect(
+      service.authorize({
+        expectedContextVersion: 3,
+        organizationId: 'org-1',
+        requestedBrandId: 'brand-1',
+        threadId: 'thread-1',
+        userId: 'user-1',
+        workflowId: 'workflow-1',
+      }),
+    ).resolves.toBe(scope);
+
+    expect(agentScopeContextService.prepareForTurn).toHaveBeenCalledWith({
+      expectedContextVersion: 3,
+      organizationId: 'org-1',
+      requestedBrandId: 'brand-1',
+      threadId: 'thread-1',
+      userId: 'user-1',
+    });
+    expect(
+      agentScopeContextService.assertConsequentialBoundary,
+    ).toHaveBeenCalledWith(scope, 'workflow');
+    expect(prisma.workflow.findFirst).toHaveBeenCalledWith({
+      select: { brandId: true, id: true },
+      where: {
+        id: 'workflow-1',
+        isDeleted: false,
+        organizationId: 'org-1',
+      },
+    });
+    expect(agentScopeContextService.assertResourceBrand).toHaveBeenCalledWith(
+      scope,
+      'brand-1',
+      'workflow',
+    );
+  });
+
+  it('rejects a workflow outside the validated thread brand before engine execution', async () => {
+    agentScopeContextService.assertResourceBrand.mockImplementationOnce(() => {
+      throw new ForbiddenException('outside scope');
+    });
+
+    await expect(
+      service.authorize({
+        expectedContextVersion: 3,
+        organizationId: 'org-1',
+        threadId: 'thread-1',
+        userId: 'user-1',
+        workflowId: 'workflow-1',
+      }),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+});

--- a/apps/server/api/src/collections/workflows/services/workflow-execution-authorization.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-execution-authorization.service.ts
@@ -1,0 +1,82 @@
+import { NotFoundException } from '@api/helpers/exceptions/http/not-found.exception';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import type { ValidatedAgentScope } from '@genfeedai/interfaces';
+import { AgentScopeContextService } from '@genfeedai/server';
+import { BadRequestException, Injectable } from '@nestjs/common';
+
+export interface AuthorizeWorkflowExecutionInput {
+  readonly expectedContextVersion?: number;
+  readonly organizationId: string;
+  readonly requestedBrandId?: string;
+  readonly threadId?: string;
+  readonly userId: string;
+  readonly workflowId: string;
+}
+
+/**
+ * Thin workflow-owned adapter from optional shell context to the canonical
+ * server scope validator. It authorizes only; deterministic execution remains
+ * owned by WorkflowExecutorService and the workflow engine.
+ */
+@Injectable()
+export class WorkflowExecutionAuthorizationService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly agentScopeContextService: AgentScopeContextService,
+  ) {}
+
+  async authorize(
+    input: AuthorizeWorkflowExecutionInput,
+  ): Promise<ValidatedAgentScope | undefined> {
+    const hasThreadId = Boolean(input.threadId);
+    const hasContextVersion = input.expectedContextVersion !== undefined;
+
+    if (!hasThreadId && !hasContextVersion) {
+      return undefined;
+    }
+    if (!input.threadId || input.expectedContextVersion === undefined) {
+      throw new BadRequestException(
+        'threadId and expectedContextVersion are required together for workflow actions.',
+      );
+    }
+
+    const prepared = await this.agentScopeContextService.prepareForTurn({
+      expectedContextVersion: input.expectedContextVersion,
+      organizationId: input.organizationId,
+      requestedBrandId: input.requestedBrandId,
+      threadId: input.threadId,
+      userId: input.userId,
+    });
+    const scope = prepared.existingScope;
+    if (!scope) {
+      throw new BadRequestException(
+        'A persisted thread context is required for workflow execution.',
+      );
+    }
+
+    await this.agentScopeContextService.assertConsequentialBoundary(
+      scope,
+      'workflow',
+    );
+
+    const workflow = await this.prisma.workflow.findFirst({
+      select: { brandId: true, id: true },
+      where: {
+        id: input.workflowId,
+        isDeleted: false,
+        organizationId: input.organizationId,
+      },
+    });
+    if (!workflow) {
+      throw new NotFoundException('Workflow');
+    }
+
+    this.agentScopeContextService.assertResourceBrand(
+      scope,
+      workflow.brandId,
+      'workflow',
+    );
+
+    return scope;
+  }
+}

--- a/apps/server/api/src/collections/workflows/workflows.module.ts
+++ b/apps/server/api/src/collections/workflows/workflows.module.ts
@@ -38,6 +38,7 @@ import { LegacyWorkflowStepRunner } from '@api/collections/workflows/services/le
 import { ReplyPollingWorkflowService } from '@api/collections/workflows/services/reply-polling-workflow.service';
 import { ReviewGateNotificationService } from '@api/collections/workflows/services/review-gate-notification.service';
 import { WorkflowEngineAdapterService } from '@api/collections/workflows/services/workflow-engine-adapter.service';
+import { WorkflowExecutionAuthorizationService } from '@api/collections/workflows/services/workflow-execution-authorization.service';
 import { WorkflowExecutionQueueService } from '@api/collections/workflows/services/workflow-execution-queue.service';
 import { WorkflowExecutorService } from '@api/collections/workflows/services/workflow-executor.service';
 import { WorkflowFormatConverterService } from '@api/collections/workflows/services/workflow-format-converter.service';
@@ -92,6 +93,7 @@ import { forwardRef, Module } from '@nestjs/common';
     WorkflowTemplateSeederService,
     WorkflowWebhookService,
     WorkflowEngineAdapterService,
+    WorkflowExecutionAuthorizationService,
     WorkflowExecutorService,
     WorkflowExecutionQueueService,
     WorkflowFormatConverterService,
@@ -159,6 +161,7 @@ import { forwardRef, Module } from '@nestjs/common';
     BatchWorkflowService,
     LegacyWorkflowStepRunner,
     WorkflowEngineAdapterService,
+    WorkflowExecutionAuthorizationService,
     WorkflowExecutorService,
     WorkflowExecutionQueueService,
     WorkflowFormatConverterService,

--- a/packages/agent/src/components/WorkflowExecuteCard.tsx
+++ b/packages/agent/src/components/WorkflowExecuteCard.tsx
@@ -5,6 +5,7 @@ import type {
   WorkflowInterfaceSchema,
 } from '@genfeedai/agent/services/agent-api.service';
 import { runAgentApiEffect } from '@genfeedai/agent/services/agent-base-api.service';
+import { useAgentChatStore } from '@genfeedai/agent/stores/agent-chat.store';
 import { useOrgUrl } from '@hooks/navigation/use-org-url';
 import {
   type ChangeEvent,
@@ -68,6 +69,10 @@ export function WorkflowExecuteCard({
   const workflowId = action.workflowId;
   const currentWorkflowId = workflowId ?? null;
   const workflowName = action.workflowName ?? 'Workflow';
+  const activeThreadId = useAgentChatStore((state) => state.activeThreadId);
+  const activeThread = useAgentChatStore((state) =>
+    state.threads.find((thread) => thread.id === state.activeThreadId),
+  );
   const [status, setStatus] = useState<CardStatus>('idle');
   const [executionId, setExecutionId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -198,6 +203,12 @@ export function WorkflowExecuteCard({
           workflowId,
           sanitizeInputValues(formValues),
           controller.signal,
+          activeThreadId && activeThread?.contextVersion !== undefined
+            ? {
+                expectedContextVersion: activeThread.contextVersion,
+                threadId: activeThreadId,
+              }
+            : undefined,
         ),
       );
       setExecutionId(result.id);
@@ -211,7 +222,14 @@ export function WorkflowExecuteCard({
       );
       setStatus('error');
     }
-  }, [apiService, formValues, inputEntries, workflowId]);
+  }, [
+    activeThread?.contextVersion,
+    activeThreadId,
+    apiService,
+    formValues,
+    inputEntries,
+    workflowId,
+  ]);
 
   const handleRetry = useCallback(() => {
     setStatus('idle');

--- a/packages/agent/src/components/WorkflowTriggerCard.tsx
+++ b/packages/agent/src/components/WorkflowTriggerCard.tsx
@@ -1,6 +1,7 @@
 import type { AgentUiAction } from '@genfeedai/agent/models/agent-chat.model';
 import type { AgentApiService } from '@genfeedai/agent/services/agent-api.service';
 import { runAgentApiEffect } from '@genfeedai/agent/services/agent-base-api.service';
+import { useAgentChatStore } from '@genfeedai/agent/stores/agent-chat.store';
 import { ButtonVariant } from '@genfeedai/enums';
 import { useOrgUrl } from '@hooks/navigation/use-org-url';
 import { Button } from '@ui/primitives/button';
@@ -36,6 +37,10 @@ export function WorkflowTriggerCard({
   const [executionId, setExecutionId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
+  const activeThreadId = useAgentChatStore((state) => state.activeThreadId);
+  const activeThread = useAgentChatStore((state) =>
+    state.threads.find((thread) => thread.id === state.activeThreadId),
+  );
 
   const handleTrigger = useCallback(async () => {
     if (!selectedId) return;
@@ -48,7 +53,17 @@ export function WorkflowTriggerCard({
 
     try {
       const result = await runAgentApiEffect(
-        apiService.triggerWorkflowEffect(selectedId, {}, controller.signal),
+        apiService.triggerWorkflowEffect(
+          selectedId,
+          {},
+          controller.signal,
+          activeThreadId && activeThread?.contextVersion !== undefined
+            ? {
+                expectedContextVersion: activeThread.contextVersion,
+                threadId: activeThreadId,
+              }
+            : undefined,
+        ),
       );
       setExecutionId(result.id);
       setStatus('done');
@@ -59,7 +74,7 @@ export function WorkflowTriggerCard({
       );
       setStatus('error');
     }
-  }, [selectedId, apiService]);
+  }, [activeThread?.contextVersion, activeThreadId, apiService, selectedId]);
 
   const handleRetry = useCallback(() => {
     setStatus('idle');

--- a/packages/agent/src/components/useClipWorkflowRunCard.ts
+++ b/packages/agent/src/components/useClipWorkflowRunCard.ts
@@ -1,6 +1,7 @@
 import type { AgentUiAction } from '@genfeedai/agent/models/agent-chat.model';
 import type { AgentApiService } from '@genfeedai/agent/services/agent-api.service';
 import { runAgentApiEffect } from '@genfeedai/agent/services/agent-base-api.service';
+import { useAgentChatStore } from '@genfeedai/agent/stores/agent-chat.store';
 import {
   buildAgentGenerationRequestBody,
   getPromptCategoryForGenerationType,
@@ -103,6 +104,10 @@ export function useClipWorkflowRunCard({
   const [mergedVideoId, setMergedVideoId] = useState<string | null>(null);
   const [portraitVideoId, setPortraitVideoId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const activeThreadId = useAgentChatStore((state) => state.activeThreadId);
+  const activeThread = useAgentChatStore((state) =>
+    state.threads.find((thread) => thread.id === state.activeThreadId),
+  );
   const [steps, setSteps] = useState<Record<StepKey, StepStatus>>({
     generate_clip: 'pending',
     merge_clips: mergeGeneratedVideos ? 'pending' : 'skipped',
@@ -155,11 +160,23 @@ export function useClipWorkflowRunCard({
     };
 
     const execution = await runAgentApiEffect(
-      apiService.triggerWorkflowEffect(workflowId, inputValues),
+      apiService.triggerWorkflowEffect(
+        workflowId,
+        inputValues,
+        undefined,
+        activeThreadId && activeThread?.contextVersion !== undefined
+          ? {
+              expectedContextVersion: activeThread.contextVersion,
+              threadId: activeThreadId,
+            }
+          : undefined,
+      ),
     );
     setWorkflowExecutionId(execution.id);
     setStep('trigger_workflow', 'completed');
   }, [
+    activeThread?.contextVersion,
+    activeThreadId,
     apiService,
     clipRun.inputValues,
     durationSeconds,

--- a/packages/agent/src/services/agent-api.service.ts
+++ b/packages/agent/src/services/agent-api.service.ts
@@ -100,6 +100,11 @@ export interface WorkflowInterfaceSchema {
   outputs: Record<string, WorkflowInterfaceField>;
 }
 
+export interface WorkflowTriggerScope {
+  expectedContextVersion: number;
+  threadId: string;
+}
+
 export interface ManualReviewBatchPayload {
   brandId: string;
   items: Array<{
@@ -589,12 +594,14 @@ export class AgentApiService extends AgentBaseApiService {
     workflowId: string,
     inputValues?: Record<string, unknown>,
     signal?: AbortSignal,
+    scope?: WorkflowTriggerScope,
   ): Effect.Effect<{ id: string; status: string }, AgentApiError> {
     return this.fetchJsonEffect<{ id: string; status: string }>(
       `${this.config.baseUrl}/workflow-executions`,
       {
         body: JSON.stringify({
           inputValues: inputValues ?? {},
+          ...(scope ?? {}),
           workflow: workflowId,
         }),
         method: 'POST',

--- a/packages/interfaces/src/ui/workspace-shell.interface.ts
+++ b/packages/interfaces/src/ui/workspace-shell.interface.ts
@@ -42,13 +42,17 @@ export interface WorkspaceShellTypedReference {
   readonly kind: WorkspaceShellReferenceKind;
 }
 
-export type WorkspaceShellOverlayKey = 'notifications' | 'shell-preview';
+export type WorkspaceShellOverlayKey =
+  | 'notifications'
+  | 'shell-preview'
+  | 'workflow-picker';
 
 export interface WorkspaceShellOverlayParameterMap {
   readonly notifications: Readonly<Record<string, never>>;
   readonly 'shell-preview': {
     readonly reference: WorkspaceShellTypedReference | null;
   };
+  readonly 'workflow-picker': Readonly<Record<string, never>>;
 }
 
 export type WorkspaceShellOverlayRequest = {
@@ -141,7 +145,10 @@ export interface WorkspaceShellOverlayRegistration {
   readonly restoration: WorkspaceShellRestorationPolicy;
   readonly safeFallback: 'same-canonical-url';
   readonly scope: 'organization';
-  readonly telemetryClass: 'notifications' | 'shell_preview';
+  readonly telemetryClass:
+    | 'notifications'
+    | 'shell_preview'
+    | 'workflow_picker';
 }
 
 export interface WorkspaceShellChromeRegistration {

--- a/packages/props/ui/workspace-overlay-host.props.ts
+++ b/packages/props/ui/workspace-overlay-host.props.ts
@@ -2,10 +2,11 @@ import type {
   WorkspaceShellOverlayRegistration,
   WorkspaceShellOverlayRequest,
 } from '@genfeedai/interfaces/ui/workspace-shell.interface';
-import type { Ref, RefObject } from 'react';
+import type { ReactNode, Ref, RefObject } from 'react';
 
 export interface WorkspaceOverlayHostProps {
   readonly composerPortalRef?: Ref<HTMLDivElement>;
+  readonly content?: ReactNode;
   readonly fallbackFocusRef: RefObject<HTMLElement | null>;
   readonly isOpen: boolean;
   readonly onDismiss: () => void;


### PR DESCRIPTION
## Summary
- add the trusted compact workflow picker overlay with attach, editor, pagination, brand-scoped authorization, and restoration
- host workflow editor and run inspection on canonical focused canvases with persistent thread context, graph input ownership, run status, required inputs, provenance, schedules, approvals, and failed-run resume
- revalidate thread context version and exact workflow brand before execute, approve, or resume while preserving the existing deterministic workflow engine and direct routed behavior
- add organization run-detail route parity plus focused shell, picker, inspector, client, controller, and authorization regression coverage

## Boundaries
- no workflow engine replacement or refactor
- no new workflow node types
- no graph editor in dialogs
- no React dependency added to server workflow code

## Verification
- Biome checked all 41 TypeScript/JSON change paths with no errors; the generated 1.3 MiB OpenAPI file reports only the existing size warning
- staged UI control guard and no-bespoke-card guard passed
- OpenAPI JSON parsing and staged diff checks passed
- Secretlint and Gitleaks staged scans passed with no findings
- local tests, typechecks, builds, and E2E were intentionally not run on Vincent’s MacBook; PR CI is authoritative

Closes #1678
Part of #1670