### PR TITLE
fix(agent): deduplicate workspace references

### DIFF
--- a/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.controller.spec.ts
+++ b/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.controller.spec.ts
@@ -8,6 +8,12 @@ import type { AgentOrchestratorService } from '@api/services/agent-orchestrator/
 import type { AgentArtifactReference } from '@genfeedai/interfaces';
 import type { LoggerService } from '@libs/logger/logger.service';
 
+const identity = vi.hoisted(() => ({
+  databaseUserId: '507f191e810c19729de860ec',
+  metadataUserId: '507f191e810c19729de860eb',
+  organizationId: '507f191e810c19729de860ea',
+}));
+
 vi.mock('@genfeedai/tools', () => ({
   getToolsForSurface: vi.fn(() => []),
   toAgentTools: vi.fn(() => []),
@@ -15,8 +21,8 @@ vi.mock('@genfeedai/tools', () => ({
 vi.mock('@api/helpers/utils/auth/auth.util', () => ({
   getPublicMetadata: vi.fn(() => ({
     brand: 'brand-1',
-    organization: '507f191e810c19729de860ea',
-    user: '507f191e810c19729de860ea',
+    organization: identity.organizationId,
+    user: identity.metadataUserId,
   })),
 }));
 vi.mock('@api/helpers/utils/error-response/error-response.util', () => ({
@@ -115,7 +121,7 @@ describe('AgentOrchestratorController', () => {
       );
     });
 
-    it('passes typed selected artifact references to the scoped turn', async () => {
+    it('uses the metadata organization and canonical database user for a scoped turn', async () => {
       const user = {
         id: 'authProvider_123',
         publicMetadata: { organization: 'org', user: 'usr' },
@@ -123,12 +129,12 @@ describe('AgentOrchestratorController', () => {
       const reference = {
         brandId: 'brand-1',
         kind: 'post',
-        organizationId: '507f191e810c19729de860ea',
+        organizationId: identity.organizationId,
         recordId: 'post-1',
         serializer: 'post',
       } satisfies AgentArtifactReference;
       usersService.findOne.mockResolvedValue({
-        id: '507f191e810c19729de860ea',
+        id: identity.databaseUserId,
       });
       service.chat.mockResolvedValue({} as never);
 
@@ -145,8 +151,16 @@ describe('AgentOrchestratorController', () => {
       expect(service.chat).toHaveBeenCalledWith(
         expect.objectContaining({ artifactReferences: [reference] }),
         expect.objectContaining({
-          organizationId: '507f191e810c19729de860ea',
+          organizationId: identity.organizationId,
+          userId: identity.databaseUserId,
         }),
+      );
+      expect(usersService.findOne).toHaveBeenCalledWith(
+        {
+          _id: identity.metadataUserId,
+          authProviderId: 'authProvider_123',
+        },
+        [],
       );
     });
 

--- a/packages/agent/src/components/AgentChatInput.spec.tsx
+++ b/packages/agent/src/components/AgentChatInput.spec.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const storeState = {
@@ -46,10 +52,12 @@ vi.mock('@genfeedai/agent/stores/agent-chat.store', () => ({
 
 import { AgentChatInput } from '@genfeedai/agent/components/AgentChatInput';
 import { ConversationComposerShellProvider } from '@genfeedai/agent/components/ConversationComposerShellContext';
+import { writeConversationComposerDocument } from '@genfeedai/agent/stores/conversation-composer-draft.store';
 
 describe('AgentChatInput', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    sessionStorage.clear();
     storeState.activeThreadId = null;
     storeState.draftPlanModeEnabled = false;
     storeState.composerSeed = null;
@@ -283,5 +291,58 @@ describe('AgentChatInput', () => {
 
     expect(screen.getByText('1 reference')).toBeInTheDocument();
     expect(screen.getByText('^post:post-1')).toBeInTheDocument();
+  });
+
+  it('renders one tray item and count when an editor mention overlaps a workspace selection', () => {
+    const draftScopeKey = 'acme:thread-overlap:1';
+    writeConversationComposerDocument(
+      draftScopeKey,
+      {
+        content: [
+          {
+            content: [
+              { text: 'Review ', type: 'text' },
+              {
+                attrs: {
+                  contentId: 'post-1',
+                  contentTitle: 'Launch post',
+                  contentType: 'post',
+                },
+                type: 'contentMention',
+              },
+            ],
+            type: 'paragraph',
+          },
+        ],
+        type: 'doc',
+      },
+      'Review Launch post',
+    );
+
+    render(
+      <ConversationComposerShellProvider
+        artifactReferences={[
+          {
+            brandId: 'brand-1',
+            kind: 'post',
+            organizationId: 'org-1',
+            recordId: 'post-1',
+            serializer: 'post',
+          },
+        ]}
+        contextLabel="Brand Workspace overview"
+        draftScopeKey={draftScopeKey}
+        portalTarget={null}
+        shellState="canvas"
+      >
+        <AgentChatInput onSend={vi.fn()} />
+      </ConversationComposerShellProvider>,
+    );
+
+    const tray = screen.getByRole('group', {
+      name: 'Composer attachments and references',
+    });
+    expect(screen.getByText('1 reference')).toBeInTheDocument();
+    expect(within(tray).getAllByText('^Launch post')).toHaveLength(1);
   });
 });

--- a/packages/agent/src/components/useAgentChatInput.spec.tsx
+++ b/packages/agent/src/components/useAgentChatInput.spec.tsx
@@ -1,0 +1,145 @@
+import { ConversationComposerShellProvider } from '@genfeedai/agent/components/ConversationComposerShellContext';
+import { useAgentChatInput } from '@genfeedai/agent/components/useAgentChatInput';
+import { writeConversationComposerDocument } from '@genfeedai/agent/stores/conversation-composer-draft.store';
+import type { AgentArtifactReference } from '@genfeedai/interfaces';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const storeState = {
+  activeThreadId: null,
+  clearComposerSeed: vi.fn(),
+  composerSeed: null,
+};
+
+vi.mock('@genfeedai/agent/hooks/use-brand-mentions', () => ({
+  useBrandMentions: () => ({ mentions: [] }),
+}));
+
+vi.mock('@genfeedai/agent/hooks/use-content-mentions', () => ({
+  useContentMentions: () => ({ mentions: [] }),
+}));
+
+vi.mock('@genfeedai/agent/hooks/use-credential-mentions', () => ({
+  useCredentialMentions: () => ({ mentions: [] }),
+}));
+
+vi.mock('@genfeedai/agent/hooks/use-team-mentions', () => ({
+  useTeamMentions: () => ({ mentions: [] }),
+}));
+
+vi.mock('@genfeedai/agent/hooks/use-microphone-input', () => ({
+  useMicrophoneInput: () => ({
+    isListening: false,
+    isSupported: false,
+    isTranscribing: false,
+    startListening: vi.fn(),
+    stopListening: vi.fn(),
+  }),
+}));
+
+vi.mock('@genfeedai/agent/stores/agent-chat.store', () => ({
+  useAgentChatStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector(storeState),
+}));
+
+const draftScopeKey = 'acme:thread-overlap:1';
+const workspaceReferences = [
+  {
+    brandId: 'brand-1',
+    kind: 'post',
+    organizationId: 'org-1',
+    recordId: 'post-1',
+    serializer: 'post',
+  },
+  {
+    brandId: 'brand-1',
+    kind: 'post',
+    organizationId: 'org-1',
+    recordId: 'post-3',
+    serializer: 'post',
+  },
+] as const satisfies readonly AgentArtifactReference[];
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return (
+    <ConversationComposerShellProvider
+      artifactReferences={workspaceReferences}
+      contextLabel="Brand Workspace overview"
+      draftScopeKey={draftScopeKey}
+      portalTarget={null}
+      shellState="canvas"
+    >
+      {children}
+    </ConversationComposerShellProvider>
+  );
+}
+
+describe('useAgentChatInput references', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStorage.clear();
+    writeConversationComposerDocument(
+      draftScopeKey,
+      {
+        content: [
+          {
+            content: [
+              { text: 'Compare ', type: 'text' },
+              {
+                attrs: {
+                  contentId: 'post-1',
+                  contentTitle: 'Launch post',
+                  contentType: 'post',
+                },
+                type: 'contentMention',
+              },
+              { text: ' with ', type: 'text' },
+              {
+                attrs: {
+                  contentId: 'post-2',
+                  contentTitle: 'Campaign brief',
+                  contentType: 'post',
+                },
+                type: 'contentMention',
+              },
+            ],
+            type: 'paragraph',
+          },
+        ],
+        type: 'doc',
+      },
+      'Compare Launch post with Campaign brief',
+    );
+  });
+
+  it('deduplicates displayed stable IDs without changing workspace selections', async () => {
+    const onSend = vi.fn();
+    const { result } = renderHook(() => useAgentChatInput({ onSend }), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.editor).not.toBeNull();
+    });
+
+    expect(result.current.references).toEqual([
+      { id: 'post-1', label: '^Launch post', type: 'content' },
+      { id: 'post-2', label: '^Campaign brief', type: 'content' },
+      { id: 'post-3', label: '^post:post-3', type: 'asset' },
+    ]);
+
+    await act(async () => {
+      await result.current.handleSend();
+    });
+
+    expect(onSend).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Array),
+      undefined,
+      expect.objectContaining({
+        artifactReferences: workspaceReferences,
+      }),
+    );
+  });
+});

--- a/packages/agent/src/components/useAgentChatInput.ts
+++ b/packages/agent/src/components/useAgentChatInput.ts
@@ -682,20 +682,29 @@ export function useAgentChatInput({
 
     return [...referencesByKey.values()];
   }, [composerShell?.references, mentionReferences]);
-  const displayedReferences = useMemo<AgentChatReferenceItem[]>(
-    () => [
-      ...references,
-      ...surfaceArtifactReferences.map((item) => {
-        const normalizedItem = normalizeSurfaceArtifactReference(item);
-        return {
-          id: normalizedItem.reference.recordId,
+  const displayedReferences = useMemo<AgentChatReferenceItem[]>(() => {
+    const referencesById = new Map<string, AgentChatReferenceItem>();
+
+    for (const reference of references) {
+      if (!referencesById.has(reference.id)) {
+        referencesById.set(reference.id, reference);
+      }
+    }
+
+    for (const item of surfaceArtifactReferences) {
+      const normalizedItem = normalizeSurfaceArtifactReference(item);
+      const referenceId = normalizedItem.reference.recordId;
+      if (!referencesById.has(referenceId)) {
+        referencesById.set(referenceId, {
+          id: referenceId,
           label: normalizedItem.label,
-          type: 'asset' as const,
-        };
-      }),
-    ],
-    [references, surfaceArtifactReferences],
-  );
+          type: 'asset',
+        });
+      }
+    }
+
+    return [...referencesById.values()];
+  }, [references, surfaceArtifactReferences]);
 
   const isDragActive = dragState?.isActive ?? false;
   const canSendMessage = !isEmpty || hasCompletedAttachments;


### PR DESCRIPTION
## Summary

- merge displayed composer references by stable reference ID so editor mentions and workspace selections render once
- preserve first-source ordering and workspace artifact selection payloads while correcting attachment tray keys and composer counts
- distinguish organization metadata from the canonical database user in the controller regression
- add focused hook, rendered composer, and controller coverage

## Related issue

Closes #1713

## Scope and boundaries

- OSS-only agent composer and API controller test changes; no EE boundary changes
- no package API, serializer, schema, migration, generated file, or deployment changes
- open PR #1715 also touches `useAgentChatInput.ts`, but only in the draft-focus effect; this PR changes the later displayed-reference merge and remains independently reviewable against `master`

## Verification

- `bunx biome check` passed for all four changed files
- `git diff --cached --check` passed
- staged sensitive-path and credential-pattern scans passed
- Gitleaks staged scan passed with no leaks
- pre-commit Secretlint, Biome, UI control guard, and no-bespoke-card guard passed
- local tests, typechecks, builds, compilation, and E2E were intentionally not run per workstation policy; PR CI is authoritative

## Screenshots

Not applicable; this corrects duplicate data presentation without changing visual design.

## Checklist

- [x] I removed secrets, credentials, personal data, and customer data.
- [x] I updated relevant documentation or explained why no docs change is needed.
- [x] I preserved the Community/Cloud/Enterprise boundary.
- [x] I documented migration, release, or external-setting actions, or marked them not applicable.

Documentation changes are not needed for this regression fix. Migration, release, and external-setting actions are not applicable.
