### PR TITLE
fix(agent): harden artifact reference persistence

### DIFF
--- a/apps/server/api/src/collections/agent-messages/services/agent-messages.service.spec.ts
+++ b/apps/server/api/src/collections/agent-messages/services/agent-messages.service.spec.ts
@@ -335,4 +335,27 @@ describe('AgentMessagesService', () => {
       }),
     });
   });
+
+  it('preserves tool-result linkage while copying messages between rooms', async () => {
+    agentMessage.findMany.mockResolvedValueOnce([
+      {
+        artifactReferences: [],
+        artifactVersionPinIds: [],
+        id: 'tool-result-message',
+        organizationId: 'org-1',
+        role: 'tool',
+        threadId: 'source',
+        toolCallId: 'tool-call-1',
+      },
+    ]);
+
+    await service.copyMessages('source', 'target', 'org-1');
+
+    expect(agentMessage.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        threadId: 'target',
+        toolCallId: 'tool-call-1',
+      }),
+    });
+  });
 });

--- a/apps/server/api/src/collections/agent-messages/services/agent-messages.service.ts
+++ b/apps/server/api/src/collections/agent-messages/services/agent-messages.service.ts
@@ -349,6 +349,7 @@ export class AgentMessagesService extends BaseService<
               organizationId: doc.organizationId,
               role: doc.role,
               threadId: targetRoomId,
+              toolCallId: doc.toolCallId,
               toolCalls: doc.toolCalls,
               userId: doc.userId,
             },

--- a/apps/server/api/src/collections/agent-threads/services/agent-artifact-reference.service.spec.ts
+++ b/apps/server/api/src/collections/agent-threads/services/agent-artifact-reference.service.spec.ts
@@ -244,6 +244,36 @@ describe('AgentArtifactReferenceService', () => {
     expect(prisma.contentVersionPin.create).toHaveBeenCalledTimes(1);
   });
 
+  it('creates the version pin through a caller-provided transaction', async () => {
+    const transaction = createPrismaMock();
+    transaction.member.findFirst.mockResolvedValue({ id: 'member-1' });
+    transaction.post.findFirst.mockResolvedValue({
+      brandId,
+      description: 'Approved copy',
+      id: 'post-1',
+      ingredients: [],
+      organizationId: orgId,
+    });
+    transaction.contentVersionPin.findFirst.mockResolvedValue(null);
+    transaction.contentVersionPin.create.mockImplementation(
+      async ({ data }: { data: Record<string, unknown> }) => ({
+        ...data,
+        createdAt: new Date('2026-07-13T20:00:00.000Z'),
+      }),
+    );
+
+    await service.createOrReuseVersionPin({
+      createdByUserId: userId,
+      reference: reference('post'),
+      transaction,
+    });
+
+    expect(transaction.post.findFirst).toHaveBeenCalled();
+    expect(transaction.contentVersionPin.create).toHaveBeenCalled();
+    expect(prisma.post.findFirst).not.toHaveBeenCalled();
+    expect(prisma.contentVersionPin.create).not.toHaveBeenCalled();
+  });
+
   it('fails closed when canonical post material changes after pinning', async () => {
     const original = {
       brandId,

--- a/apps/server/api/src/collections/publish-approvals/services/publish-approvals.service.spec.ts
+++ b/apps/server/api/src/collections/publish-approvals/services/publish-approvals.service.spec.ts
@@ -146,6 +146,7 @@ describe('PublishApprovalsService', () => {
     const artifactReferenceService = {
       createOrReuseVersionPin: vi.fn().mockResolvedValue({ id: 'pin-1' }),
     };
+    const transaction = { post: prisma.post, publishApproval };
     const service = new PublishApprovalsService(
       prisma as never,
       artifactReferenceService as unknown as AgentArtifactReferenceService,
@@ -157,6 +158,7 @@ describe('PublishApprovalsService', () => {
       organizationId: 'org-1',
       postId: 'post-1',
       provenance: { surface: 'review-queue' },
+      transaction: transaction as never,
     });
 
     expect(approval).toEqual(
@@ -193,6 +195,10 @@ describe('PublishApprovalsService', () => {
         }),
       }),
     );
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+    expect(
+      artifactReferenceService.createOrReuseVersionPin,
+    ).toHaveBeenCalledWith(expect.objectContaining({ transaction }));
   });
 
   it('fails closed and invalidates when the canonical brand drifts', async () => {

--- a/apps/server/api/src/services/batch-generation/batch-generation.service.spec.ts
+++ b/apps/server/api/src/services/batch-generation/batch-generation.service.spec.ts
@@ -2,6 +2,7 @@ import { BrandsService } from '@api/collections/brands/services/brands.service';
 import { ContentGeneratorService } from '@api/collections/content-intelligence/services/content-generator.service';
 import { PostsService } from '@api/collections/posts/services/posts.service';
 import { PublishApprovalsService } from '@api/collections/publish-approvals/services/publish-approvals.service';
+import { NotFoundException } from '@api/helpers/exceptions/http/not-found.exception';
 import { BatchGenerationService } from '@api/services/batch-generation/batch-generation.service';
 import { CacheService } from '@api/services/cache/services/cache.service';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
@@ -23,6 +24,12 @@ describe('BatchGenerationService approval version pins', () => {
     updateMany: ReturnType<typeof vi.fn>;
   };
   let service: BatchGenerationService;
+  let prisma: {
+    $transaction: ReturnType<typeof vi.fn>;
+    batch: typeof batchDelegate;
+    post: typeof postDelegate;
+    postAnalytics: { findMany: ReturnType<typeof vi.fn> };
+  };
   let publishApprovalsService: {
     createForCurrentPost: ReturnType<typeof vi.fn>;
     toPublicInterface: ReturnType<typeof vi.fn>;
@@ -66,6 +73,14 @@ describe('BatchGenerationService approval version pins', () => {
       }),
       toPublicInterface: vi.fn((value) => value),
     };
+    prisma = {
+      $transaction: vi.fn((callback) =>
+        callback({ batch: batchDelegate, post: postDelegate }),
+      ),
+      batch: batchDelegate,
+      post: postDelegate,
+      postAnalytics: { findMany: vi.fn().mockResolvedValue([]) },
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -91,11 +106,7 @@ describe('BatchGenerationService approval version pins', () => {
         },
         {
           provide: PrismaService,
-          useValue: {
-            batch: batchDelegate,
-            post: postDelegate,
-            postAnalytics: { findMany: vi.fn().mockResolvedValue([]) },
-          },
+          useValue: prisma,
         },
       ],
     }).compile();
@@ -133,6 +144,10 @@ describe('BatchGenerationService approval version pins', () => {
         reviewItemId: 'item-1',
         surface: 'review-queue',
       },
+      transaction: expect.objectContaining({
+        batch: batchDelegate,
+        post: postDelegate,
+      }),
     });
     expect(postDelegate.updateMany).toHaveBeenCalledWith({
       data: {
@@ -189,6 +204,89 @@ describe('BatchGenerationService approval version pins', () => {
     ).rejects.toThrow('Canonical Post changed.');
 
     expect(postDelegate.updateMany).not.toHaveBeenCalled();
+    expect(batchDelegate.update).not.toHaveBeenCalled();
+  });
+
+  it('rolls back Post reference state when the batch approval write fails', async () => {
+    const item = {
+      _id: 'item-1',
+      format: ContentFormat.IMAGE,
+      postId: 'post-1',
+      status: BatchItemStatus.COMPLETED,
+    };
+    batchDelegate.findFirst.mockResolvedValue(createBatchRecord([item]));
+
+    const durableState = {
+      batchItems: [item],
+      postReviewDecision: null as string | null,
+      postVersionPinId: null as string | null,
+    };
+    const transactionPost = {
+      updateMany: vi.fn().mockImplementation(({ data }) => {
+        durableState.postReviewDecision = data.reviewDecision;
+        durableState.postVersionPinId = data.reviewVersionPinId;
+        return Promise.resolve({ count: 1 });
+      }),
+    };
+    const transactionBatch = {
+      update: vi.fn().mockRejectedValue(new Error('batch write failed')),
+    };
+    const transaction = {
+      batch: transactionBatch,
+      post: transactionPost,
+    };
+    prisma.$transaction.mockImplementationOnce(async (callback) => {
+      const originalState = { ...durableState };
+      try {
+        return await callback(transaction);
+      } catch (error: unknown) {
+        Object.assign(durableState, originalState);
+        throw error;
+      }
+    });
+
+    await expect(
+      service.approveItems('batch-1', ['item-1'], 'org-1', 'canonical-user-1'),
+    ).rejects.toThrow('batch write failed');
+
+    expect(durableState).toEqual({
+      batchItems: [item],
+      postReviewDecision: null,
+      postVersionPinId: null,
+    });
+    expect(
+      artifactReferenceService.createOrReuseVersionPin,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        transaction: expect.objectContaining(transaction),
+      }),
+    );
+    expect(postDelegate.updateMany).not.toHaveBeenCalled();
+    expect(batchDelegate.update).not.toHaveBeenCalled();
+  });
+
+  it('maps a missing canonical Post to the API NotFoundException convention', async () => {
+    batchDelegate.findFirst.mockResolvedValue(
+      createBatchRecord([
+        {
+          _id: 'item-1',
+          format: ContentFormat.IMAGE,
+          postId: 'post-1',
+          status: BatchItemStatus.COMPLETED,
+        },
+      ]),
+    );
+    postDelegate.updateMany.mockResolvedValueOnce({ count: 0 });
+
+    const error = await service
+      .approveItems('batch-1', ['item-1'], 'org-1', 'canonical-user-1')
+      .catch((cause: unknown) => cause);
+
+    expect(error).toBeInstanceOf(NotFoundException);
+    expect((error as NotFoundException).getResponse()).toEqual({
+      detail: 'A canonical Post disappeared before approval completed.',
+      title: 'Resource Not Found',
+    });
     expect(batchDelegate.update).not.toHaveBeenCalled();
   });
 

--- a/apps/server/api/src/services/batch-generation/batch-generation.service.ts
+++ b/apps/server/api/src/services/batch-generation/batch-generation.service.ts
@@ -799,110 +799,118 @@ export class BatchGenerationService {
           .flatMap((item) => (item.postId ? [item.postId] : [])),
       ),
     ];
-    const versionPinIds = new Map<string, string>();
-    const publishApprovals = new Map<string, IPublishApproval>();
+    const updatedBatch = await this.prisma.$transaction(async (transaction) => {
+      const versionPinIds = new Map<string, string>();
+      const publishApprovals = new Map<string, IPublishApproval>();
 
-    for (const postId of selectedPostIds) {
-      const item = batchItems.find((candidate) => candidate.postId === postId);
-      if (item?.scheduledDate) {
-        const approval =
-          await this.publishApprovalsService.createForCurrentPost({
-            actorUserId: createdByUserId,
-            mode: 'scheduled',
-            organizationId: orgId,
-            postId,
-            provenance: {
-              batchId,
-              reviewItemId: item._id,
-              surface: 'review-queue',
-            },
-          });
-        publishApprovals.set(postId, approval);
-        versionPinIds.set(postId, approval.artifactVersionPinId);
-      } else {
-        const versionPin =
-          await this.agentArtifactReferenceService.createOrReuseVersionPin({
-            createdByUserId,
-            reference: {
-              ...(batchRecord.brandId ? { brandId: batchRecord.brandId } : {}),
-              kind: 'post',
+      for (const postId of selectedPostIds) {
+        const item = batchItems.find(
+          (candidate) => candidate.postId === postId,
+        );
+        if (item?.scheduledDate) {
+          const approval =
+            await this.publishApprovalsService.createForCurrentPost({
+              actorUserId: createdByUserId,
+              mode: 'scheduled',
               organizationId: orgId,
-              recordId: postId,
-              serializer: 'post',
-            },
-          });
-        versionPinIds.set(postId, versionPin.id);
-      }
-    }
-
-    const postIdsToSchedule: string[] = [];
-
-    for (const item of batchItems) {
-      if (
-        itemIdSet.has(item._id) &&
-        item.status === BatchItemStatus.COMPLETED
-      ) {
-        const versionPinId = item.postId
-          ? versionPinIds.get(item.postId)
-          : undefined;
-        item.reviewDecision = 'approved';
-        item.publishApproval = item.postId
-          ? publishApprovals.get(item.postId)
-          : undefined;
-        item.reviewFeedback = undefined;
-        item.versionPinId = versionPinId;
-        item.reviewedAt = reviewedAt;
-        item.reviewEvents = [
-          ...(item.reviewEvents ?? []),
-          {
-            decision: 'approved',
-            reviewedAt,
-            ...(versionPinId ? { versionPinId } : {}),
-          },
-        ];
-        if (item.postId && item.scheduledDate) {
-          postIdsToSchedule.push(item.postId);
+              postId,
+              provenance: {
+                batchId,
+                reviewItemId: item._id,
+                surface: 'review-queue',
+              },
+              transaction,
+            });
+          publishApprovals.set(postId, approval);
+          versionPinIds.set(postId, approval.artifactVersionPinId);
+        } else {
+          const versionPin =
+            await this.agentArtifactReferenceService.createOrReuseVersionPin({
+              createdByUserId,
+              reference: {
+                ...(batchRecord.brandId
+                  ? { brandId: batchRecord.brandId }
+                  : {}),
+                kind: 'post',
+                organizationId: orgId,
+                recordId: postId,
+                serializer: 'post',
+              },
+              transaction,
+            });
+          versionPinIds.set(postId, versionPin.id);
         }
       }
-    }
 
-    const approvalUpdates = await Promise.all(
-      selectedPostIds.map((postId) =>
-        this.prisma.post.updateMany({
-          data: {
-            reviewDecision: 'APPROVED' as never,
-            reviewVersionPinId: versionPinIds.get(postId),
-            reviewedAt: new Date(reviewedAt),
-          },
+      const postIdsToSchedule: string[] = [];
+
+      for (const item of batchItems) {
+        if (
+          itemIdSet.has(item._id) &&
+          item.status === BatchItemStatus.COMPLETED
+        ) {
+          const versionPinId = item.postId
+            ? versionPinIds.get(item.postId)
+            : undefined;
+          item.reviewDecision = 'approved';
+          item.publishApproval = item.postId
+            ? publishApprovals.get(item.postId)
+            : undefined;
+          item.reviewFeedback = undefined;
+          item.versionPinId = versionPinId;
+          item.reviewedAt = reviewedAt;
+          item.reviewEvents = [
+            ...(item.reviewEvents ?? []),
+            {
+              decision: 'approved',
+              reviewedAt,
+              ...(versionPinId ? { versionPinId } : {}),
+            },
+          ];
+          if (item.postId && item.scheduledDate) {
+            postIdsToSchedule.push(item.postId);
+          }
+        }
+      }
+
+      const approvalUpdates = await Promise.all(
+        selectedPostIds.map((postId) =>
+          transaction.post.updateMany({
+            data: {
+              reviewDecision: 'APPROVED' as never,
+              reviewVersionPinId: versionPinIds.get(postId),
+              reviewedAt: new Date(reviewedAt),
+            },
+            where: {
+              id: postId,
+              isDeleted: false,
+              organizationId: orgId,
+            },
+          }),
+        ),
+      );
+      if (approvalUpdates.some((result) => result.count !== 1)) {
+        throw new NotFoundException({
+          message: 'A canonical Post disappeared before approval completed.',
+        });
+      }
+
+      if (postIdsToSchedule.length > 0) {
+        await transaction.post.updateMany({
+          data: { status: PostStatus.SCHEDULED as never },
           where: {
-            id: postId,
+            id: { in: postIdsToSchedule },
             isDeleted: false,
             organizationId: orgId,
           },
-        }),
-      ),
-    );
-    if (approvalUpdates.some((result) => result.count !== 1)) {
-      throw new Error(
-        'A canonical Post disappeared before approval completed.',
-      );
-    }
+        });
+      }
 
-    if (postIdsToSchedule.length > 0) {
-      await this.prisma.post.updateMany({
-        data: { status: PostStatus.SCHEDULED as never },
-        where: {
-          id: { in: postIdsToSchedule },
-          isDeleted: false,
-          organizationId: orgId,
-        },
-      });
-    }
-
-    const updatedBatch = (await this.prisma.batch.update({
-      data: { items: batchItems as never },
-      where: { id: batchId },
-    })) as BatchWithConfig;
+      return (await transaction.batch.update({
+        data: { items: batchItems as never },
+        where: { id: batchId },
+      })) as BatchWithConfig;
+    });
 
     this.logger.log(`Approved ${itemIds.length} items in batch ${batchId}`, {
       batchId,

--- a/apps/server/api/src/shared/utils/agent-artifact-reference-write.util.spec.ts
+++ b/apps/server/api/src/shared/utils/agent-artifact-reference-write.util.spec.ts
@@ -1,0 +1,79 @@
+import { authorizeAgentArtifactWrite } from '@api/shared/utils/agent-artifact-reference-write.util';
+import type { AgentArtifactReference } from '@genfeedai/interfaces';
+import { describe, expect, it, vi } from 'vitest';
+
+function makeReference(index: number): AgentArtifactReference {
+  return {
+    brandId: 'brand-1',
+    kind: 'post',
+    organizationId: 'org-1',
+    recordId: `post-${index}`,
+    serializer: 'post',
+  };
+}
+
+describe('authorizeAgentArtifactWrite', () => {
+  it('allows idempotent repeated references and pins at the 100-entry cap', async () => {
+    const references = Array.from({ length: 100 }, (_, index) =>
+      makeReference(index),
+    );
+    const pinIds = Array.from({ length: 100 }, (_, index) => `pin-${index}`);
+    const authorizer = {
+      resolveReference: vi.fn((reference: AgentArtifactReference) =>
+        Promise.resolve({ reference }),
+      ),
+      resolveVersionPin: vi.fn(({ pinId }: { pinId: string }) =>
+        Promise.resolve({
+          reference: makeReference(Number(pinId.replace('pin-', ''))),
+        }),
+      ),
+    };
+
+    const result = await authorizeAgentArtifactWrite({
+      authorizer: authorizer as never,
+      inputs: [
+        {
+          artifactReferences: references,
+          artifactVersionPinIds: pinIds,
+        },
+        {
+          artifactReferences: references,
+          artifactVersionPinIds: pinIds,
+        },
+      ],
+      readContext: { brandId: 'brand-1', organizationId: 'org-1' },
+    });
+
+    expect(result.artifactReferences).toHaveLength(100);
+    expect(result.artifactVersionPinIds).toHaveLength(100);
+    expect(authorizer.resolveReference).toHaveBeenCalledTimes(100);
+    expect(authorizer.resolveVersionPin).toHaveBeenCalledTimes(100);
+  });
+
+  it('rejects when pin resolution pushes the deduplicated result over 100 references', async () => {
+    const references = Array.from({ length: 100 }, (_, index) =>
+      makeReference(index),
+    );
+    const authorizer = {
+      resolveReference: vi.fn((reference: AgentArtifactReference) =>
+        Promise.resolve({ reference }),
+      ),
+      resolveVersionPin: vi.fn(() =>
+        Promise.resolve({ reference: makeReference(100) }),
+      ),
+    };
+
+    await expect(
+      authorizeAgentArtifactWrite({
+        authorizer: authorizer as never,
+        inputs: [
+          {
+            artifactReferences: references,
+            artifactVersionPinIds: ['pin-100'],
+          },
+        ],
+        readContext: { brandId: 'brand-1', organizationId: 'org-1' },
+      }),
+    ).rejects.toThrow('artifactReferences cannot contain more than 100');
+  });
+});

--- a/apps/server/api/src/shared/utils/agent-artifact-reference-write.util.ts
+++ b/apps/server/api/src/shared/utils/agent-artifact-reference-write.util.ts
@@ -176,13 +176,12 @@ export async function authorizeAgentArtifactWrite(
 ): Promise<AuthorizedAgentArtifactWrite> {
   const referenceValues = collectField(params.inputs, 'artifactReferences');
   const pinValues = collectField(params.inputs, 'artifactVersionPinIds');
-  assertBounded(referenceValues, 'artifactReferences');
-  assertBounded(pinValues, 'artifactVersionPinIds');
-
-  const references = referenceValues.map((value) =>
-    rebuildReference(value, params.readContext),
+  const references = dedupeReferences(
+    referenceValues.map((value) => rebuildReference(value, params.readContext)),
   );
   const pinIds = readPinIds(pinValues);
+  assertBounded(references, 'artifactReferences');
+  assertBounded(pinIds, 'artifactVersionPinIds');
   const [resolvedReferences, resolvedPins] = await Promise.all([
     Promise.all(
       references.map((reference) =>
@@ -199,11 +198,14 @@ export async function authorizeAgentArtifactWrite(
     ),
   ]);
 
+  const artifactReferences = dedupeReferences([
+    ...resolvedReferences.map((resolved) => resolved.reference),
+    ...resolvedPins.map((resolved) => resolved.reference),
+  ]);
+  assertBounded(artifactReferences, 'artifactReferences');
+
   return {
-    artifactReferences: dedupeReferences([
-      ...resolvedReferences.map((resolved) => resolved.reference),
-      ...resolvedPins.map((resolved) => resolved.reference),
-    ]),
+    artifactReferences,
     artifactVersionPinIds: pinIds,
   };
 }

--- a/apps/server/server/src/agent-artifacts/agent-artifact-reference.service.ts
+++ b/apps/server/server/src/agent-artifacts/agent-artifact-reference.service.ts
@@ -8,7 +8,7 @@ import type {
   ResolvedAgentArtifactReference,
 } from '@genfeedai/interfaces';
 import { AGENT_ARTIFACT_SERIALIZER_BY_KIND } from '@genfeedai/interfaces';
-import type { ContentVersionPin } from '@genfeedai/prisma';
+import type { ContentVersionPin, Prisma } from '@genfeedai/prisma';
 import {
   ArticleSerializer,
   AssetSerializer,
@@ -92,6 +92,7 @@ export interface AgentArtifactReferenceTelemetryContext {
 export interface CreateOrReuseVersionPinParams {
   createdByUserId: string;
   reference: AgentArtifactReference;
+  transaction?: AgentArtifactReferenceTransaction;
 }
 
 export interface AssertVersionPinCurrentParams {
@@ -117,6 +118,20 @@ interface LegacyReferenceCandidate {
   recordId: string;
   source: LegacyReferenceSource;
 }
+
+export type AgentArtifactReferenceTransaction = Pick<
+  Prisma.TransactionClient,
+  | 'article'
+  | 'asset'
+  | 'brand'
+  | 'contentDraft'
+  | 'contentVersionPin'
+  | 'ingredient'
+  | 'member'
+  | 'newsletter'
+  | 'organization'
+  | 'post'
+>;
 
 const SERIALIZERS = {
   article: ArticleSerializer,
@@ -147,20 +162,8 @@ function artifactNotFound(label: string, id: string): HttpException {
 export class AgentArtifactReferenceService {
   constructor(
     @Inject(SERVER_TOKENS.prisma)
-    private readonly prisma: Pick<
-      ServerPrisma,
-      | 'agentMessage'
-      | 'article'
-      | 'asset'
-      | 'brand'
-      | 'contentDraft'
-      | 'contentVersionPin'
-      | 'ingredient'
-      | 'member'
-      | 'newsletter'
-      | 'organization'
-      | 'post'
-    >,
+    private readonly prisma: AgentArtifactReferenceTransaction &
+      Pick<ServerPrisma, 'agentMessage'>,
     @Inject(SERVER_TOKENS.logger)
     @Optional()
     private readonly logger?: ServerLogger,
@@ -190,6 +193,7 @@ export class AgentArtifactReferenceService {
   async createOrReuseVersionPin(
     params: CreateOrReuseVersionPinParams,
   ): Promise<AgentArtifactVersionPin> {
+    const prisma = params.transaction ?? this.prisma;
     const readContext: AgentArtifactReferenceReadContext = {
       brandId: params.reference.brandId,
       organizationId: params.reference.organizationId,
@@ -198,12 +202,14 @@ export class AgentArtifactReferenceService {
     await this.assertActorAuthorized(
       params.createdByUserId,
       params.reference.organizationId,
+      prisma,
     );
 
     const canonical = await this.loadCanonicalRecord(
       params.reference.kind,
       params.reference.recordId,
       params.reference.organizationId,
+      prisma,
     );
     this.assertCanonicalScope(params.reference, canonical.brandId);
 
@@ -224,6 +230,7 @@ export class AgentArtifactReferenceService {
     const existing = await this.findPinByIdempotencyKey(
       params.reference.organizationId,
       idempotencyKey,
+      prisma,
     );
     if (existing) {
       return this.toVersionPin(existing);
@@ -231,7 +238,7 @@ export class AgentArtifactReferenceService {
 
     const id = randomUUID();
     try {
-      const created = await this.prisma.contentVersionPin.create({
+      const created = await prisma.contentVersionPin.create({
         data: {
           brandId: params.reference.brandId ?? null,
           contentDigest,
@@ -253,13 +260,17 @@ export class AgentArtifactReferenceService {
       });
       return this.toVersionPin(created);
     } catch (error: unknown) {
-      if ((error as { code?: unknown }).code !== 'P2002') {
+      if (
+        params.transaction ||
+        (error as { code?: unknown }).code !== 'P2002'
+      ) {
         throw error;
       }
 
       const winner = await this.findPinByIdempotencyKey(
         params.reference.organizationId,
         idempotencyKey,
+        prisma,
       );
       if (!winner) {
         throw error;
@@ -479,12 +490,13 @@ export class AgentArtifactReferenceService {
     kind: AgentArtifactRecordKind,
     recordId: string,
     organizationId: string,
+    prisma: AgentArtifactReferenceTransaction = this.prisma,
   ): Promise<CanonicalRecordState> {
     switch (kind) {
       case 'article':
         return this.loadScopedRecord(
           'Article',
-          this.prisma.article,
+          prisma.article,
           recordId,
           organizationId,
           [
@@ -498,11 +510,11 @@ export class AgentArtifactReferenceService {
           ],
         );
       case 'asset':
-        return this.loadAsset(recordId, organizationId);
+        return this.loadAsset(recordId, organizationId, prisma);
       case 'content-draft':
         return this.loadScopedRecord(
           'Content draft',
-          this.prisma.contentDraft,
+          prisma.contentDraft,
           recordId,
           organizationId,
           [
@@ -519,12 +531,12 @@ export class AgentArtifactReferenceService {
           ],
         );
       case 'ingredient': {
-        return this.loadIngredient(recordId, organizationId);
+        return this.loadIngredient(recordId, organizationId, prisma);
       }
       case 'newsletter':
         return this.loadScopedRecord(
           'Newsletter',
-          this.prisma.newsletter,
+          prisma.newsletter,
           recordId,
           organizationId,
           [
@@ -541,15 +553,16 @@ export class AgentArtifactReferenceService {
           ],
         );
       case 'post':
-        return this.loadPost(recordId, organizationId);
+        return this.loadPost(recordId, organizationId, prisma);
     }
   }
 
   private async loadIngredient(
     recordId: string,
     organizationId: string,
+    prisma: AgentArtifactReferenceTransaction,
   ): Promise<CanonicalRecordState> {
-    const result = await this.prisma.ingredient.findFirst({
+    const result = await prisma.ingredient.findFirst({
       include: {
         metadata: true,
         prompt: true,
@@ -605,8 +618,9 @@ export class AgentArtifactReferenceService {
   private async loadPost(
     recordId: string,
     organizationId: string,
+    prisma: AgentArtifactReferenceTransaction,
   ): Promise<CanonicalRecordState> {
-    const result = await this.prisma.post.findFirst({
+    const result = await prisma.post.findFirst({
       include: {
         children: {
           include: {
@@ -695,8 +709,9 @@ export class AgentArtifactReferenceService {
   private async loadAsset(
     recordId: string,
     organizationId: string,
+    prisma: AgentArtifactReferenceTransaction,
   ): Promise<CanonicalRecordState> {
-    const asset = await this.prisma.asset.findFirst({
+    const asset = await prisma.asset.findFirst({
       where: { id: recordId, isDeleted: false },
     });
     if (!asset) {
@@ -712,7 +727,7 @@ export class AgentArtifactReferenceService {
       if (!actualBrandId) {
         throw artifactNotFound('Asset', recordId);
       }
-      const brand = await this.prisma.brand.findFirst({
+      const brand = await prisma.brand.findFirst({
         select: { id: true, organizationId: true },
         where: { id: actualBrandId, isDeleted: false, organizationId },
       });
@@ -722,7 +737,7 @@ export class AgentArtifactReferenceService {
       if (!parentIngredientId) {
         throw artifactNotFound('Asset', recordId);
       }
-      const parent = await this.prisma.ingredient.findFirst({
+      const parent = await prisma.ingredient.findFirst({
         select: { brandId: true, organizationId: true },
         where: {
           id: parentIngredientId,
@@ -737,7 +752,7 @@ export class AgentArtifactReferenceService {
       if (!parentArticleId) {
         throw artifactNotFound('Asset', recordId);
       }
-      const parent = await this.prisma.article.findFirst({
+      const parent = await prisma.article.findFirst({
         select: { brandId: true, organizationId: true },
         where: {
           id: parentArticleId,
@@ -852,9 +867,10 @@ export class AgentArtifactReferenceService {
   private async assertActorAuthorized(
     userId: string,
     organizationId: string,
+    prisma: AgentArtifactReferenceTransaction,
   ): Promise<void> {
     const [member, organization] = await Promise.all([
-      this.prisma.member.findFirst({
+      prisma.member.findFirst({
         select: { id: true },
         where: {
           isActive: true,
@@ -863,7 +879,7 @@ export class AgentArtifactReferenceService {
           userId,
         },
       }),
-      this.prisma.organization.findUnique({
+      prisma.organization.findUnique({
         select: { userId: true },
         where: { id: organizationId, isDeleted: false },
       }),
@@ -927,8 +943,9 @@ export class AgentArtifactReferenceService {
   private async findPinByIdempotencyKey(
     organizationId: string,
     idempotencyKey: string,
+    prisma: AgentArtifactReferenceTransaction = this.prisma,
   ): Promise<ContentVersionPin | null> {
-    return this.prisma.contentVersionPin.findFirst({
+    return prisma.contentVersionPin.findFirst({
       where: { idempotencyKey, organizationId },
     });
   }

--- a/apps/server/server/src/index.ts
+++ b/apps/server/server/src/index.ts
@@ -1,6 +1,7 @@
 export {
   AgentArtifactReferenceService,
   type AgentArtifactReferenceTelemetryContext,
+  type AgentArtifactReferenceTransaction,
   type AssertVersionPinCurrentParams,
   type CreateOrReuseVersionPinParams,
   type ResolveMessageArtifactReferencesParams,

--- a/apps/server/server/src/publish-approvals/publish-approvals.service.ts
+++ b/apps/server/server/src/publish-approvals/publish-approvals.service.ts
@@ -84,6 +84,11 @@ type PublishApprovalRow = {
   updatedAt: Date;
 };
 
+type PublishApprovalTransaction = Pick<
+  Prisma.TransactionClient,
+  'post' | 'publishApproval'
+>;
+
 type ApprovalPost = {
   agentContextVersion: number | null;
   brandId: string;
@@ -104,6 +109,7 @@ export interface CreatePostPublishApprovalParams {
   body: unknown;
   organizationId: string;
   provenance?: Record<string, unknown>;
+  transaction?: Prisma.TransactionClient;
 }
 
 export interface ClaimPublishExecutionParams {
@@ -121,6 +127,7 @@ export interface CreateCurrentPostPublishApprovalParams {
   organizationId: string;
   postId: string;
   provenance?: Record<string, unknown>;
+  transaction?: Prisma.TransactionClient;
 }
 
 export interface PublishExecutionClaim {
@@ -165,6 +172,7 @@ export class PublishApprovalsService {
     const post = await this.getPostOrThrow(
       params.organizationId,
       params.postId,
+      params.transaction,
     );
     const scheduleIntent: IPublishScheduleIntent =
       params.mode === 'scheduled'
@@ -189,14 +197,20 @@ export class PublishApprovalsService {
       },
       organizationId: params.organizationId,
       provenance: params.provenance,
+      transaction: params.transaction,
     });
   }
 
   async createForPost(
     params: CreatePostPublishApprovalParams,
   ): Promise<IPublishApproval> {
+    const client = params.transaction ?? this.prisma;
     const input = this.parseCreateInput(params.body);
-    const post = await this.getPostOrThrow(params.organizationId, input.postId);
+    const post = await this.getPostOrThrow(
+      params.organizationId,
+      input.postId,
+      client,
+    );
     this.assertTargetStatus(post);
     if (
       input.contextVersion !== undefined &&
@@ -216,6 +230,7 @@ export class PublishApprovalsService {
           recordId: post.id,
           serializer: 'post',
         },
+        transaction: params.transaction,
       });
 
     const destinations = this.canonicalDestinations(post);
@@ -231,7 +246,7 @@ export class PublishApprovalsService {
       scheduleIntent: input.scheduleIntent,
     };
     const scopeDigest = this.digest(scope);
-    const existing = (await this.prisma.publishApproval.findFirst({
+    const existing = (await client.publishApproval.findFirst({
       where: {
         organizationId: post.organizationId,
         postId: post.id,
@@ -239,7 +254,7 @@ export class PublishApprovalsService {
       },
     })) as PublishApprovalRow | null;
     if (existing) {
-      await this.activatePostApproval(post, existing);
+      await this.activatePostApproval(post, existing, client);
       return this.toInterface(existing);
     }
 
@@ -259,7 +274,9 @@ export class PublishApprovalsService {
 
     let approval: PublishApprovalRow;
     try {
-      approval = await this.prisma.$transaction(async (tx) => {
+      const persistApproval = async (
+        tx: PublishApprovalTransaction,
+      ): Promise<PublishApprovalRow> => {
         const active = (await tx.publishApproval.findMany({
           where: {
             organizationId: post.organizationId,
@@ -332,12 +349,18 @@ export class PublishApprovalsService {
           where: { id: post.id },
         });
         return created;
-      });
+      };
+      approval = params.transaction
+        ? await persistApproval(params.transaction)
+        : await this.prisma.$transaction(persistApproval);
     } catch (error: unknown) {
-      if ((error as { code?: unknown }).code !== 'P2002') {
+      if (
+        params.transaction ||
+        (error as { code?: unknown }).code !== 'P2002'
+      ) {
         throw error;
       }
-      const concurrentWinner = (await this.prisma.publishApproval.findFirst({
+      const concurrentWinner = (await client.publishApproval.findFirst({
         where: {
           organizationId: post.organizationId,
           postId: post.id,
@@ -347,7 +370,7 @@ export class PublishApprovalsService {
       if (!concurrentWinner) {
         throw error;
       }
-      await this.activatePostApproval(post, concurrentWinner);
+      await this.activatePostApproval(post, concurrentWinner, client);
       return this.toInterface(concurrentWinner);
     }
 
@@ -680,6 +703,7 @@ export class PublishApprovalsService {
   private async activatePostApproval(
     post: ApprovalPost,
     approval: PublishApprovalRow,
+    client: PublishApprovalTransaction = this.prisma,
   ): Promise<void> {
     const status = this.parseStatus(approval.status);
     if (
@@ -690,7 +714,7 @@ export class PublishApprovalsService {
         'The matching approval was revoked; create a new version before approval.',
       );
     }
-    await this.prisma.post.update({
+    await client.post.update({
       data: {
         publishApprovalId: approval.id,
         reviewDecision: 'APPROVED',
@@ -703,8 +727,9 @@ export class PublishApprovalsService {
   private async getPostOrThrow(
     organizationId: string,
     postId: string,
+    client: Pick<Prisma.TransactionClient, 'post'> = this.prisma,
   ): Promise<ApprovalPost> {
-    const post = (await this.prisma.post.findFirst({
+    const post = (await client.post.findFirst({
       select: {
         agentContextVersion: true,
         brandId: true,


### PR DESCRIPTION
## Summary

- preserve `toolCallId` when messages are copied between agent rooms
- persist version pins, publish approvals, Post review/scheduling fields, and Batch item reference state through one shared Prisma transaction
- map the missing canonical Post race to the repository JSON:API-shaped `NotFoundException`
- enforce the 100-entry limit after deduplicating both inputs and the final resolved reference set, preserving idempotent writes at the cap
- add focused regressions for room copy linkage, transaction rollback, mapped exceptions, transaction-aware approval/pin creation, and repeated near-cap writes

## Atomicity approach

I compared wrapping only the final Post and Batch updates with making the existing version-pin and publish-approval services transaction-aware. The narrow wrapper would still leave committed pin/approval state if the later Batch write failed, especially after #1702. This PR uses the existing interactive Prisma transaction pattern and passes the same transaction client through all approval/reference writes.

## Verification

- targeted Biome check on all 11 changed files: clean
- package API surface static check: passed
- `git diff --check`: passed
- sensitive filename and high-confidence credential pattern scans: clean
- Gitleaks staged and commit-range scans: clean
- Secretlint could not run locally because workspace dependencies are absent and the transient runner could not resolve configured rule packages
- `check:di-value-imports` could not run because the current local TypeScript runtime import exposes no `ScriptTarget`; no DI import was changed by this PR
- local tests, typechecks, builds, E2E, Vitest, tsc, and compilation were intentionally not run per workstation policy; PR CI is authoritative

Closes #1712