### PR TITLE
perf(workflows): eliminate redundant execution result reads

### DIFF
--- a/apps/server/api/src/collections/workflow-executions/services/workflow-executions.service.spec.ts
+++ b/apps/server/api/src/collections/workflow-executions/services/workflow-executions.service.spec.ts
@@ -22,6 +22,8 @@ describe('WorkflowExecutionsService', () => {
     };
 
     const prisma = {
+      $executeRaw: vi.fn().mockResolvedValue(0),
+      $queryRaw: vi.fn().mockResolvedValue([]),
       workflowExecution,
     };
 
@@ -162,10 +164,50 @@ describe('WorkflowExecutionsService', () => {
     );
   });
 
-  it('updates node results by reading only the result column', async () => {
+  it('updates node results atomically without a separate result read', async () => {
+    const { prisma, service } = makeService();
+    prisma.$queryRaw.mockResolvedValue([
+      {
+        id: 'execution-1',
+        result: {
+          metadata: { retained: true },
+          nodeResults: [
+            {
+              nodeId: 'node-1',
+              nodeType: 'input',
+              status: SharedWorkflowExecutionStatus.COMPLETED,
+            },
+          ],
+          progress: 50,
+        },
+      },
+    ]);
+
+    await service.updateNodeResult(
+      'execution-1',
+      {
+        nodeId: 'node-1',
+        nodeType: 'input',
+        status: SharedWorkflowExecutionStatus.COMPLETED,
+      },
+      2,
+    );
+
+    const query = prisma.$queryRaw.mock.calls[0]?.[0] as readonly string[];
+    const sql = query.join('?').replace(/\s+/g, ' ').trim();
+
+    expect(sql).toContain('UPDATE workflow_executions AS execution');
+    expect(sql).toContain('jsonb_array_elements(node_results)');
+    expect(sql).toContain('WHERE execution.id = next_execution.id');
+    expect(sql).toContain('RETURNING execution.id, execution.result');
+    expect(prisma.workflowExecution.findUnique).not.toHaveBeenCalled();
+    expect(prisma.workflowExecution.update).not.toHaveBeenCalled();
+  });
+
+  it('preserves the tolerant node-result fallback for encoded legacy JSON', async () => {
     const { prisma, service } = makeService();
     prisma.workflowExecution.findUnique.mockResolvedValue({
-      result: {
+      result: JSON.stringify({
         metadata: { retained: true },
         nodeResults: [
           {
@@ -174,7 +216,7 @@ describe('WorkflowExecutionsService', () => {
             status: SharedWorkflowExecutionStatus.RUNNING,
           },
         ],
-      },
+      }),
     });
 
     await service.updateNodeResult(
@@ -256,10 +298,28 @@ describe('WorkflowExecutionsService', () => {
     await expect(service.getRuntimeState('execution-1')).resolves.toBeNull();
   });
 
-  it('narrows result-only void patch updates to the id return field', async () => {
+  it('patches terminal result fields atomically without separate reads', async () => {
+    const { prisma, service } = makeService();
+    prisma.$executeRaw.mockResolvedValue(1);
+
+    await service.setFailedNodeId('execution-1', 'node-1');
+    await service.setCreditsUsed('execution-1', 17);
+
+    expect(prisma.$executeRaw).toHaveBeenCalledTimes(2);
+    for (const call of prisma.$executeRaw.mock.calls) {
+      const query = call[0] as readonly string[];
+      const sql = query.join('?').replace(/\s+/g, ' ').trim();
+      expect(sql).toContain('UPDATE workflow_executions AS execution');
+      expect(sql).toContain('WHERE execution.id = ?');
+    }
+    expect(prisma.workflowExecution.findUnique).not.toHaveBeenCalled();
+    expect(prisma.workflowExecution.update).not.toHaveBeenCalled();
+  });
+
+  it('preserves legacy result fallbacks for terminal field patches', async () => {
     const { prisma, service } = makeService();
     prisma.workflowExecution.findUnique.mockResolvedValue({
-      result: { metadata: { retained: true } },
+      result: JSON.stringify({ metadata: { retained: true } }),
     });
 
     await service.setFailedNodeId('execution-1', 'node-1');
@@ -310,26 +370,28 @@ describe('WorkflowExecutionsService', () => {
     expect(prisma.workflowExecution.update).not.toHaveBeenCalled();
   });
 
-  it('updates execution metadata with a narrow return payload', async () => {
+  it('updates execution metadata atomically without a separate result read', async () => {
     const { prisma, service } = makeService();
-    prisma.workflowExecution.findUnique.mockResolvedValue({
-      result: { metadata: { retained: true }, progress: 20 },
-    });
-
-    await service.updateExecutionMetadata('execution-1', { phase: 'running' });
-
-    expect(prisma.workflowExecution.update).toHaveBeenCalledWith({
-      data: {
+    prisma.$queryRaw.mockResolvedValue([
+      {
+        id: 'execution-1',
         result: {
-          metadata: {
-            phase: 'running',
-            retained: true,
-          },
+          metadata: { phase: 'running', retained: true },
           progress: 20,
         },
       },
-      select: { id: true, result: true },
-      where: { id: 'execution-1' },
-    });
+    ]);
+
+    await service.updateExecutionMetadata('execution-1', { phase: 'running' });
+
+    const query = prisma.$queryRaw.mock.calls[0]?.[0] as readonly string[];
+    const sql = query.join('?').replace(/\s+/g, ' ').trim();
+
+    expect(sql).toContain('UPDATE workflow_executions AS execution');
+    expect(sql).toContain("'{metadata}'");
+    expect(sql).toContain('WHERE execution.id = ?');
+    expect(sql).toContain('RETURNING execution.id, execution.result');
+    expect(prisma.workflowExecution.findUnique).not.toHaveBeenCalled();
+    expect(prisma.workflowExecution.update).not.toHaveBeenCalled();
   });
 });

--- a/apps/server/api/src/collections/workflow-executions/services/workflow-executions.service.ts
+++ b/apps/server/api/src/collections/workflow-executions/services/workflow-executions.service.ts
@@ -38,6 +38,10 @@ type WorkflowExecutionResultRow = {
   result: unknown;
 };
 
+type WorkflowExecutionResultUpdateRow = WorkflowExecutionResultRow & {
+  id: string;
+};
+
 type WorkflowExecutionRuntimeStateRow = WorkflowExecutionResultRow & {
   isDeleted: boolean;
   startedAt: Date | null;
@@ -324,6 +328,136 @@ export class WorkflowExecutionsService extends BaseService<
     nodeResult: WorkflowNodeResult,
     totalNodes?: number,
   ): Promise<WorkflowExecutionDocument | null> {
+    const nodeResultJson = JSON.stringify(nodeResult);
+    const useStoredNodeCount = totalNodes === undefined;
+    const expectedNodeCount = totalNodes ?? 0;
+
+    // sql-risk-audit: ignore raw-sql-review -- Primary-key-scoped single-row JSONB update with bound payloads; removes the redundant result hydration identified by Sentry API-GENFEED-AI-6P.
+    const [updatedExecution] = await this.prisma.$queryRaw<
+      WorkflowExecutionResultUpdateRow[]
+    >`
+      WITH current_execution AS (
+        SELECT
+          id,
+          CASE
+            WHEN jsonb_typeof(result) = 'object' THEN result
+            ELSE '{}'::jsonb
+          END AS current_result
+        FROM workflow_executions
+        WHERE id = ${executionId}
+          AND jsonb_typeof(result) IS DISTINCT FROM 'string'
+        FOR UPDATE
+      ),
+      current_node_results AS (
+        SELECT
+          id,
+          current_result,
+          CASE
+            WHEN jsonb_typeof(current_result->'nodeResults') = 'array'
+              THEN current_result->'nodeResults'
+            ELSE '[]'::jsonb
+          END AS node_results
+        FROM current_execution
+      ),
+      target_node AS (
+        SELECT
+          id,
+          current_result,
+          node_results,
+          (
+            SELECT MIN(ordinal)
+            FROM jsonb_array_elements(node_results)
+              WITH ORDINALITY AS nodes(existing_node, ordinal)
+            WHERE existing_node->>'nodeId' = ${nodeResult.nodeId}
+          ) AS target_ordinal
+        FROM current_node_results
+      ),
+      merged_node_results AS (
+        SELECT
+          id,
+          current_result,
+          CASE
+            WHEN target_ordinal IS NULL
+              THEN node_results || jsonb_build_array(${nodeResultJson}::jsonb)
+            ELSE (
+              SELECT COALESCE(
+                jsonb_agg(
+                  CASE
+                    WHEN ordinal = target_ordinal
+                      THEN ${nodeResultJson}::jsonb
+                    ELSE existing_node
+                  END
+                  ORDER BY ordinal
+                ),
+                '[]'::jsonb
+              )
+              FROM jsonb_array_elements(node_results)
+                WITH ORDINALITY AS nodes(existing_node, ordinal)
+            )
+          END AS node_results
+        FROM target_node
+      ),
+      next_execution AS (
+        SELECT
+          id,
+          jsonb_set(
+            jsonb_set(
+              current_result,
+              '{nodeResults}',
+              node_results,
+              true
+            ),
+            '{progress}',
+            to_jsonb(
+              CASE
+                WHEN (
+                  CASE
+                    WHEN ${useStoredNodeCount}
+                      THEN jsonb_array_length(node_results)
+                    ELSE ${expectedNodeCount}
+                  END
+                ) > 0
+                  THEN ROUND(
+                    (
+                      SELECT COUNT(*)
+                      FROM jsonb_array_elements(node_results) AS updated_node
+                      WHERE updated_node->>'status' IN (
+                        ${SharedWorkflowExecutionStatus.COMPLETED},
+                        ${SharedWorkflowExecutionStatus.FAILED}
+                      )
+                    )::numeric * 100 / (
+                      CASE
+                        WHEN ${useStoredNodeCount}
+                          THEN jsonb_array_length(node_results)
+                        ELSE ${expectedNodeCount}
+                      END
+                    )::numeric
+                  )::int
+                ELSE 0
+              END
+            ),
+            true
+          ) AS result
+        FROM merged_node_results
+      )
+      UPDATE workflow_executions AS execution
+      SET
+        result = next_execution.result,
+        "updatedAt" = NOW()
+      FROM next_execution
+      WHERE execution.id = next_execution.id
+      RETURNING execution.id, execution.result
+    `;
+
+    if (updatedExecution) {
+      return this.normalizeDocument(
+        updatedExecution,
+      ) as WorkflowExecutionDocument;
+    }
+
+    // Legacy Mongo imports may contain a JSON-encoded string. Preserve the
+    // tolerant parser for those rows without keeping that fallback on the hot
+    // path for current object-shaped executions.
     const execution = (await this.prisma.workflowExecution.findUnique({
       select: { result: true },
       where: { id: executionId },
@@ -379,11 +513,44 @@ export class WorkflowExecutionsService extends BaseService<
     return this.normalizeDocument(result) as WorkflowExecutionDocument | null;
   }
 
+  private async patchExecutionResult(
+    executionId: string,
+    patch: Record<string, unknown>,
+  ): Promise<boolean> {
+    const patchJson = JSON.stringify(patch);
+
+    // sql-risk-audit: ignore raw-sql-review -- Primary-key-scoped single-row JSONB merge with a bound payload; current executions take this path while legacy encoded strings retain the tolerant fallback.
+    const updated = await this.prisma.$executeRaw`
+      UPDATE workflow_executions AS execution
+      SET
+        result = (
+          CASE
+            WHEN jsonb_typeof(execution.result) = 'object'
+              THEN execution.result
+            ELSE '{}'::jsonb
+          END
+        ) || ${patchJson}::jsonb,
+        "updatedAt" = NOW()
+      WHERE execution.id = ${executionId}
+        AND jsonb_typeof(execution.result) IS DISTINCT FROM 'string'
+    `;
+
+    return updated === 1;
+  }
+
   @HandleErrors('set failed node', 'workflow-executions')
   async setFailedNodeId(
     executionId: string,
     failedNodeId: string,
   ): Promise<void> {
+    if (
+      await this.patchExecutionResult(executionId, {
+        failedNodeId,
+      })
+    ) {
+      return;
+    }
+
     const execution = (await this.prisma.workflowExecution.findUnique({
       select: { result: true },
       where: { id: executionId },
@@ -406,6 +573,14 @@ export class WorkflowExecutionsService extends BaseService<
     executionId: string,
     creditsUsed: number,
   ): Promise<void> {
+    if (
+      await this.patchExecutionResult(executionId, {
+        creditsUsed,
+      })
+    ) {
+      return;
+    }
+
     const execution = (await this.prisma.workflowExecution.findUnique({
       select: { result: true },
       where: { id: executionId },
@@ -450,6 +625,44 @@ export class WorkflowExecutionsService extends BaseService<
     executionId: string,
     metadataUpdates: Record<string, unknown>,
   ): Promise<WorkflowExecutionDocument | null> {
+    const metadataUpdatesJson = JSON.stringify(metadataUpdates);
+
+    // sql-risk-audit: ignore raw-sql-review -- Primary-key-scoped single-row JSONB merge with a bound payload; avoids re-reading the growing execution result for every ETA update.
+    const [updatedExecution] = await this.prisma.$queryRaw<
+      WorkflowExecutionResultUpdateRow[]
+    >`
+      UPDATE workflow_executions AS execution
+      SET
+        result = jsonb_set(
+          CASE
+            WHEN jsonb_typeof(execution.result) = 'object'
+              THEN execution.result
+            ELSE '{}'::jsonb
+          END,
+          '{metadata}',
+          COALESCE(
+            CASE
+              WHEN jsonb_typeof(execution.result->'metadata') = 'object'
+                THEN execution.result->'metadata'
+            END,
+            '{}'::jsonb
+          ) || ${metadataUpdatesJson}::jsonb,
+          true
+        ),
+        "updatedAt" = NOW()
+      WHERE execution.id = ${executionId}
+        AND jsonb_typeof(execution.result) IS DISTINCT FROM 'string'
+      RETURNING execution.id, execution.result
+    `;
+
+    if (updatedExecution) {
+      return this.normalizeDocument(
+        updatedExecution,
+      ) as WorkflowExecutionDocument;
+    }
+
+    // Keep tolerant handling for legacy JSON-encoded string rows off the
+    // current execution path while preserving their existing merge behavior.
     const execution = (await this.prisma.workflowExecution.findUnique({
       select: { result: true },
       where: { id: executionId },


### PR DESCRIPTION
## Summary

- replace the workflow progress hot path's `findUnique(result)` + `update(result)` pairs with primary-key-scoped atomic JSONB updates
- preserve node replacement/append order, progress calculation, metadata merge semantics, `updatedAt`, normalized return payloads, error decorators, and Prisma/Postgres tracing
- retain the tolerant Prisma fallback for legacy workflow execution rows whose JSON column contains an encoded string
- add focused query-shape guards proving current object-shaped executions no longer issue the redundant result read

Closes #1636.

## Root-cause evidence

Sentry issue [`API-GENFEED-AI-6P`](https://genfeedai.sentry.io/issues/133739863/) was still active when this PR was prepared:

- production, 43 events
- first seen `2026-07-12T05:19:28Z`
- latest seen `2026-07-14T17:41:42Z`
- grouped SQL: `SELECT workflow_executions.id, workflow_executions.result WHERE workflow_executions.id = $1 LIMIT/OFFSET`

The latest complete sampled trace (`baf2b5d65398434ead090d612fc12658`) shows:

- parent transaction: `queue.process` / `workflow-execution process`
- Prisma operation: `WorkflowExecution.findUnique`
- offending Postgres span: ~`1216 ms` (with ~`63 ms` pool-connect child time)
- the first occurrence follows execution create/start and precedes the first `UPDATE ... result RETURNING id, result`

Repository call ordering maps that first read to:

`WorkflowExecutionProcessor` → `WorkflowExecutorService` → `WorkflowNodeProgressTrackerService` → `WorkflowExecutionProgressService.trackNodeResult` → `WorkflowExecutionsService.updateNodeResult`

Every node transition then performed another identical result read for ETA metadata. Credits and failed-node finalization used the same read-modify-write shape.

### What this rules out

- **Missing index:** `workflow_executions.id` is the Prisma `@id` / PostgreSQL primary key. Adding another ID index would duplicate existing coverage.
- **Polling:** the offending trace is the BullMQ `workflow-execution process` transaction, not the Discord/Slack HTTP polling paths or `GET /workflow-executions/:id`.
- **Selection breadth alone:** the application needs existing `nodeResults`/`metadata` to merge state, so a narrower Prisma projection would still transfer growing JSON and keep a second database round trip.

The avoidable cost is hydrating the entire growing `result` JSON into Node before immediately writing a merged copy. This PR moves the merge into a single row-locked PostgreSQL update. The returned `{ id, result }` shape stays unchanged for progress consumers and normalization.

## Verification

Local execution intentionally excludes tests, typechecks, builds, and E2E per the repository's MacBook policy; PR CI is the execution gate.

Completed locally:

- `bunx biome check --write` on both changed files — clean
- `bunx biome check` on both changed files — clean
- `git diff --check` / staged `git diff --check` — clean
- staged sensitive-path check — clean
- `gitleaks protect --staged --redact --verbose` — no leaks
- pre-commit `lint-staged` — passed
  - repository `secretlint` wrapper — passed
  - staged Biome — passed
  - UI control guard — passed

Focused coverage added for:

- atomic node-result update query shape with no `findUnique` or Prisma `update`
- atomic metadata merge query shape with no `findUnique` or Prisma `update`
- atomic credits/failed-node patches with no result read
- legacy encoded-JSON fallback behavior

The standalone local SQL-risk audit could not run because its TypeScript module import resolved `ts.ScriptTarget` as undefined under the local Bun/worktree dependency state; it failed before scanning any source. PR CI remains authoritative for that audit.

## Production evidence still required

No production database access or deployment is performed by this PR. Before calling the runtime incident fully validated:

1. Run `EXPLAIN (ANALYZE, BUFFERS)` for both new primary-key updates against a production-shaped execution with a large `result`; confirm a one-row primary-key index lookup and record execution/TOAST buffer costs.
2. After deployment from `master`, confirm `API-GENFEED-AI-6P` receives no new instances of the exact `SELECT id, result` fingerprint across at least one normal workflow volume window.
3. Compare the replacement JSONB `UPDATE` spans and `workflow-execution process` p95/p99 latency against the pre-deploy trace; investigate storage/IO if the single update remains slow.
