### PR TITLE
refactor(brands): extract generation service

### DIFF
--- a/apps/server/api/src/collections/brands/brands.module.ts
+++ b/apps/server/api/src/collections/brands/brands.module.ts
@@ -8,6 +8,7 @@ import { ArticlesModule } from '@api/collections/articles/articles.module';
 import { BrandsController } from '@api/collections/brands/controllers/brands.controller';
 import { BrandsRelationshipsController } from '@api/collections/brands/controllers/relationships/brands-relationships.controller';
 import { BrandDataMapper } from '@api/collections/brands/services/brand-data.mapper';
+import { BrandGenerationService } from '@api/collections/brands/services/brand-generation.service';
 import { BrandPersistenceService } from '@api/collections/brands/services/brand-persistence.service';
 import { BrandRelocationService } from '@api/collections/brands/services/brand-relocation.service';
 import { BrandSetupService } from '@api/collections/brands/services/brand-setup.service';
@@ -70,6 +71,7 @@ import { forwardRef, Module } from '@nestjs/common';
     // routes no longer round-trip back through OnboardingService and close an
     // OnboardingModule ↔ BrandsModule import cycle.
     BrandSetupService,
+    BrandGenerationService,
     BrandPersistenceService,
     BrandRelocationService,
     BrandDataMapper,

--- a/apps/server/api/src/collections/brands/services/brand-generation.service.spec.ts
+++ b/apps/server/api/src/collections/brands/services/brand-generation.service.spec.ts
@@ -1,0 +1,135 @@
+import type { BrandDocument } from '@api/collections/brands/schemas/brand.schema';
+import { BrandGenerationService } from '@api/collections/brands/services/brand-generation.service';
+import type { BrandScraperService } from '@api/services/brand-scraper/brand-scraper.service';
+import type { LlmDispatcherService } from '@api/services/integrations/llm/llm-dispatcher.service';
+import type { LoggerService } from '@libs/logger/logger.service';
+import {
+  BadRequestException,
+  InternalServerErrorException,
+} from '@nestjs/common';
+
+describe('BrandGenerationService', () => {
+  const organizationId = 'org-1';
+  let brandScraperService: {
+    scrapeWebsite: ReturnType<typeof vi.fn>;
+    validateUrl: ReturnType<typeof vi.fn>;
+  };
+  let findBrand: ReturnType<typeof vi.fn>;
+  let llmDispatcherService: { chatCompletion: ReturnType<typeof vi.fn> };
+  let service: BrandGenerationService;
+
+  beforeEach(() => {
+    brandScraperService = {
+      scrapeWebsite: vi.fn(),
+      validateUrl: vi.fn().mockReturnValue({ isValid: true }),
+    };
+    findBrand = vi.fn();
+    llmDispatcherService = { chatCompletion: vi.fn() };
+    service = new BrandGenerationService(
+      brandScraperService as unknown as BrandScraperService,
+      llmDispatcherService as unknown as LlmDispatcherService,
+      {
+        debug: vi.fn(),
+        warn: vi.fn(),
+      } as unknown as LoggerService,
+    );
+  });
+
+  it('rejects an invalid source URL before scraping', async () => {
+    brandScraperService.validateUrl.mockReturnValue({
+      error: 'Invalid URL',
+      isValid: false,
+    });
+
+    await expect(
+      service.generateBrandVoice({ url: 'invalid' }, organizationId, findBrand),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(brandScraperService.scrapeWebsite).not.toHaveBeenCalled();
+  });
+
+  it('scopes stored brand lookup to the organization', async () => {
+    findBrand.mockResolvedValue(null);
+
+    await expect(
+      service.generateBrandVoice(
+        { brandId: 'brand-1' },
+        organizationId,
+        findBrand,
+      ),
+    ).rejects.toThrow('Brand not found');
+    expect(findBrand).toHaveBeenCalledWith({
+      id: 'brand-1',
+      isDeleted: false,
+      organizationId,
+    });
+  });
+
+  it('requires either a URL or a stored brand', async () => {
+    await expect(
+      service.generateBrandVoice({}, organizationId, findBrand),
+    ).rejects.toThrow('Either url or brandId must be provided');
+  });
+
+  it('generates a normalized brand profile from website evidence', async () => {
+    brandScraperService.scrapeWebsite.mockResolvedValue({
+      companyName: 'Acme',
+      description: 'Automation for founders',
+      tagline: 'Ship faster',
+      valuePropositions: ['Fast'],
+    });
+    llmDispatcherService.chatCompletion.mockResolvedValue({
+      choices: [
+        {
+          message: {
+            content: JSON.stringify({
+              audience: ['founders'],
+              goals: ['increase adoption'],
+              messagingPillars: ['automation'],
+              promptSeeds: [],
+              style: 'direct',
+              tone: 'bold',
+              topics: ['automation'],
+            }),
+          },
+        },
+      ],
+    });
+
+    await expect(
+      service.generateBrandVoice(
+        { url: 'https://example.com' },
+        organizationId,
+        findBrand,
+      ),
+    ).resolves.toMatchObject({
+      audience: ['founders'],
+      style: 'direct',
+      tone: 'bold',
+    });
+    expect(llmDispatcherService.chatCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: [expect.objectContaining({ role: 'user' })],
+      }),
+      organizationId,
+    );
+  });
+
+  it('maps an invalid model response to the stable generation error', async () => {
+    findBrand.mockResolvedValue({
+      description: 'A brand',
+      id: 'brand-1',
+      label: 'Acme',
+    } as BrandDocument);
+    llmDispatcherService.chatCompletion.mockResolvedValue({
+      choices: [{ message: { content: 'not-json' } }],
+    });
+
+    await expect(
+      service.generateBrandVoice(
+        { brandId: 'brand-1' },
+        organizationId,
+        findBrand,
+      ),
+    ).rejects.toBeInstanceOf(InternalServerErrorException);
+  });
+});

--- a/apps/server/api/src/collections/brands/services/brand-generation.service.ts
+++ b/apps/server/api/src/collections/brands/services/brand-generation.service.ts
@@ -1,0 +1,279 @@
+import { randomUUID } from 'node:crypto';
+import type {
+  GenerateBrandVoiceDto,
+  GeneratedBrandVoice,
+} from '@api/collections/brands/dto/generate-brand-voice.dto';
+import {
+  FASTLANE_FORMATS,
+  type GenerateFastlaneIdeasDto,
+} from '@api/collections/brands/dto/generate-fastlane-ideas.dto';
+import type { BrandDocument } from '@api/collections/brands/schemas/brand.schema';
+import { buildPromptBrandingFromBrand } from '@api/collections/brands/utils/brand-context.util';
+import {
+  buildBrandProfileAnalysisPrompt,
+  parseGeneratedBrandProfile,
+} from '@api/collections/brands/utils/brand-profile-generation.util';
+import { NotFoundException } from '@api/helpers/exceptions/http/not-found.exception';
+import { BrandScraperService } from '@api/services/brand-scraper/brand-scraper.service';
+import { LlmDispatcherService } from '@api/services/integrations/llm/llm-dispatcher.service';
+import type { FastlaneFormat, FastlaneIdea } from '@genfeedai/interfaces';
+import { LoggerService } from '@libs/logger/logger.service';
+import {
+  BadRequestException,
+  Injectable,
+  InternalServerErrorException,
+} from '@nestjs/common';
+
+export type BrandFinder = (
+  criteria: Record<string, unknown>,
+) => Promise<BrandDocument | null>;
+
+@Injectable()
+export class BrandGenerationService {
+  private readonly constructorName = this.constructor.name;
+
+  constructor(
+    private readonly brandScraperService: BrandScraperService,
+    private readonly llmDispatcherService: LlmDispatcherService,
+    private readonly logger: LoggerService,
+  ) {}
+
+  /**
+   * Generate brand voice configuration from a URL or existing brand data using
+   * BrandScraperService for web scraping and LlmDispatcherService for AI analysis.
+   */
+  async generateBrandVoice(
+    dto: GenerateBrandVoiceDto,
+    organizationId: string,
+    findBrand: BrandFinder,
+  ): Promise<GeneratedBrandVoice> {
+    this.logger.debug('Generating brand voice', {
+      brandId: dto.brandId,
+      operation: 'generateBrandVoice',
+      service: this.constructorName,
+      url: dto.url,
+    });
+
+    let contextText = '';
+
+    if (dto.url) {
+      const validation = this.brandScraperService.validateUrl(dto.url);
+      if (!validation.isValid) {
+        throw new BadRequestException(validation.error ?? 'Invalid URL');
+      }
+
+      const scraped = await this.brandScraperService.scrapeWebsite(dto.url);
+      const parts = [
+        scraped.companyName && `Company: ${scraped.companyName}`,
+        scraped.description && `Description: ${scraped.description}`,
+        scraped.tagline && `Tagline: ${scraped.tagline}`,
+        scraped.aboutText && `About: ${scraped.aboutText}`,
+        scraped.valuePropositions?.length &&
+          `Value propositions: ${scraped.valuePropositions.join(', ')}`,
+      ].filter(Boolean);
+      contextText = parts.join('\n');
+    } else if (dto.brandId) {
+      const brand = await findBrand({
+        id: dto.brandId,
+        isDeleted: false,
+        organizationId,
+      });
+      if (!brand) {
+        throw new BadRequestException('Brand not found');
+      }
+      const parts = [
+        brand.label && `Brand name: ${brand.label}`,
+        brand.description && `Description: ${brand.description}`,
+        brand.text && `System prompt: ${brand.text}`,
+      ].filter(Boolean);
+      contextText = parts.join('\n');
+    } else {
+      throw new BadRequestException('Either url or brandId must be provided');
+    }
+
+    const audienceContext = dto.targetAudience
+      ? `\nTarget audience: ${dto.targetAudience}`
+      : '';
+    const industryContext = dto.industry ? `\nIndustry: ${dto.industry}` : '';
+    const offeringContext = dto.offering
+      ? `\nWhat the brand sells or creates: ${dto.offering}`
+      : '';
+    const emulateContext =
+      dto.examplesToEmulate?.length && dto.examplesToEmulate.length > 0
+        ? `\nExamples to emulate: ${dto.examplesToEmulate.join(' | ')}`
+        : '';
+    const avoidContext =
+      dto.examplesToAvoid?.length && dto.examplesToAvoid.length > 0
+        ? `\nExamples or styles to avoid: ${dto.examplesToAvoid.join(' | ')}`
+        : '';
+
+    const prompt = buildBrandProfileAnalysisPrompt(
+      `${contextText}${audienceContext}${industryContext}${offeringContext}${emulateContext}${avoidContext}`,
+    );
+
+    const completion = await this.llmDispatcherService.chatCompletion(
+      {
+        max_tokens: 1200,
+        messages: [{ content: prompt, role: 'user' }],
+        model: 'anthropic/claude-sonnet-4-5-20250514',
+        temperature: 0.7,
+      },
+      organizationId,
+    );
+
+    const rawContent = completion.choices?.[0]?.message?.content?.trim() ?? '';
+
+    try {
+      return parseGeneratedBrandProfile(rawContent);
+    } catch (error: unknown) {
+      this.logger.warn('Failed to parse brand voice LLM response', {
+        error,
+        rawContent,
+        service: this.constructorName,
+      });
+      throw new InternalServerErrorException(
+        'The generated brand profile was invalid. Please try again.',
+      );
+    }
+  }
+
+  /**
+   * Turns structured brand data into a batch of ready-to-produce short-form
+   * content ideas distributed across the requested formats. This is the
+   * brand-data-driven core of Fastlane — the user never writes a prompt.
+   *
+   * Org-scoped: the brand is loaded with the caller's organizationId so a brand
+   * from another org cannot be targeted. Requires a configured brand voice.
+   */
+  async generateFastlaneIdeas(
+    brandId: string,
+    dto: GenerateFastlaneIdeasDto,
+    organizationId: string,
+    findBrand: BrandFinder,
+  ): Promise<FastlaneIdea[]> {
+    this.logger.debug('Generating fastlane ideas', {
+      brandId,
+      count: dto.count,
+      formats: dto.formats,
+      operation: 'generateFastlaneIdeas',
+      service: this.constructorName,
+    });
+
+    const brand = await findBrand({
+      id: brandId,
+      isDeleted: false,
+      organizationId,
+    });
+    if (!brand) {
+      throw new NotFoundException('Brand not found');
+    }
+
+    const branding = buildPromptBrandingFromBrand(brand);
+    if (!branding) {
+      throw new BadRequestException('Brand voice not configured');
+    }
+
+    const brandParts = [
+      brand.label && `Brand name: ${brand.label}`,
+      brand.description && `Description: ${brand.description}`,
+      branding.tone && `Tone: ${branding.tone}`,
+      branding.voice && `Style: ${branding.voice}`,
+      branding.audience && `Audience: ${branding.audience}`,
+      Array.isArray(branding.values) &&
+        branding.values.length > 0 &&
+        `Values: ${branding.values.join(', ')}`,
+      Array.isArray(branding.messagingPillars) &&
+        branding.messagingPillars.length > 0 &&
+        `Messaging pillars: ${branding.messagingPillars.join(', ')}`,
+      Array.isArray(branding.taglines) &&
+        branding.taglines.length > 0 &&
+        `Taglines: ${branding.taglines.join(' | ')}`,
+      Array.isArray(branding.hashtags) &&
+        branding.hashtags.length > 0 &&
+        `Hashtags: ${branding.hashtags.join(' ')}`,
+      Array.isArray(branding.doNotSoundLike) &&
+        branding.doNotSoundLike.length > 0 &&
+        `Avoid sounding like: ${branding.doNotSoundLike.join(', ')}`,
+      branding.sampleOutput && `Sample voice: ${branding.sampleOutput}`,
+    ].filter(Boolean);
+
+    const angleContext = dto.angle ? `\nCreative angle: ${dto.angle}` : '';
+    const formatsList = dto.formats.join(', ');
+
+    const prompt = `You are a short-form content strategist. Using ONLY the brand profile below, generate ${dto.count} distinct, ready-to-produce short-form content ideas distributed as evenly as possible across these formats: ${formatsList}.
+
+Format meanings:
+- image: a single scroll-stopping still or slideshow frame
+- video: a short b-roll or hook-and-demo style clip
+- avatar: a UGC-style talking-avatar clip with a spoken script
+
+Return ONLY a JSON array (no markdown fences). Each element must be an object with these exact fields:
+- format: one of ${formatsList}
+- hook: a short scroll-stopping hook line (max ~12 words)
+- caption: a ready-to-publish caption with a clear call to action
+- visualPrompt: a vivid visual/scene description to feed an image or video generator
+- platformHints: array of 1-3 platforms from ["tiktok","instagram","youtube"] this idea suits
+- speechText: ONLY for format "avatar" — the spoken script (2-4 sentences); omit for other formats
+
+Brand profile:
+${brandParts.join('\n')}${angleContext}
+
+Respond ONLY with the JSON array.`;
+
+    const completion = await this.llmDispatcherService.chatCompletion(
+      {
+        max_tokens: 2000,
+        messages: [{ content: prompt, role: 'user' }],
+        model: 'anthropic/claude-sonnet-4-5-20250514',
+        temperature: 0.8,
+      },
+      organizationId,
+    );
+
+    const rawContent = completion.choices?.[0]?.message?.content?.trim() ?? '';
+
+    try {
+      const parsed = JSON.parse(rawContent) as unknown;
+      if (!Array.isArray(parsed)) {
+        return [];
+      }
+
+      return parsed
+        .filter(
+          (item): item is Partial<FastlaneIdea> =>
+            Boolean(item) && typeof item === 'object',
+        )
+        .map((item) => {
+          const format: FastlaneFormat = FASTLANE_FORMATS.includes(
+            item.format as FastlaneFormat,
+          )
+            ? (item.format as FastlaneFormat)
+            : dto.formats[0];
+
+          return {
+            caption: typeof item.caption === 'string' ? item.caption : '',
+            format,
+            hook: typeof item.hook === 'string' ? item.hook : '',
+            id: randomUUID(),
+            platformHints: Array.isArray(item.platformHints)
+              ? item.platformHints.filter(
+                  (platform): platform is string =>
+                    typeof platform === 'string',
+                )
+              : [],
+            speechText:
+              typeof item.speechText === 'string' ? item.speechText : undefined,
+            visualPrompt:
+              typeof item.visualPrompt === 'string' ? item.visualPrompt : '',
+          } satisfies FastlaneIdea;
+        })
+        .filter((idea) => idea.hook || idea.caption || idea.visualPrompt);
+    } catch {
+      this.logger.warn('Failed to parse fastlane ideas LLM response', {
+        rawContent,
+        service: this.constructorName,
+      });
+      return [];
+    }
+  }
+}

--- a/apps/server/api/src/collections/brands/services/brands.service.spec.ts
+++ b/apps/server/api/src/collections/brands/services/brands.service.spec.ts
@@ -10,6 +10,7 @@ vi.mock('@genfeedai/prisma', async () => {
   return canonicalPrismaMock();
 });
 
+import { BrandGenerationService } from '@api/collections/brands/services/brand-generation.service';
 import type { BrandRelocationService } from '@api/collections/brands/services/brand-relocation.service';
 import { BrandsService } from '@api/collections/brands/services/brands.service';
 import { CacheInvalidationService } from '@api/common/services/cache-invalidation.service';
@@ -37,6 +38,7 @@ describe('BrandsService', () => {
   };
   let filesClientService: { uploadToS3: ReturnType<typeof vi.fn> };
   let llmDispatcher: { chatCompletion: ReturnType<typeof vi.fn> };
+  let loggerService: LoggerService;
 
   beforeEach(() => {
     brandScraperService = {
@@ -68,6 +70,12 @@ describe('BrandsService', () => {
     filesClientService = {
       uploadToS3: vi.fn(),
     };
+    loggerService = {
+      debug: vi.fn(),
+      error: vi.fn(),
+      log: vi.fn(),
+      warn: vi.fn(),
+    } as unknown as LoggerService;
 
     const prisma = {
       asset: assetDelegate,
@@ -76,18 +84,17 @@ describe('BrandsService', () => {
 
     service = new BrandsService(
       prisma,
-      {
-        debug: vi.fn(),
-        error: vi.fn(),
-        log: vi.fn(),
-        warn: vi.fn(),
-      } as unknown as LoggerService,
+      loggerService,
       { invalidateByTags: vi.fn() } as unknown as CacheService,
       brandScraperService as unknown as BrandScraperService,
-      llmDispatcher as unknown as LlmDispatcherService,
       cacheInvalidationService as unknown as CacheInvalidationService,
       filesClientService as unknown as FilesClientService,
       {} as unknown as BrandRelocationService,
+      new BrandGenerationService(
+        brandScraperService as unknown as BrandScraperService,
+        llmDispatcher as unknown as LlmDispatcherService,
+        loggerService,
+      ),
     );
   });
 

--- a/apps/server/api/src/collections/brands/services/brands.service.ts
+++ b/apps/server/api/src/collections/brands/services/brands.service.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import type { ApplyBrandKitDto } from '@api/collections/brands/dto/apply-brand-kit.dto';
 import type { CrawlBrandKitDto } from '@api/collections/brands/dto/crawl-brand-kit.dto';
 import { CreateBrandDto } from '@api/collections/brands/dto/create-brand.dto';
@@ -6,10 +5,7 @@ import type {
   GenerateBrandVoiceDto,
   GeneratedBrandVoice,
 } from '@api/collections/brands/dto/generate-brand-voice.dto';
-import {
-  FASTLANE_FORMATS,
-  type GenerateFastlaneIdeasDto,
-} from '@api/collections/brands/dto/generate-fastlane-ideas.dto';
+import type { GenerateFastlaneIdeasDto } from '@api/collections/brands/dto/generate-fastlane-ideas.dto';
 import type { ManualBrandKitDto } from '@api/collections/brands/dto/manual-brand-kit.dto';
 import { UpdateBrandDto } from '@api/collections/brands/dto/update-brand.dto';
 import { UpdateBrandAgentConfigDto } from '@api/collections/brands/dto/update-brand-agent-config.dto';
@@ -18,16 +14,12 @@ import type {
   BrandAgentVoice,
   BrandDocument,
 } from '@api/collections/brands/schemas/brand.schema';
+import { BrandGenerationService } from '@api/collections/brands/services/brand-generation.service';
 import {
   type BrandRelocationPreview,
   type BrandRelocationResult,
   BrandRelocationService,
 } from '@api/collections/brands/services/brand-relocation.service';
-import { buildPromptBrandingFromBrand } from '@api/collections/brands/utils/brand-context.util';
-import {
-  buildBrandProfileAnalysisPrompt,
-  parseGeneratedBrandProfile,
-} from '@api/collections/brands/utils/brand-profile-generation.util';
 import {
   CACHE_PATTERNS,
   CACHE_TAGS,
@@ -37,7 +29,6 @@ import { NotFoundException } from '@api/helpers/exceptions/http/not-found.except
 import { assertUrlNotPrivate } from '@api/helpers/utils/ssrf/ssrf.util';
 import { BrandScraperService } from '@api/services/brand-scraper/brand-scraper.service';
 import { CacheService } from '@api/services/cache/services/cache.service';
-import { LlmDispatcherService } from '@api/services/integrations/llm/llm-dispatcher.service';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { BaseService } from '@api/shared/services/base/base.service';
 import { FileInputType, FontFamily } from '@genfeedai/enums';
@@ -50,7 +41,6 @@ import {
 import type {
   BrandKitAssetRole,
   BrandKitFieldKey,
-  FastlaneFormat,
   FastlaneIdea,
   IBrandKitApplyResult,
   IBrandKitAssetImportCandidate,
@@ -65,11 +55,7 @@ import type {
 import { BRAND_KIT_FIELD_OWNERSHIP } from '@genfeedai/interfaces';
 import { Prisma } from '@genfeedai/prisma';
 import { LoggerService } from '@libs/logger/logger.service';
-import {
-  BadRequestException,
-  Injectable,
-  InternalServerErrorException,
-} from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { FilesClientService } from '@server/services/files-microservice/client/files-client.service';
 
 export type {
@@ -184,10 +170,10 @@ export class BrandsService extends BaseService<
     public readonly logger: LoggerService,
     cacheService: CacheService,
     private readonly brandScraperService: BrandScraperService,
-    private readonly llmDispatcherService: LlmDispatcherService,
     private readonly cacheInvalidationService: CacheInvalidationService,
     private readonly filesClientService: FilesClientService,
     private readonly brandRelocationService: BrandRelocationService,
+    private readonly brandGenerationService: BrandGenerationService,
   ) {
     super(prisma, 'brand', logger, undefined, cacheService);
   }
@@ -1238,241 +1224,28 @@ export class BrandsService extends BaseService<
     return undefined;
   }
 
-  /**
-   * Generate brand voice configuration from a URL or existing brand data using
-   * BrandScraperService for web scraping and LlmDispatcherService for AI analysis.
-   */
   async generateBrandVoice(
     dto: GenerateBrandVoiceDto,
     organizationId: string,
   ): Promise<GeneratedBrandVoice> {
-    this.logger.debug('Generating brand voice', {
-      brandId: dto.brandId,
-      operation: 'generateBrandVoice',
-      service: this.constructorName,
-      url: dto.url,
-    });
-
-    let contextText = '';
-
-    if (dto.url) {
-      const validation = this.brandScraperService.validateUrl(dto.url);
-      if (!validation.isValid) {
-        throw new BadRequestException(validation.error ?? 'Invalid URL');
-      }
-
-      const scraped = await this.brandScraperService.scrapeWebsite(dto.url);
-      const parts = [
-        scraped.companyName && `Company: ${scraped.companyName}`,
-        scraped.description && `Description: ${scraped.description}`,
-        scraped.tagline && `Tagline: ${scraped.tagline}`,
-        scraped.aboutText && `About: ${scraped.aboutText}`,
-        scraped.valuePropositions?.length &&
-          `Value propositions: ${scraped.valuePropositions.join(', ')}`,
-      ].filter(Boolean);
-      contextText = parts.join('\n');
-    } else if (dto.brandId) {
-      const brand = await this.findOne({
-        id: dto.brandId,
-        isDeleted: false,
-        organizationId,
-      });
-      if (!brand) {
-        throw new BadRequestException('Brand not found');
-      }
-      const parts = [
-        brand.label && `Brand name: ${brand.label}`,
-        brand.description && `Description: ${brand.description}`,
-        brand.text && `System prompt: ${brand.text}`,
-      ].filter(Boolean);
-      contextText = parts.join('\n');
-    } else {
-      throw new BadRequestException('Either url or brandId must be provided');
-    }
-
-    const audienceContext = dto.targetAudience
-      ? `\nTarget audience: ${dto.targetAudience}`
-      : '';
-    const industryContext = dto.industry ? `\nIndustry: ${dto.industry}` : '';
-    const offeringContext = dto.offering
-      ? `\nWhat the brand sells or creates: ${dto.offering}`
-      : '';
-    const emulateContext =
-      dto.examplesToEmulate?.length && dto.examplesToEmulate.length > 0
-        ? `\nExamples to emulate: ${dto.examplesToEmulate.join(' | ')}`
-        : '';
-    const avoidContext =
-      dto.examplesToAvoid?.length && dto.examplesToAvoid.length > 0
-        ? `\nExamples or styles to avoid: ${dto.examplesToAvoid.join(' | ')}`
-        : '';
-
-    const prompt = buildBrandProfileAnalysisPrompt(
-      `${contextText}${audienceContext}${industryContext}${offeringContext}${emulateContext}${avoidContext}`,
-    );
-
-    const completion = await this.llmDispatcherService.chatCompletion(
-      {
-        max_tokens: 1200,
-        messages: [{ content: prompt, role: 'user' }],
-        model: 'anthropic/claude-sonnet-4-5-20250514',
-        temperature: 0.7,
-      },
+    return this.brandGenerationService.generateBrandVoice(
+      dto,
       organizationId,
+      (criteria) => this.findOne(criteria),
     );
-
-    const rawContent = completion.choices?.[0]?.message?.content?.trim() ?? '';
-
-    try {
-      return parseGeneratedBrandProfile(rawContent);
-    } catch (error: unknown) {
-      this.logger.warn('Failed to parse brand voice LLM response', {
-        error,
-        rawContent,
-        service: this.constructorName,
-      });
-      throw new InternalServerErrorException(
-        'The generated brand profile was invalid. Please try again.',
-      );
-    }
   }
 
-  /**
-   * Turns structured brand data into a batch of ready-to-produce short-form
-   * content ideas distributed across the requested formats. This is the
-   * brand-data-driven core of Fastlane — the user never writes a prompt.
-   *
-   * Org-scoped: the brand is loaded with the caller's organizationId so a brand
-   * from another org cannot be targeted. Requires a configured brand voice.
-   */
   async generateFastlaneIdeas(
     brandId: string,
     dto: GenerateFastlaneIdeasDto,
     organizationId: string,
   ): Promise<FastlaneIdea[]> {
-    this.logger.debug('Generating fastlane ideas', {
+    return this.brandGenerationService.generateFastlaneIdeas(
       brandId,
-      count: dto.count,
-      formats: dto.formats,
-      operation: 'generateFastlaneIdeas',
-      service: this.constructorName,
-    });
-
-    const brand = await this.findOne({
-      id: brandId,
-      isDeleted: false,
+      dto,
       organizationId,
-    });
-    if (!brand) {
-      throw new NotFoundException('Brand not found');
-    }
-
-    const branding = buildPromptBrandingFromBrand(brand);
-    if (!branding) {
-      throw new BadRequestException('Brand voice not configured');
-    }
-
-    const brandParts = [
-      brand.label && `Brand name: ${brand.label}`,
-      brand.description && `Description: ${brand.description}`,
-      branding.tone && `Tone: ${branding.tone}`,
-      branding.voice && `Style: ${branding.voice}`,
-      branding.audience && `Audience: ${branding.audience}`,
-      Array.isArray(branding.values) &&
-        branding.values.length > 0 &&
-        `Values: ${branding.values.join(', ')}`,
-      Array.isArray(branding.messagingPillars) &&
-        branding.messagingPillars.length > 0 &&
-        `Messaging pillars: ${branding.messagingPillars.join(', ')}`,
-      Array.isArray(branding.taglines) &&
-        branding.taglines.length > 0 &&
-        `Taglines: ${branding.taglines.join(' | ')}`,
-      Array.isArray(branding.hashtags) &&
-        branding.hashtags.length > 0 &&
-        `Hashtags: ${branding.hashtags.join(' ')}`,
-      Array.isArray(branding.doNotSoundLike) &&
-        branding.doNotSoundLike.length > 0 &&
-        `Avoid sounding like: ${branding.doNotSoundLike.join(', ')}`,
-      branding.sampleOutput && `Sample voice: ${branding.sampleOutput}`,
-    ].filter(Boolean);
-
-    const angleContext = dto.angle ? `\nCreative angle: ${dto.angle}` : '';
-    const formatsList = dto.formats.join(', ');
-
-    const prompt = `You are a short-form content strategist. Using ONLY the brand profile below, generate ${dto.count} distinct, ready-to-produce short-form content ideas distributed as evenly as possible across these formats: ${formatsList}.
-
-Format meanings:
-- image: a single scroll-stopping still or slideshow frame
-- video: a short b-roll or hook-and-demo style clip
-- avatar: a UGC-style talking-avatar clip with a spoken script
-
-Return ONLY a JSON array (no markdown fences). Each element must be an object with these exact fields:
-- format: one of ${formatsList}
-- hook: a short scroll-stopping hook line (max ~12 words)
-- caption: a ready-to-publish caption with a clear call to action
-- visualPrompt: a vivid visual/scene description to feed an image or video generator
-- platformHints: array of 1-3 platforms from ["tiktok","instagram","youtube"] this idea suits
-- speechText: ONLY for format "avatar" — the spoken script (2-4 sentences); omit for other formats
-
-Brand profile:
-${brandParts.join('\n')}${angleContext}
-
-Respond ONLY with the JSON array.`;
-
-    const completion = await this.llmDispatcherService.chatCompletion(
-      {
-        max_tokens: 2000,
-        messages: [{ content: prompt, role: 'user' }],
-        model: 'anthropic/claude-sonnet-4-5-20250514',
-        temperature: 0.8,
-      },
-      organizationId,
+      (criteria) => this.findOne(criteria),
     );
-
-    const rawContent = completion.choices?.[0]?.message?.content?.trim() ?? '';
-
-    try {
-      const parsed = JSON.parse(rawContent) as unknown;
-      if (!Array.isArray(parsed)) {
-        return [];
-      }
-
-      return parsed
-        .filter(
-          (item): item is Partial<FastlaneIdea> =>
-            Boolean(item) && typeof item === 'object',
-        )
-        .map((item) => {
-          const format: FastlaneFormat = FASTLANE_FORMATS.includes(
-            item.format as FastlaneFormat,
-          )
-            ? (item.format as FastlaneFormat)
-            : dto.formats[0];
-
-          return {
-            caption: typeof item.caption === 'string' ? item.caption : '',
-            format,
-            hook: typeof item.hook === 'string' ? item.hook : '',
-            id: randomUUID(),
-            platformHints: Array.isArray(item.platformHints)
-              ? item.platformHints.filter(
-                  (platform): platform is string =>
-                    typeof platform === 'string',
-                )
-              : [],
-            speechText:
-              typeof item.speechText === 'string' ? item.speechText : undefined,
-            visualPrompt:
-              typeof item.visualPrompt === 'string' ? item.visualPrompt : '',
-          } satisfies FastlaneIdea;
-        })
-        .filter((idea) => idea.hook || idea.caption || idea.visualPrompt);
-    } catch {
-      this.logger.warn('Failed to parse fastlane ideas LLM response', {
-        rawContent,
-        service: this.constructorName,
-      });
-      return [];
-    }
   }
 
   async remove(id: string): Promise<BrandDocument> {


### PR DESCRIPTION
## Summary

- extract brand voice and Fastlane idea generation into BrandGenerationService
- preserve the BrandsService public facade and tenant-scoped brand lookup callback
- move scraper, LLM dispatch, prompt building, normalization, and provider error handling under the generation owner
- retain existing Fastlane regression coverage and add focused brand-voice URL, tenant scope, normalization, and invalid-provider-response tests

## Size impact

- BrandsService: 1,603 to 1,376 lines on top of #1751
- BrandGenerationService: 279 lines

## Verification

- Biome check passed for all changed files
- git diff --check passed
- staged Gitleaks scan passed
- commit hooks passed Biome, control guard, and Secretlint
- local tests, typecheck, and build intentionally deferred to PR CI per workstation policy

Stacked on #1751
Part of #1738
Epic: #1736