### PR TITLE
refactor(articles): extract content generation boundaries

### DIFF
--- a/apps/server/api/src/collections/articles/articles.module.ts
+++ b/apps/server/api/src/collections/articles/articles.module.ts
@@ -6,8 +6,11 @@ Twitter thread conversion, virality analysis, and public link sharing.
 import { ActivitiesModule } from '@api/collections/activities/activities.module';
 import { ArticlesController } from '@api/collections/articles/controllers/articles.controller';
 import { ArticleAnalyticsService } from '@api/collections/articles/services/article-analytics.service';
+import { ArticleContentPersistenceService } from '@api/collections/articles/services/article-content-persistence.service';
 import { ArticleInsightsService } from '@api/collections/articles/services/article-insights.service';
 import { ArticleRemixService } from '@api/collections/articles/services/article-remix.service';
+import { ArticleReviewService } from '@api/collections/articles/services/article-review.service';
+import { ArticleTextGenerationService } from '@api/collections/articles/services/article-text-generation.service';
 import { ArticleTranscriptService } from '@api/collections/articles/services/article-transcript.service';
 import { ArticleVersionService } from '@api/collections/articles/services/article-version.service';
 import { ArticlesService } from '@api/collections/articles/services/articles.service';
@@ -62,8 +65,11 @@ import { forwardRef, Module } from '@nestjs/common';
   ],
   providers: [
     ArticleAnalyticsService,
+    ArticleContentPersistenceService,
     ArticleInsightsService,
     ArticleRemixService,
+    ArticleReviewService,
+    ArticleTextGenerationService,
     ArticleTranscriptService,
     ArticleVersionService,
     ArticlesContentService,

--- a/apps/server/api/src/collections/articles/services/article-content-persistence.service.spec.ts
+++ b/apps/server/api/src/collections/articles/services/article-content-persistence.service.spec.ts
@@ -1,0 +1,73 @@
+import type { ArticleDocument } from '@api/collections/articles/schemas/article.schema';
+import { ArticleContentPersistenceService } from '@api/collections/articles/services/article-content-persistence.service';
+import type { ArticlesService } from '@api/collections/articles/services/articles.service';
+import type { PromptsService } from '@api/collections/prompts/services/prompts.service';
+import type { NotificationsPublisherService } from '@api/services/notifications/publisher/notifications-publisher.service';
+import type { LoggerService } from '@libs/logger/logger.service';
+import type { ModuleRef } from '@nestjs/core';
+
+describe('ArticleContentPersistenceService', () => {
+  it('persists enhanced content, version history, and completion status', async () => {
+    const articlesService = {
+      findOne: vi.fn().mockResolvedValue(null),
+      patch: vi.fn().mockResolvedValue({ id: 'article_1' }),
+    } as unknown as ArticlesService;
+    const promptsService = {
+      create: vi.fn().mockResolvedValue({ id: 'prompt_1' }),
+    } as unknown as PromptsService;
+    const websocketService = {
+      publishArticleStatus: vi.fn().mockResolvedValue(undefined),
+    } as unknown as NotificationsPublisherService;
+    const logger = {
+      error: vi.fn(),
+      log: vi.fn(),
+    } as unknown as LoggerService;
+    const moduleRef = {
+      get: vi.fn().mockReturnValue(articlesService),
+    } as unknown as ModuleRef;
+    const service = new ArticleContentPersistenceService(
+      logger,
+      moduleRef,
+      promptsService,
+      websocketService,
+    );
+
+    await service.updateArticleWithEnhancedContent(
+      {
+        content: 'Old body',
+        id: 'article_1',
+        label: 'Old title',
+        slug: 'old-title',
+        summary: 'Old summary',
+      } as unknown as ArticleDocument,
+      {
+        content: 'New body',
+        label: 'New title',
+        slug: 'new-title',
+        summary: 'New summary',
+      },
+      'Improve this article',
+      undefined,
+      'user_1',
+      'org_1',
+      'brand_1',
+    );
+
+    expect(articlesService.patch).toHaveBeenCalledWith(
+      'article_1',
+      expect.objectContaining({
+        content: 'New body',
+        label: 'New title',
+        slug: 'new-title',
+        summary: 'New summary',
+      }),
+    );
+    expect(promptsService.create).toHaveBeenCalledTimes(1);
+    expect(websocketService.publishArticleStatus).toHaveBeenCalledWith(
+      'article_1',
+      'completed',
+      'user_1',
+      expect.objectContaining({ label: 'New title' }),
+    );
+  });
+});

--- a/apps/server/api/src/collections/articles/services/article-content-persistence.service.ts
+++ b/apps/server/api/src/collections/articles/services/article-content-persistence.service.ts
@@ -1,0 +1,223 @@
+import { UpdateArticleDto } from '@api/collections/articles/dto/update-article.dto';
+import type { ArticleDocument } from '@api/collections/articles/schemas/article.schema';
+import { ArticlesService } from '@api/collections/articles/services/articles.service';
+import { PromptEntity } from '@api/collections/prompts/entities/prompt.entity';
+import { PromptsService } from '@api/collections/prompts/services/prompts.service';
+import { NotificationsPublisherService } from '@api/services/notifications/publisher/notifications-publisher.service';
+import {
+  ArticleStatus,
+  AssetScope,
+  PromptCategory,
+  PromptStatus,
+} from '@genfeedai/enums';
+import type {
+  ArticleGenerationResponse,
+  GeneratedArticleData,
+} from '@genfeedai/interfaces/content/article.interface';
+import { LoggerService } from '@libs/logger/logger.service';
+import { Injectable, Optional } from '@nestjs/common';
+import { ModuleRef } from '@nestjs/core';
+
+@Injectable()
+export class ArticleContentPersistenceService {
+  private readonly constructorName = this.constructor.name;
+
+  constructor(
+    private readonly logger: LoggerService,
+    private readonly moduleRef: ModuleRef,
+    @Optional() private readonly promptsService?: PromptsService,
+    @Optional()
+    private readonly websocketService?: NotificationsPublisherService,
+  ) {}
+
+  private get articlesService(): ArticlesService | undefined {
+    try {
+      return this.moduleRef.get(ArticlesService, { strict: false });
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
+   * Update article with enhanced content from OpenAI response
+   */
+  async updateArticleWithEnhancedContent(
+    article: ArticleDocument,
+    response: ArticleGenerationResponse,
+    prompt: string,
+    _assistantId: string | undefined,
+    userId: string,
+    organizationId: string,
+    brandId: string,
+  ): Promise<void> {
+    try {
+      // Extract article data from response
+      // Response can be: { articles: [...] } or direct article object with { label, summary, content }
+      let articleData: GeneratedArticleData;
+      if (
+        response.articles &&
+        Array.isArray(response.articles) &&
+        response.articles.length > 0
+      ) {
+        articleData = response.articles[0];
+      } else if (response.label || response.content || response.summary) {
+        // Direct article format
+        articleData = response as GeneratedArticleData;
+      } else {
+        this.logger.error('Invalid response format from OpenAI assistant', {
+          hasArticles: !!response.articles,
+          isArray: Array.isArray(response.articles),
+          responseKeys: Object.keys(response),
+        });
+        throw new Error('Invalid response format from AI assistant');
+      }
+
+      // Assistant returns ONLY changed fields - build update data accordingly
+      const updateData: Record<string, unknown> = {
+        'aiGeneration.completedAt': new Date(),
+        status: ArticleStatus.DRAFT,
+      };
+
+      if (articleData.label) {
+        updateData.label = articleData.label.substring(0, 200);
+      }
+
+      if (articleData.summary) {
+        updateData.summary = articleData.summary.substring(0, 500);
+      }
+
+      if (articleData.content) {
+        updateData.content = articleData.content;
+      }
+
+      if (articleData.slug) {
+        // Ensure slug is unique if being changed
+        let slug = articleData.slug
+          .toLowerCase()
+          .replace(/[^a-z0-9-]/g, '-')
+          .replace(/-+/g, '-')
+          .trim();
+
+        if (slug !== article.slug) {
+          let counter = 1;
+          while (await this.slugExists(slug, organizationId, brandId)) {
+            slug = `${articleData.slug}-${counter}`;
+            counter++;
+          }
+          updateData.slug = slug;
+        }
+      }
+
+      // Update article
+      await this.articlesService?.patch(article.id, updateData);
+
+      // Create a prompt record to track this edit
+      if (this.promptsService) {
+        await this.promptsService.create(
+          new PromptEntity({
+            articleId: String(
+              (article as Record<string, unknown>).id ?? article.id,
+            ),
+            brandId: brandId,
+            category: PromptCategory.ARTICLE,
+            enhanced: JSON.stringify(response),
+            isDeleted: false,
+            isFavorite: false,
+            isSkipEnhancement: false,
+            organizationId: organizationId,
+            original: prompt,
+            scope: AssetScope.USER,
+            status: PromptStatus.GENERATED,
+            userId: userId,
+          }),
+        );
+      }
+
+      // Publish websocket event for article completion
+      if (this.websocketService) {
+        await this.websocketService.publishArticleStatus(
+          article.id.toString(),
+          'completed',
+          userId,
+          {
+            content: updateData.content || article.content,
+            label: updateData.label || article.label,
+            slug: updateData.slug || article.slug,
+            summary: updateData.summary || article.summary,
+          },
+        );
+      }
+
+      this.logger.log(`${this.constructorName} enhanced article with AI`, {
+        articleId: article.id,
+        prompt,
+      });
+    } catch (error: unknown) {
+      this.logger.error('Failed to update article with enhanced content', {
+        articleId: article.id,
+        error: {
+          message: (error as Error)?.message || 'Unknown error',
+          stack: (error as Error)?.stack,
+        },
+      });
+      await this.markArticleAsFailed(
+        article,
+        (error as Error)?.message || 'Failed to process enhanced content',
+        userId,
+      );
+    }
+  }
+
+  /**
+   * Mark article as failed during enhancement
+   */
+  private async markArticleAsFailed(
+    article: ArticleDocument,
+    errorMessage: string,
+    userId: string,
+  ): Promise<void> {
+    await this.articlesService?.patch(
+      ((article as Record<string, unknown>).id as string) ?? String(article.id),
+      {
+        aiGenerationCompletedAt: new Date(),
+        aiGenerationError: errorMessage,
+        status: ArticleStatus.DRAFT,
+      } as unknown as Partial<UpdateArticleDto>,
+    );
+
+    // Publish websocket event for article failure
+    if (this.websocketService) {
+      await this.websocketService.publishArticleStatus(
+        article.id.toString(),
+        'failed',
+        userId,
+        {
+          error: errorMessage,
+        },
+      );
+    }
+
+    this.logger.error('Article enhancement failed', {
+      articleId: article.id,
+      error: errorMessage,
+    });
+  }
+
+  /**
+   * Check if slug exists for the organization/brand
+   */
+  private async slugExists(
+    slug: string,
+    organizationId: string,
+    brandId: string,
+  ): Promise<boolean> {
+    const existing = await this.articlesService?.findOne({
+      brandId: brandId,
+      isDeleted: false,
+      organizationId: organizationId,
+      slug,
+    });
+
+    return !!existing;
+  }
+}

--- a/apps/server/api/src/collections/articles/services/article-review.service.spec.ts
+++ b/apps/server/api/src/collections/articles/services/article-review.service.spec.ts
@@ -1,0 +1,58 @@
+import type { ArticleDocument } from '@api/collections/articles/schemas/article.schema';
+import { ArticleReviewService } from '@api/collections/articles/services/article-review.service';
+import type { ArticleTextGenerationService } from '@api/collections/articles/services/article-text-generation.service';
+
+describe('ArticleReviewService', () => {
+  it('generates and parses a bounded review rubric', async () => {
+    const textGeneration = {
+      generateTextWithModel: vi.fn().mockResolvedValue({
+        charge: {
+          amount: 3,
+          inputTokens: 100,
+          modelKey: 'review-model',
+          outputTokens: 50,
+        },
+        output: JSON.stringify({
+          issues: [
+            {
+              category: 'clarity',
+              message: 'Tighten the opening',
+              recommendation: 'Lead with the result',
+              severity: 'high',
+            },
+          ],
+          revisionInstructions: 'Rewrite the opening.',
+          score: 82,
+          strengths: ['Useful examples'],
+          summary: 'Strong draft with a slow opening.',
+        }),
+      }),
+    } as unknown as ArticleTextGenerationService;
+    const service = new ArticleReviewService(textGeneration);
+    const onBilling = vi.fn();
+
+    const result = await service.reviewExistingArticle(
+      {
+        brand: 'brand_1',
+        category: 'post',
+        content: 'Article body',
+        label: 'Article title',
+        summary: 'Article summary',
+      } as unknown as ArticleDocument,
+      'org_1',
+      { reviewModel: 'review-model' },
+      { promptBuilder: {} },
+      'clarity',
+      onBilling,
+    );
+
+    expect(result).toMatchObject({
+      revisionInstructions: 'Rewrite the opening.',
+      score: 82,
+      strengths: ['Useful examples'],
+    });
+    expect(onBilling).toHaveBeenCalledWith(
+      expect.objectContaining({ amount: 3, modelKey: 'review-model' }),
+    );
+  });
+});

--- a/apps/server/api/src/collections/articles/services/article-review.service.ts
+++ b/apps/server/api/src/collections/articles/services/article-review.service.ts
@@ -1,0 +1,276 @@
+import { ArticleGenerationType } from '@api/collections/articles/dto/generate-articles.dto';
+import type { ArticleDocument } from '@api/collections/articles/schemas/article.schema';
+import { ArticleTextGenerationService } from '@api/collections/articles/services/article-text-generation.service';
+import type {
+  ArticleCycleModelConfig,
+  ArticleHarnessContext,
+  ArticleReviewRubric,
+  TextGenerationCharge,
+} from '@api/collections/articles/services/articles-content.types';
+import { DEFAULT_MINI_TEXT_MODEL } from '@api/constants/default-mini-text-model.constant';
+import { appendHarnessBriefToPrompt } from '@api/services/harness/harness-brief.util';
+import { ArticleCategory } from '@genfeedai/enums';
+import type { ContentHarnessBrief } from '@genfeedai/harness';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class ArticleReviewService {
+  private readonly defaultArticleLabel = 'Untitled Article';
+
+  constructor(
+    private readonly articleTextGenerationService: ArticleTextGenerationService,
+  ) {}
+
+  async reviewExistingArticle(
+    article: ArticleDocument,
+    organizationId: string,
+    modelConfig: ArticleCycleModelConfig,
+    harnessContext: ArticleHarnessContext,
+    focus?: string,
+    onBilling?: (charge: TextGenerationCharge) => void,
+  ): Promise<ArticleReviewRubric> {
+    const reviewModel = modelConfig.reviewModel || DEFAULT_MINI_TEXT_MODEL;
+    const reviewPrompt = this.buildReviewPrompt({
+      content: article.content ?? '',
+      focus,
+      harnessBrief: harnessContext.brief,
+      label: this.getArticleLabel(article),
+      summary: article.summary || '',
+      type:
+        article.category === ArticleCategory.X_ARTICLE
+          ? ArticleGenerationType.X_ARTICLE
+          : ArticleGenerationType.STANDARD,
+    });
+
+    const { output: reviewRaw, charge } =
+      await this.articleTextGenerationService.generateTextWithModel(
+        reviewModel,
+        reviewPrompt,
+        organizationId,
+        harnessContext.promptBuilder,
+      );
+    onBilling?.(charge);
+
+    return this.parseReviewRubric(reviewRaw);
+  }
+
+  async runReviewUpdateCycle(params: {
+    draft: { label: string; summary: string; content: string };
+    harnessContext?: ArticleHarnessContext;
+    prompt: string;
+    organizationId: string;
+    modelConfig: ArticleCycleModelConfig;
+    type: ArticleGenerationType;
+    onBilling?: (charge: TextGenerationCharge) => void;
+  }): Promise<{
+    review: ArticleReviewRubric;
+    updated: { label: string; summary: string; content: string };
+  }> {
+    const reviewModel =
+      params.modelConfig.reviewModel || DEFAULT_MINI_TEXT_MODEL;
+    const updateModel =
+      params.modelConfig.updateModel || DEFAULT_MINI_TEXT_MODEL;
+
+    const { output: reviewRaw, charge: reviewCharge } =
+      await this.articleTextGenerationService.generateTextWithModel(
+        reviewModel,
+        this.buildReviewPrompt({
+          content: params.draft.content,
+          harnessBrief: params.harnessContext?.brief,
+          label: params.draft.label,
+          summary: params.draft.summary,
+          type: params.type,
+        }),
+        params.organizationId,
+        params.harnessContext?.promptBuilder,
+      );
+    params.onBilling?.(reviewCharge);
+    const review = this.parseReviewRubric(reviewRaw);
+
+    const { output: revisionRaw, charge: revisionCharge } =
+      await this.articleTextGenerationService.generateTextWithModel(
+        updateModel,
+        this.buildRevisionPrompt(
+          params.draft,
+          params.prompt,
+          review,
+          params.type,
+          params.harnessContext?.brief,
+        ),
+        params.organizationId,
+        params.harnessContext?.promptBuilder,
+      );
+    params.onBilling?.(revisionCharge);
+    const updated = this.parseUpdatedArticle(revisionRaw, params.draft);
+
+    return { review, updated };
+  }
+
+  private getArticleLabel(article: Pick<ArticleDocument, 'label'>): string {
+    const label = article.label?.trim();
+
+    return label ? label : this.defaultArticleLabel;
+  }
+
+  private buildReviewPrompt(input: {
+    label: string;
+    summary: string;
+    content: string;
+    type: ArticleGenerationType;
+    focus?: string;
+    harnessBrief?: ContentHarnessBrief;
+  }): string {
+    const typeLabel =
+      input.type === ArticleGenerationType.X_ARTICLE
+        ? 'X long-form article'
+        : 'standard article';
+    const focusLine = input.focus ? `Focus area: ${input.focus}` : '';
+
+    return appendHarnessBriefToPrompt(
+      `You are an expert content reviewer. Review this ${typeLabel} and return strict JSON only.
+
+${focusLine}
+
+TITLE:
+${input.label}
+
+SUMMARY:
+${input.summary}
+
+CONTENT:
+${input.content}
+
+Return this exact JSON shape:
+{
+  "score": 0,
+  "summary": "One paragraph overview",
+  "strengths": ["..."],
+  "issues": [
+    {
+      "severity": "low|medium|high",
+      "category": "clarity|structure|tone|seo|accuracy|cta",
+      "message": "...",
+      "recommendation": "..."
+    }
+  ],
+  "revisionInstructions": "Concrete instructions to improve the draft in one pass"
+}`,
+      input.harnessBrief,
+    );
+  }
+
+  private buildRevisionPrompt(
+    draft: { label: string; summary: string; content: string },
+    originalPrompt: string,
+    review: ArticleReviewRubric,
+    type: ArticleGenerationType,
+    harnessBrief?: ContentHarnessBrief,
+  ): string {
+    const typeLine =
+      type === ArticleGenerationType.X_ARTICLE
+        ? 'Keep X article style and section depth.'
+        : 'Keep standard article/blog style.';
+    return appendHarnessBriefToPrompt(
+      `You are an expert content editor. Improve the draft using the review feedback.
+
+Original request:
+${originalPrompt}
+
+${typeLine}
+
+Current draft:
+Title: ${draft.label}
+Summary: ${draft.summary}
+Content:
+${draft.content}
+
+Review summary:
+${review.summary}
+Score: ${review.score}
+Revision instructions:
+${review.revisionInstructions}
+
+Issues:
+${review.issues
+  .map(
+    (issue, index) =>
+      `${index + 1}. [${issue.severity}] ${issue.category}: ${issue.message} -> ${issue.recommendation}`,
+  )
+  .join('\n')}
+
+Return strict JSON only:
+{
+  "label": "Improved title",
+  "summary": "Improved summary",
+  "content": "Improved content (HTML allowed)"
+}`,
+      harnessBrief,
+    );
+  }
+
+  private parseReviewRubric(raw: string): ArticleReviewRubric {
+    try {
+      const parsed = JSON.parse(raw) as Partial<ArticleReviewRubric>;
+      const issues = Array.isArray(parsed.issues)
+        ? parsed.issues
+            .map((issue) => ({
+              category: String(issue.category || 'clarity'),
+              message: String(issue.message || ''),
+              recommendation: String(issue.recommendation || ''),
+              severity:
+                issue.severity === 'high' ||
+                issue.severity === 'medium' ||
+                issue.severity === 'low'
+                  ? issue.severity
+                  : 'medium',
+            }))
+            .filter((issue) => issue.message.length > 0)
+        : [];
+
+      return {
+        issues,
+        revisionInstructions: String(parsed.revisionInstructions || ''),
+        score:
+          typeof parsed.score === 'number' && Number.isFinite(parsed.score)
+            ? Math.max(0, Math.min(100, parsed.score))
+            : 70,
+        strengths: Array.isArray(parsed.strengths)
+          ? parsed.strengths
+              .map((item) => String(item))
+              .filter((item) => item.length > 0)
+          : [],
+        summary: String(parsed.summary || ''),
+      };
+    } catch {
+      return {
+        issues: [],
+        revisionInstructions:
+          'Improve clarity, structure, and call to action while preserving intent.',
+        score: 70,
+        strengths: [],
+        summary:
+          'Review model returned unstructured output, using fallback rubric.',
+      };
+    }
+  }
+
+  private parseUpdatedArticle(
+    raw: string,
+    fallback: { label: string; summary: string; content: string },
+  ): { label: string; summary: string; content: string } {
+    try {
+      const parsed = JSON.parse(raw) as Partial<{
+        label: string;
+        summary: string;
+        content: string;
+      }>;
+      return {
+        content: String(parsed.content || fallback.content),
+        label: String(parsed.label || fallback.label),
+        summary: String(parsed.summary || fallback.summary),
+      };
+    } catch {
+      return fallback;
+    }
+  }
+}

--- a/apps/server/api/src/collections/articles/services/article-text-generation.service.ts
+++ b/apps/server/api/src/collections/articles/services/article-text-generation.service.ts
@@ -1,0 +1,200 @@
+import type {
+  ArticleHarnessContext,
+  TextGenerationCharge,
+} from '@api/collections/articles/services/articles-content.types';
+import { ModelsService } from '@api/collections/models/services/models.service';
+import { baseModelKey } from '@api/collections/models/utils/model-key.util';
+import { getMinimumTextCredits } from '@api/helpers/utils/text-pricing/text-pricing.util';
+import { appendHarnessBriefToPrompt } from '@api/services/harness/harness-brief.util';
+import type { PromptBuilderParams } from '@api/services/prompt-builder/interfaces/prompt-builder-params.interface';
+import { PromptBuilderService } from '@api/services/prompt-builder/prompt-builder.service';
+import { ModelCategory, SystemPromptKey } from '@genfeedai/enums';
+import { ConfigService } from '@libs/config/config.service';
+import { Injectable, Optional } from '@nestjs/common';
+import { ReplicateService } from '@server/services/integrations/replicate/services/replicate.service';
+
+@Injectable()
+export class ArticleTextGenerationService {
+  constructor(
+    private readonly configService: ConfigService,
+    @Optional() private readonly modelsService?: ModelsService,
+    @Optional() private readonly replicateService?: ReplicateService,
+    @Optional() private readonly promptBuilderService?: PromptBuilderService,
+  ) {}
+
+  /**
+   * Shared generation prologue for the article generators.
+   *
+   * Appends the harness brief to `basePrompt`, builds the model input via the
+   * PromptBuilderService (merging the harness brand context), runs the Replicate
+   * text completion, and — when an `onBilling` callback is supplied — meters the
+   * charge. Returns the raw model response for the caller to parse. The differing
+   * pieces (model, prompt-builder options, failure message, whether the step is
+   * billed) are passed in so generateArticles/generateLongFormArticle/enhance can
+   * share one body without changing their individual behaviour.
+   */
+  async runTextGenerationStep(params: {
+    model: string;
+    basePrompt: string;
+    harnessContext: ArticleHarnessContext;
+    buildPromptOptions: Omit<
+      PromptBuilderParams,
+      'prompt' | 'brand' | 'branding' | 'brandingMode' | 'isBrandingEnabled'
+    >;
+    organizationId: string;
+    failureMessage: string;
+    onBilling?: (charge: TextGenerationCharge) => void;
+  }): Promise<string> {
+    const promptWithHarness = appendHarnessBriefToPrompt(
+      params.basePrompt,
+      params.harnessContext.brief,
+    );
+
+    if (!this.promptBuilderService) {
+      throw new Error('Prompt builder service not available');
+    }
+
+    const { input } = await this.promptBuilderService.buildPrompt(
+      params.model,
+      {
+        ...params.buildPromptOptions,
+        prompt: promptWithHarness,
+        ...params.harnessContext.promptBuilder,
+      },
+      params.organizationId,
+    );
+
+    const responseText =
+      await this.replicateService?.generateTextCompletionSync(
+        params.model,
+        input,
+      );
+
+    if (!responseText) {
+      throw new Error(params.failureMessage);
+    }
+
+    if (params.onBilling) {
+      params.onBilling(
+        await this.calculateTextGenerationCharge(
+          params.model,
+          input,
+          responseText,
+        ),
+      );
+    }
+
+    return responseText;
+  }
+
+  async generateTextWithModel(
+    model: string,
+    prompt: string,
+    organizationId: string,
+    promptBuilderContext?: Pick<
+      PromptBuilderParams,
+      'brand' | 'branding' | 'brandingMode' | 'isBrandingEnabled'
+    >,
+  ): Promise<{ output: string; charge: TextGenerationCharge }> {
+    const { input } = (await this.promptBuilderService?.buildPrompt(
+      model as string,
+      {
+        maxTokens: this.configService.get('MAX_TOKENS'),
+        modelCategory: ModelCategory.TEXT,
+        prompt,
+        systemPromptTemplate: SystemPromptKey.ARTICLE,
+        temperature: 0.7,
+        useTemplate: false,
+        ...promptBuilderContext,
+      },
+      organizationId,
+    )) || { input: {} };
+
+    const output = await this.replicateService?.generateTextCompletionSync(
+      model,
+      input,
+    );
+
+    if (!output) {
+      throw new Error(`Failed to generate text with model: ${model}`);
+    }
+
+    return {
+      charge: await this.calculateTextGenerationCharge(model, input, output),
+      output,
+    };
+  }
+
+  private async calculateTextGenerationCharge(
+    modelKey: string,
+    input: unknown,
+    output: string,
+  ): Promise<TextGenerationCharge> {
+    if (!this.modelsService) {
+      throw new Error('ModelsService not available');
+    }
+
+    const model = await this.modelsService.findOne({
+      isDeleted: false,
+      key: baseModelKey(modelKey),
+    });
+
+    if (!model) {
+      throw new Error(`Model pricing is not configured for ${modelKey}`);
+    }
+
+    const inputTokens = this.estimateTokens(input);
+    const outputTokens = this.estimateTokens(output);
+
+    const amount =
+      model.pricingType === 'per-token'
+        ? Math.max(
+            Math.ceil(
+              (inputTokens * Number(model.inputCostPerMillionTokens || 0) +
+                outputTokens * Number(model.outputCostPerMillionTokens || 0)) /
+                1_000_000,
+            ),
+            getMinimumTextCredits(model),
+          )
+        : model.cost || 0;
+
+    return {
+      amount,
+      inputTokens,
+      modelKey,
+      outputTokens,
+    };
+  }
+
+  private estimateTokens(value: unknown): number {
+    const text = this.extractBillableText(value).trim();
+
+    if (!text) {
+      return 0;
+    }
+
+    return Math.ceil(text.length / 4);
+  }
+
+  private extractBillableText(value: unknown): string {
+    if (typeof value === 'string') {
+      return value;
+    }
+
+    if (typeof value === 'number' || typeof value === 'boolean') {
+      return String(value);
+    }
+
+    if (Array.isArray(value)) {
+      return value.map((item) => this.extractBillableText(item)).join(' ');
+    }
+
+    if (value && typeof value === 'object') {
+      return Object.values(value as Record<string, unknown>)
+        .map((item) => this.extractBillableText(item))
+        .join(' ');
+    }
+
+    return '';
+  }
+}

--- a/apps/server/api/src/collections/articles/services/articles-content.service.run-step.spec.ts
+++ b/apps/server/api/src/collections/articles/services/articles-content.service.run-step.spec.ts
@@ -1,9 +1,11 @@
+import type { ModelsService } from '@api/collections/models/services/models.service';
+import type { PromptBuilderService } from '@api/services/prompt-builder/prompt-builder.service';
+import { ModelCategory } from '@genfeedai/enums';
+import type { ConfigService } from '@libs/config/config.service';
+import type { ReplicateService } from '@server/services/integrations/replicate/services/replicate.service';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { ArticlesContentService } from './articles-content.service';
-import type {
-  ArticlesContentServiceInternals,
-  RunTextGenerationStepParams,
-} from './articles-content.types';
+import { ArticleTextGenerationService } from './article-text-generation.service';
+import type { RunTextGenerationStepParams } from './articles-content.types';
 
 /**
  * Focused unit tests for the shared `runTextGenerationStep` prologue that backs
@@ -14,12 +16,6 @@ import type {
  */
 
 function makeService() {
-  const logger = {
-    debug: vi.fn(),
-    error: vi.fn(),
-    log: vi.fn(),
-    warn: vi.fn(),
-  };
   const config = { get: vi.fn() };
   const models = {
     findOne: vi.fn().mockResolvedValue({ cost: 5, pricingType: 'flat' }),
@@ -31,49 +27,44 @@ function makeService() {
     buildPrompt: vi.fn().mockResolvedValue({ input: { prompt: 'built' } }),
   };
 
-  // Construct via an untyped ctor cast to avoid wiring every Nest dependency
-  // type into the test; the step only touches the mocks provided here.
-  const Ctor = ArticlesContentService as unknown as new (
-    ...args: unknown[]
-  ) => ArticlesContentService;
-  const service = new Ctor(
-    logger,
-    config,
-    {},
-    models,
-    undefined,
-    replicate,
-    promptBuilder,
+  const service = new ArticleTextGenerationService(
+    config as unknown as ConfigService,
+    models as unknown as ModelsService,
+    replicate as unknown as ReplicateService,
+    promptBuilder as unknown as PromptBuilderService,
   );
 
-  const internal = service as unknown as ArticlesContentServiceInternals;
-  return { internal, models, promptBuilder, replicate };
+  return { service, models, promptBuilder, replicate };
 }
 
 const baseParams: RunTextGenerationStepParams = {
   basePrompt: 'BASE PROMPT',
-  buildPromptOptions: { systemPromptTemplate: 'ARTICLE', temperature: 0.8 },
+  buildPromptOptions: {
+    modelCategory: ModelCategory.TEXT,
+    systemPromptTemplate: 'ARTICLE',
+    temperature: 0.8,
+  },
   failureMessage: 'fail',
-  harnessContext: { promptBuilder: { brand: 'brand-x' } },
+  harnessContext: { promptBuilder: { brand: { label: 'brand-x' } } },
   model: 'test-model',
   organizationId: 'org-1',
 };
 
-describe('ArticlesContentService.runTextGenerationStep', () => {
+describe('ArticleTextGenerationService.runTextGenerationStep', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it('builds the prompt, runs the model, and returns the raw response', async () => {
-    const { internal, promptBuilder, replicate } = makeService();
+    const { service, promptBuilder, replicate } = makeService();
 
-    const output = await internal.runTextGenerationStep(baseParams);
+    const output = await service.runTextGenerationStep(baseParams);
 
     expect(output).toBe('AI OUTPUT');
     expect(promptBuilder.buildPrompt).toHaveBeenCalledWith(
       'test-model',
       expect.objectContaining({
-        brand: 'brand-x',
+        brand: { label: 'brand-x' },
         prompt: expect.stringContaining('BASE PROMPT'),
         temperature: 0.8,
       }),
@@ -86,10 +77,10 @@ describe('ArticlesContentService.runTextGenerationStep', () => {
   });
 
   it('meters a charge only when an onBilling callback is supplied', async () => {
-    const { internal } = makeService();
+    const { service } = makeService();
     const onBilling = vi.fn();
 
-    await internal.runTextGenerationStep({ ...baseParams, onBilling });
+    await service.runTextGenerationStep({ ...baseParams, onBilling });
 
     expect(onBilling).toHaveBeenCalledTimes(1);
     expect(onBilling).toHaveBeenCalledWith(
@@ -98,20 +89,20 @@ describe('ArticlesContentService.runTextGenerationStep', () => {
   });
 
   it('never computes a charge when onBilling is omitted (enhance path)', async () => {
-    const { internal, models } = makeService();
+    const { service, models } = makeService();
 
-    await internal.runTextGenerationStep(baseParams);
+    await service.runTextGenerationStep(baseParams);
 
     // calculateTextGenerationCharge() is the only caller of modelsService.findOne
     expect(models.findOne).not.toHaveBeenCalled();
   });
 
   it('throws the caller-supplied failure message when the model returns no text', async () => {
-    const { internal, replicate } = makeService();
+    const { service, replicate } = makeService();
     replicate.generateTextCompletionSync.mockResolvedValueOnce('');
 
     await expect(
-      internal.runTextGenerationStep({
+      service.runTextGenerationStep({
         ...baseParams,
         failureMessage: 'custom failure message',
       }),

--- a/apps/server/api/src/collections/articles/services/articles-content.service.ts
+++ b/apps/server/api/src/collections/articles/services/articles-content.service.ts
@@ -16,10 +16,15 @@ import {
   type EditArticleWithAIDto,
   type GenerateArticlesDto,
 } from '@api/collections/articles/dto/generate-articles.dto';
-import { UpdateArticleDto } from '@api/collections/articles/dto/update-article.dto';
 import { type ArticleDocument } from '@api/collections/articles/schemas/article.schema';
+import { ArticleContentPersistenceService } from '@api/collections/articles/services/article-content-persistence.service';
+import { ArticleReviewService } from '@api/collections/articles/services/article-review.service';
+import { ArticleTextGenerationService } from '@api/collections/articles/services/article-text-generation.service';
 import { ArticlesService } from '@api/collections/articles/services/articles.service';
 import type {
+  ArticleCycleModelConfig,
+  ArticleHarnessContext,
+  ArticleReviewRubric,
   TextGenerationCharge,
   XArticleContentMetadata,
 } from '@api/collections/articles/services/articles-content.types';
@@ -27,37 +32,24 @@ import { buildTwitterThreadTweets } from '@api/collections/articles/utils/articl
 import { BrandsService } from '@api/collections/brands/services/brands.service';
 import { AccountPublishingContextService } from '@api/collections/credentials/services/account-publishing-context.service';
 import { HarnessProfilesService } from '@api/collections/harness-profiles/services/harness-profiles.service';
-import { ModelsService } from '@api/collections/models/services/models.service';
-import { baseModelKey } from '@api/collections/models/utils/model-key.util';
 import type { PersonaDocument } from '@api/collections/personas/schemas/persona.schema';
 import { PersonasService } from '@api/collections/personas/services/personas.service';
-import { PromptEntity } from '@api/collections/prompts/entities/prompt.entity';
-import { PromptsService } from '@api/collections/prompts/services/prompts.service';
 import { TemplatesService } from '@api/collections/templates/services/templates.service';
 import { DEFAULT_MINI_TEXT_MODEL } from '@api/constants/default-mini-text-model.constant';
 import { DEFAULT_TEXT_MODEL } from '@api/constants/default-text-model.constant';
 import { TEXT_GENERATION_LIMITS } from '@api/constants/text-generation-limits.constant';
-import { getMinimumTextCredits } from '@api/helpers/utils/text-pricing/text-pricing.util';
 import { ContentHarnessService } from '@api/services/harness/harness.service';
 import {
-  appendHarnessBriefToPrompt,
   buildHarnessInput,
   buildPromptBuilderBrandContext,
 } from '@api/services/harness/harness-brief.util';
-import { NotificationsPublisherService } from '@api/services/notifications/publisher/notifications-publisher.service';
-import type { PromptBuilderParams } from '@api/services/prompt-builder/interfaces/prompt-builder-params.interface';
-import { PromptBuilderService } from '@api/services/prompt-builder/prompt-builder.service';
 import {
   ArticleCategory,
   ArticleStatus,
-  AssetScope,
   ModelCategory,
-  PromptCategory,
-  PromptStatus,
   PromptTemplateKey,
   SystemPromptKey,
 } from '@genfeedai/enums';
-import type { ContentHarnessBrief } from '@genfeedai/harness';
 import type { AccountPublishingContext } from '@genfeedai/interfaces';
 import type {
   ArticleCreatePayload,
@@ -68,34 +60,11 @@ import { ConfigService } from '@libs/config/config.service';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable, Optional } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
-import { ReplicateService } from '@server/services/integrations/replicate/services/replicate.service';
 
-export interface ArticleCycleModelConfig {
-  generationModel?: string;
-  reviewModel?: string;
-  updateModel?: string;
-}
-
-export interface ArticleReviewRubric {
-  score: number;
-  strengths: string[];
-  issues: Array<{
-    severity: 'low' | 'medium' | 'high';
-    category: string;
-    message: string;
-    recommendation: string;
-  }>;
-  revisionInstructions: string;
-  summary: string;
-}
-
-interface ArticleHarnessContext {
-  brief?: ContentHarnessBrief;
-  promptBuilder: Pick<
-    PromptBuilderParams,
-    'brand' | 'branding' | 'brandingMode' | 'isBrandingEnabled'
-  >;
-}
+export type {
+  ArticleCycleModelConfig,
+  ArticleReviewRubric,
+} from '@api/collections/articles/services/articles-content.types';
 
 type HarnessPersonaInput = Parameters<typeof buildHarnessInput>[0]['persona'];
 
@@ -108,14 +77,11 @@ export class ArticlesContentService {
     private readonly logger: LoggerService,
     private readonly configService: ConfigService,
     private readonly moduleRef: ModuleRef,
+    private readonly articleTextGenerationService: ArticleTextGenerationService,
+    private readonly articleReviewService: ArticleReviewService,
+    private readonly articleContentPersistenceService: ArticleContentPersistenceService,
 
-    @Optional() private readonly modelsService?: ModelsService,
-    @Optional() private readonly promptsService?: PromptsService,
-    @Optional() private readonly replicateService?: ReplicateService,
-    @Optional() private readonly promptBuilderService?: PromptBuilderService,
     @Optional() private readonly templatesService?: TemplatesService,
-    @Optional()
-    private readonly websocketService?: NotificationsPublisherService,
     @Optional() private readonly brandsService?: BrandsService,
     @Optional() private readonly personasService?: PersonasService,
     @Optional() private readonly contentHarnessService?: ContentHarnessService,
@@ -255,21 +221,22 @@ export class ArticlesContentService {
       });
       // Build prompt with PromptBuilderService then call Replicate
       const generationModel = modelConfig.generationModel || DEFAULT_TEXT_MODEL;
-      const responseText = await this.runTextGenerationStep({
-        basePrompt: prompt,
-        buildPromptOptions: {
-          maxTokens: this.configService.get('MAX_TOKENS'),
-          modelCategory: ModelCategory.TEXT,
-          promptTemplate: PromptTemplateKey.TEXT_ARTICLE,
-          systemPromptTemplate: SystemPromptKey.ARTICLE,
-          temperature: 0.8,
-        },
-        failureMessage: 'Failed to generate content from AI service',
-        harnessContext,
-        model: generationModel,
-        onBilling,
-        organizationId,
-      });
+      const responseText =
+        await this.articleTextGenerationService.runTextGenerationStep({
+          basePrompt: prompt,
+          buildPromptOptions: {
+            maxTokens: this.configService.get('MAX_TOKENS'),
+            modelCategory: ModelCategory.TEXT,
+            promptTemplate: PromptTemplateKey.TEXT_ARTICLE,
+            systemPromptTemplate: SystemPromptKey.ARTICLE,
+            temperature: 0.8,
+          },
+          failureMessage: 'Failed to generate content from AI service',
+          harnessContext,
+          model: generationModel,
+          onBilling,
+          organizationId,
+        });
 
       // Parse JSON response
       let response: ArticleGenerationResponse;
@@ -307,7 +274,7 @@ export class ArticlesContentService {
             generated.label || generated.title || `Generated Article ${i + 1}`,
           summary: generated.summary || '',
         };
-        const cycle = await this.runReviewUpdateCycle({
+        const cycle = await this.articleReviewService.runReviewUpdateCycle({
           draft,
           harnessContext,
           modelConfig,
@@ -438,24 +405,25 @@ export class ArticlesContentService {
       });
       // Build prompt with PromptBuilderService then call Replicate
       const generationModel = modelConfig.generationModel || DEFAULT_TEXT_MODEL;
-      const responseText = await this.runTextGenerationStep({
-        basePrompt: this.appendAccountPublishingContextToPrompt(
-          prompt,
-          accountPublishingContext,
-        ),
-        buildPromptOptions: {
-          maxTokens: this.configService.get('MAX_TOKENS'),
-          modelCategory: ModelCategory.TEXT,
-          promptTemplate: PromptTemplateKey.X_ARTICLE_GENERATE,
-          systemPromptTemplate: SystemPromptKey.X_ARTICLE,
-          temperature: 0.8,
-        },
-        failureMessage: 'Failed to generate content from AI service',
-        harnessContext,
-        model: generationModel,
-        onBilling,
-        organizationId,
-      });
+      const responseText =
+        await this.articleTextGenerationService.runTextGenerationStep({
+          basePrompt: this.appendAccountPublishingContextToPrompt(
+            prompt,
+            accountPublishingContext,
+          ),
+          buildPromptOptions: {
+            maxTokens: this.configService.get('MAX_TOKENS'),
+            modelCategory: ModelCategory.TEXT,
+            promptTemplate: PromptTemplateKey.X_ARTICLE_GENERATE,
+            systemPromptTemplate: SystemPromptKey.X_ARTICLE,
+            temperature: 0.8,
+          },
+          failureMessage: 'Failed to generate content from AI service',
+          harnessContext,
+          model: generationModel,
+          onBilling,
+          organizationId,
+        });
 
       // Parse JSON response
       let response: ArticleGenerationResponse;
@@ -485,7 +453,7 @@ export class ArticlesContentService {
         wordCount,
       } = this.buildXArticleContentAndMetadata(response.sections);
 
-      const cycle = await this.runReviewUpdateCycle({
+      const cycle = await this.articleReviewService.runReviewUpdateCycle({
         draft: {
           content: fullContent,
           label: response.title,
@@ -601,20 +569,21 @@ export class ArticlesContentService {
       });
       // Build prompt with PromptBuilderService then call Replicate.
       // Enhancement is intentionally unbilled, so no onBilling callback is passed.
-      const responseText = await this.runTextGenerationStep({
-        basePrompt: prompt,
-        buildPromptOptions: {
-          maxTokens: TEXT_GENERATION_LIMITS.articleEnhancement,
-          modelCategory: ModelCategory.TEXT,
-          systemPromptTemplate: SystemPromptKey.ARTICLE,
-          temperature: 0.8,
-          useTemplate: false,
-        },
-        failureMessage: 'Failed to enhance content from AI service',
-        harnessContext,
-        model: DEFAULT_MINI_TEXT_MODEL,
-        organizationId,
-      });
+      const responseText =
+        await this.articleTextGenerationService.runTextGenerationStep({
+          basePrompt: prompt,
+          buildPromptOptions: {
+            maxTokens: TEXT_GENERATION_LIMITS.articleEnhancement,
+            modelCategory: ModelCategory.TEXT,
+            systemPromptTemplate: SystemPromptKey.ARTICLE,
+            temperature: 0.8,
+            useTemplate: false,
+          },
+          failureMessage: 'Failed to enhance content from AI service',
+          harnessContext,
+          model: DEFAULT_MINI_TEXT_MODEL,
+          organizationId,
+        });
 
       // Parse JSON response
       let response: ArticleGenerationResponse;
@@ -627,7 +596,7 @@ export class ArticlesContentService {
       }
 
       // Update article with enhanced content
-      await this.updateArticleWithEnhancedContent(
+      await this.articleContentPersistenceService.updateArticleWithEnhancedContent(
         article,
         response,
         prompt,
@@ -709,71 +678,6 @@ export class ArticlesContentService {
       );
       throw error;
     }
-  }
-
-  /**
-   * Shared generation prologue for the article generators.
-   *
-   * Appends the harness brief to `basePrompt`, builds the model input via the
-   * PromptBuilderService (merging the harness brand context), runs the Replicate
-   * text completion, and — when an `onBilling` callback is supplied — meters the
-   * charge. Returns the raw model response for the caller to parse. The differing
-   * pieces (model, prompt-builder options, failure message, whether the step is
-   * billed) are passed in so generateArticles/generateLongFormArticle/enhance can
-   * share one body without changing their individual behaviour.
-   */
-  private async runTextGenerationStep(params: {
-    model: string;
-    basePrompt: string;
-    harnessContext: ArticleHarnessContext;
-    buildPromptOptions: Omit<
-      PromptBuilderParams,
-      'prompt' | 'brand' | 'branding' | 'brandingMode' | 'isBrandingEnabled'
-    >;
-    organizationId: string;
-    failureMessage: string;
-    onBilling?: (charge: TextGenerationCharge) => void;
-  }): Promise<string> {
-    const promptWithHarness = appendHarnessBriefToPrompt(
-      params.basePrompt,
-      params.harnessContext.brief,
-    );
-
-    if (!this.promptBuilderService) {
-      throw new Error('Prompt builder service not available');
-    }
-
-    const { input } = await this.promptBuilderService.buildPrompt(
-      params.model,
-      {
-        ...params.buildPromptOptions,
-        prompt: promptWithHarness,
-        ...params.harnessContext.promptBuilder,
-      },
-      params.organizationId,
-    );
-
-    const responseText =
-      await this.replicateService?.generateTextCompletionSync(
-        params.model,
-        input,
-      );
-
-    if (!responseText) {
-      throw new Error(params.failureMessage);
-    }
-
-    if (params.onBilling) {
-      params.onBilling(
-        await this.calculateTextGenerationCharge(
-          params.model,
-          input,
-          responseText,
-        ),
-      );
-    }
-
-    return responseText;
   }
 
   /**
@@ -919,191 +823,15 @@ export class ArticlesContentService {
       sourceLines: focus ? [`review-focus: ${focus}`] : [],
       topic: this.getArticleLabel(article),
     });
-    const reviewModel = modelConfig.reviewModel || DEFAULT_MINI_TEXT_MODEL;
-    const reviewPrompt = this.buildReviewPrompt({
-      content: article.content ?? '',
+
+    return this.articleReviewService.reviewExistingArticle(
+      article,
+      organizationId,
+      modelConfig,
+      harnessContext,
       focus,
-      harnessBrief: harnessContext.brief,
-      label: this.getArticleLabel(article),
-      summary: article.summary || '',
-      type:
-        article.category === ArticleCategory.X_ARTICLE
-          ? ArticleGenerationType.X_ARTICLE
-          : ArticleGenerationType.STANDARD,
-    });
-
-    const { output: reviewRaw, charge } = await this.generateTextWithModel(
-      reviewModel,
-      reviewPrompt,
-      organizationId,
-      harnessContext.promptBuilder,
+      onBilling,
     );
-    onBilling?.(charge);
-
-    return this.parseReviewRubric(reviewRaw);
-  }
-
-  private async runReviewUpdateCycle(params: {
-    draft: { label: string; summary: string; content: string };
-    harnessContext?: ArticleHarnessContext;
-    prompt: string;
-    organizationId: string;
-    modelConfig: ArticleCycleModelConfig;
-    type: ArticleGenerationType;
-    onBilling?: (charge: TextGenerationCharge) => void;
-  }): Promise<{
-    review: ArticleReviewRubric;
-    updated: { label: string; summary: string; content: string };
-  }> {
-    const reviewModel =
-      params.modelConfig.reviewModel || DEFAULT_MINI_TEXT_MODEL;
-    const updateModel =
-      params.modelConfig.updateModel || DEFAULT_MINI_TEXT_MODEL;
-
-    const { output: reviewRaw, charge: reviewCharge } =
-      await this.generateTextWithModel(
-        reviewModel,
-        this.buildReviewPrompt({
-          content: params.draft.content,
-          harnessBrief: params.harnessContext?.brief,
-          label: params.draft.label,
-          summary: params.draft.summary,
-          type: params.type,
-        }),
-        params.organizationId,
-        params.harnessContext?.promptBuilder,
-      );
-    params.onBilling?.(reviewCharge);
-    const review = this.parseReviewRubric(reviewRaw);
-
-    const { output: revisionRaw, charge: revisionCharge } =
-      await this.generateTextWithModel(
-        updateModel,
-        this.buildRevisionPrompt(
-          params.draft,
-          params.prompt,
-          review,
-          params.type,
-          params.harnessContext?.brief,
-        ),
-        params.organizationId,
-        params.harnessContext?.promptBuilder,
-      );
-    params.onBilling?.(revisionCharge);
-    const updated = this.parseUpdatedArticle(revisionRaw, params.draft);
-
-    return { review, updated };
-  }
-
-  private async generateTextWithModel(
-    model: string,
-    prompt: string,
-    organizationId: string,
-    promptBuilderContext?: Pick<
-      PromptBuilderParams,
-      'brand' | 'branding' | 'brandingMode' | 'isBrandingEnabled'
-    >,
-  ): Promise<{ output: string; charge: TextGenerationCharge }> {
-    const { input } = (await this.promptBuilderService?.buildPrompt(
-      model as string,
-      {
-        maxTokens: this.configService.get('MAX_TOKENS'),
-        modelCategory: ModelCategory.TEXT,
-        prompt,
-        systemPromptTemplate: SystemPromptKey.ARTICLE,
-        temperature: 0.7,
-        useTemplate: false,
-        ...promptBuilderContext,
-      },
-      organizationId,
-    )) || { input: {} };
-
-    const output = await this.replicateService?.generateTextCompletionSync(
-      model,
-      input,
-    );
-
-    if (!output) {
-      throw new Error(`Failed to generate text with model: ${model}`);
-    }
-
-    return {
-      charge: await this.calculateTextGenerationCharge(model, input, output),
-      output,
-    };
-  }
-
-  private async calculateTextGenerationCharge(
-    modelKey: string,
-    input: unknown,
-    output: string,
-  ): Promise<TextGenerationCharge> {
-    if (!this.modelsService) {
-      throw new Error('ModelsService not available');
-    }
-
-    const model = await this.modelsService.findOne({
-      isDeleted: false,
-      key: baseModelKey(modelKey),
-    });
-
-    if (!model) {
-      throw new Error(`Model pricing is not configured for ${modelKey}`);
-    }
-
-    const inputTokens = this.estimateTokens(input);
-    const outputTokens = this.estimateTokens(output);
-
-    const amount =
-      model.pricingType === 'per-token'
-        ? Math.max(
-            Math.ceil(
-              (inputTokens * Number(model.inputCostPerMillionTokens || 0) +
-                outputTokens * Number(model.outputCostPerMillionTokens || 0)) /
-                1_000_000,
-            ),
-            getMinimumTextCredits(model),
-          )
-        : model.cost || 0;
-
-    return {
-      amount,
-      inputTokens,
-      modelKey,
-      outputTokens,
-    };
-  }
-
-  private estimateTokens(value: unknown): number {
-    const text = this.extractBillableText(value).trim();
-
-    if (!text) {
-      return 0;
-    }
-
-    return Math.ceil(text.length / 4);
-  }
-
-  private extractBillableText(value: unknown): string {
-    if (typeof value === 'string') {
-      return value;
-    }
-
-    if (typeof value === 'number' || typeof value === 'boolean') {
-      return String(value);
-    }
-
-    if (Array.isArray(value)) {
-      return value.map((item) => this.extractBillableText(item)).join(' ');
-    }
-
-    if (value && typeof value === 'object') {
-      return Object.values(value as Record<string, unknown>)
-        .map((item) => this.extractBillableText(item))
-        .join(' ');
-    }
-
-    return '';
   }
 
   private getArticleLabel(article: Pick<ArticleDocument, 'label'>): string {
@@ -1136,350 +864,5 @@ export class ArticlesContentService {
     };
 
     return normalizedPersona;
-  }
-
-  private buildReviewPrompt(input: {
-    label: string;
-    summary: string;
-    content: string;
-    type: ArticleGenerationType;
-    focus?: string;
-    harnessBrief?: ContentHarnessBrief;
-  }): string {
-    const typeLabel =
-      input.type === ArticleGenerationType.X_ARTICLE
-        ? 'X long-form article'
-        : 'standard article';
-    const focusLine = input.focus ? `Focus area: ${input.focus}` : '';
-
-    return appendHarnessBriefToPrompt(
-      `You are an expert content reviewer. Review this ${typeLabel} and return strict JSON only.
-
-${focusLine}
-
-TITLE:
-${input.label}
-
-SUMMARY:
-${input.summary}
-
-CONTENT:
-${input.content}
-
-Return this exact JSON shape:
-{
-  "score": 0,
-  "summary": "One paragraph overview",
-  "strengths": ["..."],
-  "issues": [
-    {
-      "severity": "low|medium|high",
-      "category": "clarity|structure|tone|seo|accuracy|cta",
-      "message": "...",
-      "recommendation": "..."
-    }
-  ],
-  "revisionInstructions": "Concrete instructions to improve the draft in one pass"
-}`,
-      input.harnessBrief,
-    );
-  }
-
-  private buildRevisionPrompt(
-    draft: { label: string; summary: string; content: string },
-    originalPrompt: string,
-    review: ArticleReviewRubric,
-    type: ArticleGenerationType,
-    harnessBrief?: ContentHarnessBrief,
-  ): string {
-    const typeLine =
-      type === ArticleGenerationType.X_ARTICLE
-        ? 'Keep X article style and section depth.'
-        : 'Keep standard article/blog style.';
-    return appendHarnessBriefToPrompt(
-      `You are an expert content editor. Improve the draft using the review feedback.
-
-Original request:
-${originalPrompt}
-
-${typeLine}
-
-Current draft:
-Title: ${draft.label}
-Summary: ${draft.summary}
-Content:
-${draft.content}
-
-Review summary:
-${review.summary}
-Score: ${review.score}
-Revision instructions:
-${review.revisionInstructions}
-
-Issues:
-${review.issues
-  .map(
-    (issue, index) =>
-      `${index + 1}. [${issue.severity}] ${issue.category}: ${issue.message} -> ${issue.recommendation}`,
-  )
-  .join('\n')}
-
-Return strict JSON only:
-{
-  "label": "Improved title",
-  "summary": "Improved summary",
-  "content": "Improved content (HTML allowed)"
-}`,
-      harnessBrief,
-    );
-  }
-
-  private parseReviewRubric(raw: string): ArticleReviewRubric {
-    try {
-      const parsed = JSON.parse(raw) as Partial<ArticleReviewRubric>;
-      const issues = Array.isArray(parsed.issues)
-        ? parsed.issues
-            .map((issue) => ({
-              category: String(issue.category || 'clarity'),
-              message: String(issue.message || ''),
-              recommendation: String(issue.recommendation || ''),
-              severity:
-                issue.severity === 'high' ||
-                issue.severity === 'medium' ||
-                issue.severity === 'low'
-                  ? issue.severity
-                  : 'medium',
-            }))
-            .filter((issue) => issue.message.length > 0)
-        : [];
-
-      return {
-        issues,
-        revisionInstructions: String(parsed.revisionInstructions || ''),
-        score:
-          typeof parsed.score === 'number' && Number.isFinite(parsed.score)
-            ? Math.max(0, Math.min(100, parsed.score))
-            : 70,
-        strengths: Array.isArray(parsed.strengths)
-          ? parsed.strengths
-              .map((item) => String(item))
-              .filter((item) => item.length > 0)
-          : [],
-        summary: String(parsed.summary || ''),
-      };
-    } catch {
-      return {
-        issues: [],
-        revisionInstructions:
-          'Improve clarity, structure, and call to action while preserving intent.',
-        score: 70,
-        strengths: [],
-        summary:
-          'Review model returned unstructured output, using fallback rubric.',
-      };
-    }
-  }
-
-  private parseUpdatedArticle(
-    raw: string,
-    fallback: { label: string; summary: string; content: string },
-  ): { label: string; summary: string; content: string } {
-    try {
-      const parsed = JSON.parse(raw) as Partial<{
-        label: string;
-        summary: string;
-        content: string;
-      }>;
-      return {
-        content: String(parsed.content || fallback.content),
-        label: String(parsed.label || fallback.label),
-        summary: String(parsed.summary || fallback.summary),
-      };
-    } catch {
-      return fallback;
-    }
-  }
-
-  /**
-   * Update article with enhanced content from OpenAI response
-   */
-  private async updateArticleWithEnhancedContent(
-    article: ArticleDocument,
-    response: ArticleGenerationResponse,
-    prompt: string,
-    _assistantId: string | undefined,
-    userId: string,
-    organizationId: string,
-    brandId: string,
-  ): Promise<void> {
-    try {
-      // Extract article data from response
-      // Response can be: { articles: [...] } or direct article object with { label, summary, content }
-      let articleData: GeneratedArticleData;
-      if (
-        response.articles &&
-        Array.isArray(response.articles) &&
-        response.articles.length > 0
-      ) {
-        articleData = response.articles[0];
-      } else if (response.label || response.content || response.summary) {
-        // Direct article format
-        articleData = response as GeneratedArticleData;
-      } else {
-        this.logger.error('Invalid response format from OpenAI assistant', {
-          hasArticles: !!response.articles,
-          isArray: Array.isArray(response.articles),
-          responseKeys: Object.keys(response),
-        });
-        throw new Error('Invalid response format from AI assistant');
-      }
-
-      // Assistant returns ONLY changed fields - build update data accordingly
-      const updateData: Record<string, unknown> = {
-        'aiGeneration.completedAt': new Date(),
-        status: ArticleStatus.DRAFT,
-      };
-
-      if (articleData.label) {
-        updateData.label = articleData.label.substring(0, 200);
-      }
-
-      if (articleData.summary) {
-        updateData.summary = articleData.summary.substring(0, 500);
-      }
-
-      if (articleData.content) {
-        updateData.content = articleData.content;
-      }
-
-      if (articleData.slug) {
-        // Ensure slug is unique if being changed
-        let slug = articleData.slug
-          .toLowerCase()
-          .replace(/[^a-z0-9-]/g, '-')
-          .replace(/-+/g, '-')
-          .trim();
-
-        if (slug !== article.slug) {
-          let counter = 1;
-          while (await this.slugExists(slug, organizationId, brandId)) {
-            slug = `${articleData.slug}-${counter}`;
-            counter++;
-          }
-          updateData.slug = slug;
-        }
-      }
-
-      // Update article
-      await this.articlesService?.patch(article.id, updateData);
-
-      // Create a prompt record to track this edit
-      if (this.promptsService) {
-        await this.promptsService.create(
-          new PromptEntity({
-            articleId: String(
-              (article as Record<string, unknown>).id ?? article.id,
-            ),
-            brandId: brandId,
-            category: PromptCategory.ARTICLE,
-            enhanced: JSON.stringify(response),
-            isDeleted: false,
-            isFavorite: false,
-            isSkipEnhancement: false,
-            organizationId: organizationId,
-            original: prompt,
-            scope: AssetScope.USER,
-            status: PromptStatus.GENERATED,
-            userId: userId,
-          }),
-        );
-      }
-
-      // Publish websocket event for article completion
-      if (this.websocketService) {
-        await this.websocketService.publishArticleStatus(
-          article.id.toString(),
-          'completed',
-          userId,
-          {
-            content: updateData.content || article.content,
-            label: updateData.label || article.label,
-            slug: updateData.slug || article.slug,
-            summary: updateData.summary || article.summary,
-          },
-        );
-      }
-
-      this.logger.log(`${this.constructorName} enhanced article with AI`, {
-        articleId: article.id,
-        prompt,
-      });
-    } catch (error: unknown) {
-      this.logger.error('Failed to update article with enhanced content', {
-        articleId: article.id,
-        error: {
-          message: (error as Error)?.message || 'Unknown error',
-          stack: (error as Error)?.stack,
-        },
-      });
-      await this.markArticleAsFailed(
-        article,
-        (error as Error)?.message || 'Failed to process enhanced content',
-        userId,
-      );
-    }
-  }
-
-  /**
-   * Mark article as failed during enhancement
-   */
-  private async markArticleAsFailed(
-    article: ArticleDocument,
-    errorMessage: string,
-    userId: string,
-  ): Promise<void> {
-    await this.articlesService?.patch(
-      ((article as Record<string, unknown>).id as string) ?? String(article.id),
-      {
-        aiGenerationCompletedAt: new Date(),
-        aiGenerationError: errorMessage,
-        status: ArticleStatus.DRAFT,
-      } as unknown as Partial<UpdateArticleDto>,
-    );
-
-    // Publish websocket event for article failure
-    if (this.websocketService) {
-      await this.websocketService.publishArticleStatus(
-        article.id.toString(),
-        'failed',
-        userId,
-        {
-          error: errorMessage,
-        },
-      );
-    }
-
-    this.logger.error('Article enhancement failed', {
-      articleId: article.id,
-      error: errorMessage,
-    });
-  }
-
-  /**
-   * Check if slug exists for the organization/brand
-   */
-  private async slugExists(
-    slug: string,
-    organizationId: string,
-    brandId: string,
-  ): Promise<boolean> {
-    const existing = await this.articlesService?.findOne({
-      brandId: brandId,
-      isDeleted: false,
-      organizationId: organizationId,
-      slug,
-    });
-
-    return !!existing;
   }
 }

--- a/apps/server/api/src/collections/articles/services/articles-content.service.ts
+++ b/apps/server/api/src/collections/articles/services/articles-content.service.ts
@@ -60,6 +60,7 @@ import { ConfigService } from '@libs/config/config.service';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable, Optional } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
+import { ReplicateService } from '@server/services/integrations/replicate/services/replicate.service';
 
 export type {
   ArticleCycleModelConfig,
@@ -89,6 +90,7 @@ export class ArticlesContentService {
     private readonly harnessProfilesService?: HarnessProfilesService,
     @Optional()
     private readonly accountPublishingContextService?: AccountPublishingContextService,
+    @Optional() private readonly replicateService?: ReplicateService,
   ) {}
 
   /**

--- a/apps/server/api/src/collections/articles/services/articles-content.types.ts
+++ b/apps/server/api/src/collections/articles/services/articles-content.types.ts
@@ -14,26 +14,9 @@ export interface TextGenerationCharge {
  * Parameters accepted by ArticlesContentService.runTextGenerationStep.
  * Used as the type anchor for spec-level test mocks and internal callers.
  */
-export interface RunTextGenerationStepParams {
-  model: string;
-  basePrompt: string;
-  harnessContext: {
-    brief?: unknown;
-    promptBuilder: Record<string, unknown>;
-  };
-  buildPromptOptions: Record<string, unknown>;
-  organizationId: string;
-  failureMessage: string;
-  onBilling?: (charge: TextGenerationCharge) => void;
-}
-
-/**
- * Minimal surface of ArticlesContentService used when accessing private
- * runTextGenerationStep in tests via an untyped cast.
- */
-export interface ArticlesContentServiceInternals {
-  runTextGenerationStep(params: RunTextGenerationStepParams): Promise<string>;
-}
+export type RunTextGenerationStepParams = Parameters<
+  ArticleTextGenerationService['runTextGenerationStep']
+>[0];
 
 /**
  * Return shape of buildXArticleContentAndMetadata.
@@ -52,4 +35,35 @@ export interface XArticleContentMetadata {
     wordCount: number;
   };
   wordCount: number;
+}
+
+import type { ArticleTextGenerationService } from '@api/collections/articles/services/article-text-generation.service';
+import type { PromptBuilderParams } from '@api/services/prompt-builder/interfaces/prompt-builder-params.interface';
+import type { ContentHarnessBrief } from '@genfeedai/harness';
+
+export interface ArticleCycleModelConfig {
+  generationModel?: string;
+  reviewModel?: string;
+  updateModel?: string;
+}
+
+export interface ArticleReviewRubric {
+  score: number;
+  strengths: string[];
+  issues: Array<{
+    severity: 'low' | 'medium' | 'high';
+    category: string;
+    message: string;
+    recommendation: string;
+  }>;
+  revisionInstructions: string;
+  summary: string;
+}
+
+export interface ArticleHarnessContext {
+  brief?: ContentHarnessBrief;
+  promptBuilder: Pick<
+    PromptBuilderParams,
+    'brand' | 'branding' | 'brandingMode' | 'isBrandingEnabled'
+  >;
 }


### PR DESCRIPTION
## Summary

- extract shared provider calls, prompt building, token estimation, and billing into `ArticleTextGenerationService`
- extract review/update cycles and rubric parsing into `ArticleReviewService`
- extract enhanced-content persistence, version records, websocket status, failure handling, and slug collision checks into `ArticleContentPersistenceService`
- preserve `ArticlesContentService` as the generation facade while reducing it from 1,485 to 868 lines
- reduce provider dependency fan-out and add focused text-generation, review, and persistence coverage

## Verification

- targeted Biome checks passed for all changed files
- staged Biome, UI control guard, Secretlint, and Gitleaks checks passed
- `git diff --check` passed
- original method inventory preserved across the facade and extracted services
- tests, typecheck, and build delegated to PR CI per local machine policy

Part of #1738.
Stacked on #1756.