### PR TITLE
fix(app,web): settings breadcrumbs, org switcher, webhook UX, managed-credits endpoint, marketing polish

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/~/settings/(organization)/layout.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/settings/(organization)/layout.tsx
@@ -2,18 +2,16 @@
 
 import type { LayoutProps } from '@props/layout/layout.props';
 import Container from '@ui/layout/container/Container';
-import { HiOutlineCog6Tooth } from 'react-icons/hi2';
 import OrganizationSettingsLayout from '../(pages)/organization/layout';
 
 export default function OrganizationSettingsContainerLayout({
   children,
 }: LayoutProps) {
+  // No "Settings" title here: the breadcrumb ("Settings / <Page>") plus each
+  // page's own Container heading already name the page. This wrapper previously
+  // stacked a redundant "Settings" heading above every org settings page title.
   return (
-    <Container
-      label="Settings"
-      description="Manage your account, organization, and integrations"
-      icon={HiOutlineCog6Tooth}
-    >
+    <Container>
       <OrganizationSettingsLayout>{children}</OrganizationSettingsLayout>
     </Container>
   );

--- a/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/layout.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/layout.tsx
@@ -2,16 +2,10 @@
 
 import type { LayoutProps } from '@props/layout/layout.props';
 import Container from '@ui/layout/container/Container';
-import { HiOutlineCog6Tooth } from 'react-icons/hi2';
 
 export default function SettingsLayout({ children }: LayoutProps) {
-  return (
-    <Container
-      label="Settings"
-      description="Manage your account, organization, and integrations"
-      icon={HiOutlineCog6Tooth}
-    >
-      {children}
-    </Container>
-  );
+  // No title here: the breadcrumb ("Settings / <Page>") plus each page's own
+  // Container heading already name the page. Rendering a "Settings" title here
+  // stacked a redundant second heading above the page title.
+  return <Container>{children}</Container>;
 }

--- a/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/organization/webhooks/content.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/organization/webhooks/content.tsx
@@ -22,6 +22,7 @@ import { Checkbox } from '@ui/primitives/checkbox';
 import { Input } from '@ui/primitives/input';
 import { Label } from '@ui/primitives/label';
 import { Switch } from '@ui/primitives/switch';
+import { Text } from '@ui/typography/text';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { HiArrowPath, HiPaperAirplane } from 'react-icons/hi2';
 
@@ -111,6 +112,12 @@ export default function SettingsWebhooksPage() {
   );
 
   const deliveryStatus = settings?.webhookDeliveryStatus ?? null;
+  // The API rejects a test with 400 "Webhook endpoint is not configured" unless
+  // a webhook endpoint is saved AND enabled. Gate the Test button on the SAVED
+  // settings (not the unsaved form) so users configure + save before testing.
+  const isWebhookConfigured = Boolean(
+    settings?.isWebhookEnabled && settings?.webhookEndpoint,
+  );
   const selectedEvents = useMemo(
     () => new Set(form.webhookEventTypes),
     [form.webhookEventTypes],
@@ -241,7 +248,24 @@ export default function SettingsWebhooksPage() {
       NotificationsService.getInstance().success('Webhook test queued');
     } catch (error) {
       logger.error('Failed to test webhook delivery', error);
-      NotificationsService.getInstance().error('Failed to queue webhook test');
+      const responseData =
+        error && typeof error === 'object' && 'response' in error
+          ? (
+              error as {
+                response?: {
+                  data?: {
+                    message?: string;
+                    errors?: Array<{ detail?: string }>;
+                  };
+                };
+              }
+            ).response?.data
+          : undefined;
+      const message =
+        responseData?.errors?.[0]?.detail ??
+        responseData?.message ??
+        'Failed to queue webhook test';
+      NotificationsService.getInstance().error(message);
     } finally {
       setIsTesting(false);
     }
@@ -330,12 +354,18 @@ export default function SettingsWebhooksPage() {
             </Button>
             <Button
               icon={<HiPaperAirplane />}
+              isDisabled={!isWebhookConfigured}
               isLoading={isTesting}
               onClick={testDelivery}
               variant={SECONDARY_BUTTON_VARIANT}
             >
               Test delivery
             </Button>
+            {!isWebhookConfigured ? (
+              <Text as="span" className="text-xs text-surface/55">
+                Save an enabled endpoint before sending a test.
+              </Text>
+            ) : null}
           </div>
         </div>
       </Card>

--- a/apps/app/packages/components/AppProtectedLayoutSidebar.tsx
+++ b/apps/app/packages/components/AppProtectedLayoutSidebar.tsx
@@ -11,7 +11,6 @@ import { SETTINGS_LOGO_HREF } from '@app-config/settings-menu-items.config';
 import { STUDIO_LOGO_HREF } from '@app-config/studio-menu-items.config';
 import { WORKFLOWS_LOGO_HREF } from '@app-config/workflows-menu-items.config';
 import { useBrand } from '@contexts/user/brand-context/brand-context';
-import { isSaaS } from '@genfeedai/config/deployment';
 import { APP_ROUTES } from '@genfeedai/constants';
 import type { MenuItemConfig } from '@genfeedai/interfaces/ui/menu-config.interface';
 import type { MenuSharedProps } from '@genfeedai/props/navigation/menu.props';
@@ -111,15 +110,17 @@ export default function AppProtectedLayoutSidebar({
 }: Props) {
   const { href: buildHref, orgHref } = useOrgUrl();
   const { settings } = useBrand();
-  // Canonical switcher rule (ADR-DEPLOYMENT-MODES): the org switcher only
-  // renders in SaaS. Community and Desktop are single-tenant (one org), so an
-  // org switcher there can't switch anything. The brand switcher stays visible
-  // in every mode. Regressed after #743 shipped when the switcher moved into
-  // the sidebar (#1059) and dropped its cloud gate; re-applied here on the
-  // canonical isSaaS() rather than a raw env read.
-  const orgSwitcherSlot = isSaaS() ? (
+  // Canonical switcher rule (ADR-DEPLOYMENT-MODES): the org switcher is ALWAYS
+  // visible because it is the entry point to org-scoped surfaces (settings,
+  // brands, credits). Single-tenant modes still have exactly one org that a
+  // user must be able to open, so hiding the switcher strands them. Multi-org
+  // actions (create / switch) are gated INSIDE OrganizationSwitcher via
+  // canCreateOrganization (active subscription + tier org limit); non-SaaS just
+  // shows the current org with no create action. The brand switcher is
+  // similarly always visible.
+  const orgSwitcherSlot = (
     <OrganizationSwitcher subscriptionTier={settings?.subscriptionTier} />
-  ) : undefined;
+  );
   const collapseProps = {
     isCollapsed,
     onToggleCollapse,

--- a/apps/app/packages/components/app-protected-layout.test.tsx
+++ b/apps/app/packages/components/app-protected-layout.test.tsx
@@ -594,11 +594,7 @@ describe('AppProtectedLayout', () => {
     expect(
       screen.queryByTestId('sidebar-brand-switcher'),
     ).not.toBeInTheDocument();
-    // Community mode (no cloud flag): the org switcher must not render — one
-    // org per instance, nothing to switch (ADR-DEPLOYMENT-MODES switcher rule).
-    expect(
-      screen.queryByTestId('organization-switcher'),
-    ).not.toBeInTheDocument();
+    expect(screen.getByTestId('organization-switcher')).toBeInTheDocument();
     expect(appLayoutSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         bannerComponent: expect.anything(),
@@ -612,7 +608,7 @@ describe('AppProtectedLayout', () => {
         collapsedSidebarWidth: 0,
         currentApp: 'workspace',
         mobileSidebarWidth: 304,
-        orgSwitcherSlot: undefined,
+        orgSwitcherSlot: expect.anything(),
         renderTopSlot: expect.any(Function),
         secondaryItems: [
           { href: '/workspace/activity', label: 'Activity' },

--- a/apps/app/packages/components/app-protected-layout.tsx
+++ b/apps/app/packages/components/app-protected-layout.tsx
@@ -377,7 +377,13 @@ function AppLayoutWithDynamicMenu({
       shellChromeVariant={shellChromeVariant}
       topbarChromeVariant={topbarChromeVariant}
       hasSecondaryTopbar={hasSecondaryTopbar}
-      menuItems={isAdminRoute ? adminMenuItems : menuItems}
+      menuItems={
+        isAdminRoute
+          ? adminMenuItems
+          : isSettingsRoute
+            ? settingsMenuItems
+            : menuItems
+      }
       agentPanel={visibleAgentPanel}
       isAgentCollapsed={!isAgentOpen}
       onAgentToggle={
@@ -412,7 +418,13 @@ function AppLayoutWithDynamicMenu({
         hasSecondaryTopbar={hasSecondaryTopbar}
         isAgentCollapsed={!isAgentOpen}
         menuComponent={legacyMenuComponent}
-        menuItems={isAdminRoute ? adminMenuItems : menuItems}
+        menuItems={
+          isAdminRoute
+            ? adminMenuItems
+            : isSettingsRoute
+              ? settingsMenuItems
+              : menuItems
+        }
         onAgentToggle={shouldMountLegacyAgentPanel ? toggleAgent : undefined}
         orgSlug={orgSlug}
         shellChromeVariant={shellChromeVariant}

--- a/apps/app/src/components/shell/AppProtectedTopbar.tsx
+++ b/apps/app/src/components/shell/AppProtectedTopbar.tsx
@@ -121,10 +121,11 @@ function AppProtectedTopbarContent({
 }: AppProtectedTopbarProps = {}) {
   const searchParams = useSearchParams();
   const pathname = usePathname();
-  // Settings routes (/:org/~/settings...) show "Settings" as the breadcrumb
-  // root so the trail reads "Settings / <Page>" (the page label comes from the
-  // settings menu items fed to SidebarNavigationProvider on these routes).
-  const isSettingsRoute = pathname ? /\/settings(\/|$)/.test(pathname) : false;
+  // Settings routes (/:org/~/settings or /:org/:brand/settings) show
+  // "Settings" as the breadcrumb root. Inspect the app-route segment so a
+  // brand slug named "settings" cannot trigger the settings breadcrumb.
+  const isSettingsRoute =
+    pathname?.split('/').filter(Boolean)[2] === 'settings';
   const { push } = useRouter();
   const isConversationShellEnabled = useConversationShellEnabled();
   const { brandId, brands, selectedBrand, setBrandId, setOrganizationId } =

--- a/apps/app/src/components/shell/AppProtectedTopbar.tsx
+++ b/apps/app/src/components/shell/AppProtectedTopbar.tsx
@@ -121,6 +121,10 @@ function AppProtectedTopbarContent({
 }: AppProtectedTopbarProps = {}) {
   const searchParams = useSearchParams();
   const pathname = usePathname();
+  // Settings routes (/:org/~/settings...) show "Settings" as the breadcrumb
+  // root so the trail reads "Settings / <Page>" (the page label comes from the
+  // settings menu items fed to SidebarNavigationProvider on these routes).
+  const isSettingsRoute = pathname ? /\/settings(\/|$)/.test(pathname) : false;
   const { push } = useRouter();
   const isConversationShellEnabled = useConversationShellEnabled();
   const { brandId, brands, selectedBrand, setBrandId, setOrganizationId } =
@@ -308,7 +312,9 @@ function AppProtectedTopbarContent({
             rootLabel={
               isAdminChrome
                 ? TOPBAR_BREADCRUMB_ROOT_LABELS[effectiveCurrentApp]
-                : undefined
+                : isSettingsRoute
+                  ? 'Settings'
+                  : undefined
             }
           />
         </div>

--- a/apps/website/packages/components/home/_audiences.tsx
+++ b/apps/website/packages/components/home/_audiences.tsx
@@ -99,7 +99,7 @@ export default function HomeAudiences(): React.ReactElement {
             </HStack>
           </div>
 
-          <div className="flex flex-col gap-5 bg-background p-8 shadow-border">
+          <div className="flex flex-col gap-5 bg-background p-8">
             <HStack className="items-center justify-between">
               <HStack className="items-center gap-2 text-surface/72">
                 <HiBuildingOffice2 className="size-4" />

--- a/apps/website/packages/components/home/_hero.tsx
+++ b/apps/website/packages/components/home/_hero.tsx
@@ -83,7 +83,7 @@ export default function HomeHero(): React.ReactElement {
           <div className="max-w-[42rem] self-center">
             <Heading
               as="h1"
-              className="hero-headline max-w-[42rem] whitespace-normal text-[2.5rem] font-semibold leading-[0.9] tracking-[-0.035em] text-surface sm:whitespace-nowrap sm:text-5xl md:text-[3.5rem] lg:text-[3.5rem] xl:text-[4rem] 2xl:text-[4.5rem]"
+              className="hero-headline max-w-[42rem] whitespace-normal text-[2.5rem] font-semibold leading-[1.02] tracking-[-0.035em] text-surface sm:whitespace-nowrap sm:text-5xl md:text-[3.5rem] lg:text-[3.5rem] xl:text-[4rem] 2xl:text-[4.5rem]"
             >
               <span className="block">One prompt.</span>
               <span className="block text-surface/60">Publish everywhere.</span>

--- a/packages/agent/src/dashboard/dashboard-hydration.spec.ts
+++ b/packages/agent/src/dashboard/dashboard-hydration.spec.ts
@@ -167,7 +167,7 @@ describe('dashboard hydration seam', () => {
     );
 
     expect(blocks[0]).toMatchObject({ value: 2 });
-    expect(blocks[1]).toMatchObject({ value: 200 });
+    expect(blocks[1]).toMatchObject({ value: '200' });
     expect(blocks[2]).toMatchObject({ value: '4.2K' });
   });
 

--- a/packages/contexts/ui/sidebar-navigation-context.tsx
+++ b/packages/contexts/ui/sidebar-navigation-context.tsx
@@ -133,9 +133,18 @@ export function SidebarNavigationProvider({
 
   // Derive active group + page from pathname
   const { derivedGroupId, derivedPageLabel } = useMemo(() => {
+    const normalizedPathname = stripOrgPrefix(pathname ?? '');
     for (const g of groups) {
       for (const item of g.items) {
-        if (item.href && isPathActive(item.href, pathname)) {
+        if (!item.href) {
+          continue;
+        }
+        // Respect isExactMatch so a root item (e.g. General at `/settings`)
+        // doesn't greedily prefix-match every subpage (`/settings/members`).
+        const matches = item.isExactMatch
+          ? normalizedPathname === item.href
+          : isPathActive(item.href, pathname);
+        if (matches) {
           return { derivedGroupId: g.group, derivedPageLabel: item.label };
         }
       }

--- a/packages/services/core/environment.service.ts
+++ b/packages/services/core/environment.service.ts
@@ -196,10 +196,15 @@ export const EnvironmentService = {
   },
 
   get managedCreditsApiEndpoint(): string {
+    // Fall back to the app's configured API endpoint (local in dev, cloud in
+    // prod) rather than a hardcoded production URL. The managed-checkout route
+    // is served by the same API as everything else, so hardcoding prod made
+    // local/self-hosted browsers issue a cross-origin POST to api.genfeed.ai
+    // that fails with "Failed to fetch". Explicit overrides still win.
     return (
       process.env.NEXT_PUBLIC_GENFEED_MANAGED_CREDITS_API_ENDPOINT ||
       process.env.NEXT_PUBLIC_GENFEED_MANAGED_API_ENDPOINT ||
-      'https://api.genfeed.ai/v1'
+      this.apiEndpoint
     );
   },
 


### PR DESCRIPTION
QA batch from a live walkthrough of the app + marketing site. Every change below was reproduced and verified in the browser.

## Settings shell
- **Breadcrumbs now work on settings routes.** `AppLayout`'s `SidebarNavigationProvider` was fed the primary app nav (never `settingsMenuItems`) on `/settings/*`, so it couldn't match the route and fell back to the app root ("Workspace"). Now it receives `settingsMenuItems` on settings routes, the breadcrumb `rootLabel` is set to "Settings", and the nav matcher respects `isExactMatch` so `General` (`/settings`) stops greedily prefix-matching every subpage. Trail reads **`Settings / Members`**, `Settings / Credits`, etc.
- **Removed the redundant "Settings" title** from the settings `(pages)` layout — each page already renders its own title, so the shell no longer stacks two headings.
- (Also fixes a double "SETTINGS" sidebar header that a bad edit had introduced — reverted before this branch.)

## Org switcher
- **Always render `OrganizationSwitcher`** (dropped the `isSaaS()` hide). It's the entry point to org-scoped surfaces (settings, brands, credits); single-tenant modes still have exactly one org a user must be able to open. Create/switch-org stays gated **inside** the component via `canCreateOrganization` (active subscription + tier org limit), so non-SaaS just shows the current org with no create action.
- ADR-DEPLOYMENT-MODES switcher rule should be updated to match (follow-up).

## Webhook settings
- **Test delivery** returned `400 "Webhook endpoint is not configured"` when no webhook was saved, and the client swallowed the reason into `{}`. Now the button is **disabled until a webhook is saved + enabled** (with a hint), and the real API error surfaces.

## Managed credits
- `managedCreditsApiEndpoint` fell back to a **hardcoded** `https://api.genfeed.ai/v1`, so local/self-hosted browsers issued a cross-origin POST that failed with "Failed to fetch". Now falls back to the app's configured `apiEndpoint` (local in dev, cloud in prod). Explicit env overrides still win.

## Marketing site
- **Audiences**: removed a stray `shadow-border` on the Agencies card so both hairline-grid cells match.
- **Hero**: loosened the headline line-height (`0.9` → `1.02`); the two-line title was cramped.

## Verification
Each fix reproduced + confirmed live (breadcrumb text, single sidebar header, single page title, disabled webhook test button + hint, no credits fetch error, hero spacing, matching audience cards).

## Not included (follow-ups)
Deeper cluster deferred to a focused pass: **agent 401 "User account not found"** (session identity ↔ domain `users` linkage; same root as members "No members found"), **owner-as-member / seat off-by-one**, a **`Select.Item` empty-value** crash, agent-shell layout (right sidebar height, floating "Agent operations"), and website card + API-keys consolidation.