### PR TITLE
feat(app): embed Library and Remix surfaces

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/remix/page.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/remix/page.test.tsx
@@ -1,5 +1,73 @@
 import { assertSourceHasExport } from '@shared/pages/sourceContractTestUtils';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import PostsRemixPage from './page';
+
+vi.mock('@/features/library-remix/LibraryRemixSurface', () => ({
+  default: ({
+    sourceArtifact,
+    threadId,
+  }: {
+    sourceArtifact?: string | null;
+    threadId?: string | null;
+  }) => (
+    <div data-testid="library-remix-surface">
+      {sourceArtifact ?? 'none'}:{threadId ?? 'none'}
+    </div>
+  ),
+}));
+
+vi.mock('./trend-remix-page', () => ({
+  default: () => <div data-testid="trend-remix-surface" />,
+}));
 
 assertSourceHasExport(
   'app/(protected)/[orgSlug]/[brandSlug]/posts/remix/page.tsx',
 );
+
+describe('PostsRemixPage', () => {
+  it('launches the focused Library Remix surface with its typed source intent', async () => {
+    const page = await PostsRemixPage({
+      searchParams: Promise.resolve({
+        sourceArtifact: 'ingredient:ingredient-1',
+        thread: 'thread-1',
+      }),
+    });
+
+    render(page);
+
+    expect(screen.getByTestId('library-remix-surface')).toHaveTextContent(
+      'ingredient:ingredient-1:thread-1',
+    );
+    expect(screen.queryByTestId('trend-remix-surface')).not.toBeInTheDocument();
+  });
+
+  it('preserves the existing trend Remix route contract', async () => {
+    const page = await PostsRemixPage({
+      searchParams: Promise.resolve({
+        sourceArtifact: 'ingredient:ingredient-1',
+        sourceReferenceId: 'trend-1',
+      }),
+    });
+
+    render(page);
+
+    expect(screen.getByTestId('trend-remix-surface')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('library-remix-surface'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('preserves the existing no-input Trend Remix entry', async () => {
+    const page = await PostsRemixPage({
+      searchParams: Promise.resolve({ thread: 'thread-1' }),
+    });
+
+    render(page);
+
+    expect(screen.getByTestId('trend-remix-surface')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('library-remix-surface'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/remix/page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/remix/page.tsx
@@ -1,5 +1,46 @@
+import LibraryRemixSurface from '@/features/library-remix/LibraryRemixSurface';
+import { LIBRARY_REMIX_SOURCE_QUERY_KEY } from '@/features/library-remix/library-remix-reference';
 import TrendRemixPage from './trend-remix-page';
 
-export default function PostsRemixPage() {
-  return <TrendRemixPage />;
+type PostsRemixPageProps = {
+  readonly searchParams?: Promise<
+    Record<string, string | string[] | undefined>
+  >;
+};
+
+const LEGACY_TREND_REMIX_QUERY_KEYS = [
+  'sourceAuthor',
+  'sourceReferenceId',
+  'sourceText',
+  'sourceUrl',
+  'topic',
+  'trendId',
+] as const;
+
+export default async function PostsRemixPage({
+  searchParams,
+}: PostsRemixPageProps) {
+  const resolvedSearchParams = searchParams ? await searchParams : {};
+  const hasLegacyTrendIntent = LEGACY_TREND_REMIX_QUERY_KEYS.some((key) => {
+    const value = resolvedSearchParams[key];
+    return typeof value === 'string' ? value.trim().length > 0 : Boolean(value);
+  });
+
+  if (hasLegacyTrendIntent) {
+    return <TrendRemixPage />;
+  }
+
+  const sourceArtifact = resolvedSearchParams[LIBRARY_REMIX_SOURCE_QUERY_KEY];
+  const threadId = resolvedSearchParams.thread;
+
+  if (typeof sourceArtifact !== 'string' || !sourceArtifact.trim()) {
+    return <TrendRemixPage />;
+  }
+
+  return (
+    <LibraryRemixSurface
+      sourceArtifact={sourceArtifact}
+      threadId={typeof threadId === 'string' ? threadId : null}
+    />
+  );
 }

--- a/apps/app/src/components/workspace-shell/UniversalWorkspaceShell.test.tsx
+++ b/apps/app/src/components/workspace-shell/UniversalWorkspaceShell.test.tsx
@@ -84,16 +84,32 @@ vi.mock('@genfeedai/agent', () => ({
         }
         type="button"
       />
+      <button
+        aria-label="Dispatch remix action"
+        onClick={() =>
+          dispatchAction({
+            action: {
+              isConsequentialProposal: false,
+              label: 'Remix',
+              name: 'remix',
+              requiredScope: 'brand',
+              route: '/posts/remix',
+            },
+            arguments: '',
+          })
+        }
+        type="button"
+      />
     </div>
   ),
   getConversationComposerAction: (name: string) =>
-    name === 'publish'
+    name === 'publish' || name === 'remix'
       ? {
-          isConsequentialProposal: true,
-          label: 'Publish',
-          name: 'publish',
+          isConsequentialProposal: name === 'publish',
+          label: name === 'publish' ? 'Publish' : 'Remix',
+          name,
           requiredScope: 'brand',
-          route: '/posts/review',
+          route: name === 'publish' ? '/posts/review' : '/posts/remix',
         }
       : null,
   useAgentChatStore: Object.assign(
@@ -131,6 +147,42 @@ vi.mock('@hooks/navigation/use-org-url', () => ({
     orgHref: (href: string) => `/acme/~${href}`,
     orgSlug: navigation.pathname.split('/').filter(Boolean)[0] ?? '',
   }),
+}));
+
+vi.mock('@contexts/user/brand-context/brand-context', () => ({
+  useBrand: () => ({
+    brandId: 'brand-1',
+    organizationId: 'org-1',
+  }),
+}));
+
+vi.mock('@/features/library-remix/LibraryPickerOverlay', () => ({
+  default: ({
+    onSelect,
+  }: {
+    onSelect: (reference: {
+      brandId: string;
+      kind: 'ingredient';
+      organizationId: string;
+      recordId: string;
+      serializer: 'ingredient';
+    }) => void;
+  }) => (
+    <button
+      onClick={() =>
+        onSelect({
+          brandId: 'brand-1',
+          kind: 'ingredient',
+          organizationId: 'org-1',
+          recordId: 'ingredient-1',
+          serializer: 'ingredient',
+        })
+      }
+      type="button"
+    >
+      Select Library source
+    </button>
+  ),
 }));
 
 vi.mock('next/navigation', () => ({
@@ -344,6 +396,47 @@ describe('UniversalWorkspaceShell', () => {
 
     expect(router.push).toHaveBeenCalledWith(
       '/acme/moonrise/posts/review?thread=thread-1',
+    );
+  });
+
+  it('dispatches Remix through the authorized no-parameter Library overlay', () => {
+    navigation.pathname = '/acme/moonrise/workspace/overview';
+    navigation.searchParams = new URLSearchParams({ thread: 'thread-1' });
+
+    render(
+      <UniversalWorkspaceShell agentApiService={agentApiService}>
+        <div>Workspace</div>
+      </UniversalWorkspaceShell>,
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Dispatch remix action' }),
+    );
+
+    expect(router.push).toHaveBeenCalledWith(
+      '/acme/moonrise/workspace/overview?thread=thread-1&overlay=library-picker',
+    );
+  });
+
+  it('consumes a reauthorized Library reference into the canonical Remix route', () => {
+    navigation.pathname = '/acme/moonrise/workspace/overview';
+    navigation.searchParams = new URLSearchParams({
+      overlay: 'library-picker',
+      thread: 'thread-1',
+    });
+
+    render(
+      <UniversalWorkspaceShell agentApiService={agentApiService}>
+        <div>Workspace</div>
+      </UniversalWorkspaceShell>,
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Select Library source' }),
+    );
+
+    expect(router.replace).toHaveBeenCalledWith(
+      '/acme/moonrise/posts/remix?sourceArtifact=ingredient%3Aingredient-1&thread=thread-1',
     );
   });
 

--- a/apps/app/src/components/workspace-shell/UniversalWorkspaceShell.tsx
+++ b/apps/app/src/components/workspace-shell/UniversalWorkspaceShell.tsx
@@ -2,6 +2,7 @@
 
 import { AgentWorkspaceLayoutClient } from '@app/(protected)/[orgSlug]/~/agent/AgentWorkspaceLayoutClient';
 import { AgentWorkspacePageShell } from '@app/(protected)/[orgSlug]/~/agent/AgentWorkspacePageShell';
+import { useBrand } from '@contexts/user/brand-context/brand-context';
 import {
   type AgentApiService,
   type ConversationComposerActionInvocation,
@@ -12,6 +13,10 @@ import {
 } from '@genfeedai/agent';
 import { APP_ROUTES } from '@genfeedai/constants';
 import { ButtonSize, ButtonVariant } from '@genfeedai/enums';
+import type {
+  AgentArtifactReference,
+  WorkspaceShellOverlayRequest,
+} from '@genfeedai/interfaces';
 import { cn } from '@helpers/formatting/cn/cn.util';
 import { useOrgUrl } from '@hooks/navigation/use-org-url';
 import { Button } from '@ui/primitives/button';
@@ -41,6 +46,7 @@ import {
   HiOutlineSquares2X2,
   HiOutlineViewColumns,
 } from 'react-icons/hi2';
+import { buildLibraryRemixIntentHref } from '@/features/library-remix/library-remix-reference';
 import {
   appendSearchParamsToHref,
   normalizeProtectedPathname,
@@ -60,6 +66,7 @@ import {
 } from '@/lib/workspace-shell/workspace-shell-telemetry';
 import { resolveWorkspaceSurfaceLaunch } from '@/lib/workspace-shell/workspace-surface-launcher';
 import WorkspaceOverlayHost from './WorkspaceOverlayHost';
+import { WorkspaceShellActionsProvider } from './WorkspaceShellActionsContext';
 
 const INSPECTOR_DEFAULT_WIDTH = 320;
 const INSPECTOR_MIN_WIDTH = 256;
@@ -100,6 +107,7 @@ function UniversalWorkspaceShellContent({
   const searchParams = useSearchParams();
   const searchParamsString = searchParams.toString();
   const { back, push, replace } = useRouter();
+  const { brandId, organizationId } = useBrand();
   const { brandSlug, href, orgHref, orgSlug } = useOrgUrl();
   const activeThreadId = useAgentChatStore((state) => state.activeThreadId);
   const threads = useAgentChatStore((state) => state.threads);
@@ -306,33 +314,41 @@ function UniversalWorkspaceShellContent({
     );
   }, [activeThreadId, effectiveThreadId, orgHref, push]);
 
+  const launchWorkspaceOverlay = useCallback(
+    (overlayRequest: WorkspaceShellOverlayRequest): boolean => {
+      const launch = resolveWorkspaceOverlayLaunch({
+        currentHref,
+        invocation: 'user',
+        overlay: overlayRequest,
+      });
+      if (launch.history === 'none') {
+        return false;
+      }
+
+      pendingTransitionRef.current = 'overlay_open';
+      overlayReturnFocusRef.current =
+        document.activeElement instanceof HTMLElement
+          ? document.activeElement
+          : null;
+      hasOverlayReturnFocusRef.current = Boolean(overlayReturnFocusRef.current);
+      if (launch.history === 'replace') {
+        replace(launch.href);
+        return true;
+      }
+
+      isOwnedOverlayEntryRef.current = true;
+      push(launch.href);
+      return true;
+    },
+    [currentHref, push, replace],
+  );
+
   const handleOpenOverlay = useCallback(() => {
-    const launch = resolveWorkspaceOverlayLaunch({
-      currentHref,
-      invocation: 'user',
-      overlay: {
-        key: 'shell-preview',
-        parameters: { reference: null },
-      },
+    launchWorkspaceOverlay({
+      key: 'shell-preview',
+      parameters: { reference: null },
     });
-    if (launch.history === 'none') {
-      return;
-    }
-
-    pendingTransitionRef.current = 'overlay_open';
-    overlayReturnFocusRef.current =
-      document.activeElement instanceof HTMLElement
-        ? document.activeElement
-        : null;
-    hasOverlayReturnFocusRef.current = Boolean(overlayReturnFocusRef.current);
-    if (launch.history === 'replace') {
-      replace(launch.href);
-      return;
-    }
-
-    isOwnedOverlayEntryRef.current = true;
-    push(launch.href);
-  }, [currentHref, push, replace]);
+  }, [launchWorkspaceOverlay]);
 
   const handleComposerAction = useCallback(
     (
@@ -358,6 +374,24 @@ function UniversalWorkspaceShellContent({
           message: `/${trustedAction.name} needs an explicit brand route. Select a brand through the scoped controls; your draft has been preserved.`,
           status: 'unauthorized',
         };
+      }
+
+      if (trustedAction.name === 'remix') {
+        const didOpen = launchWorkspaceOverlay({
+          key: 'library-picker',
+          parameters: {},
+        });
+        return didOpen
+          ? {
+              message:
+                'Opened the authorized Library picker. Your draft and active thread are preserved.',
+              status: 'dispatched',
+            }
+          : {
+              message:
+                'The Library picker is unavailable. Your draft and references are unchanged.',
+              status: 'unavailable',
+            };
       }
 
       const destination =
@@ -393,8 +427,46 @@ function UniversalWorkspaceShellContent({
       currentHref,
       effectiveThreadId,
       href,
+      launchWorkspaceOverlay,
       orgHref,
       push,
+    ],
+  );
+
+  const handleSelectLibraryReference = useCallback(
+    (reference: AgentArtifactReference) => {
+      if (
+        (reference.kind !== 'asset' && reference.kind !== 'ingredient') ||
+        reference.organizationId !== organizationId ||
+        reference.brandId !== brandId
+      ) {
+        return;
+      }
+
+      const destinationHref = buildLibraryRemixIntentHref(
+        href(APP_ROUTES.POSTS.REMIX),
+        reference,
+      );
+      const launch = resolveWorkspaceSurfaceLaunch({
+        currentHref,
+        destinationHref,
+        threadId: effectiveThreadId ?? activeThreadId,
+      });
+      if (launch.history !== 'push' || launch.mode !== 'canvas') {
+        return;
+      }
+
+      pendingTransitionRef.current = 'canvas_launch';
+      replace(launch.href);
+    },
+    [
+      activeThreadId,
+      brandId,
+      currentHref,
+      effectiveThreadId,
+      href,
+      organizationId,
+      replace,
     ],
   );
 
@@ -614,7 +686,13 @@ function UniversalWorkspaceShellContent({
                   Context
                 </Button>
               </div>
-              {baseState === 'canvas' ? children : null}
+              {baseState === 'canvas' ? (
+                <WorkspaceShellActionsProvider
+                  openOverlay={launchWorkspaceOverlay}
+                >
+                  {children}
+                </WorkspaceShellActionsProvider>
+              ) : null}
             </section>
 
             {state !== 'overlay' ? (
@@ -684,9 +762,11 @@ function UniversalWorkspaceShellContent({
           fallbackFocusRef={primaryRegionRef}
           isOpen={state === 'overlay'}
           onDismiss={handleDismissOverlay}
+          onSelectLibraryReference={handleSelectLibraryReference}
           overlay={overlay}
           registration={overlayRegistration}
           returnFocusRef={overlayReturnFocusRef}
+          threadId={effectiveThreadId ?? activeThreadId}
         />
       </div>
     </ConversationComposerShellProvider>

--- a/apps/app/src/components/workspace-shell/WorkspaceOverlayHost.test.tsx
+++ b/apps/app/src/components/workspace-shell/WorkspaceOverlayHost.test.tsx
@@ -5,6 +5,37 @@ import { describe, expect, it, vi } from 'vitest';
 import '@testing-library/jest-dom/vitest';
 import { getWorkspaceShellOverlayRegistration } from '@/lib/workspace-shell/workspace-shell-registry';
 
+vi.mock('@/features/library-remix/LibraryPickerOverlay', () => ({
+  default: ({
+    onSelect,
+    threadId,
+  }: {
+    onSelect: (reference: {
+      brandId: string;
+      kind: 'ingredient';
+      organizationId: string;
+      recordId: string;
+      serializer: 'ingredient';
+    }) => void;
+    threadId?: string | null;
+  }) => (
+    <button
+      type="button"
+      onClick={() =>
+        onSelect({
+          brandId: 'brand-1',
+          kind: 'ingredient',
+          organizationId: 'org-1',
+          recordId: 'ingredient-1',
+          serializer: 'ingredient',
+        })
+      }
+    >
+      Select Library source for {threadId}
+    </button>
+  ),
+}));
+
 vi.mock('@ui/primitives/dialog', () => ({
   Dialog: ({
     children,
@@ -167,5 +198,36 @@ describe('WorkspaceOverlayHost', () => {
     );
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('renders the trusted Library adapter and returns the canonical reference', () => {
+    const onSelectLibraryReference = vi.fn();
+
+    render(
+      <WorkspaceOverlayHost
+        fallbackFocusRef={createRef<HTMLElement>()}
+        isOpen
+        onDismiss={vi.fn()}
+        onSelectLibraryReference={onSelectLibraryReference}
+        overlay={{ key: 'library-picker', parameters: {} }}
+        registration={getWorkspaceShellOverlayRegistration('library-picker')}
+        returnFocusRef={createRef<HTMLElement>()}
+        threadId="thread-1"
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Select Library source for thread-1',
+      }),
+    );
+
+    expect(onSelectLibraryReference).toHaveBeenCalledWith({
+      brandId: 'brand-1',
+      kind: 'ingredient',
+      organizationId: 'org-1',
+      recordId: 'ingredient-1',
+      serializer: 'ingredient',
+    });
   });
 });

--- a/apps/app/src/components/workspace-shell/WorkspaceOverlayHost.tsx
+++ b/apps/app/src/components/workspace-shell/WorkspaceOverlayHost.tsx
@@ -8,6 +8,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@ui/primitives/dialog';
+import LibraryPickerOverlay from '@/features/library-remix/LibraryPickerOverlay';
 
 function formatOverlayParameters(
   overlay: WorkspaceOverlayHostProps['overlay'],
@@ -29,9 +30,11 @@ export default function WorkspaceOverlayHost({
   fallbackFocusRef,
   isOpen,
   onDismiss,
+  onSelectLibraryReference,
   overlay,
   registration,
   returnFocusRef,
+  threadId,
 }: WorkspaceOverlayHostProps) {
   const isResolved = Boolean(
     overlay && registration && overlay.key === registration.key,
@@ -70,9 +73,16 @@ export default function WorkspaceOverlayHost({
               {registration.presentation.description}
             </DialogDescription>
           </DialogHeader>
-          <div className="p-5 pb-2 text-sm text-muted-foreground">
-            {formatOverlayParameters(overlay)}
-          </div>
+          {overlay?.key === 'library-picker' && onSelectLibraryReference ? (
+            <LibraryPickerOverlay
+              onSelect={onSelectLibraryReference}
+              threadId={threadId}
+            />
+          ) : (
+            <div className="p-5 pb-2 text-sm text-muted-foreground">
+              {formatOverlayParameters(overlay)}
+            </div>
+          )}
           <div
             className="border-t border-border p-3"
             data-testid="workspace-overlay-composer-slot"

--- a/apps/app/src/components/workspace-shell/WorkspaceShellActionsContext.tsx
+++ b/apps/app/src/components/workspace-shell/WorkspaceShellActionsContext.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import type { WorkspaceShellOverlayRequest } from '@genfeedai/interfaces';
+import { createContext, type ReactNode, useContext, useMemo } from 'react';
+
+type WorkspaceShellActionsContextValue = {
+  readonly openOverlay: (overlay: WorkspaceShellOverlayRequest) => boolean;
+};
+
+const WorkspaceShellActionsContext =
+  createContext<WorkspaceShellActionsContextValue | null>(null);
+
+export function WorkspaceShellActionsProvider({
+  children,
+  openOverlay,
+}: {
+  readonly children: ReactNode;
+  readonly openOverlay: WorkspaceShellActionsContextValue['openOverlay'];
+}) {
+  const value = useMemo(() => ({ openOverlay }), [openOverlay]);
+  return (
+    <WorkspaceShellActionsContext.Provider value={value}>
+      {children}
+    </WorkspaceShellActionsContext.Provider>
+  );
+}
+
+export function useWorkspaceShellActions(): WorkspaceShellActionsContextValue | null {
+  return useContext(WorkspaceShellActionsContext);
+}

--- a/apps/app/src/features/library-remix/LibraryPickerOverlay.test.tsx
+++ b/apps/app/src/features/library-remix/LibraryPickerOverlay.test.tsx
@@ -1,0 +1,150 @@
+import '@testing-library/jest-dom/vitest';
+import { IngredientCategory } from '@genfeedai/enums';
+import type { IIngredient } from '@genfeedai/interfaces';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { UseLibraryPickerResult } from './use-library-picker';
+
+const mocks = vi.hoisted(() => ({
+  result: null as UseLibraryPickerResult | null,
+}));
+
+vi.mock('@hooks/navigation/use-org-url', () => ({
+  useOrgUrl: () => ({ href: (path: string) => `/acme/moonrise${path}` }),
+}));
+
+vi.mock('./LibrarySourcePreview', () => ({
+  default: ({ record }: { record: IIngredient }) => (
+    <div data-testid={`source-preview-${record.id}`} />
+  ),
+  getLibrarySourceLabel: (record: IIngredient) =>
+    record.metadataLabel || record.id,
+}));
+
+vi.mock('./use-library-picker', () => ({
+  LIBRARY_PICKER_CATEGORIES: [
+    { category: 'image', key: 'images', label: 'Images' },
+    { category: 'video', key: 'videos', label: 'Videos' },
+    { category: 'gif', key: 'gifs', label: 'GIFs' },
+  ],
+  useLibraryPicker: () => {
+    if (!mocks.result) {
+      throw new Error('Picker test state was not initialized.');
+    }
+    return mocks.result;
+  },
+}));
+
+import LibraryPickerOverlay from './LibraryPickerOverlay';
+
+function ingredient(id: string): IIngredient {
+  return {
+    category: IngredientCategory.IMAGE,
+    id,
+    ingredientUrl: `https://cdn.example/${id}.jpg`,
+    metadataLabel: `Source ${id}`,
+  } as IIngredient;
+}
+
+function pickerResult(
+  overrides: Partial<UseLibraryPickerResult> = {},
+): UseLibraryPickerResult {
+  return {
+    category: 'images',
+    isLoadingMore: false,
+    isValidatingId: null,
+    loadMore: vi.fn(),
+    retry: vi.fn(),
+    select: vi.fn(),
+    selectionFailure: null,
+    setCategory: vi.fn(),
+    state: { hasMore: false, items: [], status: 'empty', total: 0 },
+    ...overrides,
+  };
+}
+
+describe('LibraryPickerOverlay', () => {
+  beforeEach(() => {
+    mocks.result = pickerResult();
+  });
+
+  it('renders bounded loading, empty, and permission states', () => {
+    mocks.result = pickerResult({
+      state: { hasMore: false, items: [], status: 'loading', total: 0 },
+    });
+    const view = render(
+      <LibraryPickerOverlay onSelect={vi.fn()} threadId="thread-1" />,
+    );
+    expect(
+      screen.getByLabelText('Loading Library sources'),
+    ).toBeInTheDocument();
+
+    mocks.result = pickerResult();
+    view.rerender(
+      <LibraryPickerOverlay onSelect={vi.fn()} threadId="thread-1" />,
+    );
+    expect(screen.getByText('No images available')).toBeInTheDocument();
+
+    mocks.result = pickerResult({
+      state: {
+        hasMore: false,
+        items: [],
+        status: 'permission-denied',
+        total: 0,
+      },
+    });
+    view.rerender(
+      <LibraryPickerOverlay onSelect={vi.fn()} threadId="thread-1" />,
+    );
+    expect(
+      screen.getByText(/unavailable for the effective brand/i),
+    ).toBeInTheDocument();
+  });
+
+  it('renders media incrementally and revalidates the chosen record', () => {
+    const source = ingredient('image-1');
+    const loadMore = vi.fn();
+    const select = vi.fn();
+    mocks.result = pickerResult({
+      loadMore,
+      select,
+      state: {
+        hasMore: true,
+        items: [source],
+        status: 'ready',
+        total: 75,
+      },
+    });
+
+    render(<LibraryPickerOverlay onSelect={vi.fn()} threadId="thread-1" />);
+
+    expect(screen.getByTestId('source-preview-image-1')).toBeInTheDocument();
+    expect(
+      screen.getByText('75 Library sources available'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: /manage library/i }),
+    ).toHaveAttribute(
+      'href',
+      '/acme/moonrise/library/ingredients?thread=thread-1',
+    );
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Select Source image-1' }),
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }));
+
+    expect(select).toHaveBeenCalledWith(source);
+    expect(loadMore).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps stale selection failures recoverable in the overlay', () => {
+    mocks.result = pickerResult({ selectionFailure: 'stale' });
+
+    render(<LibraryPickerOverlay onSelect={vi.fn()} />);
+
+    expect(
+      screen.getByText(/source is no longer available/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/app/src/features/library-remix/LibraryPickerOverlay.tsx
+++ b/apps/app/src/features/library-remix/LibraryPickerOverlay.tsx
@@ -1,0 +1,212 @@
+'use client';
+
+import { APP_ROUTES } from '@genfeedai/constants';
+import { AlertCategory, ButtonSize, ButtonVariant } from '@genfeedai/enums';
+import type {
+  AgentArtifactReference,
+  IIngredient,
+} from '@genfeedai/interfaces';
+import { useOrgUrl } from '@hooks/navigation/use-org-url';
+import { Skeleton } from '@ui/display/skeleton/skeleton';
+import Alert from '@ui/feedback/alert/Alert';
+import { Button } from '@ui/primitives/button';
+import { Tabs, TabsList, TabsTrigger } from '@ui/primitives/tabs';
+import Link from 'next/link';
+import { HiOutlineArrowRight, HiOutlineFolderOpen } from 'react-icons/hi2';
+import { buildWorkspaceShellHref } from '@/lib/workspace-shell/workspace-shell-location';
+import LibrarySourcePreview, {
+  getLibrarySourceLabel,
+} from './LibrarySourcePreview';
+import {
+  LIBRARY_PICKER_CATEGORIES,
+  type LibraryPickerCategory,
+  useLibraryPicker,
+} from './use-library-picker';
+
+type LibraryPickerOverlayProps = {
+  readonly onSelect: (reference: AgentArtifactReference) => void;
+  readonly threadId?: string | null;
+};
+
+function LibraryPickerSkeleton() {
+  return (
+    <div
+      aria-label="Loading Library sources"
+      className="grid grid-cols-2 gap-3 sm:grid-cols-3"
+      role="status"
+    >
+      {Array.from({ length: 12 }, (_, index) => `source-${index + 1}`).map(
+        (key) => (
+          <Skeleton key={key} className="aspect-[4/3] w-full" />
+        ),
+      )}
+    </div>
+  );
+}
+
+function SelectionFailure({
+  failure,
+}: {
+  readonly failure: ReturnType<typeof useLibraryPicker>['selectionFailure'];
+}) {
+  if (!failure) {
+    return null;
+  }
+
+  const message =
+    failure === 'stale'
+      ? 'That source is no longer available. Your conversation and picker state were preserved.'
+      : failure === 'unauthorized'
+        ? 'That source is not available to the effective brand. Choose another source or open Library management.'
+        : 'The source could not be verified. Retry without losing your current context.';
+
+  return <Alert type={AlertCategory.WARNING}>{message}</Alert>;
+}
+
+function LibrarySourceButton({
+  ingredient,
+  isValidating,
+  onSelect,
+}: {
+  readonly ingredient: IIngredient;
+  readonly isValidating: boolean;
+  readonly onSelect: () => void;
+}) {
+  const label = getLibrarySourceLabel(ingredient);
+
+  return (
+    <Button
+      ariaLabel={`Select ${label}`}
+      className="group min-w-0 overflow-hidden text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      isDisabled={isValidating}
+      onClick={onSelect}
+      variant={ButtonVariant.UNSTYLED}
+      withWrapper={false}
+    >
+      <LibrarySourcePreview record={ingredient} />
+      <span className="block truncate border-t border-border px-2.5 py-2 text-xs font-medium text-foreground">
+        {isValidating ? 'Verifying source…' : label}
+      </span>
+    </Button>
+  );
+}
+
+export default function LibraryPickerOverlay({
+  onSelect,
+  threadId,
+}: LibraryPickerOverlayProps) {
+  const { href } = useOrgUrl();
+  const {
+    category,
+    isLoadingMore,
+    isValidatingId,
+    loadMore,
+    retry,
+    select,
+    selectionFailure,
+    setCategory,
+    state,
+  } = useLibraryPicker({ onSelect });
+  const managementHref = buildWorkspaceShellHref(
+    href(APP_ROUTES.LIBRARY.ROOT),
+    { threadId },
+  );
+
+  return (
+    <div className="flex min-h-0 flex-col">
+      <div className="flex items-center justify-between gap-3 border-b border-border px-5 py-3">
+        <Tabs
+          onValueChange={(value) => setCategory(value as LibraryPickerCategory)}
+          value={category}
+        >
+          <TabsList aria-label="Library media type">
+            {LIBRARY_PICKER_CATEGORIES.map((candidate) => (
+              <TabsTrigger key={candidate.key} value={candidate.key}>
+                {candidate.label}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </Tabs>
+        <Link
+          className="inline-flex shrink-0 items-center gap-1 text-xs font-medium text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          href={managementHref}
+        >
+          Manage Library
+          <HiOutlineArrowRight aria-hidden="true" className="size-3.5" />
+        </Link>
+      </div>
+
+      <div className="max-h-[min(58vh,34rem)] min-h-72 overflow-y-auto p-5">
+        <SelectionFailure failure={selectionFailure} />
+
+        {state.status === 'loading' ? <LibraryPickerSkeleton /> : null}
+
+        {state.status === 'permission-denied' ? (
+          <Alert type={AlertCategory.ERROR}>
+            Library sources are unavailable for the effective brand. Your
+            conversation context has not changed.
+          </Alert>
+        ) : null}
+
+        {state.status === 'error' ? (
+          <Alert type={AlertCategory.WARNING}>
+            <div className="flex items-center justify-between gap-3">
+              <span>Library sources could not be loaded.</span>
+              <Button
+                label="Retry"
+                onClick={retry}
+                size={ButtonSize.SM}
+                variant={ButtonVariant.OUTLINE}
+              />
+            </div>
+          </Alert>
+        ) : null}
+
+        {state.status === 'empty' ? (
+          <div className="flex min-h-56 flex-col items-center justify-center gap-3 text-center">
+            <HiOutlineFolderOpen
+              aria-hidden="true"
+              className="size-8 text-muted-foreground"
+            />
+            <div>
+              <p className="text-sm font-medium text-foreground">
+                No {category} available
+              </p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Add media in full Library management, then return here.
+              </p>
+            </div>
+          </div>
+        ) : null}
+
+        {state.status === 'ready' ? (
+          <>
+            <p className="sr-only" role="status">
+              {state.total} Library sources available
+            </p>
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+              {state.items.map((ingredient) => (
+                <LibrarySourceButton
+                  ingredient={ingredient}
+                  isValidating={isValidatingId === ingredient.id}
+                  key={ingredient.id}
+                  onSelect={() => void select(ingredient)}
+                />
+              ))}
+            </div>
+            {state.hasMore ? (
+              <div className="flex justify-center pt-5">
+                <Button
+                  isDisabled={isLoadingMore}
+                  label={isLoadingMore ? 'Loading more…' : 'Load more'}
+                  onClick={loadMore}
+                  variant={ButtonVariant.OUTLINE}
+                />
+              </div>
+            ) : null}
+          </>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/features/library-remix/LibraryRemixSurface.tsx
+++ b/apps/app/src/features/library-remix/LibraryRemixSurface.tsx
@@ -1,0 +1,220 @@
+'use client';
+
+import { useBrand } from '@contexts/user/brand-context/brand-context';
+import { APP_ROUTES } from '@genfeedai/constants';
+import {
+  AlertCategory,
+  ButtonVariant,
+  IngredientCategory,
+} from '@genfeedai/enums';
+import type { IAsset, IIngredient } from '@genfeedai/interfaces';
+import { useOrgUrl } from '@hooks/navigation/use-org-url';
+import { Skeleton } from '@ui/display/skeleton/skeleton';
+import Alert from '@ui/feedback/alert/Alert';
+import { Button } from '@ui/primitives/button';
+import Link from 'next/link';
+import { HiOutlineArrowRight, HiOutlineSparkles } from 'react-icons/hi2';
+import { useWorkspaceShellActions } from '@/components/workspace-shell/WorkspaceShellActionsContext';
+import { buildWorkspaceShellHref } from '@/lib/workspace-shell/workspace-shell-location';
+import LibrarySourcePreview, {
+  getLibrarySourceLabel,
+} from './LibrarySourcePreview';
+import { useLibraryRemixSource } from './use-library-remix-source';
+
+type LibraryRemixSurfaceProps = {
+  readonly sourceArtifact?: string | null;
+  readonly threadId?: string | null;
+};
+
+function isIngredient(record: IAsset | IIngredient): record is IIngredient {
+  return 'ingredientUrl' in record || 'scope' in record;
+}
+
+function getManagementRoute(record: IAsset | IIngredient): string {
+  if (!isIngredient(record)) {
+    return APP_ROUTES.LIBRARY.ROOT;
+  }
+
+  switch (record.category) {
+    case IngredientCategory.VIDEO:
+      return APP_ROUTES.LIBRARY.VIDEOS;
+    case IngredientCategory.GIF:
+      return APP_ROUTES.LIBRARY.GIFS;
+    default:
+      return APP_ROUTES.LIBRARY.IMAGES;
+  }
+}
+
+export default function LibraryRemixSurface({
+  sourceArtifact,
+  threadId,
+}: LibraryRemixSurfaceProps) {
+  const { selectedBrand } = useBrand();
+  const { href } = useOrgUrl();
+  const shellActions = useWorkspaceShellActions();
+  const { record, reference, retry, status } =
+    useLibraryRemixSource(sourceArtifact);
+  const openLibraryPicker = () =>
+    shellActions?.openOverlay({
+      key: 'library-picker',
+      parameters: {},
+    });
+  const fullLibraryHref = buildWorkspaceShellHref(
+    href(APP_ROUTES.LIBRARY.ROOT),
+    { threadId },
+  );
+
+  if (!sourceArtifact) {
+    return (
+      <section
+        aria-labelledby="library-remix-heading"
+        className="mx-auto flex min-h-[55vh] max-w-2xl items-center px-6 py-12"
+      >
+        <div className="w-full space-y-5 text-center">
+          <HiOutlineSparkles
+            aria-hidden="true"
+            className="mx-auto size-9 text-muted-foreground"
+          />
+          <div>
+            <h1 id="library-remix-heading" className="text-2xl font-semibold">
+              Start a Remix from Library
+            </h1>
+            <p className="mt-2 text-sm leading-6 text-muted-foreground">
+              Choose a scoped media source for{' '}
+              {selectedBrand?.label || 'the effective brand'}. Full Library
+              management remains available on its canonical route.
+            </p>
+          </div>
+          <div className="flex flex-wrap justify-center gap-3">
+            {shellActions ? (
+              <Button
+                label="Choose a source"
+                onClick={openLibraryPicker}
+                variant={ButtonVariant.PRIMARY}
+              />
+            ) : null}
+            <Link
+              className="inline-flex items-center gap-1 text-sm font-medium text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              href={fullLibraryHref}
+            >
+              {shellActions ? 'Manage Library' : 'Choose in Library'}
+              <HiOutlineArrowRight aria-hidden="true" className="size-4" />
+            </Link>
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  if (status === 'loading') {
+    return (
+      <div
+        aria-label="Loading Remix source"
+        className="mx-auto grid min-h-[55vh] max-w-4xl gap-6 px-6 py-12 md:grid-cols-[minmax(0,1fr)_18rem]"
+        role="status"
+      >
+        <div className="space-y-3">
+          <Skeleton className="h-8 w-56" />
+          <Skeleton className="h-5 w-80 max-w-full" />
+        </div>
+        <Skeleton className="aspect-[4/3] w-full" />
+      </div>
+    );
+  }
+
+  if (status !== 'ready' || !record || !reference) {
+    const message =
+      status === 'permission-denied'
+        ? 'This source is not authorized for the effective brand. The active thread and brand context were preserved.'
+        : status === 'stale' || status === 'invalid'
+          ? 'This Library source is stale or invalid. Choose another source without losing the active thread.'
+          : 'The Remix source could not be loaded. Retry or choose another source.';
+
+    return (
+      <section className="mx-auto flex min-h-[55vh] max-w-2xl items-center px-6 py-12">
+        <div className="w-full space-y-4">
+          <Alert type={AlertCategory.WARNING}>{message}</Alert>
+          <div className="flex flex-wrap gap-3">
+            {status === 'error' ? (
+              <Button
+                label="Retry"
+                onClick={retry}
+                variant={ButtonVariant.OUTLINE}
+              />
+            ) : null}
+            {shellActions ? (
+              <Button
+                label="Choose another source"
+                onClick={openLibraryPicker}
+                variant={ButtonVariant.PRIMARY}
+              />
+            ) : null}
+            <Link
+              className="inline-flex items-center text-sm font-medium text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              href={fullLibraryHref}
+            >
+              Open full Library
+            </Link>
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  const label = getLibrarySourceLabel(record);
+  const managementHref = buildWorkspaceShellHref(
+    href(getManagementRoute(record)),
+    { threadId },
+  );
+
+  return (
+    <section
+      aria-labelledby="library-remix-heading"
+      className="mx-auto grid min-h-[55vh] max-w-4xl items-center gap-8 px-6 py-12 md:grid-cols-[minmax(0,1fr)_18rem]"
+    >
+      <div className="space-y-5">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">
+            Remix source ready
+          </p>
+          <h1
+            id="library-remix-heading"
+            className="mt-2 text-2xl font-semibold"
+          >
+            {label}
+          </h1>
+          <p className="mt-2 text-sm leading-6 text-muted-foreground">
+            The canonical {reference.kind} reference is scoped to{' '}
+            {selectedBrand?.label || 'the effective brand'}. Source media stays
+            authoritative in Library while this focused Remix surface keeps the
+            active thread connected.
+          </p>
+        </div>
+        <p className="font-mono text-xs text-muted-foreground">
+          {reference.kind}:{reference.recordId}
+        </p>
+        <div className="flex flex-wrap gap-3">
+          {shellActions ? (
+            <Button
+              label="Choose a different source"
+              onClick={openLibraryPicker}
+              variant={ButtonVariant.PRIMARY}
+            />
+          ) : null}
+          <Link
+            className="inline-flex items-center gap-1 text-sm font-medium text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            href={managementHref}
+          >
+            Open source in Library
+            <HiOutlineArrowRight aria-hidden="true" className="size-4" />
+          </Link>
+        </div>
+      </div>
+      <LibrarySourcePreview
+        className="shadow-border"
+        record={record}
+        reference={reference}
+      />
+    </section>
+  );
+}

--- a/apps/app/src/features/library-remix/LibrarySourcePreview.test.tsx
+++ b/apps/app/src/features/library-remix/LibrarySourcePreview.test.tsx
@@ -1,0 +1,91 @@
+import '@testing-library/jest-dom/vitest';
+import { IngredientCategory } from '@genfeedai/enums';
+import type { IIngredient } from '@genfeedai/interfaces';
+import { render, screen } from '@testing-library/react';
+import type { ImgHTMLAttributes } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('next/image', () => ({
+  default: ({ alt, loading, src }: ImgHTMLAttributes<HTMLImageElement>) => (
+    // biome-ignore lint/performance/noImgElement: test stub for next/image
+    <img alt={alt} data-loading={loading} src={src} />
+  ),
+}));
+
+vi.mock('@ui/display/video-player/VideoPlayer', () => ({
+  default: ({
+    config,
+    src,
+  }: {
+    config: { autoPlay: boolean; preload: string };
+    src: string;
+  }) => (
+    <div
+      data-autoplay={String(config.autoPlay)}
+      data-preload={config.preload}
+      data-testid="video-preview"
+    >
+      {src}
+    </div>
+  ),
+}));
+
+import LibrarySourcePreview from './LibrarySourcePreview';
+
+function ingredient(
+  category: IngredientCategory,
+  ingredientUrl?: string,
+): IIngredient {
+  return {
+    category,
+    id: `${category}-1`,
+    ingredientUrl,
+    metadataLabel: `${category} source`,
+  } as IIngredient;
+}
+
+describe('LibrarySourcePreview', () => {
+  it('loads image media lazily', () => {
+    render(
+      <LibrarySourcePreview
+        record={ingredient(
+          IngredientCategory.IMAGE,
+          'https://cdn.example/image.jpg',
+        )}
+      />,
+    );
+
+    expect(screen.getByRole('img', { name: 'image source' })).toHaveAttribute(
+      'data-loading',
+      'lazy',
+    );
+  });
+
+  it('preloads video metadata without autoplay', () => {
+    render(
+      <LibrarySourcePreview
+        record={ingredient(
+          IngredientCategory.VIDEO,
+          'https://cdn.example/video.mp4',
+        )}
+      />,
+    );
+
+    expect(screen.getByTestId('video-preview')).toHaveAttribute(
+      'data-autoplay',
+      'false',
+    );
+    expect(screen.getByTestId('video-preview')).toHaveAttribute(
+      'data-preload',
+      'metadata',
+    );
+  });
+
+  it('renders an accessible fallback when media is missing', () => {
+    render(
+      <LibrarySourcePreview record={ingredient(IngredientCategory.GIF)} />,
+    );
+
+    expect(screen.getByText('Preview unavailable')).toBeInTheDocument();
+  });
+});

--- a/apps/app/src/features/library-remix/LibrarySourcePreview.tsx
+++ b/apps/app/src/features/library-remix/LibrarySourcePreview.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { IngredientCategory } from '@genfeedai/enums';
+import type { IAsset, IIngredient } from '@genfeedai/interfaces';
+import VideoPlayer from '@ui/display/video-player/VideoPlayer';
+import Image from 'next/image';
+import { HiOutlinePhoto } from 'react-icons/hi2';
+import type { LibraryArtifactReference } from './library-remix-reference';
+
+type LibrarySourcePreviewProps = {
+  readonly className?: string;
+  readonly record: IAsset | IIngredient;
+  readonly reference?: LibraryArtifactReference;
+};
+
+function isIngredient(record: IAsset | IIngredient): record is IIngredient {
+  return 'ingredientUrl' in record || 'scope' in record;
+}
+
+export function getLibrarySourceLabel(record: IAsset | IIngredient): string {
+  if (isIngredient(record)) {
+    return (
+      record.metadataLabel || `${record.category} ${record.id.slice(0, 8)}`
+    );
+  }
+
+  return `${record.category} ${record.id.slice(0, 8)}`;
+}
+
+export default function LibrarySourcePreview({
+  className = '',
+  record,
+  reference,
+}: LibrarySourcePreviewProps) {
+  const ingredient = isIngredient(record) ? record : null;
+  const sourceUrl = isIngredient(record) ? record.ingredientUrl : record.url;
+  const isVideo = isIngredient(record)
+    ? record.category === IngredientCategory.VIDEO
+    : record.mimeType?.startsWith('video/') === true;
+  const label = getLibrarySourceLabel(record);
+
+  return (
+    <div
+      className={`relative aspect-[4/3] min-h-0 overflow-hidden bg-background-secondary ${className}`}
+      data-library-record-id={record.id}
+      data-library-reference={
+        reference ? `${reference.kind}:${reference.recordId}` : undefined
+      }
+    >
+      {sourceUrl && isVideo ? (
+        <VideoPlayer
+          className="bg-black"
+          src={sourceUrl}
+          thumbnail={ingredient?.thumbnailUrl}
+          config={{
+            autoPlay: false,
+            controls: false,
+            loop: false,
+            muted: true,
+            playsInline: true,
+            preload: 'metadata',
+          }}
+        />
+      ) : sourceUrl ? (
+        <Image
+          alt={label}
+          className="object-cover"
+          fill
+          loading="lazy"
+          sizes="(max-width: 768px) 45vw, 12rem"
+          src={sourceUrl}
+          unoptimized={ingredient?.category === IngredientCategory.GIF}
+        />
+      ) : (
+        <div className="flex size-full items-center justify-center text-muted-foreground">
+          <HiOutlinePhoto aria-hidden="true" className="size-7" />
+          <span className="sr-only">Preview unavailable</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/app/src/features/library-remix/library-remix-reference.test.ts
+++ b/apps/app/src/features/library-remix/library-remix-reference.test.ts
@@ -1,0 +1,71 @@
+import { AGENT_ARTIFACT_SERIALIZER_BY_KIND } from '@genfeedai/interfaces';
+import { describe, expect, it } from 'vitest';
+import {
+  buildLibraryArtifactReference,
+  buildLibraryRemixIntentHref,
+  encodeLibraryRemixSource,
+  parseLibraryRemixSource,
+} from './library-remix-reference';
+
+const context = {
+  brandId: 'brand-1',
+  organizationId: 'org-1',
+};
+
+describe('Library Remix references', () => {
+  it('builds the existing canonical typed reference without redefining identity', () => {
+    const reference = buildLibraryArtifactReference({
+      ...context,
+      kind: 'ingredient',
+      recordId: 'ingredient_1',
+    });
+
+    expect(reference).toEqual({
+      ...context,
+      kind: 'ingredient',
+      recordId: 'ingredient_1',
+      serializer: AGENT_ARTIFACT_SERIALIZER_BY_KIND.ingredient,
+    });
+    expect(reference && encodeLibraryRemixSource(reference)).toBe(
+      'ingredient:ingredient_1',
+    );
+  });
+
+  it.each([
+    '',
+    'post:post-1',
+    'ingredient:',
+    ':ingredient-1',
+    'ingredient:../../forged',
+    'ingredient:undefined',
+  ])('rejects malformed or unsupported source intent %s', (value) => {
+    expect(parseLibraryRemixSource(value, context)).toBeNull();
+  });
+
+  it('reconstructs scope from effective context rather than URL authority', () => {
+    expect(parseLibraryRemixSource('asset:asset-1', context)).toEqual({
+      ...context,
+      kind: 'asset',
+      recordId: 'asset-1',
+      serializer: AGENT_ARTIFACT_SERIALIZER_BY_KIND.asset,
+    });
+  });
+
+  it('consumes overlay intent while preserving thread and unrelated route state', () => {
+    const reference = buildLibraryArtifactReference({
+      ...context,
+      kind: 'ingredient',
+      recordId: 'ingredient-1',
+    });
+
+    expect(
+      reference &&
+        buildLibraryRemixIntentHref(
+          '/acme/moonrise/posts/remix?thread=thread-1&overlay=library-picker&folder=recent',
+          reference,
+        ),
+    ).toBe(
+      '/acme/moonrise/posts/remix?thread=thread-1&folder=recent&sourceArtifact=ingredient%3Aingredient-1',
+    );
+  });
+});

--- a/apps/app/src/features/library-remix/library-remix-reference.ts
+++ b/apps/app/src/features/library-remix/library-remix-reference.ts
@@ -1,0 +1,102 @@
+import {
+  AGENT_ARTIFACT_SERIALIZER_BY_KIND,
+  type AgentArtifactReference,
+} from '@genfeedai/interfaces';
+
+export const LIBRARY_REMIX_SOURCE_QUERY_KEY = 'sourceArtifact';
+
+export type LibraryArtifactReference = Extract<
+  AgentArtifactReference,
+  { kind: 'asset' | 'ingredient' }
+>;
+
+const LIBRARY_ARTIFACT_KINDS = Object.freeze(['asset', 'ingredient'] as const);
+
+function isSafeOpaqueId(value: string): boolean {
+  return (
+    value.length > 0 &&
+    value !== 'undefined' &&
+    value !== 'null' &&
+    /^[A-Za-z0-9_-]+$/.test(value)
+  );
+}
+
+export function buildLibraryArtifactReference(params: {
+  readonly brandId: string;
+  readonly kind: LibraryArtifactReference['kind'];
+  readonly organizationId: string;
+  readonly recordId: string;
+}): LibraryArtifactReference | null {
+  const { brandId, kind, organizationId, recordId } = params;
+  if (!brandId.trim() || !organizationId.trim() || !isSafeOpaqueId(recordId)) {
+    return null;
+  }
+
+  return {
+    brandId,
+    kind,
+    organizationId,
+    recordId,
+    serializer: AGENT_ARTIFACT_SERIALIZER_BY_KIND[kind],
+  } as LibraryArtifactReference;
+}
+
+export function encodeLibraryRemixSource(
+  reference: LibraryArtifactReference,
+): string {
+  return `${reference.kind}:${reference.recordId}`;
+}
+
+export function parseLibraryRemixSource(
+  value: string | null | undefined,
+  context: { readonly brandId: string; readonly organizationId: string },
+): LibraryArtifactReference | null {
+  if (!value) {
+    return null;
+  }
+
+  const separatorIndex = value.indexOf(':');
+  if (separatorIndex <= 0 || separatorIndex === value.length - 1) {
+    return null;
+  }
+
+  const kind = value.slice(0, separatorIndex);
+  if (
+    !LIBRARY_ARTIFACT_KINDS.includes(
+      kind as (typeof LIBRARY_ARTIFACT_KINDS)[number],
+    )
+  ) {
+    return null;
+  }
+
+  return buildLibraryArtifactReference({
+    ...context,
+    kind: kind as LibraryArtifactReference['kind'],
+    recordId: value.slice(separatorIndex + 1),
+  });
+}
+
+export function buildLibraryRemixIntentHref(
+  href: string,
+  reference: LibraryArtifactReference,
+): string {
+  const url = new URL(href, 'https://workspace.genfeed.invalid');
+  url.searchParams.set(
+    LIBRARY_REMIX_SOURCE_QUERY_KEY,
+    encodeLibraryRemixSource(reference),
+  );
+  url.searchParams.delete('overlay');
+  url.searchParams.delete('overlayRef');
+
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
+export function readRelationshipId(
+  value: { readonly id?: string } | string | null | undefined,
+): string | null {
+  if (typeof value === 'string') {
+    return value || null;
+  }
+
+  return value?.id || null;
+}

--- a/apps/app/src/features/library-remix/use-library-picker.test.ts
+++ b/apps/app/src/features/library-remix/use-library-picker.test.ts
@@ -1,0 +1,142 @@
+import { IngredientCategory } from '@genfeedai/enums';
+import type { IIngredient } from '@genfeedai/interfaces';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useLibraryPicker } from './use-library-picker';
+
+const mocks = vi.hoisted(() => ({
+  findAll: vi.fn(),
+  findOne: vi.fn(),
+  getService: vi.fn(),
+  total: 0,
+  totalPages: 1,
+}));
+
+vi.mock('@contexts/user/brand-context/brand-context', () => ({
+  useBrand: () => ({
+    brandId: 'brand-1',
+    isReady: true,
+    organizationId: 'org-1',
+  }),
+}));
+
+vi.mock('@hooks/auth/use-authed-service/use-authed-service', () => ({
+  useAuthedService: () => mocks.getService,
+}));
+
+vi.mock('@genfeedai/services/content/pages.service', () => ({
+  PagesService: {
+    getTotalDocs: () => mocks.total,
+    getTotalPages: () => mocks.totalPages,
+  },
+}));
+
+function ingredient(
+  id: string,
+  overrides: Partial<IIngredient> = {},
+): IIngredient {
+  return {
+    brand: 'brand-1',
+    category: IngredientCategory.IMAGE,
+    id,
+    ingredientUrl: `https://cdn.example/${id}.jpg`,
+    organization: 'org-1',
+    ...overrides,
+  } as IIngredient;
+}
+
+describe('useLibraryPicker', () => {
+  beforeEach(() => {
+    mocks.findAll.mockReset();
+    mocks.findOne.mockReset();
+    mocks.getService.mockReset();
+    mocks.getService.mockResolvedValue({
+      findAll: mocks.findAll,
+      findOne: mocks.findOne,
+    });
+    mocks.total = 1;
+    mocks.totalPages = 1;
+  });
+
+  it('paginates a large media library without loading every record', async () => {
+    const firstPage = Array.from({ length: 24 }, (_, index) =>
+      ingredient(`image-${index + 1}`),
+    );
+    mocks.total = 25;
+    mocks.totalPages = 2;
+    mocks.findAll
+      .mockResolvedValueOnce(firstPage)
+      .mockResolvedValueOnce([ingredient('image-25')]);
+
+    const { result } = renderHook(() =>
+      useLibraryPicker({ onSelect: vi.fn() }),
+    );
+
+    await waitFor(() => expect(result.current.state.status).toBe('ready'));
+    expect(result.current.state.items).toHaveLength(24);
+    expect(result.current.state.hasMore).toBe(true);
+
+    act(() => result.current.loadMore());
+
+    await waitFor(() => expect(result.current.state.items).toHaveLength(25));
+    expect(mocks.findAll).toHaveBeenLastCalledWith(
+      expect.objectContaining({ limit: 24, page: 2 }),
+      undefined,
+    );
+  });
+
+  it('surfaces permission failures without leaking records', async () => {
+    mocks.findAll.mockRejectedValue({ status: 403 });
+
+    const { result } = renderHook(() =>
+      useLibraryPicker({ onSelect: vi.fn() }),
+    );
+
+    await waitFor(() =>
+      expect(result.current.state.status).toBe('permission-denied'),
+    );
+    expect(result.current.state.items).toEqual([]);
+  });
+
+  it('re-fetches before returning a canonical typed reference', async () => {
+    const source = ingredient('image-1');
+    const onSelect = vi.fn();
+    mocks.findAll.mockResolvedValue([source]);
+    mocks.findOne.mockResolvedValue(source);
+
+    const { result } = renderHook(() => useLibraryPicker({ onSelect }));
+    await waitFor(() => expect(result.current.state.status).toBe('ready'));
+
+    await act(async () => result.current.select(source));
+
+    expect(mocks.findOne).toHaveBeenCalledWith('image-1');
+    expect(onSelect).toHaveBeenCalledWith({
+      brandId: 'brand-1',
+      kind: 'ingredient',
+      organizationId: 'org-1',
+      recordId: 'image-1',
+      serializer: 'ingredient',
+    });
+  });
+
+  it('fails closed when a selected source becomes stale or changes brand', async () => {
+    const source = ingredient('image-1');
+    const onSelect = vi.fn();
+    mocks.findAll.mockResolvedValue([source]);
+    mocks.findOne.mockResolvedValue(
+      ingredient('image-1', { brand: 'brand-2' }),
+    );
+
+    const { result } = renderHook(() => useLibraryPicker({ onSelect }));
+    await waitFor(() => expect(result.current.state.status).toBe('ready'));
+
+    await act(async () => result.current.select(source));
+
+    expect(result.current.selectionFailure).toBe('unauthorized');
+    expect(onSelect).not.toHaveBeenCalled();
+
+    mocks.findOne.mockRejectedValueOnce({ status: 404 });
+    await act(async () => result.current.select(source));
+    expect(result.current.selectionFailure).toBe('stale');
+  });
+});

--- a/apps/app/src/features/library-remix/use-library-picker.ts
+++ b/apps/app/src/features/library-remix/use-library-picker.ts
@@ -1,0 +1,280 @@
+'use client';
+
+import { useBrand } from '@contexts/user/brand-context/brand-context';
+import { IngredientCategory, IngredientStatus } from '@genfeedai/enums';
+import type { IIngredient } from '@genfeedai/interfaces';
+import type { Ingredient } from '@genfeedai/models/content/ingredient.model';
+import { IngredientsService } from '@genfeedai/services/content/ingredients.service';
+import { PagesService } from '@genfeedai/services/content/pages.service';
+import { useAuthedService } from '@hooks/auth/use-authed-service/use-authed-service';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  buildLibraryArtifactReference,
+  type LibraryArtifactReference,
+  readRelationshipId,
+} from './library-remix-reference';
+
+const LIBRARY_PICKER_PAGE_SIZE = 24;
+
+export type LibraryPickerCategory = 'gifs' | 'images' | 'videos';
+
+export const LIBRARY_PICKER_CATEGORIES = Object.freeze([
+  Object.freeze({
+    category: IngredientCategory.IMAGE,
+    key: 'images',
+    label: 'Images',
+  }),
+  Object.freeze({
+    category: IngredientCategory.VIDEO,
+    key: 'videos',
+    label: 'Videos',
+  }),
+  Object.freeze({
+    category: IngredientCategory.GIF,
+    key: 'gifs',
+    label: 'GIFs',
+  }),
+] as const);
+
+type LibraryPickerLoadStatus =
+  | 'empty'
+  | 'error'
+  | 'loading'
+  | 'permission-denied'
+  | 'ready';
+
+export type LibraryPickerSelectionFailure = 'error' | 'stale' | 'unauthorized';
+
+export interface LibraryPickerState {
+  readonly hasMore: boolean;
+  readonly items: readonly IIngredient[];
+  readonly status: LibraryPickerLoadStatus;
+  readonly total: number;
+}
+
+export interface UseLibraryPickerResult {
+  readonly category: LibraryPickerCategory;
+  readonly isLoadingMore: boolean;
+  readonly isValidatingId: string | null;
+  readonly loadMore: () => void;
+  readonly retry: () => void;
+  readonly select: (ingredient: IIngredient) => Promise<void>;
+  readonly selectionFailure: LibraryPickerSelectionFailure | null;
+  readonly setCategory: (category: LibraryPickerCategory) => void;
+  readonly state: LibraryPickerState;
+}
+
+function getErrorStatus(error: unknown): number | null {
+  if (!error || typeof error !== 'object' || !('status' in error)) {
+    return null;
+  }
+
+  return typeof error.status === 'number' ? error.status : null;
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
+}
+
+function getCategoryConfig(category: LibraryPickerCategory) {
+  return (
+    LIBRARY_PICKER_CATEGORIES.find((candidate) => candidate.key === category) ??
+    LIBRARY_PICKER_CATEGORIES[0]
+  );
+}
+
+export function useLibraryPicker(params: {
+  readonly onSelect: (reference: LibraryArtifactReference) => void;
+}): UseLibraryPickerResult {
+  const { onSelect } = params;
+  const { brandId, isReady, organizationId } = useBrand();
+  const [category, setCategory] = useState<LibraryPickerCategory>('images');
+  const [page, setPage] = useState(1);
+  const [reloadVersion, setReloadVersion] = useState(0);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [isValidatingId, setIsValidatingId] = useState<string | null>(null);
+  const [selectionFailure, setSelectionFailure] =
+    useState<LibraryPickerSelectionFailure | null>(null);
+  const [state, setState] = useState<LibraryPickerState>({
+    hasMore: false,
+    items: [],
+    status: 'loading',
+    total: 0,
+  });
+  const categoryConfig = useMemo(() => getCategoryConfig(category), [category]);
+  const getIngredientsService = useAuthedService((token: string) =>
+    IngredientsService.getInstance<Ingredient>(categoryConfig.key, token),
+  );
+
+  const loadPage = useCallback(
+    async (nextPage: number, append: boolean, signal?: AbortSignal) => {
+      if (!isReady) {
+        return;
+      }
+      if (!brandId || !organizationId) {
+        setState({
+          hasMore: false,
+          items: [],
+          status: 'permission-denied',
+          total: 0,
+        });
+        return;
+      }
+
+      if (append) {
+        setIsLoadingMore(true);
+      } else {
+        setState((current) => ({ ...current, status: 'loading' }));
+      }
+
+      try {
+        const service = (await getIngredientsService()) as IngredientsService;
+        const items = await service.findAll(
+          {
+            brand: brandId,
+            lightweight: true,
+            limit: LIBRARY_PICKER_PAGE_SIZE,
+            page: nextPage,
+            sort: 'createdAt: -1',
+            status: [
+              IngredientStatus.UPLOADED,
+              IngredientStatus.GENERATED,
+              IngredientStatus.VALIDATED,
+            ],
+          },
+          signal,
+        );
+        if (signal?.aborted) {
+          return;
+        }
+
+        const totalPages = PagesService.getTotalPages();
+        const total = PagesService.getTotalDocs();
+        setState((current) => {
+          const nextItems = append
+            ? Array.from(
+                new Map(
+                  [...current.items, ...items].map((item) => [item.id, item]),
+                ).values(),
+              )
+            : items;
+
+          return {
+            hasMore: nextPage < totalPages,
+            items: nextItems,
+            status: nextItems.length > 0 ? 'ready' : 'empty',
+            total,
+          };
+        });
+        setPage(nextPage);
+      } catch (error) {
+        if (isAbortError(error)) {
+          return;
+        }
+
+        const status = getErrorStatus(error);
+        setState((current) => ({
+          hasMore: false,
+          items: append ? current.items : [],
+          status:
+            status === 401 || status === 403 ? 'permission-denied' : 'error',
+          total: append ? current.total : 0,
+        }));
+      } finally {
+        if (!signal?.aborted) {
+          setIsLoadingMore(false);
+        }
+      }
+    },
+    [brandId, getIngredientsService, isReady, organizationId],
+  );
+
+  useEffect(() => {
+    void reloadVersion;
+    const abortController = new AbortController();
+    setPage(1);
+    setSelectionFailure(null);
+    void loadPage(1, false, abortController.signal);
+
+    return () => abortController.abort();
+  }, [loadPage, reloadVersion]);
+
+  const select = useCallback(
+    async (ingredient: IIngredient) => {
+      if (!brandId || !organizationId || isValidatingId) {
+        return;
+      }
+
+      setIsValidatingId(ingredient.id);
+      setSelectionFailure(null);
+      try {
+        const service = (await getIngredientsService()) as IngredientsService;
+        const confirmed = await service.findOne(ingredient.id);
+        if (!confirmed || confirmed.category !== categoryConfig.category) {
+          setSelectionFailure('stale');
+          return;
+        }
+
+        const confirmedBrandId = readRelationshipId(confirmed.brand);
+        const confirmedOrganizationId = readRelationshipId(
+          confirmed.organization,
+        );
+        if (
+          confirmedBrandId !== brandId ||
+          confirmedOrganizationId !== organizationId
+        ) {
+          setSelectionFailure('unauthorized');
+          return;
+        }
+
+        const reference = buildLibraryArtifactReference({
+          brandId: confirmedBrandId,
+          kind: 'ingredient',
+          organizationId,
+          recordId: confirmed.id,
+        });
+        if (!reference) {
+          setSelectionFailure('stale');
+          return;
+        }
+
+        onSelect(reference);
+      } catch (error) {
+        const status = getErrorStatus(error);
+        setSelectionFailure(
+          status === 404
+            ? 'stale'
+            : status === 401 || status === 403
+              ? 'unauthorized'
+              : 'error',
+        );
+      } finally {
+        setIsValidatingId(null);
+      }
+    },
+    [
+      brandId,
+      categoryConfig.category,
+      getIngredientsService,
+      isValidatingId,
+      organizationId,
+      onSelect,
+    ],
+  );
+
+  return {
+    category,
+    isLoadingMore,
+    isValidatingId,
+    loadMore: () => {
+      if (!isLoadingMore && state.hasMore) {
+        void loadPage(page + 1, true);
+      }
+    },
+    retry: () => setReloadVersion((version) => version + 1),
+    select,
+    selectionFailure,
+    setCategory,
+    state,
+  };
+}

--- a/apps/app/src/features/library-remix/use-library-remix-source.test.ts
+++ b/apps/app/src/features/library-remix/use-library-remix-source.test.ts
@@ -1,0 +1,99 @@
+import { AssetParent, IngredientCategory } from '@genfeedai/enums';
+import type { IAsset, IIngredient } from '@genfeedai/interfaces';
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useLibraryRemixSource } from './use-library-remix-source';
+
+const mocks = vi.hoisted(() => ({
+  findAsset: vi.fn(),
+  findIngredients: vi.fn(),
+  getService: vi.fn(),
+}));
+
+vi.mock('@contexts/user/brand-context/brand-context', () => ({
+  useBrand: () => ({
+    brandId: 'brand-1',
+    isReady: true,
+    organizationId: 'org-1',
+  }),
+}));
+
+vi.mock('@genfeedai/services/content/assets.service', () => ({
+  AssetsService: {
+    getInstance: () => ({ findOne: mocks.findAsset }),
+  },
+}));
+
+vi.mock('@genfeedai/services/content/ingredients.service', () => ({
+  IngredientsService: {
+    getInstance: () => ({ findByIds: mocks.findIngredients }),
+  },
+}));
+
+vi.mock('@hooks/auth/use-authed-service/use-authed-service', () => ({
+  useAuthedService: () => mocks.getService,
+}));
+
+describe('useLibraryRemixSource', () => {
+  beforeEach(() => {
+    mocks.findAsset.mockReset();
+    mocks.findIngredients.mockReset();
+    mocks.getService.mockReset();
+    mocks.getService.mockResolvedValue({
+      findByIds: mocks.findIngredients,
+      findOne: mocks.findAsset,
+    });
+  });
+
+  it('resolves an ingredient from intent under effective server-backed scope', async () => {
+    mocks.findIngredients.mockResolvedValue([
+      {
+        brand: 'brand-1',
+        category: IngredientCategory.IMAGE,
+        id: 'ingredient-1',
+        ingredientUrl: 'https://cdn.example/ingredient-1.jpg',
+        organization: 'org-1',
+      } as IIngredient,
+    ]);
+
+    const { result } = renderHook(() =>
+      useLibraryRemixSource('ingredient:ingredient-1'),
+    );
+
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+    expect(mocks.findIngredients).toHaveBeenCalledWith(['ingredient-1']);
+    expect(result.current.reference).toEqual({
+      brandId: 'brand-1',
+      kind: 'ingredient',
+      organizationId: 'org-1',
+      recordId: 'ingredient-1',
+      serializer: 'ingredient',
+    });
+  });
+
+  it('rejects a canonical asset that is outside the effective brand', async () => {
+    mocks.findAsset.mockResolvedValue({
+      id: 'asset-1',
+      isDeleted: false,
+      parent: 'brand-2',
+      parentModel: AssetParent.BRAND,
+      url: 'https://cdn.example/asset-1.jpg',
+    } as IAsset);
+
+    const { result } = renderHook(() => useLibraryRemixSource('asset:asset-1'));
+
+    await waitFor(() =>
+      expect(result.current.status).toBe('permission-denied'),
+    );
+    expect(result.current.record).toBeNull();
+  });
+
+  it('reports deleted and missing media as stale', async () => {
+    mocks.findAsset.mockRejectedValue({ status: 404 });
+
+    const { result } = renderHook(() => useLibraryRemixSource('asset:asset-1'));
+
+    await waitFor(() => expect(result.current.status).toBe('stale'));
+    expect(result.current.record).toBeNull();
+  });
+});

--- a/apps/app/src/features/library-remix/use-library-remix-source.ts
+++ b/apps/app/src/features/library-remix/use-library-remix-source.ts
@@ -1,0 +1,173 @@
+'use client';
+
+import { useBrand } from '@contexts/user/brand-context/brand-context';
+import { AssetParent } from '@genfeedai/enums';
+import type { IAsset, IIngredient } from '@genfeedai/interfaces';
+import { AssetsService } from '@genfeedai/services/content/assets.service';
+import { IngredientsService } from '@genfeedai/services/content/ingredients.service';
+import { useAuthedService } from '@hooks/auth/use-authed-service/use-authed-service';
+import { useCallback, useEffect, useState } from 'react';
+import {
+  type LibraryArtifactReference,
+  parseLibraryRemixSource,
+  readRelationshipId,
+} from './library-remix-reference';
+
+export type LibraryRemixSourceRecord = IAsset | IIngredient;
+
+export type LibraryRemixSourceStatus =
+  | 'error'
+  | 'invalid'
+  | 'loading'
+  | 'permission-denied'
+  | 'ready'
+  | 'stale';
+
+export interface UseLibraryRemixSourceResult {
+  readonly record: LibraryRemixSourceRecord | null;
+  readonly reference: LibraryArtifactReference | null;
+  readonly retry: () => void;
+  readonly status: LibraryRemixSourceStatus;
+}
+
+function getErrorStatus(error: unknown): number | null {
+  if (!error || typeof error !== 'object' || !('status' in error)) {
+    return null;
+  }
+
+  return typeof error.status === 'number' ? error.status : null;
+}
+
+function isAssetInBrand(asset: IAsset, brandId: string): boolean {
+  return (
+    !asset.isDeleted &&
+    asset.parentModel === AssetParent.BRAND &&
+    asset.parent === brandId
+  );
+}
+
+function isIngredientInScope(
+  ingredient: IIngredient,
+  brandId: string,
+  organizationId: string,
+): boolean {
+  return (
+    readRelationshipId(ingredient.brand) === brandId &&
+    readRelationshipId(ingredient.organization) === organizationId
+  );
+}
+
+export function useLibraryRemixSource(
+  sourceArtifact: string | null | undefined,
+): UseLibraryRemixSourceResult {
+  const { brandId, isReady, organizationId } = useBrand();
+  const [reloadVersion, setReloadVersion] = useState(0);
+  const [state, setState] = useState<{
+    record: LibraryRemixSourceRecord | null;
+    reference: LibraryArtifactReference | null;
+    status: LibraryRemixSourceStatus;
+  }>({ record: null, reference: null, status: 'loading' });
+  const getAssetsService = useAuthedService((token: string) =>
+    AssetsService.getInstance(token),
+  );
+  const getIngredientsService = useAuthedService((token: string) =>
+    IngredientsService.getInstance(token),
+  );
+
+  const resolve = useCallback(
+    async (signal: AbortSignal) => {
+      if (!isReady) {
+        return;
+      }
+      if (!brandId || !organizationId) {
+        setState({
+          record: null,
+          reference: null,
+          status: 'permission-denied',
+        });
+        return;
+      }
+
+      const reference = parseLibraryRemixSource(sourceArtifact, {
+        brandId,
+        organizationId,
+      });
+      if (!reference) {
+        setState({ record: null, reference: null, status: 'invalid' });
+        return;
+      }
+
+      setState({ record: null, reference, status: 'loading' });
+      try {
+        if (reference.kind === 'asset') {
+          const service = await getAssetsService();
+          const asset = await service.findOne(reference.recordId, {}, signal);
+          if (signal.aborted) {
+            return;
+          }
+          if (!isAssetInBrand(asset, brandId)) {
+            setState({ record: null, reference, status: 'permission-denied' });
+            return;
+          }
+
+          setState({ record: asset, reference, status: 'ready' });
+          return;
+        }
+
+        const service = (await getIngredientsService()) as IngredientsService;
+        const ingredients = await service.findByIds([reference.recordId]);
+        if (signal.aborted) {
+          return;
+        }
+        const ingredient = ingredients.find(
+          (candidate) => candidate.id === reference.recordId,
+        );
+        if (!ingredient) {
+          setState({ record: null, reference, status: 'stale' });
+          return;
+        }
+        if (!isIngredientInScope(ingredient, brandId, organizationId)) {
+          setState({ record: null, reference, status: 'permission-denied' });
+          return;
+        }
+
+        setState({ record: ingredient, reference, status: 'ready' });
+      } catch (error) {
+        if (signal.aborted) {
+          return;
+        }
+        const status = getErrorStatus(error);
+        setState({
+          record: null,
+          reference,
+          status:
+            status === 404
+              ? 'stale'
+              : status === 401 || status === 403
+                ? 'permission-denied'
+                : 'error',
+        });
+      }
+    },
+    [
+      brandId,
+      getAssetsService,
+      getIngredientsService,
+      isReady,
+      organizationId,
+      sourceArtifact,
+    ],
+  );
+
+  useEffect(() => {
+    void reloadVersion;
+    const abortController = new AbortController();
+    void resolve(abortController.signal);
+    return () => abortController.abort();
+  }, [reloadVersion, resolve]);
+
+  return {
+    ...state,
+    retry: () => setReloadVersion((version) => version + 1),
+  };
+}

--- a/apps/app/src/lib/workspace-shell/workspace-overlay-launcher.spec.ts
+++ b/apps/app/src/lib/workspace-shell/workspace-overlay-launcher.spec.ts
@@ -7,6 +7,11 @@ const SHELL_PREVIEW_OVERLAY = {
   parameters: { reference: null },
 } as const satisfies WorkspaceShellOverlayRequest;
 
+const LIBRARY_PICKER_OVERLAY = {
+  key: 'library-picker',
+  parameters: {},
+} as const satisfies WorkspaceShellOverlayRequest;
+
 describe('workspace overlay launcher', () => {
   it('pushes one trusted overlay over the complete underlying URL', () => {
     expect(
@@ -21,6 +26,21 @@ describe('workspace overlay launcher', () => {
       history: 'push',
       href: '/acme/moonrise/library/images?folder=launch&thread=thread-1&overlay=shell-preview#asset-grid',
       overlay: SHELL_PREVIEW_OVERLAY,
+    });
+  });
+
+  it('opens the no-parameter Library picker without encoding selection authority', () => {
+    expect(
+      resolveWorkspaceOverlayLaunch({
+        currentHref: '/acme/~/agent/thread-1',
+        invocation: 'user',
+        overlay: LIBRARY_PICKER_OVERLAY,
+      }),
+    ).toEqual({
+      announcement: 'Library picker opened.',
+      history: 'push',
+      href: '/acme/~/agent/thread-1?overlay=library-picker',
+      overlay: LIBRARY_PICKER_OVERLAY,
     });
   });
 

--- a/apps/app/src/lib/workspace-shell/workspace-overlay-launcher.ts
+++ b/apps/app/src/lib/workspace-shell/workspace-overlay-launcher.ts
@@ -46,6 +46,9 @@ function createUnavailableLaunch(
 
 function encodeOverlayReference(
   overlay: WorkspaceShellOverlayRequest,
+  registration: NonNullable<
+    ReturnType<typeof getWorkspaceShellOverlayRegistration>
+  >,
 ): string | null | undefined {
   if (
     !overlay.parameters ||
@@ -55,7 +58,7 @@ function encodeOverlayReference(
     return undefined;
   }
 
-  if (overlay.key === 'notifications') {
+  if (registration.parameterContract.kind === 'none') {
     return Object.keys(overlay.parameters).length === 0 ? null : undefined;
   }
 
@@ -119,7 +122,7 @@ export function resolveWorkspaceOverlayLaunch({
     return createUnavailableLaunch(currentUrl);
   }
 
-  const encodedReference = encodeOverlayReference(overlay);
+  const encodedReference = encodeOverlayReference(overlay, registration);
   if (encodedReference === undefined) {
     return createUnavailableLaunch(currentUrl);
   }

--- a/apps/app/src/lib/workspace-shell/workspace-shell-location.spec.ts
+++ b/apps/app/src/lib/workspace-shell/workspace-shell-location.spec.ts
@@ -164,6 +164,24 @@ describe('workspace shell URL restoration', () => {
     });
   });
 
+  it('restores the no-parameter Library picker over the exact base route', () => {
+    expect(
+      restoreWorkspaceShellLocation({
+        normalizedPathname: '/posts/remix',
+        pathname: '/acme/moonrise/posts/remix',
+        searchParams: new URLSearchParams({
+          overlay: 'library-picker',
+          thread: 'thread-1',
+        }),
+      }),
+    ).toMatchObject({
+      baseState: 'canvas',
+      overlay: { key: 'library-picker', parameters: {} },
+      state: 'overlay',
+      threadId: 'thread-1',
+    });
+  });
+
   it('marks malformed conversation thread routes for safe canonical fallback', () => {
     expect(
       restoreWorkspaceShellLocation({

--- a/apps/app/src/lib/workspace-shell/workspace-shell-location.ts
+++ b/apps/app/src/lib/workspace-shell/workspace-shell-location.ts
@@ -68,6 +68,10 @@ function createOverlayRequest(
   reference: WorkspaceShellTypedReference | null,
 ): WorkspaceShellOverlayRequest | null {
   switch (registration.key) {
+    case 'library-picker':
+      return reference
+        ? null
+        : { key: 'library-picker', parameters: Object.freeze({}) };
     case 'notifications':
       return reference
         ? null

--- a/apps/app/src/lib/workspace-shell/workspace-shell-registry.spec.ts
+++ b/apps/app/src/lib/workspace-shell/workspace-shell-registry.spec.ts
@@ -123,6 +123,14 @@ describe('workspace shell trusted registry', () => {
   });
 
   it('keeps notifications and deployment-specific dock chrome explicit', () => {
+    expect(
+      getWorkspaceShellOverlayRegistration('library-picker'),
+    ).toMatchObject({
+      adapter: { key: 'library-picker', status: 'ready' },
+      parameterContract: { kind: 'none' },
+      presentation: { title: 'Choose from Library' },
+      telemetryClass: 'library_picker',
+    });
     expect(getWorkspaceShellOverlayRegistration('notifications')).toMatchObject(
       {
         allowedShellModes: ['overlay'],

--- a/apps/app/src/lib/workspace-shell/workspace-shell-registry.ts
+++ b/apps/app/src/lib/workspace-shell/workspace-shell-registry.ts
@@ -666,6 +666,28 @@ export const PROTECTED_ROUTE_INVENTORY = Object.freeze([
 export const WORKSPACE_SHELL_AUXILIARY_REGISTRY = Object.freeze([
   Object.freeze({
     accessPolicy: 'organization-member',
+    adapter: Object.freeze({ key: 'library-picker', status: 'ready' }),
+    allowedShellModes: Object.freeze(['overlay'] as const),
+    availability: 'conversation-shell',
+    canonicalUrl: null,
+    deployments: ALL_DEPLOYMENTS,
+    key: 'library-picker',
+    kind: 'overlay',
+    launchTarget: 'overlay',
+    parameterContract: Object.freeze({ kind: 'none' } as const),
+    presentation: Object.freeze({
+      description:
+        'Choose an authorized media source without leaving the active conversation.',
+      openAnnouncement: 'Library picker opened.',
+      title: 'Choose from Library',
+    }),
+    restoration: URL_RESTORATION_POLICY,
+    safeFallback: 'same-canonical-url',
+    scope: 'organization',
+    telemetryClass: 'library_picker',
+  }),
+  Object.freeze({
+    accessPolicy: 'organization-member',
     adapter: Object.freeze({ key: 'notifications', status: 'placeholder' }),
     allowedShellModes: Object.freeze(['overlay'] as const),
     availability: 'conversation-shell',

--- a/packages/interfaces/src/ui/workspace-shell.interface.ts
+++ b/packages/interfaces/src/ui/workspace-shell.interface.ts
@@ -42,9 +42,13 @@ export interface WorkspaceShellTypedReference {
   readonly kind: WorkspaceShellReferenceKind;
 }
 
-export type WorkspaceShellOverlayKey = 'notifications' | 'shell-preview';
+export type WorkspaceShellOverlayKey =
+  | 'library-picker'
+  | 'notifications'
+  | 'shell-preview';
 
 export interface WorkspaceShellOverlayParameterMap {
+  readonly 'library-picker': Readonly<Record<string, never>>;
   readonly notifications: Readonly<Record<string, never>>;
   readonly 'shell-preview': {
     readonly reference: WorkspaceShellTypedReference | null;
@@ -96,7 +100,7 @@ export interface WorkspaceShellRestorationPolicy {
 
 export interface WorkspaceShellAdapterSeam {
   readonly key: string;
-  readonly status: 'dedicated-route' | 'placeholder';
+  readonly status: 'dedicated-route' | 'placeholder' | 'ready';
 }
 
 export interface WorkspaceShellRouteRegistration {
@@ -141,7 +145,7 @@ export interface WorkspaceShellOverlayRegistration {
   readonly restoration: WorkspaceShellRestorationPolicy;
   readonly safeFallback: 'same-canonical-url';
   readonly scope: 'organization';
-  readonly telemetryClass: 'notifications' | 'shell_preview';
+  readonly telemetryClass: 'library_picker' | 'notifications' | 'shell_preview';
 }
 
 export interface WorkspaceShellChromeRegistration {

--- a/packages/props/ui/workspace-overlay-host.props.ts
+++ b/packages/props/ui/workspace-overlay-host.props.ts
@@ -1,7 +1,8 @@
 import type {
+  AgentArtifactReference,
   WorkspaceShellOverlayRegistration,
   WorkspaceShellOverlayRequest,
-} from '@genfeedai/interfaces/ui/workspace-shell.interface';
+} from '@genfeedai/interfaces';
 import type { Ref, RefObject } from 'react';
 
 export interface WorkspaceOverlayHostProps {
@@ -9,7 +10,11 @@ export interface WorkspaceOverlayHostProps {
   readonly fallbackFocusRef: RefObject<HTMLElement | null>;
   readonly isOpen: boolean;
   readonly onDismiss: () => void;
+  readonly onSelectLibraryReference?: (
+    reference: AgentArtifactReference,
+  ) => void;
   readonly overlay: WorkspaceShellOverlayRequest | null;
   readonly registration: WorkspaceShellOverlayRegistration | null;
   readonly returnFocusRef: RefObject<HTMLElement | null>;
+  readonly threadId?: string | null;
 }


### PR DESCRIPTION
## Summary

- add a registered no-parameter Library picker overlay that paginates brand-scoped images, videos, and GIFs while preserving the active thread
- re-fetch and authorize selected records before returning the existing canonical typed artifact reference
- hand the selected source into the canonical Remix route through a namespaced intent, then reauthorize it against the effective brand and organization in a focused surface
- preserve full Library management and every existing Trend Remix route/input
- cover loading, empty, permission, stale, pagination, image, video, fallback, overlay-history, and canonical-route states with focused tests

## Boundaries

- reuses the #1673 `AgentArtifactReference` contract; no shared asset identity was redefined
- does not edit Studio adapter files; #1679 has no available implementation seam yet
- keeps registry changes additive and places substantive behavior under the app-local `library-remix` feature

## Verification

- `biome check` on all 26 changed files
- `bun run design:check` (passes; existing DESIGN.md unused-token warnings only)
- staged `lint-staged` checks: Biome, Secretlint, raw-control guard, and bespoke-card guard
- Gitleaks staged scan: no leaks
- repo UI guards passed design boundaries, app boundaries, raw controls, bespoke cards, modal architecture, org navigation, and hardcoded-route checks; the pre-existing nested-card scanner crashed before scanning because its TypeScript runtime import exposes no `ScriptTarget`
- tests, typechecks, builds, and E2E were intentionally not run locally per repository workstation policy; PR CI is authoritative

Closes #1685
Part of #1670