### PR TITLE
fix(onboarding): gate agent-first routing on SaaS

### DIFF
--- a/apps/app/app/(onboarding)/onboarding/post-signup/page.behavior.test.tsx
+++ b/apps/app/app/(onboarding)/onboarding/post-signup/page.behavior.test.tsx
@@ -13,8 +13,8 @@ const {
   currentUserState,
   getTokenMock,
   getMyOrganizationsMock,
-  isCloudMock,
   isEEEnabledMock,
+  isSaaSMock,
   isSelfHostedMock,
   managedCreateCheckoutSessionMock,
   resolveAuthTokenMock,
@@ -34,8 +34,8 @@ const {
   },
   getTokenMock: vi.fn(),
   getMyOrganizationsMock: vi.fn(),
-  isCloudMock: vi.fn(),
   isEEEnabledMock: vi.fn(),
+  isSaaSMock: vi.fn(),
   isSelfHostedMock: vi.fn(),
   managedCreateCheckoutSessionMock: vi.fn(),
   resolveAuthTokenMock: vi.fn(),
@@ -158,7 +158,7 @@ vi.mock('@genfeedai/config/license', () => ({
 }));
 
 vi.mock('@genfeedai/config/deployment', () => ({
-  isCloudDeployment: () => isCloudMock(),
+  isSaaS: () => isSaaSMock(),
   isSelfHostedDeployment: () => isSelfHostedMock(),
 }));
 
@@ -188,8 +188,8 @@ describe('PostSignupPage behavior', () => {
     managedCreateCheckoutSessionMock.mockReset();
     getTokenMock.mockReset();
     getMyOrganizationsMock.mockReset();
-    isCloudMock.mockReset();
     isEEEnabledMock.mockReset();
+    isSaaSMock.mockReset();
     isSelfHostedMock.mockReset();
     resolveAuthTokenMock.mockReset();
     localStorageMock.clear();
@@ -202,8 +202,8 @@ describe('PostSignupPage behavior', () => {
       onboardingStepsCompleted: [],
     };
     currentUserState.isLoading = false;
-    isCloudMock.mockReturnValue(false);
     isEEEnabledMock.mockReturnValue(false);
+    isSaaSMock.mockReturnValue(false);
     isSelfHostedMock.mockReturnValue(true);
     resolveAuthTokenMock.mockResolvedValue('api-token');
     getMyOrganizationsMock.mockResolvedValue([]);
@@ -376,8 +376,8 @@ describe('PostSignupPage behavior', () => {
     );
   });
 
-  it('routes new cloud signups to the org-scoped agent onboarding surface', async () => {
-    isCloudMock.mockReturnValue(true);
+  it('routes new SaaS signups to the org-scoped agent onboarding surface', async () => {
+    isSaaSMock.mockReturnValue(true);
     isSelfHostedMock.mockReturnValue(false);
     getMyOrganizationsMock.mockResolvedValue([
       {
@@ -398,8 +398,8 @@ describe('PostSignupPage behavior', () => {
     expect(createCheckoutSessionMock).not.toHaveBeenCalled();
   });
 
-  it('falls back to the wizard when no cloud org slug can be resolved', async () => {
-    isCloudMock.mockReturnValue(true);
+  it('falls back to the wizard when no SaaS org slug can be resolved', async () => {
+    isSaaSMock.mockReturnValue(true);
     isSelfHostedMock.mockReturnValue(false);
     getMyOrganizationsMock.mockResolvedValue([]);
 
@@ -410,8 +410,8 @@ describe('PostSignupPage behavior', () => {
     });
   });
 
-  it('keeps plan checkout returns on the wizard even on cloud (preserves #1421)', async () => {
-    isCloudMock.mockReturnValue(true);
+  it('keeps plan checkout returns on the wizard even on SaaS (preserves #1421)', async () => {
+    isSaaSMock.mockReturnValue(true);
     isEEEnabledMock.mockReturnValue(true);
     isSelfHostedMock.mockReturnValue(false);
     getMyOrganizationsMock.mockResolvedValue([
@@ -438,5 +438,27 @@ describe('PostSignupPage behavior', () => {
       });
     });
     expect(locationState.href).toBe('https://checkout.stripe.test/session');
+  });
+
+  it('keeps cloud-connected desktop signups on the classic wizard', async () => {
+    isSaaSMock.mockReturnValue(false);
+    isSelfHostedMock.mockReturnValue(false);
+    getMyOrganizationsMock.mockResolvedValue([
+      {
+        brand: null,
+        id: 'org-1',
+        isActive: true,
+        isOwner: true,
+        label: 'Acme',
+        slug: 'acme',
+      },
+    ]);
+
+    render(<PostSignupPage />);
+
+    await waitFor(() => {
+      expect(locationState.href).toBe('/onboarding/brand');
+    });
+    expect(getMyOrganizationsMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/app/app/(onboarding)/onboarding/post-signup/use-post-signup-routing.hook.ts
+++ b/apps/app/app/(onboarding)/onboarding/post-signup/use-post-signup-routing.hook.ts
@@ -7,10 +7,7 @@ import {
   parseSelectedCredits,
 } from '@app/(onboarding)/onboarding/post-signup/post-signup-routing.util';
 import { useCurrentUser } from '@contexts/user/user-context/user-context';
-import {
-  isCloudDeployment,
-  isSelfHostedDeployment,
-} from '@genfeedai/config/deployment';
+import { isSaaS, isSelfHostedDeployment } from '@genfeedai/config/deployment';
 import { isEEEnabled } from '@genfeedai/config/license';
 import {
   APP_ROUTES,
@@ -155,7 +152,7 @@ export function usePostSignupRouting(): PostSignupRoutingState {
       localStorage.getItem(ONBOARDING_STORAGE_KEYS.brandDomain),
     );
 
-    if (!isCloudDeployment()) {
+    if (!isSaaS()) {
       return wizardHref;
     }
 

--- a/apps/app/app/(protected)/[orgSlug]/org-landing-content.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/org-landing-content.test.tsx
@@ -78,6 +78,8 @@ describe('OrgLandingContent', () => {
       onboardingStepsCompleted: ['brand', 'providers', 'summary'],
     };
     mocks.currentUserState.isLoading = false;
+    vi.stubEnv('NEXT_PUBLIC_DESKTOP_SHELL', undefined);
+    vi.stubEnv('NEXT_PUBLIC_GENFEED_CLOUD', undefined);
   });
 
   it('redirects to onboarding when the organization has no projects', async () => {
@@ -129,7 +131,7 @@ describe('OrgLandingContent', () => {
     });
   });
 
-  it('routes incomplete cloud users to the agent onboarding surface', async () => {
+  it('routes incomplete SaaS users to the agent onboarding surface', async () => {
     vi.stubEnv('NEXT_PUBLIC_GENFEED_CLOUD', 'true');
     mocks.currentUserState.currentUser = {
       id: 'user_1',
@@ -149,6 +151,30 @@ describe('OrgLandingContent', () => {
 
     await waitFor(() => {
       expect(mocks.replace).toHaveBeenCalledWith('/acme/~/agent/onboarding');
+    });
+  });
+
+  it('keeps cloud-connected desktop org-root navigation on the classic wizard', async () => {
+    vi.stubEnv('NEXT_PUBLIC_DESKTOP_SHELL', 'true');
+    vi.stubEnv('NEXT_PUBLIC_GENFEED_CLOUD', 'true');
+    mocks.currentUserState.currentUser = {
+      id: 'user_1',
+      isOnboardingCompleted: false,
+      onboardingStepsCompleted: [],
+    };
+    mocks.brandState.brands = [
+      {
+        id: 'brand_1',
+        label: 'Default Organization',
+        slug: 'default',
+        totalCredentials: 0,
+      },
+    ];
+
+    render(<OrgLandingContent />);
+
+    await waitFor(() => {
+      expect(mocks.replace).toHaveBeenCalledWith('/onboarding/brand');
     });
   });
 

--- a/apps/app/app/(protected)/[orgSlug]/org-landing-content.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/org-landing-content.tsx
@@ -2,7 +2,7 @@
 
 import { useBrand } from '@contexts/user/brand-context/brand-context';
 import { useCurrentUser } from '@contexts/user/user-context/user-context';
-import { isCloudDeployment } from '@genfeedai/config/deployment';
+import { isSaaS } from '@genfeedai/config/deployment';
 import {
   APP_ROUTES,
   createBrandAppRoute,
@@ -101,7 +101,7 @@ export default function OrgLandingContent() {
 
     if (!hasCompletedOnboarding) {
       replace(
-        isCloudDeployment() && orgSlug
+        isSaaS() && orgSlug
           ? createOrganizationAppRoute(orgSlug, APP_ROUTES.AGENT.ONBOARDING)
           : `/onboarding/${getResumeStep(completedSteps)}`,
       );

--- a/apps/app/app/(protected)/root-resolver-client.test.tsx
+++ b/apps/app/app/(protected)/root-resolver-client.test.tsx
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
       organization?: { slug?: string };
       slug?: string;
     }>,
+    isReady: true,
     organizationId: '',
     selectedBrand: null as {
       organization?: { slug?: string };
@@ -68,6 +69,7 @@ describe('ProtectedRootResolver', () => {
     mocks.isAccessStateLoading = false;
     mocks.brandState.brandId = '';
     mocks.brandState.brands = [];
+    mocks.brandState.isReady = true;
     mocks.brandState.organizationId = '';
     mocks.brandState.selectedBrand = null;
     mocks.currentUserState.currentUser = {
@@ -76,6 +78,8 @@ describe('ProtectedRootResolver', () => {
       onboardingStepsCompleted: ['brand', 'providers', 'summary'],
     };
     mocks.currentUserState.isLoading = false;
+    vi.stubEnv('NEXT_PUBLIC_DESKTOP_SHELL', undefined);
+    vi.stubEnv('NEXT_PUBLIC_GENFEED_CLOUD', undefined);
   });
 
   it('opens the selected brand workspace when org and brand are selected', async () => {
@@ -142,7 +146,7 @@ describe('ProtectedRootResolver', () => {
     });
   });
 
-  it('routes incomplete cloud users to the agent onboarding surface', async () => {
+  it('routes incomplete SaaS users to the agent onboarding surface', async () => {
     vi.stubEnv('NEXT_PUBLIC_GENFEED_CLOUD', 'true');
     mocks.currentUserState.currentUser = {
       id: 'user_1',
@@ -158,6 +162,51 @@ describe('ProtectedRootResolver', () => {
 
     await waitFor(() => {
       expect(mocks.replace).toHaveBeenCalledWith('/acme/~/agent/onboarding');
+    });
+  });
+
+  it('waits for brand readiness before resolving the agent organization', async () => {
+    vi.stubEnv('NEXT_PUBLIC_GENFEED_CLOUD', 'true');
+    mocks.brandState.isReady = false;
+    mocks.currentUserState.currentUser = {
+      id: 'user_1',
+      isOnboardingCompleted: false,
+      onboardingStepsCompleted: [],
+    };
+
+    const { rerender } = render(<ProtectedRootResolver />);
+
+    expect(mocks.replace).not.toHaveBeenCalled();
+
+    mocks.brandState.isReady = true;
+    mocks.brandState.selectedBrand = {
+      organization: { slug: 'acme' },
+      slug: 'default',
+    };
+    rerender(<ProtectedRootResolver />);
+
+    await waitFor(() => {
+      expect(mocks.replace).toHaveBeenCalledWith('/acme/~/agent/onboarding');
+    });
+  });
+
+  it('keeps cloud-connected desktop users on the classic wizard', async () => {
+    vi.stubEnv('NEXT_PUBLIC_DESKTOP_SHELL', 'true');
+    vi.stubEnv('NEXT_PUBLIC_GENFEED_CLOUD', 'true');
+    mocks.currentUserState.currentUser = {
+      id: 'user_1',
+      isOnboardingCompleted: false,
+      onboardingStepsCompleted: ['brand'],
+    };
+    mocks.brandState.selectedBrand = {
+      organization: { slug: 'acme' },
+      slug: 'default',
+    };
+
+    render(<ProtectedRootResolver />);
+
+    await waitFor(() => {
+      expect(mocks.replace).toHaveBeenCalledWith('/onboarding/providers');
     });
   });
 });

--- a/apps/app/app/(protected)/root-resolver-client.tsx
+++ b/apps/app/app/(protected)/root-resolver-client.tsx
@@ -2,7 +2,7 @@
 
 import { useBrand } from '@contexts/user/brand-context/brand-context';
 import { useCurrentUser } from '@contexts/user/user-context/user-context';
-import { isCloudDeployment } from '@genfeedai/config/deployment';
+import { isSaaS } from '@genfeedai/config/deployment';
 import {
   APP_ROUTES,
   createBrandAppRoute,
@@ -33,7 +33,8 @@ function getBrandOrganizationSlug(
 }
 
 export default function ProtectedRootResolver() {
-  const { brandId, brands, organizationId, selectedBrand } = useBrand();
+  const { brandId, brands, isReady, organizationId, selectedBrand } =
+    useBrand();
   const { currentUser, isLoading: isCurrentUserLoading } = useCurrentUser();
   const { accessState, isLoading: isAccessStateLoading } = useAccessState();
   const { replace } = useRouter();
@@ -46,6 +47,7 @@ export default function ProtectedRootResolver() {
     if (
       isAccessStateLoading ||
       isCurrentUserLoading ||
+      !isReady ||
       !currentUser ||
       hasStartedRef.current
     ) {
@@ -64,7 +66,7 @@ export default function ProtectedRootResolver() {
         getBrandOrganizationSlug(selectedBrand) ||
         getBrandOrganizationSlug(brands[0]);
       replace(
-        isCloudDeployment() && agentOrgSlug
+        isSaaS() && agentOrgSlug
           ? createOrganizationAppRoute(
               agentOrgSlug,
               APP_ROUTES.AGENT.ONBOARDING,
@@ -129,6 +131,7 @@ export default function ProtectedRootResolver() {
     currentUser,
     isCurrentUserLoading,
     isAccessStateLoading,
+    isReady,
     organizationId,
     replace,
     selectedBrand,

--- a/apps/app/proxy.test.ts
+++ b/apps/app/proxy.test.ts
@@ -80,6 +80,7 @@ describe('proxy', () => {
     vi.stubEnv('API_URL', undefined);
     vi.stubEnv('NEXT_PUBLIC_API_ENDPOINT', 'http://localhost:3010/v1');
     vi.stubEnv('NEXT_PUBLIC_DESKTOP_SHELL', undefined);
+    vi.stubEnv('NEXT_PUBLIC_GENFEED_CLOUD', undefined);
     vi.resetModules();
     globalThis.fetch = fetchMock as typeof fetch;
 
@@ -263,7 +264,7 @@ describe('proxy', () => {
     );
   });
 
-  describe('agent-first onboarding (cloud)', () => {
+  describe('agent-first onboarding (SaaS)', () => {
     const mockIncompleteUser = () =>
       fetchMock.mockImplementation(async (input: string | URL) => {
         const url = String(input);
@@ -299,7 +300,7 @@ describe('proxy', () => {
         return new Response('not found', { status: 404 });
       });
 
-    it('redirects an incomplete cloud user on a protected route to the agent onboarding surface', async () => {
+    it('redirects an incomplete SaaS user on a protected route to the agent onboarding surface', async () => {
       vi.stubEnv('NEXT_PUBLIC_GENFEED_CLOUD', 'true');
       mockIncompleteUser();
 
@@ -315,7 +316,7 @@ describe('proxy', () => {
       );
     });
 
-    it('lets an incomplete cloud user stay on the agent onboarding surface (no redirect loop)', async () => {
+    it('lets an incomplete SaaS user stay on the agent onboarding surface (no redirect loop)', async () => {
       vi.stubEnv('NEXT_PUBLIC_GENFEED_CLOUD', 'true');
       mockIncompleteUser();
 
@@ -341,6 +342,20 @@ describe('proxy', () => {
       expect(response.headers.get('location')).toBe(
         'http://localhost:3000/onboarding',
       );
+    });
+
+    it('does not route cloud-connected desktop users into web agent onboarding', async () => {
+      vi.stubEnv('NEXT_PUBLIC_DESKTOP_SHELL', 'true');
+      vi.stubEnv('NEXT_PUBLIC_GENFEED_CLOUD', 'true');
+      mockIncompleteUser();
+
+      const { default: proxy } = await import('./proxy');
+      const response = await proxy(
+        makeSignedInRequest('/acme/default/workspace/overview'),
+        {} as never,
+      );
+
+      expect(response.headers.get('location')).toBeNull();
     });
   });
 

--- a/apps/app/proxy.ts
+++ b/apps/app/proxy.ts
@@ -2,6 +2,7 @@ import { isBetterAuthEnabled } from '@genfeedai/auth-client/server';
 import {
   isCloudDeployment,
   isDesktopClient,
+  isSaaS,
 } from '@genfeedai/config/deployment';
 import { type NextRequest, NextResponse } from 'next/server';
 
@@ -473,7 +474,7 @@ function isAgentOnboardingPath(pathname: string): boolean {
 }
 
 // Resolve the org-scoped agent onboarding destination for an incomplete user.
-// Agent-first onboarding is the cloud default; callers fall back to the wizard
+// Agent-first onboarding is the SaaS default; callers fall back to the wizard
 // (`ONBOARDING_PATH`) when the workspace slug can't be resolved.
 async function resolveAgentOnboardingRedirect(
   token: string,
@@ -638,7 +639,7 @@ async function redirectSignedInUserToDefaultRoute(
   cacheKey?: string | null,
 ): Promise<NextResponse | null> {
   if (await shouldRedirectSignedInUserToOnboarding(token)) {
-    if (isCloudDeployment()) {
+    if (isSaaS()) {
       const agentOnboarding = await resolveAgentOnboardingRedirect(
         token,
         cacheKey,
@@ -836,8 +837,8 @@ export async function proxy(req: NextRequest) {
     }
 
     if (await shouldRedirectSignedInUserToOnboarding(token)) {
-      // Self-hosted/desktop keep the form wizard; only cloud gets agent-first.
-      if (!isCloudDeployment()) {
+      // Community/Desktop keep the form wizard; only SaaS gets agent-first.
+      if (!isSaaS()) {
         return redirectPreservingSearch(req, ONBOARDING_PATH);
       }
 


### PR DESCRIPTION
## Summary

- gate every agent-first onboarding/root routing decision on the canonical `isSaaS()` predicate
- keep Community and cloud-connected Desktop clients on the classic wizard while SaaS continues to use org-scoped agent onboarding
- wait for brand context readiness before the client root resolver derives the agent organization slug
- add focused regressions for protected proxy routing, direct org-root navigation, post-signup handoff, client-side root resolution, and brand readiness

## Related issue

Closes #1656

## Scope and boundaries

This is limited to the four agent-first routing layers introduced by #1641. It does not change the conversation shell rollout, backend APIs, serializers, tenant queries, generated files, migrations, or EE package boundaries. Existing checkout return routing remains on the classic wizard.

## Verification

- `bunx biome check` on all 8 changed files: clean
- pre-commit staged checks: Secretlint, Biome, control guard, and bespoke-card guard passed
- `git show --check HEAD`: clean
- focused regression tests were added but not run locally; per repository machine policy, tests, typechecks, builds, and compilation are delegated to PR CI

## Screenshots

Not applicable; routing behavior only.

## Checklist

- [x] I removed secrets, credentials, personal data, and customer data.
- [x] I updated relevant documentation or explained why no docs change is needed.
- [x] I preserved the Community/Cloud/Enterprise boundary.
- [x] I documented migration, release, or external-setting actions, or marked them not applicable.

Documentation changes are not needed because this fixes implementation drift against the existing deployment-modes ADR. Migration, release, and external-setting actions are not applicable.