### PR TITLE
refactor(brand-scraper): extract website parser

### DIFF
--- a/apps/server/api/src/services/brand-scraper/brand-scraper.module.ts
+++ b/apps/server/api/src/services/brand-scraper/brand-scraper.module.ts
@@ -1,8 +1,9 @@
 import { BrandScraperService } from '@api/services/brand-scraper/brand-scraper.service';
+import { BrandWebsiteParserService } from '@api/services/brand-scraper/brand-website-parser.service';
 import { Module } from '@nestjs/common';
 
 @Module({
   exports: [BrandScraperService],
-  providers: [BrandScraperService],
+  providers: [BrandScraperService, BrandWebsiteParserService],
 })
 export class BrandScraperModule {}

--- a/apps/server/api/src/services/brand-scraper/brand-scraper.service.spec.ts
+++ b/apps/server/api/src/services/brand-scraper/brand-scraper.service.spec.ts
@@ -1,4 +1,5 @@
 import { BrandScraperService } from '@api/services/brand-scraper/brand-scraper.service';
+import { BrandWebsiteParserService } from '@api/services/brand-scraper/brand-website-parser.service';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Test, TestingModule } from '@nestjs/testing';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -99,6 +100,7 @@ describe('BrandScraperService', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         BrandScraperService,
+        BrandWebsiteParserService,
         { provide: LoggerService, useValue: mockLogger },
       ],
     }).compile();

--- a/apps/server/api/src/services/brand-scraper/brand-scraper.service.ts
+++ b/apps/server/api/src/services/brand-scraper/brand-scraper.service.ts
@@ -1,4 +1,5 @@
 import { assertHostNotPrivate } from '@api/helpers/utils/ssrf/ssrf.util';
+import { BrandWebsiteParserService } from '@api/services/brand-scraper/brand-website-parser.service';
 import type {
   BrandScrapeSources,
   LinkedInScrapedData,
@@ -33,9 +34,6 @@ const MAX_REDIRECTS = 5;
 /** HTTP status codes we follow as redirects (re-validating each Location) */
 const REDIRECT_STATUS_CODES = new Set([301, 302, 303, 307, 308]);
 
-const MAX_IMAGE_CANDIDATES = 12;
-const MAX_FONT_CANDIDATES = 8;
-
 /**
  * BrandScraperService
  *
@@ -49,7 +47,10 @@ const MAX_FONT_CANDIDATES = 8;
 export class BrandScraperService {
   private readonly constructorName: string = String(this.constructor.name);
 
-  constructor(private readonly loggerService: LoggerService) {}
+  constructor(
+    private readonly loggerService: LoggerService,
+    private readonly brandWebsiteParser: BrandWebsiteParserService,
+  ) {}
 
   /**
    * Scrape a website URL and extract brand information
@@ -62,7 +63,10 @@ export class BrandScraperService {
 
     try {
       const rawContent = await this.fetchAndParse(normalizedUrl);
-      const scrapedData = this.extractBrandData(rawContent, normalizedUrl);
+      const scrapedData = this.brandWebsiteParser.extractBrandData(
+        rawContent,
+        normalizedUrl,
+      );
 
       this.loggerService.log(`${caller} completed`, {
         companyName: scrapedData.companyName,
@@ -78,7 +82,7 @@ export class BrandScraperService {
 
       try {
         const fallback = await this.scrapeMetaTagsFallback(normalizedUrl);
-        const companyName = this.extractCompanyName(
+        const companyName = this.brandWebsiteParser.extractCompanyName(
           fallback.title,
           fallback.ogTitle,
         );
@@ -168,7 +172,7 @@ export class BrandScraperService {
           $('meta[property="og:description"]').attr('content')?.trim(),
         headquarters: undefined,
         industry: undefined,
-        logoUrl: this.extractLogoFromDom($, normalizedUrl),
+        logoUrl: this.brandWebsiteParser.extractLogoFromDom($, normalizedUrl),
         recentPosts: [],
         scrapedAt: new Date(),
         sourceUrl: normalizedUrl,
@@ -423,11 +427,10 @@ export class BrandScraperService {
       );
     }
 
-    this.assertHtmlResponse(response);
+    this.brandWebsiteParser.assertHtmlResponse(response);
     const html = await response.text();
-    const $ = cheerio.load(html);
 
-    return this.extractFromDom($, url);
+    return this.brandWebsiteParser.parseHtml(html, url);
   }
 
   /**
@@ -562,7 +565,7 @@ export class BrandScraperService {
       );
     }
 
-    this.assertHtmlResponse(response);
+    this.brandWebsiteParser.assertHtmlResponse(response);
     const html = await response.text();
     const $ = cheerio.load(html);
 
@@ -585,535 +588,6 @@ export class BrandScraperService {
       sourceUrl: url,
       title: $('title').first().text().trim() || undefined,
     };
-  }
-
-  /**
-   * Extract all brand data from parsed HTML DOM
-   */
-  private extractFromDom(
-    $: cheerio.CheerioAPI,
-    sourceUrl: string,
-  ): WebsiteScrapingResult {
-    const title = $('title').first().text().trim() || undefined;
-    const description =
-      $('meta[name="description"]').attr('content')?.trim() || undefined;
-    const ogTitle =
-      $('meta[property="og:title"]').attr('content')?.trim() || undefined;
-    const ogDescription =
-      $('meta[property="og:description"]').attr('content')?.trim() || undefined;
-    const ogImage =
-      $('meta[property="og:image"]').attr('content')?.trim() ||
-      $(
-        'meta[name="twitter:image"], meta[property="twitter:image"], meta[name="twitter:image:src"]',
-      )
-        .first()
-        .attr('content')
-        ?.trim() ||
-      undefined;
-    const favicon =
-      $('link[rel="icon"]').attr('href')?.trim() ||
-      $('link[rel="shortcut icon"]').attr('href')?.trim() ||
-      undefined;
-    const canonical =
-      $('link[rel="canonical"]').attr('href')?.trim() || undefined;
-
-    // Extract social links from <a> hrefs
-    const allLinks: string[] = [];
-    $('a[href]').each((_i, el) => {
-      const href = $(el).attr('href');
-      if (href) {
-        allLinks.push(href);
-      }
-    });
-    const socialLinks = this.extractSocialLinks(allLinks);
-
-    // Extract colors from theme-color meta, <style> tags, inline styles
-    const colors = this.extractColorsFromDom($);
-    const fonts = this.extractFontsFromDom($);
-
-    // Extract headings
-    const headings = this.extractHeadingsFromDom($);
-
-    // Extract body text for about/value prop extraction
-    const bodyText = $('body').text().replace(/\s+/g, ' ').trim();
-
-    // Extract value propositions
-    const valuePropositions = this.extractValuePropositions(bodyText);
-    const aboutText = this.extractAboutText(bodyText);
-
-    // Extract logo
-    const logoUrl = this.extractLogoFromDom($, sourceUrl);
-    const images = this.extractImagesFromDom($, sourceUrl);
-    const bannerUrl = this.extractBannerFromDom($, sourceUrl, ogImage, images);
-
-    return {
-      aboutText,
-      bannerUrl,
-      canonical,
-      colors,
-      description,
-      favicon,
-      fonts,
-      headings,
-      heroText: headings[0],
-      images,
-      logoUrl,
-      ogDescription,
-      ogImage,
-      ogTitle,
-      paragraphs: [],
-      scrapedAt: new Date(),
-      socialLinks,
-      sourceUrl,
-      title,
-      valuePropositions,
-    };
-  }
-
-  /**
-   * Extract brand data from scraped website content
-   */
-  private extractBrandData(
-    scrapedContent: WebsiteScrapingResult,
-    sourceUrl: string,
-  ): IScrapedBrandData {
-    const companyName = this.extractCompanyName(
-      scrapedContent.title,
-      scrapedContent.ogTitle,
-    );
-
-    const valuePropositions =
-      scrapedContent.valuePropositions.length > 0
-        ? scrapedContent.valuePropositions
-        : scrapedContent.headings.slice(0, 5);
-
-    return {
-      aboutText: scrapedContent.aboutText,
-      bannerUrl: scrapedContent.bannerUrl,
-      companyName,
-      description: scrapedContent.description || scrapedContent.ogDescription,
-      fontCandidates: scrapedContent.fonts,
-      fontFamily: scrapedContent.fonts[0],
-      heroText: scrapedContent.heroText,
-      logoUrl: scrapedContent.logoUrl,
-      metaDescription: scrapedContent.description,
-      ogImage: scrapedContent.ogImage,
-      primaryColor: scrapedContent.colors.primary,
-      referenceImageUrls: scrapedContent.images
-        .map((image) => image.src)
-        .filter(
-          (src, index, all) =>
-            src !== scrapedContent.logoUrl &&
-            src !== scrapedContent.bannerUrl &&
-            all.indexOf(src) === index,
-        )
-        .slice(0, MAX_IMAGE_CANDIDATES),
-      scrapedAt: scrapedContent.scrapedAt,
-      secondaryColor: scrapedContent.colors.secondary,
-      socialLinks: scrapedContent.socialLinks,
-      sourceUrl,
-      tagline: scrapedContent.heroText || scrapedContent.ogTitle,
-      valuePropositions,
-    };
-  }
-
-  /**
-   * Extract company name from title
-   */
-  private extractCompanyName(
-    title?: string,
-    ogTitle?: string,
-  ): string | undefined {
-    const source = title || ogTitle;
-    if (!source) {
-      return undefined;
-    }
-
-    const separators = [' | ', ' - ', ' – ', ' — '];
-    for (const sep of separators) {
-      if (source.includes(sep)) {
-        return source.split(sep)[0].trim();
-      }
-    }
-
-    return source.trim();
-  }
-
-  /**
-   * Extract social media links from page links
-   */
-  private extractSocialLinks(
-    links: string[],
-  ): WebsiteScrapingResult['socialLinks'] {
-    const socialPatterns: Record<string, RegExp> = {
-      facebook: /facebook\.com/i,
-      instagram: /instagram\.com/i,
-      linkedin: /linkedin\.com/i,
-      tiktok: /tiktok\.com/i,
-      twitter: /twitter\.com|x\.com/i,
-      youtube: /youtube\.com/i,
-    };
-
-    const result: WebsiteScrapingResult['socialLinks'] = {};
-
-    for (const link of links) {
-      for (const [platform, pattern] of Object.entries(socialPatterns)) {
-        if (pattern.test(link) && !result[platform as keyof typeof result]) {
-          result[platform as keyof typeof result] = link;
-        }
-      }
-    }
-
-    return result;
-  }
-
-  /**
-   * Extract colors from DOM: theme-color meta, <style> tags, inline styles
-   */
-  private extractColorsFromDom(
-    $: cheerio.CheerioAPI,
-  ): WebsiteScrapingResult['colors'] {
-    const colorCounts = new Map<string, number>();
-
-    const addColor = (color: string, weight = 1): void => {
-      const normalized = color.toLowerCase().trim();
-      if (
-        ['#000', '#000000', '#fff', '#ffffff', 'transparent', '#0000'].includes(
-          normalized,
-        )
-      ) {
-        return;
-      }
-      colorCounts.set(normalized, (colorCounts.get(normalized) || 0) + weight);
-    };
-
-    // Theme-color meta tag (high weight)
-    const themeColor = $('meta[name="theme-color"]').attr('content')?.trim();
-    if (themeColor) {
-      addColor(themeColor, 5);
-    }
-
-    // msapplication-TileColor
-    const tileColor = $('meta[name="msapplication-TileColor"]')
-      .attr('content')
-      ?.trim();
-    if (tileColor) {
-      addColor(tileColor, 3);
-    }
-
-    // Extract from <style> tags and inline style attributes
-    const cssText: string[] = [];
-    $('style').each((_i, el) => {
-      cssText.push($(el).text());
-    });
-    $('[style]').each((_i, el) => {
-      const style = $(el).attr('style');
-      if (style) {
-        cssText.push(style);
-      }
-    });
-
-    const allCss = cssText.join(' ');
-
-    // Extract hex colors
-    const hexMatches = allCss.match(/#(?:[0-9a-fA-F]{3}){1,2}\b/g);
-    if (hexMatches) {
-      for (const hex of hexMatches) {
-        addColor(hex);
-      }
-    }
-
-    // Extract rgb/rgba colors
-    const rgbMatches = allCss.match(
-      /rgba?\(\s*\d{1,3}\s*,\s*\d{1,3}\s*,\s*\d{1,3}(?:\s*,\s*[\d.]+)?\s*\)/g,
-    );
-    if (rgbMatches) {
-      for (const rgb of rgbMatches) {
-        addColor(rgb);
-      }
-    }
-
-    // Sort by frequency
-    const sorted = Array.from(colorCounts.entries())
-      .sort((a, b) => b[1] - a[1])
-      .map(([color]) => color);
-
-    return {
-      accent: sorted.slice(2, 6),
-      background: undefined,
-      primary: sorted[0],
-      secondary: sorted[1],
-    };
-  }
-
-  private extractFontsFromDom($: cheerio.CheerioAPI): string[] {
-    const candidates: string[] = [];
-    const seen = new Set<string>();
-
-    const addFont = (font: string): void => {
-      const normalized = font
-        .split(',')
-        .map((part) => part.trim().replace(/^['"]|['"]$/g, ''))
-        .find((part) => part.length > 0);
-
-      if (
-        !normalized ||
-        /^(system-ui|sans-serif|serif|monospace|inherit|initial|var\()/i.test(
-          normalized,
-        ) ||
-        seen.has(normalized)
-      ) {
-        return;
-      }
-
-      seen.add(normalized);
-      candidates.push(normalized);
-    };
-
-    $('link[href*="fonts.googleapis.com"]').each((_i, el) => {
-      const href = $(el).attr('href');
-      if (!href) {
-        return;
-      }
-      try {
-        const family = new URL(
-          href,
-          'https://fonts.googleapis.com',
-        ).searchParams
-          .get('family')
-          ?.split(':')[0]
-          ?.replace(/\+/g, ' ');
-        if (family) {
-          addFont(family);
-        }
-      } catch {
-        // Ignore malformed stylesheet URLs; inline declarations still apply.
-      }
-    });
-
-    const cssText: string[] = [];
-    $('style').each((_i, el) => {
-      cssText.push($(el).text());
-    });
-    $('[style]').each((_i, el) => {
-      const style = $(el).attr('style');
-      if (style) {
-        cssText.push(style);
-      }
-    });
-
-    const fontMatches = cssText
-      .join(' ')
-      .matchAll(/font-family\s*:\s*([^;{}]+)/gi);
-    for (const match of fontMatches) {
-      if (match[1]) {
-        addFont(match[1]);
-      }
-    }
-
-    return candidates.slice(0, MAX_FONT_CANDIDATES);
-  }
-
-  /**
-   * Extract headings from DOM
-   */
-  private extractHeadingsFromDom($: cheerio.CheerioAPI): string[] {
-    const headings: string[] = [];
-
-    $('h1, h2').each((_i, el) => {
-      const text = $(el).text().trim();
-      if (text.length > 3 && text.length < 200) {
-        headings.push(text);
-      }
-    });
-
-    return [...new Set(headings)].slice(0, 10);
-  }
-
-  /**
-   * Extract logo URL from DOM
-   */
-  private extractLogoFromDom(
-    $: cheerio.CheerioAPI,
-    sourceUrl: string,
-  ): string | undefined {
-    // Check for common logo patterns
-    const logoSelectors = [
-      'img[class*="logo"]',
-      'img[id*="logo"]',
-      'img[alt*="logo"]',
-      'a[class*="logo"] img',
-      'header img:first-of-type',
-      '.logo img',
-      '#logo img',
-    ];
-
-    for (const selector of logoSelectors) {
-      const src = $(selector).first().attr('src');
-      if (src) {
-        return this.resolveUrl(src, sourceUrl);
-      }
-    }
-
-    // Check for apple-touch-icon as fallback
-    const touchIcon = $('link[rel="apple-touch-icon"]').attr('href');
-    if (touchIcon) {
-      return this.resolveUrl(touchIcon, sourceUrl);
-    }
-
-    return undefined;
-  }
-
-  private extractImagesFromDom(
-    $: cheerio.CheerioAPI,
-    sourceUrl: string,
-  ): WebsiteScrapingResult['images'] {
-    const images: WebsiteScrapingResult['images'] = [];
-    const seen = new Set<string>();
-
-    const addImage = (
-      src: string | undefined,
-      alt?: string,
-      isSrcSet = false,
-    ): void => {
-      if (!src || src.startsWith('data:')) {
-        return;
-      }
-
-      // Only treat the value as a srcset (comma-separated candidate list) when
-      // it actually came from a srcset attribute. Plain src/data-src URLs can
-      // legitimately contain commas (e.g. CDN transform params) and must not be
-      // truncated at the first comma.
-      const candidate = isSrcSet ? this.extractSrcFromSrcSet(src) : src;
-      const resolved = this.resolveUrl(candidate, sourceUrl);
-      if (!resolved || seen.has(resolved)) {
-        return;
-      }
-
-      seen.add(resolved);
-      images.push({
-        alt: alt?.trim() || undefined,
-        src: resolved,
-      });
-    };
-
-    $('meta[property="og:image"], meta[name="twitter:image"]').each(
-      (_i, el) => {
-        addImage($(el).attr('content'), 'Social preview image');
-      },
-    );
-
-    $('img[src], img[data-src], img[srcset]').each((_i, el) => {
-      const direct = $(el).attr('src') ?? $(el).attr('data-src');
-      if (direct) {
-        addImage(direct, $(el).attr('alt'));
-      } else {
-        addImage($(el).attr('srcset'), $(el).attr('alt'), true);
-      }
-    });
-
-    return images.slice(0, MAX_IMAGE_CANDIDATES);
-  }
-
-  private extractBannerFromDom(
-    $: cheerio.CheerioAPI,
-    sourceUrl: string,
-    ogImage: string | undefined,
-    images: WebsiteScrapingResult['images'],
-  ): string | undefined {
-    const bannerSelectors = [
-      'img[class*="hero"]',
-      'img[class*="banner"]',
-      'img[id*="hero"]',
-      'img[id*="banner"]',
-      '[class*="hero"] img',
-      '[class*="banner"] img',
-    ];
-
-    for (const selector of bannerSelectors) {
-      const src = $(selector).first().attr('src');
-      if (src) {
-        return this.resolveUrl(src, sourceUrl);
-      }
-    }
-
-    if (ogImage) {
-      return this.resolveUrl(ogImage, sourceUrl);
-    }
-
-    return images[0]?.src;
-  }
-
-  private extractSrcFromSrcSet(value: string): string {
-    return value.split(',')[0]?.trim().split(/\s+/)[0] ?? value;
-  }
-
-  /**
-   * Resolve a potentially relative URL against a base URL
-   */
-  private resolveUrl(href: string, base: string): string {
-    try {
-      return new URL(href, base).href;
-    } catch {
-      return href;
-    }
-  }
-
-  private assertHtmlResponse(response: Response): void {
-    const contentType = response.headers.get('content-type');
-    if (
-      contentType &&
-      !contentType.includes('text/html') &&
-      !contentType.includes('application/xhtml+xml')
-    ) {
-      throw new Error(`Unsupported content type: ${contentType}`);
-    }
-  }
-
-  /**
-   * Extract value propositions from content
-   */
-  private extractValuePropositions(text: string): string[] {
-    const propositions: string[] = [];
-
-    const bulletPatterns = [
-      /•\s*([^•\n]+)/g,
-      /✓\s*([^✓\n]+)/g,
-      /✔\s*([^✔\n]+)/g,
-      /-\s*([A-Z][^-\n]+)/g,
-    ];
-
-    for (const pattern of bulletPatterns) {
-      const matches = text.matchAll(pattern);
-      for (const match of matches) {
-        if (match[1] && match[1].length > 10 && match[1].length < 200) {
-          propositions.push(match[1].trim());
-        }
-      }
-    }
-
-    return [...new Set(propositions)].slice(0, 6);
-  }
-
-  /**
-   * Extract about/description text
-   */
-  private extractAboutText(text: string): string | undefined {
-    const aboutPatterns = [
-      /about\s+us[\s:]+([^.]+\.)/i,
-      /who\s+we\s+are[\s:]+([^.]+\.)/i,
-      /our\s+mission[\s:]+([^.]+\.)/i,
-      /we\s+are\s+([^.]+\.)/i,
-    ];
-
-    for (const pattern of aboutPatterns) {
-      const match = text.match(pattern);
-      if (match?.[1] && match[1].length > 50) {
-        return match[1].trim();
-      }
-    }
-
-    return undefined;
   }
 
   /**

--- a/apps/server/api/src/services/brand-scraper/brand-website-parser.service.spec.ts
+++ b/apps/server/api/src/services/brand-scraper/brand-website-parser.service.spec.ts
@@ -1,0 +1,77 @@
+import { BrandWebsiteParserService } from '@api/services/brand-scraper/brand-website-parser.service';
+
+describe('BrandWebsiteParserService', () => {
+  const service = new BrandWebsiteParserService();
+
+  it('extracts brand identity and resolves relative media URLs', () => {
+    const parsed = service.parseHtml(
+      `<!doctype html>
+      <html>
+        <head>
+          <title>Acme | Better launches</title>
+          <meta name="description" content="Launch faster with Acme">
+          <meta name="theme-color" content="#123456">
+          <meta property="og:image" content="/social-card.png">
+          <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700" rel="stylesheet">
+        </head>
+        <body>
+          <header><img alt="Acme logo" class="logo" src="/logo.svg"></header>
+          <h1>Launch better products</h1>
+          <a href="https://linkedin.com/company/acme">LinkedIn</a>
+          <img alt="Product dashboard" src="/dashboard.png">
+        </body>
+      </html>`,
+      'https://acme.example/about',
+    );
+
+    expect(parsed).toMatchObject({
+      colors: { primary: '#123456' },
+      fonts: ['Inter'],
+      heroText: 'Launch better products',
+      logoUrl: 'https://acme.example/logo.svg',
+      socialLinks: { linkedin: 'https://linkedin.com/company/acme' },
+      title: 'Acme | Better launches',
+    });
+    expect(parsed.images).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ src: 'https://acme.example/dashboard.png' }),
+      ]),
+    );
+  });
+
+  it('maps parsed website content into the public scraped-brand contract', () => {
+    const parsed = service.parseHtml(
+      '<title>Acme — Ship faster</title><body><h1>Ship faster</h1><img class="logo" src="/logo.png"><img src="/reference.png"></body>',
+      'https://acme.example',
+    );
+
+    expect(
+      service.extractBrandData(parsed, 'https://acme.example'),
+    ).toMatchObject({
+      companyName: 'Acme',
+      logoUrl: 'https://acme.example/logo.png',
+      referenceImageUrls: ['https://acme.example/reference.png'],
+      sourceUrl: 'https://acme.example',
+      tagline: 'Ship faster',
+    });
+  });
+
+  it.each([
+    ['Acme | Platform', 'Acme'],
+    ['Acme - Platform', 'Acme'],
+    ['Acme — Platform', 'Acme'],
+    ['Acme', 'Acme'],
+  ])('extracts the company name from %s', (title, expected) => {
+    expect(service.extractCompanyName(title)).toBe(expected);
+  });
+
+  it('rejects non-HTML responses before parsing', () => {
+    const response = new Response('{}', {
+      headers: { 'content-type': 'application/json' },
+    });
+
+    expect(() => service.assertHtmlResponse(response)).toThrow(
+      'Expected HTML response',
+    );
+  });
+});

--- a/apps/server/api/src/services/brand-scraper/brand-website-parser.service.spec.ts
+++ b/apps/server/api/src/services/brand-scraper/brand-website-parser.service.spec.ts
@@ -71,7 +71,7 @@ describe('BrandWebsiteParserService', () => {
     });
 
     expect(() => service.assertHtmlResponse(response)).toThrow(
-      'Expected HTML response',
+      'Unsupported content type: application/json',
     );
   });
 });

--- a/apps/server/api/src/services/brand-scraper/brand-website-parser.service.spec.ts
+++ b/apps/server/api/src/services/brand-scraper/brand-website-parser.service.spec.ts
@@ -56,6 +56,35 @@ describe('BrandWebsiteParserService', () => {
     });
   });
 
+  it('matches social links by hostname and ignores redirects or non-web links', () => {
+    const parsed = service.parseHtml(
+      `<body>
+        <a href="https://example.com/redirect?next=https://facebook.com/acme">Redirect</a>
+        <a href="mailto:hello@instagram.com">Email</a>
+        <a href="https://m.facebook.com/acme">Facebook</a>
+        <a href="https://x.com/acme">X</a>
+      </body>`,
+      'https://acme.example',
+    );
+
+    expect(parsed.socialLinks).toEqual({
+      facebook: 'https://m.facebook.com/acme',
+      twitter: 'https://x.com/acme',
+    });
+  });
+
+  it('does not reuse the logo as the fallback banner', () => {
+    const parsed = service.parseHtml(
+      '<body><img class="logo" src="/logo.png"><img src="/banner.png"></body>',
+      'https://acme.example',
+    );
+
+    expect(parsed).toMatchObject({
+      bannerUrl: 'https://acme.example/banner.png',
+      logoUrl: 'https://acme.example/logo.png',
+    });
+  });
+
   it.each([
     ['Acme | Platform', 'Acme'],
     ['Acme - Platform', 'Acme'],

--- a/apps/server/api/src/services/brand-scraper/brand-website-parser.service.ts
+++ b/apps/server/api/src/services/brand-scraper/brand-website-parser.service.ts
@@ -1,0 +1,540 @@
+import type { WebsiteScrapingResult } from '@api/services/brand-scraper/interfaces/brand-scraper.interfaces';
+import type { IScrapedBrandData } from '@genfeedai/interfaces';
+import { Injectable } from '@nestjs/common';
+import * as cheerio from 'cheerio';
+
+const MAX_IMAGE_CANDIDATES = 12;
+const MAX_FONT_CANDIDATES = 8;
+
+@Injectable()
+export class BrandWebsiteParserService {
+  parseHtml(html: string, sourceUrl: string): WebsiteScrapingResult {
+    return this.extractFromDom(cheerio.load(html), sourceUrl);
+  }
+
+  /**
+   * Extract all brand data from parsed HTML DOM
+   */
+  private extractFromDom(
+    $: cheerio.CheerioAPI,
+    sourceUrl: string,
+  ): WebsiteScrapingResult {
+    const title = $('title').first().text().trim() || undefined;
+    const description =
+      $('meta[name="description"]').attr('content')?.trim() || undefined;
+    const ogTitle =
+      $('meta[property="og:title"]').attr('content')?.trim() || undefined;
+    const ogDescription =
+      $('meta[property="og:description"]').attr('content')?.trim() || undefined;
+    const ogImage =
+      $('meta[property="og:image"]').attr('content')?.trim() ||
+      $(
+        'meta[name="twitter:image"], meta[property="twitter:image"], meta[name="twitter:image:src"]',
+      )
+        .first()
+        .attr('content')
+        ?.trim() ||
+      undefined;
+    const favicon =
+      $('link[rel="icon"]').attr('href')?.trim() ||
+      $('link[rel="shortcut icon"]').attr('href')?.trim() ||
+      undefined;
+    const canonical =
+      $('link[rel="canonical"]').attr('href')?.trim() || undefined;
+
+    // Extract social links from <a> hrefs
+    const allLinks: string[] = [];
+    $('a[href]').each((_i, el) => {
+      const href = $(el).attr('href');
+      if (href) {
+        allLinks.push(href);
+      }
+    });
+    const socialLinks = this.extractSocialLinks(allLinks);
+
+    // Extract colors from theme-color meta, <style> tags, inline styles
+    const colors = this.extractColorsFromDom($);
+    const fonts = this.extractFontsFromDom($);
+
+    // Extract headings
+    const headings = this.extractHeadingsFromDom($);
+
+    // Extract body text for about/value prop extraction
+    const bodyText = $('body').text().replace(/\s+/g, ' ').trim();
+
+    // Extract value propositions
+    const valuePropositions = this.extractValuePropositions(bodyText);
+    const aboutText = this.extractAboutText(bodyText);
+
+    // Extract logo
+    const logoUrl = this.extractLogoFromDom($, sourceUrl);
+    const images = this.extractImagesFromDom($, sourceUrl);
+    const bannerUrl = this.extractBannerFromDom($, sourceUrl, ogImage, images);
+
+    return {
+      aboutText,
+      bannerUrl,
+      canonical,
+      colors,
+      description,
+      favicon,
+      fonts,
+      headings,
+      heroText: headings[0],
+      images,
+      logoUrl,
+      ogDescription,
+      ogImage,
+      ogTitle,
+      paragraphs: [],
+      scrapedAt: new Date(),
+      socialLinks,
+      sourceUrl,
+      title,
+      valuePropositions,
+    };
+  }
+
+  /**
+   * Extract brand data from scraped website content
+   */
+  extractBrandData(
+    scrapedContent: WebsiteScrapingResult,
+    sourceUrl: string,
+  ): IScrapedBrandData {
+    const companyName = this.extractCompanyName(
+      scrapedContent.title,
+      scrapedContent.ogTitle,
+    );
+
+    const valuePropositions =
+      scrapedContent.valuePropositions.length > 0
+        ? scrapedContent.valuePropositions
+        : scrapedContent.headings.slice(0, 5);
+
+    return {
+      aboutText: scrapedContent.aboutText,
+      bannerUrl: scrapedContent.bannerUrl,
+      companyName,
+      description: scrapedContent.description || scrapedContent.ogDescription,
+      fontCandidates: scrapedContent.fonts,
+      fontFamily: scrapedContent.fonts[0],
+      heroText: scrapedContent.heroText,
+      logoUrl: scrapedContent.logoUrl,
+      metaDescription: scrapedContent.description,
+      ogImage: scrapedContent.ogImage,
+      primaryColor: scrapedContent.colors.primary,
+      referenceImageUrls: scrapedContent.images
+        .map((image) => image.src)
+        .filter(
+          (src, index, all) =>
+            src !== scrapedContent.logoUrl &&
+            src !== scrapedContent.bannerUrl &&
+            all.indexOf(src) === index,
+        )
+        .slice(0, MAX_IMAGE_CANDIDATES),
+      scrapedAt: scrapedContent.scrapedAt,
+      secondaryColor: scrapedContent.colors.secondary,
+      socialLinks: scrapedContent.socialLinks,
+      sourceUrl,
+      tagline: scrapedContent.heroText || scrapedContent.ogTitle,
+      valuePropositions,
+    };
+  }
+
+  /**
+   * Extract company name from title
+   */
+  extractCompanyName(title?: string, ogTitle?: string): string | undefined {
+    const source = title || ogTitle;
+    if (!source) {
+      return undefined;
+    }
+
+    const separators = [' | ', ' - ', ' – ', ' — '];
+    for (const sep of separators) {
+      if (source.includes(sep)) {
+        return source.split(sep)[0].trim();
+      }
+    }
+
+    return source.trim();
+  }
+
+  /**
+   * Extract social media links from page links
+   */
+  private extractSocialLinks(
+    links: string[],
+  ): WebsiteScrapingResult['socialLinks'] {
+    const socialPatterns: Record<string, RegExp> = {
+      facebook: /facebook\.com/i,
+      instagram: /instagram\.com/i,
+      linkedin: /linkedin\.com/i,
+      tiktok: /tiktok\.com/i,
+      twitter: /twitter\.com|x\.com/i,
+      youtube: /youtube\.com/i,
+    };
+
+    const result: WebsiteScrapingResult['socialLinks'] = {};
+
+    for (const link of links) {
+      for (const [platform, pattern] of Object.entries(socialPatterns)) {
+        if (pattern.test(link) && !result[platform as keyof typeof result]) {
+          result[platform as keyof typeof result] = link;
+        }
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Extract colors from DOM: theme-color meta, <style> tags, inline styles
+   */
+  private extractColorsFromDom(
+    $: cheerio.CheerioAPI,
+  ): WebsiteScrapingResult['colors'] {
+    const colorCounts = new Map<string, number>();
+
+    const addColor = (color: string, weight = 1): void => {
+      const normalized = color.toLowerCase().trim();
+      if (
+        ['#000', '#000000', '#fff', '#ffffff', 'transparent', '#0000'].includes(
+          normalized,
+        )
+      ) {
+        return;
+      }
+      colorCounts.set(normalized, (colorCounts.get(normalized) || 0) + weight);
+    };
+
+    // Theme-color meta tag (high weight)
+    const themeColor = $('meta[name="theme-color"]').attr('content')?.trim();
+    if (themeColor) {
+      addColor(themeColor, 5);
+    }
+
+    // msapplication-TileColor
+    const tileColor = $('meta[name="msapplication-TileColor"]')
+      .attr('content')
+      ?.trim();
+    if (tileColor) {
+      addColor(tileColor, 3);
+    }
+
+    // Extract from <style> tags and inline style attributes
+    const cssText: string[] = [];
+    $('style').each((_i, el) => {
+      cssText.push($(el).text());
+    });
+    $('[style]').each((_i, el) => {
+      const style = $(el).attr('style');
+      if (style) {
+        cssText.push(style);
+      }
+    });
+
+    const allCss = cssText.join(' ');
+
+    // Extract hex colors
+    const hexMatches = allCss.match(/#(?:[0-9a-fA-F]{3}){1,2}\b/g);
+    if (hexMatches) {
+      for (const hex of hexMatches) {
+        addColor(hex);
+      }
+    }
+
+    // Extract rgb/rgba colors
+    const rgbMatches = allCss.match(
+      /rgba?\(\s*\d{1,3}\s*,\s*\d{1,3}\s*,\s*\d{1,3}(?:\s*,\s*[\d.]+)?\s*\)/g,
+    );
+    if (rgbMatches) {
+      for (const rgb of rgbMatches) {
+        addColor(rgb);
+      }
+    }
+
+    // Sort by frequency
+    const sorted = Array.from(colorCounts.entries())
+      .sort((a, b) => b[1] - a[1])
+      .map(([color]) => color);
+
+    return {
+      accent: sorted.slice(2, 6),
+      background: undefined,
+      primary: sorted[0],
+      secondary: sorted[1],
+    };
+  }
+
+  private extractFontsFromDom($: cheerio.CheerioAPI): string[] {
+    const candidates: string[] = [];
+    const seen = new Set<string>();
+
+    const addFont = (font: string): void => {
+      const normalized = font
+        .split(',')
+        .map((part) => part.trim().replace(/^['"]|['"]$/g, ''))
+        .find((part) => part.length > 0);
+
+      if (
+        !normalized ||
+        /^(system-ui|sans-serif|serif|monospace|inherit|initial|var\()/i.test(
+          normalized,
+        ) ||
+        seen.has(normalized)
+      ) {
+        return;
+      }
+
+      seen.add(normalized);
+      candidates.push(normalized);
+    };
+
+    $('link[href*="fonts.googleapis.com"]').each((_i, el) => {
+      const href = $(el).attr('href');
+      if (!href) {
+        return;
+      }
+      try {
+        const family = new URL(
+          href,
+          'https://fonts.googleapis.com',
+        ).searchParams
+          .get('family')
+          ?.split(':')[0]
+          ?.replace(/\+/g, ' ');
+        if (family) {
+          addFont(family);
+        }
+      } catch {
+        // Ignore malformed stylesheet URLs; inline declarations still apply.
+      }
+    });
+
+    const cssText: string[] = [];
+    $('style').each((_i, el) => {
+      cssText.push($(el).text());
+    });
+    $('[style]').each((_i, el) => {
+      const style = $(el).attr('style');
+      if (style) {
+        cssText.push(style);
+      }
+    });
+
+    const fontMatches = cssText
+      .join(' ')
+      .matchAll(/font-family\s*:\s*([^;{}]+)/gi);
+    for (const match of fontMatches) {
+      if (match[1]) {
+        addFont(match[1]);
+      }
+    }
+
+    return candidates.slice(0, MAX_FONT_CANDIDATES);
+  }
+
+  /**
+   * Extract headings from DOM
+   */
+  private extractHeadingsFromDom($: cheerio.CheerioAPI): string[] {
+    const headings: string[] = [];
+
+    $('h1, h2').each((_i, el) => {
+      const text = $(el).text().trim();
+      if (text.length > 3 && text.length < 200) {
+        headings.push(text);
+      }
+    });
+
+    return [...new Set(headings)].slice(0, 10);
+  }
+
+  /**
+   * Extract logo URL from DOM
+   */
+  extractLogoFromDom(
+    $: cheerio.CheerioAPI,
+    sourceUrl: string,
+  ): string | undefined {
+    // Check for common logo patterns
+    const logoSelectors = [
+      'img[class*="logo"]',
+      'img[id*="logo"]',
+      'img[alt*="logo"]',
+      'a[class*="logo"] img',
+      'header img:first-of-type',
+      '.logo img',
+      '#logo img',
+    ];
+
+    for (const selector of logoSelectors) {
+      const src = $(selector).first().attr('src');
+      if (src) {
+        return this.resolveUrl(src, sourceUrl);
+      }
+    }
+
+    // Check for apple-touch-icon as fallback
+    const touchIcon = $('link[rel="apple-touch-icon"]').attr('href');
+    if (touchIcon) {
+      return this.resolveUrl(touchIcon, sourceUrl);
+    }
+
+    return undefined;
+  }
+
+  private extractImagesFromDom(
+    $: cheerio.CheerioAPI,
+    sourceUrl: string,
+  ): WebsiteScrapingResult['images'] {
+    const images: WebsiteScrapingResult['images'] = [];
+    const seen = new Set<string>();
+
+    const addImage = (
+      src: string | undefined,
+      alt?: string,
+      isSrcSet = false,
+    ): void => {
+      if (!src || src.startsWith('data:')) {
+        return;
+      }
+
+      // Only treat the value as a srcset (comma-separated candidate list) when
+      // it actually came from a srcset attribute. Plain src/data-src URLs can
+      // legitimately contain commas (e.g. CDN transform params) and must not be
+      // truncated at the first comma.
+      const candidate = isSrcSet ? this.extractSrcFromSrcSet(src) : src;
+      const resolved = this.resolveUrl(candidate, sourceUrl);
+      if (!resolved || seen.has(resolved)) {
+        return;
+      }
+
+      seen.add(resolved);
+      images.push({
+        alt: alt?.trim() || undefined,
+        src: resolved,
+      });
+    };
+
+    $('meta[property="og:image"], meta[name="twitter:image"]').each(
+      (_i, el) => {
+        addImage($(el).attr('content'), 'Social preview image');
+      },
+    );
+
+    $('img[src], img[data-src], img[srcset]').each((_i, el) => {
+      const direct = $(el).attr('src') ?? $(el).attr('data-src');
+      if (direct) {
+        addImage(direct, $(el).attr('alt'));
+      } else {
+        addImage($(el).attr('srcset'), $(el).attr('alt'), true);
+      }
+    });
+
+    return images.slice(0, MAX_IMAGE_CANDIDATES);
+  }
+
+  private extractBannerFromDom(
+    $: cheerio.CheerioAPI,
+    sourceUrl: string,
+    ogImage: string | undefined,
+    images: WebsiteScrapingResult['images'],
+  ): string | undefined {
+    const bannerSelectors = [
+      'img[class*="hero"]',
+      'img[class*="banner"]',
+      'img[id*="hero"]',
+      'img[id*="banner"]',
+      '[class*="hero"] img',
+      '[class*="banner"] img',
+    ];
+
+    for (const selector of bannerSelectors) {
+      const src = $(selector).first().attr('src');
+      if (src) {
+        return this.resolveUrl(src, sourceUrl);
+      }
+    }
+
+    if (ogImage) {
+      return this.resolveUrl(ogImage, sourceUrl);
+    }
+
+    return images[0]?.src;
+  }
+
+  private extractSrcFromSrcSet(value: string): string {
+    return value.split(',')[0]?.trim().split(/\s+/)[0] ?? value;
+  }
+
+  /**
+   * Resolve a potentially relative URL against a base URL
+   */
+  private resolveUrl(href: string, base: string): string {
+    try {
+      return new URL(href, base).href;
+    } catch {
+      return href;
+    }
+  }
+
+  assertHtmlResponse(response: Response): void {
+    const contentType = response.headers.get('content-type');
+    if (
+      contentType &&
+      !contentType.includes('text/html') &&
+      !contentType.includes('application/xhtml+xml')
+    ) {
+      throw new Error(`Unsupported content type: ${contentType}`);
+    }
+  }
+
+  /**
+   * Extract value propositions from content
+   */
+  private extractValuePropositions(text: string): string[] {
+    const propositions: string[] = [];
+
+    const bulletPatterns = [
+      /•\s*([^•\n]+)/g,
+      /✓\s*([^✓\n]+)/g,
+      /✔\s*([^✔\n]+)/g,
+      /-\s*([A-Z][^-\n]+)/g,
+    ];
+
+    for (const pattern of bulletPatterns) {
+      const matches = text.matchAll(pattern);
+      for (const match of matches) {
+        if (match[1] && match[1].length > 10 && match[1].length < 200) {
+          propositions.push(match[1].trim());
+        }
+      }
+    }
+
+    return [...new Set(propositions)].slice(0, 6);
+  }
+
+  /**
+   * Extract about/description text
+   */
+  private extractAboutText(text: string): string | undefined {
+    const aboutPatterns = [
+      /about\s+us[\s:]+([^.]+\.)/i,
+      /who\s+we\s+are[\s:]+([^.]+\.)/i,
+      /our\s+mission[\s:]+([^.]+\.)/i,
+      /we\s+are\s+([^.]+\.)/i,
+    ];
+
+    for (const pattern of aboutPatterns) {
+      const match = text.match(pattern);
+      if (match?.[1] && match[1].length > 50) {
+        return match[1].trim();
+      }
+    }
+
+    return undefined;
+  }
+}

--- a/apps/server/api/src/services/brand-scraper/brand-website-parser.service.ts
+++ b/apps/server/api/src/services/brand-scraper/brand-website-parser.service.ts
@@ -1,6 +1,6 @@
 import type { WebsiteScrapingResult } from '@api/services/brand-scraper/interfaces/brand-scraper.interfaces';
 import type { IScrapedBrandData } from '@genfeedai/interfaces';
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import * as cheerio from 'cheerio';
 
 const MAX_IMAGE_CANDIDATES = 12;
@@ -69,7 +69,13 @@ export class BrandWebsiteParserService {
     // Extract logo
     const logoUrl = this.extractLogoFromDom($, sourceUrl);
     const images = this.extractImagesFromDom($, sourceUrl);
-    const bannerUrl = this.extractBannerFromDom($, sourceUrl, ogImage, images);
+    const bannerUrl = this.extractBannerFromDom(
+      $,
+      sourceUrl,
+      ogImage,
+      images,
+      logoUrl,
+    );
 
     return {
       aboutText,
@@ -167,20 +173,34 @@ export class BrandWebsiteParserService {
   private extractSocialLinks(
     links: string[],
   ): WebsiteScrapingResult['socialLinks'] {
-    const socialPatterns: Record<string, RegExp> = {
-      facebook: /facebook\.com/i,
-      instagram: /instagram\.com/i,
-      linkedin: /linkedin\.com/i,
-      tiktok: /tiktok\.com/i,
-      twitter: /twitter\.com|x\.com/i,
-      youtube: /youtube\.com/i,
+    const socialHosts: Record<string, string[]> = {
+      facebook: ['facebook.com'],
+      instagram: ['instagram.com'],
+      linkedin: ['linkedin.com'],
+      tiktok: ['tiktok.com'],
+      twitter: ['twitter.com', 'x.com'],
+      youtube: ['youtube.com'],
     };
 
     const result: WebsiteScrapingResult['socialLinks'] = {};
 
     for (const link of links) {
-      for (const [platform, pattern] of Object.entries(socialPatterns)) {
-        if (pattern.test(link) && !result[platform as keyof typeof result]) {
+      let url: URL;
+      try {
+        url = new URL(link, 'https://relative-link.invalid');
+      } catch {
+        continue;
+      }
+      if (!['http:', 'https:'].includes(url.protocol)) {
+        continue;
+      }
+
+      const hostname = url.hostname.toLowerCase();
+      for (const [platform, hosts] of Object.entries(socialHosts)) {
+        const isSocialHost = hosts.some(
+          (host) => hostname === host || hostname.endsWith(`.${host}`),
+        );
+        if (isSocialHost && !result[platform as keyof typeof result]) {
           result[platform as keyof typeof result] = link;
         }
       }
@@ -442,6 +462,7 @@ export class BrandWebsiteParserService {
     sourceUrl: string,
     ogImage: string | undefined,
     images: WebsiteScrapingResult['images'],
+    logoUrl: string | undefined,
   ): string | undefined {
     const bannerSelectors = [
       'img[class*="hero"]',
@@ -463,7 +484,7 @@ export class BrandWebsiteParserService {
       return this.resolveUrl(ogImage, sourceUrl);
     }
 
-    return images[0]?.src;
+    return images.find((image) => image.src !== logoUrl)?.src;
   }
 
   private extractSrcFromSrcSet(value: string): string {
@@ -488,7 +509,7 @@ export class BrandWebsiteParserService {
       !contentType.includes('text/html') &&
       !contentType.includes('application/xhtml+xml')
     ) {
-      throw new Error(`Unsupported content type: ${contentType}`);
+      throw new BadRequestException(`Unsupported content type: ${contentType}`);
     }
   }
 

--- a/apps/server/api/src/services/brand-scraper/brand-website-parser.service.ts
+++ b/apps/server/api/src/services/brand-scraper/brand-website-parser.service.ts
@@ -134,9 +134,7 @@ export class BrandWebsiteParserService {
         .map((image) => image.src)
         .filter(
           (src, index, all) =>
-            src !== scrapedContent.logoUrl &&
-            src !== scrapedContent.bannerUrl &&
-            all.indexOf(src) === index,
+            src !== scrapedContent.logoUrl && all.indexOf(src) === index,
         )
         .slice(0, MAX_IMAGE_CANDIDATES),
       scrapedAt: scrapedContent.scrapedAt,


### PR DESCRIPTION
## Summary

- extract pure HTML parsing, identity mapping, media discovery, colors, fonts, and brand-copy heuristics into `BrandWebsiteParserService`
- keep network retries, SSRF validation, social scraping, fallback behavior, and public routing in `BrandScraperService`
- reduce `BrandScraperService` from 1,184 to 658 lines; extracted parser is 540 lines
- add focused parser boundary coverage while retaining the existing end-to-end facade spec

## Verification

- `bunx biome check` on all changed files
- staged Biome, UI control guard, Secretlint, and Gitleaks checks passed
- `git diff --check` passed
- original method inventory preserved across the two services
- tests, typecheck, and build delegated to PR CI per local machine policy

Part of #1738.