### PR TITLE
fix(agent): repair master trunk after 16-PR flatten

### DIFF
--- a/apps/server/api/src/collections/agent-messages/services/agent-messages.service.ts
+++ b/apps/server/api/src/collections/agent-messages/services/agent-messages.service.ts
@@ -349,7 +349,6 @@ export class AgentMessagesService extends BaseService<
               organizationId: doc.organizationId,
               role: doc.role,
               threadId: targetRoomId,
-              toolCallId: doc.toolCallId,
               toolCalls: doc.toolCalls,
               userId: doc.userId,
             },

--- a/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.spec.ts
+++ b/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.spec.ts
@@ -3279,19 +3279,15 @@ describe('AgentOrchestratorService', () => {
       },
     );
 
-    // With turnCost = 0 the service checks credits with 0 (so it never blocks)
-    // and deducts 0 — the net effect is no credits billed for the turn.
+    // With turnCost = 0 the service checks credits with 0 (so it never blocks).
+    // settleAgentTurnCredits skips the deduct call entirely when the billed
+    // turn cost is 0 rather than issuing a zero-amount write — the net effect
+    // is still no credits billed for the turn.
     expect(
       creditsUtilsService.checkOrganizationCreditsAvailable,
     ).toHaveBeenCalledWith(ORG_ID, 0);
     expect(
       creditsUtilsService.deductCreditsFromOrganization,
-    ).toHaveBeenCalledWith(
-      ORG_ID,
-      USER_ID,
-      0,
-      expect.stringContaining('Agent chat turn'),
-      expect.anything(),
-    );
+    ).not.toHaveBeenCalled();
   });
 });

--- a/packages/agent/src/dashboard/dashboard-hydration.ts
+++ b/packages/agent/src/dashboard/dashboard-hydration.ts
@@ -88,7 +88,7 @@ function toFiniteNumber(value: unknown): number | undefined {
 export function isResolvableSourceKey(
   type: AgentUIBlockType,
   sourceKey: string | undefined,
-): boolean {
+): sourceKey is string {
   if (!sourceKey) {
     return false;
   }


### PR DESCRIPTION
## Summary

After flattening 16 PRs into master, the merged trunk state surfaced 3 CI failures that no individual PR showed in isolation. This fixes the two code-level ones.

## Failures fixed

- **Typecheck (required check — trunk-breaking):** `agent-messages.service.ts` wrote `toolCallId: doc.toolCallId` (introduced by #1729), but the `AgentMessage` Prisma model has no `toolCallId` column — only `toolCalls`. Removed the spurious field; `toolCalls` is still persisted. Left unfixed, every new branch off master inherits the red Typecheck.
- **Test API — `does not charge per-turn credits for BRAND_INTERVIEW`:** the test asserted the old behavior (`deductCreditsFromOrganization` called with amount `0`). #1716's new `settleAgentTurnCredits` **skips** the deduct call entirely when the billed cost is `0` (no pointless zero write); the `checkOrganizationCreditsAvailable(orgId, 0)` guard is unchanged. Updated the assertion to expect no deduct call. Net effect (no credits billed for a brand-interview turn) is unchanged.

## Not addressed here (tracked)

- **OpenAPI Spec Drift** (non-required check): `apps/server/api/openapi/openapi.json` is stale because merged PRs changed the API surface. Needs `bun run --filter=@genfeedai/api openapi:emit` (a build) — held pending owner sign-off per local-verification policy.
- One `Test API` failure was a `DB connection lost` infra flake (`YoutubeUploadCompletionService`), not a code defect.
- Review nits from the flatten remain open: #1716 gameable credit-waiver (`DRAFT_BRAND_VOICE_PROFILE` zeroes the whole turn), #1717 inspector drag-lag, #1718 microservices boot-throw, and #1724 (publish-approvals hardening).