### PR TITLE
fix(agent): surface OAuth connect in floating panel

### DIFF
--- a/apps/app/packages/components/app-protected-layout.tsx
+++ b/apps/app/packages/components/app-protected-layout.tsx
@@ -44,7 +44,7 @@ type AgentPanelProps = {
   authReady?: boolean;
   isActive?: boolean;
   onNavigateToBilling?: () => void;
-  onOAuthConnect?: (platform: string) => void;
+  onOAuthConnect?: (platform: string) => void | Promise<void>;
   onSelectCreditPack?: (pack: {
     label: string;
     price: string;

--- a/packages/agent/src/components/AgentChatMessageCards.spec.tsx
+++ b/packages/agent/src/components/AgentChatMessageCards.spec.tsx
@@ -1,0 +1,29 @@
+import { OAuthConnectCard } from '@genfeedai/agent/components/AgentChatMessageCards';
+import type { AgentUiAction } from '@genfeedai/agent/models/agent-chat.model';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+const action = {
+  id: 'connect-twitter',
+  platform: 'twitter',
+  type: 'oauth_connect_card',
+} as AgentUiAction;
+
+describe('OAuthConnectCard', () => {
+  it('keeps the dedicated conversation action retryable after OAuth rejects', async () => {
+    const user = userEvent.setup();
+    const onConnect = vi.fn().mockRejectedValue(new Error('OAuth unavailable'));
+    render(<OAuthConnectCard action={action} onConnect={onConnect} />);
+
+    const connectButton = screen.getByRole('button', {
+      name: 'Connect X (Twitter)',
+    });
+    await user.click(connectButton);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Could not start the connection. Please try again.',
+    );
+    expect(connectButton).toBeEnabled();
+  });
+});

--- a/packages/agent/src/components/AgentChatMessageCards.tsx
+++ b/packages/agent/src/components/AgentChatMessageCards.tsx
@@ -73,9 +73,27 @@ export function OAuthConnectCard({
   onConnect,
 }: {
   action: AgentUiAction;
-  onConnect?: (platform: string) => void;
+  onConnect?: (platform: string) => void | Promise<void>;
 }): ReactElement {
   const platform = action.platform?.trim();
+  const [isConnecting, setIsConnecting] = useState(false);
+  const [connectError, setConnectError] = useState<string | null>(null);
+
+  const handleConnect = useCallback(async () => {
+    if (!platform || !onConnect || isConnecting) {
+      return;
+    }
+
+    setConnectError(null);
+    setIsConnecting(true);
+    try {
+      await onConnect(platform);
+    } catch {
+      setConnectError('Could not start the connection. Please try again.');
+    } finally {
+      setIsConnecting(false);
+    }
+  }, [isConnecting, onConnect, platform]);
 
   if (!platform) {
     return <GenericOAuthConnectCard action={action} />;
@@ -91,10 +109,17 @@ export function OAuthConnectCard({
       <Button
         variant={ButtonVariant.DEFAULT}
         size={ButtonSize.SM}
-        onClick={() => onConnect?.(platform)}
+        onClick={handleConnect}
+        isDisabled={!onConnect || isConnecting}
+        isLoading={isConnecting}
       >
         Connect {label}
       </Button>
+      {connectError ? (
+        <p className="mt-2 text-xs text-red-600 dark:text-red-400" role="alert">
+          {connectError}
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/packages/agent/src/components/AgentOAuthConnectMenu.spec.tsx
+++ b/packages/agent/src/components/AgentOAuthConnectMenu.spec.tsx
@@ -1,0 +1,87 @@
+import { AgentOAuthConnectMenu } from '@genfeedai/agent/components/AgentOAuthConnectMenu';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+describe('AgentOAuthConnectMenu', () => {
+  it('invokes OAuth and closes after a successful async handoff', async () => {
+    const user = userEvent.setup();
+    const onOAuthConnect = vi.fn().mockResolvedValue(undefined);
+    render(<AgentOAuthConnectMenu onOAuthConnect={onOAuthConnect} />);
+
+    await user.click(
+      screen.getByRole('button', { name: 'Connect a social channel' }),
+    );
+    await user.click(screen.getByRole('button', { name: 'Twitter' }));
+
+    expect(onOAuthConnect).toHaveBeenCalledWith('twitter');
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('button', { name: 'Twitter' }),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it('recovers when the handoff returns without navigating', async () => {
+    const user = userEvent.setup();
+    const onOAuthConnect = vi.fn(() => undefined);
+    render(<AgentOAuthConnectMenu onOAuthConnect={onOAuthConnect} />);
+
+    const trigger = screen.getByRole('button', {
+      name: 'Connect a social channel',
+    });
+    await user.click(trigger);
+    await user.click(screen.getByRole('button', { name: 'Twitter' }));
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('button', { name: 'Twitter' }),
+      ).not.toBeInTheDocument();
+    });
+    await user.click(trigger);
+
+    expect(screen.getByRole('button', { name: 'Twitter' })).toBeEnabled();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('surfaces a synchronous failure and leaves the action retryable', async () => {
+    const user = userEvent.setup();
+    const onOAuthConnect = vi
+      .fn()
+      .mockImplementationOnce(() => {
+        throw new Error('popup blocked');
+      })
+      .mockReturnValue(undefined);
+    render(<AgentOAuthConnectMenu onOAuthConnect={onOAuthConnect} />);
+
+    await user.click(
+      screen.getByRole('button', { name: 'Connect a social channel' }),
+    );
+    const twitterButton = screen.getByRole('button', { name: 'Twitter' });
+    await user.click(twitterButton);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Could not start the connection. Please try again.',
+    );
+    expect(twitterButton).toBeEnabled();
+
+    await user.click(twitterButton);
+    expect(onOAuthConnect).toHaveBeenCalledTimes(2);
+  });
+
+  it('surfaces an async failure and leaves the action retryable', async () => {
+    const user = userEvent.setup();
+    const onOAuthConnect = vi.fn().mockRejectedValue(new Error('api down'));
+    render(<AgentOAuthConnectMenu onOAuthConnect={onOAuthConnect} />);
+
+    await user.click(
+      screen.getByRole('button', { name: 'Connect a social channel' }),
+    );
+    const twitterButton = screen.getByRole('button', { name: 'Twitter' });
+    await user.click(twitterButton);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Could not start the connection. Please try again.',
+    );
+    expect(twitterButton).toBeEnabled();
+  });
+});

--- a/packages/agent/src/components/AgentOAuthConnectMenu.tsx
+++ b/packages/agent/src/components/AgentOAuthConnectMenu.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import { ButtonVariant } from '@genfeedai/enums';
+import { cn } from '@helpers/formatting/cn/cn.util';
+import { OAUTH_CONNECT_PLATFORMS } from '@ui/constants/oauth-connect-platforms';
+import { Button } from '@ui/primitives/button';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@ui/primitives/popover';
+import { type ReactElement, useCallback, useState } from 'react';
+import { HiChevronDown, HiOutlineLink } from 'react-icons/hi2';
+
+interface AgentOAuthConnectMenuProps {
+  onOAuthConnect?: (platform: string) => void | Promise<void>;
+}
+
+const CONNECT_ERROR_MESSAGE =
+  'Could not start the connection. Please try again.';
+
+export function AgentOAuthConnectMenu({
+  onOAuthConnect,
+}: AgentOAuthConnectMenuProps): ReactElement | null {
+  const [open, setOpen] = useState(false);
+  const [connectingPlatform, setConnectingPlatform] = useState<string | null>(
+    null,
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  const handleConnect = useCallback(
+    async (platform: string) => {
+      if (!onOAuthConnect || connectingPlatform) {
+        return;
+      }
+
+      setError(null);
+      setConnectingPlatform(platform);
+
+      try {
+        await onOAuthConnect(platform);
+        // A successful handoff normally replaces the current document. Closing
+        // also restores the control when auth cancellation leaves us in place.
+        setOpen(false);
+      } catch {
+        setError(CONNECT_ERROR_MESSAGE);
+      } finally {
+        setConnectingPlatform(null);
+      }
+    },
+    [connectingPlatform, onOAuthConnect],
+  );
+
+  if (!onOAuthConnect) {
+    return null;
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant={ButtonVariant.UNSTYLED}
+          withWrapper={false}
+          className="gen-shell-control flex items-center gap-1 rounded-md px-2 py-1 text-left"
+          data-active={open ? 'true' : 'false'}
+          ariaLabel="Connect a social channel"
+        >
+          <HiOutlineLink className="size-3.5 text-foreground/55" />
+          <span className="text-[11px] font-medium text-foreground">
+            Connect
+          </span>
+          <HiChevronDown
+            className={cn(
+              'size-3 text-foreground/42 transition-transform',
+              open && 'rotate-180',
+            )}
+          />
+        </Button>
+      </PopoverTrigger>
+
+      <PopoverContent
+        align="end"
+        side="bottom"
+        sideOffset={10}
+        className="gen-shell-panel w-[20rem] rounded-[1.25rem] p-2 text-foreground shadow-[0_28px_70px_-48px_rgba(0,0,0,0.9)]"
+      >
+        <div className="px-2.5 py-2">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-foreground/42">
+            Connect a channel
+          </p>
+          <p className="mt-1 text-xs text-foreground/58">
+            Add a publishing destination without leaving your current work.
+          </p>
+        </div>
+
+        {error ? (
+          <p
+            className="mx-2 mb-2 rounded-lg border border-red-400/25 bg-red-500/10 px-3 py-2 text-xs text-red-300"
+            role="alert"
+          >
+            {error}
+          </p>
+        ) : null}
+
+        <div className="grid max-h-72 grid-cols-2 gap-1 overflow-y-auto">
+          {OAUTH_CONNECT_PLATFORMS.map((item) => (
+            <Button
+              key={item.platform}
+              variant={ButtonVariant.UNSTYLED}
+              withWrapper={false}
+              onClick={() => void handleConnect(item.platform)}
+              isDisabled={connectingPlatform !== null}
+              isLoading={connectingPlatform === item.platform}
+              className="gen-shell-surface flex w-full items-center rounded-xl px-3 py-2 text-left text-xs font-medium text-foreground transition-colors"
+            >
+              {item.icon}
+              {item.label}
+            </Button>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/packages/agent/src/components/AgentPanel.spec.tsx
+++ b/packages/agent/src/components/AgentPanel.spec.tsx
@@ -240,7 +240,12 @@ describe('AgentPanel', () => {
   });
 
   it('renders the terminal rail without the embedded chat composer toggle', () => {
-    render(<AgentPanel apiService={createCreditsInfoApiService() as never} />);
+    render(
+      <AgentPanel
+        apiService={createCreditsInfoApiService() as never}
+        onOAuthConnect={vi.fn()}
+      />,
+    );
 
     expect(screen.getByTestId('agent-cli-terminal')).toBeInTheDocument();
     expect(
@@ -255,6 +260,9 @@ describe('AgentPanel', () => {
     ).toBeInTheDocument();
     expect(
       screen.getByLabelText('Terminal working directory'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Connect a social channel' }),
     ).toBeInTheDocument();
   });
 

--- a/packages/agent/src/components/AgentPanel.tsx
+++ b/packages/agent/src/components/AgentPanel.tsx
@@ -3,6 +3,7 @@ import {
   AgentCliTerminalControls,
   useAgentCliTerminal,
 } from '@genfeedai/agent/components/AgentCliTerminal';
+import { AgentOAuthConnectMenu } from '@genfeedai/agent/components/AgentOAuthConnectMenu';
 import { AgentOutputsPanel } from '@genfeedai/agent/components/AgentOutputsPanel';
 import { AgentTerminalHeader } from '@genfeedai/agent/components/AgentTerminalHeader';
 import type { AgentRuntimeOption } from '@genfeedai/agent/models/agent-runtime.model';
@@ -33,7 +34,7 @@ interface AgentPanelProps {
   authReady?: boolean;
   isActive?: boolean;
   onNavigateToBilling?: () => void;
-  onOAuthConnect?: (platform: string) => void;
+  onOAuthConnect?: (platform: string) => void | Promise<void>;
   onSelectCreditPack?: (pack: {
     label: string;
     price: string;
@@ -65,6 +66,7 @@ export function AgentPanel({
   apiService,
   authReady = true,
   isActive = true,
+  onOAuthConnect,
 }: AgentPanelProps): ReactElement {
   const router = useRouter();
   const { href } = useOrgUrl();
@@ -301,6 +303,7 @@ export function AgentPanel({
             threadLabel={threadLabel}
             onRuntimeChange={handleRuntimeChange}
           />
+          <AgentOAuthConnectMenu onOAuthConnect={onOAuthConnect} />
           <AgentCliTerminalControls controller={terminalController} />
         </div>
       }

--- a/packages/hooks/agent/use-agent-oauth-connect/use-agent-oauth-connect.test.ts
+++ b/packages/hooks/agent/use-agent-oauth-connect/use-agent-oauth-connect.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mockPostConnect = vi.fn();
 const mockResolveAuthToken = vi.fn();
 const mockUseParams = vi.fn();
+const mockLoggerError = vi.hoisted(() => vi.fn());
 let selectedBrand: { id: string } | undefined;
 
 vi.mock('@services/external/services.service', () => ({
@@ -20,7 +21,7 @@ vi.mock('@services/external/services.service', () => ({
 }));
 
 vi.mock('@services/core/logger.service', () => ({
-  logger: { error: vi.fn() },
+  logger: { error: mockLoggerError },
 }));
 
 vi.mock('@contexts/user/brand-context/brand-context', () => ({
@@ -99,6 +100,19 @@ describe('useAgentOAuthConnect', () => {
     });
 
     expect(mockPostConnect).not.toHaveBeenCalled();
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it('logs and propagates connect failures to the invoking surface', async () => {
+    const error = new Error('OAuth unavailable');
+    mockPostConnect.mockRejectedValue(error);
+    const { result } = renderHook(() => useAgentOAuthConnect());
+
+    await expect(result.current('twitter')).rejects.toThrow(
+      'OAuth unavailable',
+    );
+
+    expect(mockLoggerError).toHaveBeenCalledWith('OAuth connect failed', error);
     expect(openSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/hooks/agent/use-agent-oauth-connect/use-agent-oauth-connect.ts
+++ b/packages/hooks/agent/use-agent-oauth-connect/use-agent-oauth-connect.ts
@@ -76,6 +76,10 @@ export function useAgentOAuthConnect(
         );
       } catch (error) {
         logger.error('OAuth connect failed', error);
+        // Let the invoking surface restore an actionable error state instead
+        // of leaving a connect control looking successful after a failed API
+        // request. Each current consumer handles the rejection locally.
+        throw error;
       }
     },
     [getToken, isOnboarding, orgHref, selectedBrand, threadId],


### PR DESCRIPTION
## Summary

- add a compact social-channel connect menu to the terminal-only `AgentPanel`, consuming the `onOAuthConnect` callback already supplied by the protected layout
- keep the conversation-first shell and dedicated `/agent` conversation surface unchanged; no `AgentOverlay` revival and no parallel chat surface
- propagate shared OAuth hook failures so existing surfaces can show recoverable error state instead of silently swallowing failed handoffs
- keep both the floating menu and dedicated OAuth card retryable after synchronous or asynchronous failures, and reset cleanly when the handoff returns without navigation

## Related issue

Closes #1655

## Scope and boundaries

- route audit: dedicated `/agent` and universal-shell conversation regions render `AgentWorkspacePageShell`; eligible legacy protected routes and shell fallback render the terminal-only `AgentPanel`
- no open PR overlaps the modified panel, card, hook, or protected-layout paths
- no backend, serializer, database, OSS/EE, tenant, navigation, or onboarding-flow boundary changes
- `AgentOverlay` remains unused

## Verification

- `bunx biome check` on all 9 intended files — passed
- pre-commit staged Biome check, UI control guard, bespoke-card guard, and Secretlint — passed
- staged Gitleaks scan — no leaks found
- `git diff --cached --check` — passed
- focused regression tests added for successful handoff, cancellation/no-navigation recovery, synchronous failure, asynchronous failure, floating-panel mounting, shared-hook propagation, and dedicated-card retry state
- local tests, typechecks, builds, E2E, and compilation were intentionally not run per workstation policy; PR CI is authoritative

## Screenshots

Not captured — local build/browser execution is intentionally disabled by workstation policy. The visible change is limited to a `Connect` popover in the existing terminal rail header.

## Checklist

- [x] I removed secrets, credentials, personal data, and customer data.
- [x] No documentation change is needed; the existing agent frontend memory already describes the panel and OAuth card contract.
- [x] I preserved the Community/Cloud/Enterprise boundary.
- [x] Migration, release, and external-setting actions are not applicable.
