### PR TITLE
refactor(api): decompose batch generation service

### DIFF
--- a/apps/server/api/src/services/batch-generation/batch-generation-creation.service.ts
+++ b/apps/server/api/src/services/batch-generation/batch-generation-creation.service.ts
@@ -172,17 +172,31 @@ export class BatchGenerationCreationService {
       totalCount: batchItems.length,
     };
 
-    const batch = (await this.prisma.batch.create({
-      data: {
-        brandId: dto.brandId,
-        config: config as never,
-        isDeleted: false,
-        items: batchItems as never,
-        organizationId: orgId,
-        status: BatchStatus.COMPLETED as never,
-        userId,
-      },
-    })) as BatchWithConfig;
+    let batch: BatchWithConfig;
+    let createdBatchId: string | undefined;
+    try {
+      batch = (await this.prisma.batch.create({
+        data: {
+          brandId: dto.brandId,
+          config: config as never,
+          isDeleted: false,
+          items: batchItems as never,
+          organizationId: orgId,
+          status: BatchStatus.COMPLETED as never,
+          userId,
+        },
+      })) as BatchWithConfig;
+      createdBatchId = batch.id;
+
+      await this.linkManualReviewPosts(batch.id, batchItems, orgId);
+    } catch (error: unknown) {
+      await this.compensateManualReviewCreation(
+        createdBatchId,
+        batchItems,
+        orgId,
+      );
+      throw error;
+    }
 
     this.logger.log(`Manual review batch created: ${batch.id}`, {
       batchId: batch.id,
@@ -190,7 +204,6 @@ export class BatchGenerationCreationService {
       orgId,
     });
 
-    await this.linkManualReviewPosts(batch.id, batchItems, orgId);
     return this.summaryService.toBatchSummary(batch);
   }
 
@@ -228,60 +241,65 @@ export class BatchGenerationCreationService {
     orgId: string,
   ): Promise<BatchItemFull[]> {
     const batchItems: BatchItemFull[] = [];
-    for (const reviewItem of dto.items) {
-      const contentRunId = reviewItem.contentRunId
-        ? String(reviewItem.contentRunId)
-        : undefined;
-      const post = await this.postsService.create({
-        brand: dto.brandId,
-        contentRunId,
-        creativeVersion: reviewItem.creativeVersion,
-        description:
-          reviewItem.caption ??
-          reviewItem.prompt ??
-          'Review this asset before publishing',
-        hookVersion: reviewItem.hookVersion,
-        ingredients: reviewItem.ingredientId ? [reviewItem.ingredientId] : [],
-        label: reviewItem.label ?? `Review ${reviewItem.format} draft`,
-        organization: orgId,
-        platform: reviewItem.platform as never,
-        publishIntent: reviewItem.publishIntent,
-        promptUsed: reviewItem.prompt,
-        scheduleSlot: reviewItem.scheduleSlot,
-        sourceActionId: reviewItem.sourceActionId,
-        sourceWorkflowId: reviewItem.sourceWorkflowId,
-        sourceWorkflowName: reviewItem.sourceWorkflowName,
-        status: PostStatus.DRAFT,
-        user: userId,
-        variantId: reviewItem.variantId,
-      } as never);
+    try {
+      for (const reviewItem of dto.items) {
+        const contentRunId = reviewItem.contentRunId
+          ? String(reviewItem.contentRunId)
+          : undefined;
+        const post = await this.postsService.create({
+          brand: dto.brandId,
+          contentRunId,
+          creativeVersion: reviewItem.creativeVersion,
+          description:
+            reviewItem.caption ??
+            reviewItem.prompt ??
+            'Review this asset before publishing',
+          hookVersion: reviewItem.hookVersion,
+          ingredients: reviewItem.ingredientId ? [reviewItem.ingredientId] : [],
+          label: reviewItem.label ?? `Review ${reviewItem.format} draft`,
+          organization: orgId,
+          platform: reviewItem.platform as never,
+          publishIntent: reviewItem.publishIntent,
+          promptUsed: reviewItem.prompt,
+          scheduleSlot: reviewItem.scheduleSlot,
+          sourceActionId: reviewItem.sourceActionId,
+          sourceWorkflowId: reviewItem.sourceWorkflowId,
+          sourceWorkflowName: reviewItem.sourceWorkflowName,
+          status: PostStatus.DRAFT,
+          user: userId,
+          variantId: reviewItem.variantId,
+        } as never);
 
-      const postId = String((post as Record<string, unknown>).id ?? post.id);
+        const postId = String((post as Record<string, unknown>).id ?? post.id);
 
-      batchItems.push({
-        _id: crypto.randomUUID(),
-        caption: reviewItem.caption,
-        contentRunId,
-        creativeVersion: reviewItem.creativeVersion,
-        format: reviewItem.format as ContentFormat,
-        gateOverallScore: reviewItem.gateOverallScore,
-        gateReasons: reviewItem.gateReasons ?? [],
-        hookVersion: reviewItem.hookVersion,
-        mediaUrl: reviewItem.mediaUrl,
-        opportunitySourceType: reviewItem.opportunitySourceType,
-        opportunityTopic: reviewItem.opportunityTopic,
-        platform: reviewItem.platform,
-        postId,
-        publishIntent: reviewItem.publishIntent,
-        prompt: reviewItem.prompt,
-        reviewEvents: [],
-        scheduleSlot: reviewItem.scheduleSlot,
-        sourceActionId: reviewItem.sourceActionId,
-        sourceWorkflowId: reviewItem.sourceWorkflowId,
-        sourceWorkflowName: reviewItem.sourceWorkflowName,
-        status: BatchItemStatus.COMPLETED,
-        variantId: reviewItem.variantId,
-      });
+        batchItems.push({
+          _id: crypto.randomUUID(),
+          caption: reviewItem.caption,
+          contentRunId,
+          creativeVersion: reviewItem.creativeVersion,
+          format: reviewItem.format as ContentFormat,
+          gateOverallScore: reviewItem.gateOverallScore,
+          gateReasons: reviewItem.gateReasons ?? [],
+          hookVersion: reviewItem.hookVersion,
+          mediaUrl: reviewItem.mediaUrl,
+          opportunitySourceType: reviewItem.opportunitySourceType,
+          opportunityTopic: reviewItem.opportunityTopic,
+          platform: reviewItem.platform,
+          postId,
+          publishIntent: reviewItem.publishIntent,
+          prompt: reviewItem.prompt,
+          reviewEvents: [],
+          scheduleSlot: reviewItem.scheduleSlot,
+          sourceActionId: reviewItem.sourceActionId,
+          sourceWorkflowId: reviewItem.sourceWorkflowId,
+          sourceWorkflowName: reviewItem.sourceWorkflowName,
+          status: BatchItemStatus.COMPLETED,
+          variantId: reviewItem.variantId,
+        });
+      }
+    } catch (error: unknown) {
+      await this.compensateManualReviewCreation(undefined, batchItems, orgId);
+      throw error;
     }
     return batchItems;
   }
@@ -291,11 +309,11 @@ export class BatchGenerationCreationService {
     batchItems: BatchItemFull[],
     orgId: string,
   ): Promise<void> {
-    await Promise.all(
+    const results = await Promise.all(
       batchItems.map(async (item) => {
-        if (!item.postId) return;
+        if (!item.postId) return { count: 0 };
 
-        await this.prisma.post.updateMany({
+        return this.prisma.post.updateMany({
           data: {
             reviewBatchId: batchId,
             reviewItemId: item._id,
@@ -308,6 +326,47 @@ export class BatchGenerationCreationService {
         });
       }),
     );
+
+    if (results.some((result) => result.count !== 1)) {
+      throw new NotFoundException({
+        message:
+          'A manual review post disappeared before batch linking completed',
+      });
+    }
+  }
+
+  private async compensateManualReviewCreation(
+    batchId: string | undefined,
+    batchItems: BatchItemFull[],
+    orgId: string,
+  ): Promise<void> {
+    try {
+      const postIds = batchItems.flatMap((item) =>
+        item.postId ? [item.postId] : [],
+      );
+      if (postIds.length > 0) {
+        await this.prisma.post.updateMany({
+          data: { isDeleted: true },
+          where: {
+            id: { in: postIds },
+            isDeleted: false,
+            organizationId: orgId,
+          },
+        });
+      }
+      if (batchId) {
+        await this.prisma.batch.updateMany({
+          data: { isDeleted: true },
+          where: { id: batchId, isDeleted: false, organizationId: orgId },
+        });
+      }
+    } catch (cleanupError: unknown) {
+      this.logger.error('Manual review batch compensation failed', {
+        batchId,
+        cleanupError,
+        orgId,
+      });
+    }
   }
 
   private generateContentPlan(
@@ -349,9 +408,6 @@ export class BatchGenerationCreationService {
     total: number,
     contentMix: ContentMixConfig,
   ): Record<string, number> {
-    const counts: Record<string, number> = {};
-    let remaining = total;
-
     const formats: Array<{ key: ContentFormat; percent: number }> = [
       { key: ContentFormat.IMAGE, percent: contentMix.imagePercent },
       { key: ContentFormat.VIDEO, percent: contentMix.videoPercent },
@@ -360,17 +416,36 @@ export class BatchGenerationCreationService {
       { key: ContentFormat.STORY, percent: contentMix.storyPercent },
     ];
 
-    for (const format of formats) {
-      const count = Math.round((format.percent / 100) * total);
-      counts[format.key] = count;
-      remaining -= count;
+    const safeTotal = Math.max(0, Math.floor(total));
+    const percentTotal = formats.reduce(
+      (sum, format) => sum + Math.max(0, format.percent),
+      0,
+    );
+    if (percentTotal === 0) {
+      return Object.fromEntries(
+        formats.map((format, index) => [
+          format.key,
+          index === 0 ? safeTotal : 0,
+        ]),
+      );
     }
 
-    if (remaining !== 0) {
-      const largest = formats.reduce((a, b) =>
-        a.percent >= b.percent ? a : b,
-      );
-      counts[largest.key] = (counts[largest.key] ?? 0) + remaining;
+    const allocations = formats.map((format, index) => {
+      const exact = (Math.max(0, format.percent) / percentTotal) * safeTotal;
+      return { count: Math.floor(exact), fraction: exact % 1, format, index };
+    });
+    let remaining =
+      safeTotal - allocations.reduce((sum, item) => sum + item.count, 0);
+    const byRemainder = [...allocations].sort(
+      (a, b) => b.fraction - a.fraction || a.index - b.index,
+    );
+    for (let index = 0; remaining > 0; index++, remaining--) {
+      byRemainder[index % byRemainder.length].count++;
+    }
+
+    const counts: Record<string, number> = {};
+    for (const allocation of allocations) {
+      counts[allocation.format.key] = allocation.count;
     }
 
     return counts;

--- a/apps/server/api/src/services/batch-generation/batch-generation-creation.service.ts
+++ b/apps/server/api/src/services/batch-generation/batch-generation-creation.service.ts
@@ -1,0 +1,390 @@
+import { BrandsService } from '@api/collections/brands/services/brands.service';
+import { PostsService } from '@api/collections/posts/services/posts.service';
+import { NotFoundException } from '@api/helpers/exceptions/http/not-found.exception';
+import { runIdempotent } from '@api/helpers/utils/idempotency/idempotency.util';
+import type {
+  BatchConfig,
+  BatchItemFull,
+  BatchWithConfig,
+} from '@api/services/batch-generation/batch-generation.types';
+import { BatchGenerationSummaryService } from '@api/services/batch-generation/batch-generation-summary.service';
+import { CreateBatchDto } from '@api/services/batch-generation/dto/create-batch.dto';
+import { CreateManualReviewBatchDto } from '@api/services/batch-generation/dto/create-manual-review-batch.dto';
+import type { ContentMixConfig } from '@api/services/batch-generation/schemas/batch.schema';
+import { CacheService } from '@api/services/cache/services/cache.service';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import {
+  BatchItemStatus,
+  BatchStatus,
+  ContentFormat,
+  PostStatus,
+} from '@genfeedai/enums';
+import type { IBatchSummary } from '@genfeedai/interfaces';
+import { LoggerService } from '@libs/logger/logger.service';
+import { BadRequestException, Injectable } from '@nestjs/common';
+
+@Injectable()
+export class BatchGenerationCreationService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly logger: LoggerService,
+    private readonly brandsService: BrandsService,
+    private readonly postsService: PostsService,
+    private readonly cacheService: CacheService,
+    private readonly summaryService: BatchGenerationSummaryService,
+  ) {}
+
+  async createBatch(
+    dto: CreateBatchDto,
+    userId: string,
+    orgId: string,
+    idempotencyKey?: string,
+  ): Promise<IBatchSummary> {
+    if (idempotencyKey) {
+      return runIdempotent(this.cacheService, idempotencyKey, () =>
+        this.doCreateBatch(dto, userId, orgId),
+      );
+    }
+
+    return this.doCreateBatch(dto, userId, orgId);
+  }
+
+  private async doCreateBatch(
+    dto: CreateBatchDto,
+    userId: string,
+    orgId: string,
+  ): Promise<IBatchSummary> {
+    // Verify brand exists and belongs to org
+    const brand = await this.brandsService.findOne({
+      _id: dto.brandId,
+      isDeleted: false,
+      organization: orgId,
+    });
+
+    if (!brand) {
+      throw new NotFoundException('Brand', dto.brandId);
+    }
+
+    const contentMix: ContentMixConfig = dto.contentMix ?? {
+      carouselPercent: 10,
+      imagePercent: 60,
+      reelPercent: 5,
+      storyPercent: 0,
+      videoPercent: 25,
+    };
+
+    const dateRangeStart = new Date(dto.dateRange.start);
+    const dateRangeEnd = new Date(dto.dateRange.end);
+
+    const items = this.generateContentPlan(
+      dto.count,
+      contentMix,
+      dto.platforms,
+      dto.topics ?? [],
+      dateRangeStart,
+      dateRangeEnd,
+    );
+
+    const config: BatchConfig = {
+      completedCount: 0,
+      contentMix,
+      dateRangeEnd: dateRangeEnd.toISOString(),
+      dateRangeStart: dateRangeStart.toISOString(),
+      failedCount: 0,
+      platforms: dto.platforms,
+      style: dto.style,
+      topics: dto.topics ?? [],
+      totalCount: dto.count,
+    };
+
+    const batch = (await this.prisma.batch.create({
+      data: {
+        brandId: dto.brandId,
+        config: config as never,
+        isDeleted: false,
+        items: items as never,
+        organizationId: orgId,
+        status: BatchStatus.PENDING as never,
+        userId,
+      },
+    })) as BatchWithConfig;
+
+    this.logger.log(`Batch created: ${batch.id}`, {
+      batchId: batch.id,
+      count: dto.count,
+      orgId,
+    });
+
+    return this.summaryService.toBatchSummary(batch);
+  }
+
+  async createManualReviewBatch(
+    dto: CreateManualReviewBatchDto,
+    userId: string,
+    orgId: string,
+    idempotencyKey?: string,
+  ): Promise<IBatchSummary> {
+    if (idempotencyKey) {
+      return runIdempotent(this.cacheService, idempotencyKey, () =>
+        this.doCreateManualReviewBatch(dto, userId, orgId),
+      );
+    }
+
+    return this.doCreateManualReviewBatch(dto, userId, orgId);
+  }
+
+  private async doCreateManualReviewBatch(
+    dto: CreateManualReviewBatchDto,
+    userId: string,
+    orgId: string,
+  ): Promise<IBatchSummary> {
+    const brand = await this.brandsService.findOne({
+      _id: dto.brandId,
+      isDeleted: false,
+      organization: orgId,
+    });
+
+    if (!brand) {
+      throw new NotFoundException('Brand', dto.brandId);
+    }
+
+    await this.validateIngredientOwnership(dto, orgId);
+    const batchItems = await this.createManualReviewItems(dto, userId, orgId);
+
+    const config: BatchConfig = {
+      completedAt: new Date().toISOString(),
+      completedCount: batchItems.length,
+      contentMix: {
+        carouselPercent: 0,
+        imagePercent: 0,
+        reelPercent: 0,
+        storyPercent: 0,
+        videoPercent: 0,
+      },
+      failedCount: 0,
+      platforms: Array.from(
+        new Set(
+          dto.items.flatMap((item) => (item.platform ? [item.platform] : [])),
+        ),
+      ),
+      source: 'manual',
+      topics: [],
+      totalCount: batchItems.length,
+    };
+
+    const batch = (await this.prisma.batch.create({
+      data: {
+        brandId: dto.brandId,
+        config: config as never,
+        isDeleted: false,
+        items: batchItems as never,
+        organizationId: orgId,
+        status: BatchStatus.COMPLETED as never,
+        userId,
+      },
+    })) as BatchWithConfig;
+
+    this.logger.log(`Manual review batch created: ${batch.id}`, {
+      batchId: batch.id,
+      itemCount: batchItems.length,
+      orgId,
+    });
+
+    await this.linkManualReviewPosts(batch.id, batchItems, orgId);
+    return this.summaryService.toBatchSummary(batch);
+  }
+
+  private async validateIngredientOwnership(
+    dto: CreateManualReviewBatchDto,
+    orgId: string,
+  ): Promise<void> {
+    const ingredientIds = [
+      ...new Set(
+        dto.items
+          .map((item) => item.ingredientId)
+          .filter((id): id is string => Boolean(id)),
+      ),
+    ];
+    if (ingredientIds.length === 0) return;
+
+    const ownedIngredients = await this.prisma.ingredient.findMany({
+      select: { id: true },
+      where: {
+        id: { in: ingredientIds },
+        isDeleted: false,
+        organizationId: orgId,
+      },
+    });
+    if (ownedIngredients.length !== ingredientIds.length) {
+      throw new BadRequestException(
+        'One or more ingredient IDs do not belong to this organization',
+      );
+    }
+  }
+
+  private async createManualReviewItems(
+    dto: CreateManualReviewBatchDto,
+    userId: string,
+    orgId: string,
+  ): Promise<BatchItemFull[]> {
+    const batchItems: BatchItemFull[] = [];
+    for (const reviewItem of dto.items) {
+      const contentRunId = reviewItem.contentRunId
+        ? String(reviewItem.contentRunId)
+        : undefined;
+      const post = await this.postsService.create({
+        brand: dto.brandId,
+        contentRunId,
+        creativeVersion: reviewItem.creativeVersion,
+        description:
+          reviewItem.caption ??
+          reviewItem.prompt ??
+          'Review this asset before publishing',
+        hookVersion: reviewItem.hookVersion,
+        ingredients: reviewItem.ingredientId ? [reviewItem.ingredientId] : [],
+        label: reviewItem.label ?? `Review ${reviewItem.format} draft`,
+        organization: orgId,
+        platform: reviewItem.platform as never,
+        publishIntent: reviewItem.publishIntent,
+        promptUsed: reviewItem.prompt,
+        scheduleSlot: reviewItem.scheduleSlot,
+        sourceActionId: reviewItem.sourceActionId,
+        sourceWorkflowId: reviewItem.sourceWorkflowId,
+        sourceWorkflowName: reviewItem.sourceWorkflowName,
+        status: PostStatus.DRAFT,
+        user: userId,
+        variantId: reviewItem.variantId,
+      } as never);
+
+      const postId = String((post as Record<string, unknown>).id ?? post.id);
+
+      batchItems.push({
+        _id: crypto.randomUUID(),
+        caption: reviewItem.caption,
+        contentRunId,
+        creativeVersion: reviewItem.creativeVersion,
+        format: reviewItem.format as ContentFormat,
+        gateOverallScore: reviewItem.gateOverallScore,
+        gateReasons: reviewItem.gateReasons ?? [],
+        hookVersion: reviewItem.hookVersion,
+        mediaUrl: reviewItem.mediaUrl,
+        opportunitySourceType: reviewItem.opportunitySourceType,
+        opportunityTopic: reviewItem.opportunityTopic,
+        platform: reviewItem.platform,
+        postId,
+        publishIntent: reviewItem.publishIntent,
+        prompt: reviewItem.prompt,
+        reviewEvents: [],
+        scheduleSlot: reviewItem.scheduleSlot,
+        sourceActionId: reviewItem.sourceActionId,
+        sourceWorkflowId: reviewItem.sourceWorkflowId,
+        sourceWorkflowName: reviewItem.sourceWorkflowName,
+        status: BatchItemStatus.COMPLETED,
+        variantId: reviewItem.variantId,
+      });
+    }
+    return batchItems;
+  }
+
+  private async linkManualReviewPosts(
+    batchId: string,
+    batchItems: BatchItemFull[],
+    orgId: string,
+  ): Promise<void> {
+    await Promise.all(
+      batchItems.map(async (item) => {
+        if (!item.postId) return;
+
+        await this.prisma.post.updateMany({
+          data: {
+            reviewBatchId: batchId,
+            reviewItemId: item._id,
+          },
+          where: {
+            id: item.postId,
+            isDeleted: false,
+            organizationId: orgId,
+          },
+        });
+      }),
+    );
+  }
+
+  private generateContentPlan(
+    count: number,
+    contentMix: ContentMixConfig,
+    platforms: string[],
+    _topics: string[],
+    dateRangeStart: Date,
+    dateRangeEnd: Date,
+  ): BatchItemFull[] {
+    const items: BatchItemFull[] = [];
+    const formatCounts = this.calculateFormatCounts(count, contentMix);
+    const timeSlots = this.distributeTimeSlots(
+      count,
+      dateRangeStart,
+      dateRangeEnd,
+    );
+
+    let index = 0;
+    const now = new Date().toISOString();
+    for (const [format, formatCount] of Object.entries(formatCounts)) {
+      for (let i = 0; i < formatCount; i++) {
+        items.push({
+          _id: crypto.randomUUID(),
+          createdAt: now,
+          format: format as ContentFormat,
+          platform: platforms[index % platforms.length],
+          scheduledDate: timeSlots[index]?.toISOString(),
+          status: BatchItemStatus.PENDING,
+        });
+        index++;
+      }
+    }
+
+    return items;
+  }
+
+  private calculateFormatCounts(
+    total: number,
+    contentMix: ContentMixConfig,
+  ): Record<string, number> {
+    const counts: Record<string, number> = {};
+    let remaining = total;
+
+    const formats: Array<{ key: ContentFormat; percent: number }> = [
+      { key: ContentFormat.IMAGE, percent: contentMix.imagePercent },
+      { key: ContentFormat.VIDEO, percent: contentMix.videoPercent },
+      { key: ContentFormat.CAROUSEL, percent: contentMix.carouselPercent },
+      { key: ContentFormat.REEL, percent: contentMix.reelPercent },
+      { key: ContentFormat.STORY, percent: contentMix.storyPercent },
+    ];
+
+    for (const format of formats) {
+      const count = Math.round((format.percent / 100) * total);
+      counts[format.key] = count;
+      remaining -= count;
+    }
+
+    if (remaining !== 0) {
+      const largest = formats.reduce((a, b) =>
+        a.percent >= b.percent ? a : b,
+      );
+      counts[largest.key] = (counts[largest.key] ?? 0) + remaining;
+    }
+
+    return counts;
+  }
+
+  private distributeTimeSlots(count: number, start: Date, end: Date): Date[] {
+    const slots: Date[] = [];
+    const totalMs = end.getTime() - start.getTime();
+    const interval = count > 1 ? totalMs / (count - 1) : 0;
+
+    for (let i = 0; i < count; i++) {
+      slots.push(new Date(start.getTime() + interval * i));
+    }
+
+    return slots;
+  }
+}

--- a/apps/server/api/src/services/batch-generation/batch-generation-processing.service.ts
+++ b/apps/server/api/src/services/batch-generation/batch-generation-processing.service.ts
@@ -1,0 +1,240 @@
+import { ContentGeneratorService } from '@api/collections/content-intelligence/services/content-generator.service';
+import { PostsService } from '@api/collections/posts/services/posts.service';
+import { NotFoundException } from '@api/helpers/exceptions/http/not-found.exception';
+import {
+  type BatchConfig,
+  type BatchItemFull,
+  type BatchProcessOptions,
+  type BatchWithConfig,
+  cloneBatchItems,
+} from '@api/services/batch-generation/batch-generation.types';
+import { BatchGenerationSummaryService } from '@api/services/batch-generation/batch-generation-summary.service';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import { findOrThrow } from '@api/shared/utils/find-or-throw/find-or-throw.util';
+import { BatchItemStatus, BatchStatus, PostStatus } from '@genfeedai/enums';
+import type { IBatchSummary } from '@genfeedai/interfaces';
+import { LoggerService } from '@libs/logger/logger.service';
+import { BadRequestException, Injectable } from '@nestjs/common';
+
+@Injectable()
+export class BatchGenerationProcessingService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly logger: LoggerService,
+    private readonly postsService: PostsService,
+    private readonly contentGeneratorService: ContentGeneratorService,
+    private readonly summaryService: BatchGenerationSummaryService,
+  ) {}
+
+  async processBatch(
+    batchId: string,
+    orgId: string,
+    options?: BatchProcessOptions,
+  ): Promise<IBatchSummary> {
+    // Idempotency guard: atomically transition PENDING → GENERATING.
+    // If two concurrent calls race, exactly one updateMany will match (count=1);
+    // the other gets count=0 and exits early, preventing duplicate processing.
+    const claimed = await this.prisma.batch.updateMany({
+      data: { status: BatchStatus.GENERATING as never },
+      where: {
+        id: batchId,
+        isDeleted: false,
+        organizationId: orgId,
+        status: BatchStatus.PENDING as never,
+      },
+    });
+
+    if (claimed.count === 0) {
+      // Either the batch doesn't exist for this org, or it's already being processed.
+      const existing = await this.prisma.batch.findFirst({
+        where: { id: batchId, isDeleted: false, organizationId: orgId },
+      });
+      if (!existing) {
+        throw new NotFoundException('Batch', batchId);
+      }
+      // Already generating or completed — return early without re-processing.
+      throw new BadRequestException(
+        `Batch ${batchId} is already being processed (status: ${String(existing.status)})`,
+      );
+    }
+
+    const batchRecord = (await findOrThrow(
+      this.prisma.batch,
+      { where: { id: batchId, isDeleted: false, organizationId: orgId } },
+      'Batch',
+      batchId,
+    )) as BatchWithConfig;
+
+    const batchConfig = (batchRecord.config ?? {}) as BatchConfig;
+    const batchItems = cloneBatchItems(batchRecord.items);
+
+    await options?.onBatchStarted?.({
+      batchId,
+      totalCount: batchConfig.totalCount ?? batchItems.length,
+    });
+
+    const { completedCount, failedCount } = await this.processItems(
+      batchId,
+      orgId,
+      batchRecord,
+      batchConfig,
+      batchItems,
+      options,
+    );
+
+    const totalCount = batchConfig.totalCount ?? batchItems.length;
+    const finalStatus =
+      failedCount === 0 && completedCount === totalCount
+        ? BatchStatus.COMPLETED
+        : completedCount > 0
+          ? BatchStatus.PARTIAL
+          : BatchStatus.FAILED;
+    const updatedConfig: BatchConfig = {
+      ...batchConfig,
+      completedAt:
+        finalStatus === BatchStatus.COMPLETED
+          ? new Date().toISOString()
+          : undefined,
+      completedCount,
+      failedCount,
+    };
+
+    const updatedBatch = (await this.prisma.batch.update({
+      data: {
+        config: updatedConfig as never,
+        items: batchItems as never,
+        status: finalStatus as never,
+      },
+      where: { id: batchId },
+    })) as BatchWithConfig;
+
+    this.logger.log(`Batch processing complete: ${batchId}`, {
+      batchId,
+      completedCount,
+      failedCount,
+      status: finalStatus,
+    });
+    await options?.onBatchCompleted?.({
+      batchId,
+      completedCount,
+      failedCount,
+      status: finalStatus,
+      totalCount,
+    });
+    return this.summaryService.toBatchSummary(updatedBatch);
+  }
+
+  private async processItems(
+    batchId: string,
+    orgId: string,
+    batchRecord: BatchWithConfig,
+    batchConfig: BatchConfig,
+    batchItems: BatchItemFull[],
+    options?: BatchProcessOptions,
+  ): Promise<{ completedCount: number; failedCount: number }> {
+    let completedCount = 0;
+    let failedCount = 0;
+    for (let i = 0; i < batchItems.length; i++) {
+      const item = batchItems[i];
+
+      if (item.status !== BatchItemStatus.PENDING) {
+        continue;
+      }
+
+      try {
+        item.status = BatchItemStatus.GENERATING;
+
+        const topics = batchConfig.topics ?? [];
+        const topic =
+          topics.length > 0
+            ? topics[i % topics.length]
+            : `${item.format} content`;
+
+        await options?.onItemStarted?.({
+          batchId,
+          completedCount,
+          failedCount,
+          index: i,
+          item,
+          topic,
+          totalCount: batchConfig.totalCount ?? batchItems.length,
+        });
+
+        const generated = await this.contentGeneratorService.generateContent(
+          orgId,
+          {
+            additionalContext: batchConfig.style
+              ? [batchConfig.style]
+              : undefined,
+            brandId: batchRecord.brandId ?? undefined,
+            platform: item.platform as never,
+            topic,
+            variationsCount: 1,
+          },
+        );
+
+        const content = generated[0];
+        item.prompt = content?.content ?? topic;
+        item.caption = content?.content ?? '';
+
+        // Create a draft post as placeholder
+        const post = await this.postsService.create({
+          brand: batchRecord.brandId,
+          credential: undefined as never,
+          description: item.caption,
+          ingredients: [],
+          label: `Batch: ${topic}`,
+          organization: orgId,
+          platform: item.platform as never,
+          scheduledDate: item.scheduledDate
+            ? new Date(item.scheduledDate)
+            : undefined,
+          status: PostStatus.DRAFT,
+          user: batchRecord.userId,
+        } as never);
+
+        const postId = String((post as Record<string, unknown>).id ?? post.id);
+        item.postId = postId;
+        item.status = BatchItemStatus.COMPLETED;
+        completedCount++;
+
+        await options?.onItemCompleted?.({
+          batchId,
+          completedCount,
+          failedCount,
+          index: i,
+          item,
+          postId,
+          previewText: item.caption,
+          topic,
+          totalCount: batchConfig.totalCount ?? batchItems.length,
+        });
+      } catch (error: unknown) {
+        item.status = BatchItemStatus.FAILED;
+        item.error = error instanceof Error ? error.message : 'Unknown error';
+        failedCount++;
+
+        this.logger.error(`Batch item ${item._id} failed: ${item.error}`, {
+          batchId,
+          itemId: item._id,
+        });
+
+        const topics = batchConfig.topics ?? [];
+        await options?.onItemFailed?.({
+          batchId,
+          completedCount,
+          error: item.error,
+          failedCount,
+          index: i,
+          item,
+          topic:
+            topics.length > 0
+              ? topics[i % topics.length]
+              : `${item.format} content`,
+          totalCount: batchConfig.totalCount ?? batchItems.length,
+        });
+      }
+    }
+    return { completedCount, failedCount };
+  }
+}

--- a/apps/server/api/src/services/batch-generation/batch-generation-processing.service.ts
+++ b/apps/server/api/src/services/batch-generation/batch-generation-processing.service.ts
@@ -131,7 +131,7 @@ export class BatchGenerationProcessingService {
 
     if (finalized.count !== 1) {
       const currentBatch = await this.findScopedBatch(batchId, orgId);
-      if (currentBatch.status === BatchStatus.CANCELLED) {
+      if (String(currentBatch.status) === BatchStatus.CANCELLED) {
         return this.summaryService.toBatchSummary(currentBatch);
       }
       throw new BadRequestException(
@@ -319,7 +319,7 @@ export class BatchGenerationProcessingService {
         organizationId: orgId,
       },
     });
-    return batch?.status === BatchStatus.GENERATING;
+    return String(batch?.status) === BatchStatus.GENERATING;
   }
 
   private async invokeLifecycleCallback(

--- a/apps/server/api/src/services/batch-generation/batch-generation-processing.service.ts
+++ b/apps/server/api/src/services/batch-generation/batch-generation-processing.service.ts
@@ -16,6 +16,12 @@ import type { IBatchSummary } from '@genfeedai/interfaces';
 import { LoggerService } from '@libs/logger/logger.service';
 import { BadRequestException, Injectable } from '@nestjs/common';
 
+type BatchProcessingCounts = {
+  cancelled: boolean;
+  completedCount: number;
+  failedCount: number;
+};
+
 @Injectable()
 export class BatchGenerationProcessingService {
   constructor(
@@ -68,12 +74,17 @@ export class BatchGenerationProcessingService {
     const batchConfig = (batchRecord.config ?? {}) as BatchConfig;
     const batchItems = cloneBatchItems(batchRecord.items);
 
-    await options?.onBatchStarted?.({
-      batchId,
-      totalCount: batchConfig.totalCount ?? batchItems.length,
-    });
+    await this.invokeLifecycleCallback(
+      'onBatchStarted',
+      () =>
+        options?.onBatchStarted?.({
+          batchId,
+          totalCount: batchConfig.totalCount ?? batchItems.length,
+        }),
+      { batchId },
+    );
 
-    const { completedCount, failedCount } = await this.processItems(
+    const { cancelled, completedCount, failedCount } = await this.processItems(
       batchId,
       orgId,
       batchRecord,
@@ -81,6 +92,11 @@ export class BatchGenerationProcessingService {
       batchItems,
       options,
     );
+
+    if (cancelled) {
+      const cancelledBatch = await this.findScopedBatch(batchId, orgId);
+      return this.summaryService.toBatchSummary(cancelledBatch);
+    }
 
     const totalCount = batchConfig.totalCount ?? batchItems.length;
     const finalStatus =
@@ -99,14 +115,31 @@ export class BatchGenerationProcessingService {
       failedCount,
     };
 
-    const updatedBatch = (await this.prisma.batch.update({
+    const finalized = await this.prisma.batch.updateMany({
       data: {
         config: updatedConfig as never,
         items: batchItems as never,
         status: finalStatus as never,
       },
-      where: { id: batchId },
-    })) as BatchWithConfig;
+      where: {
+        id: batchId,
+        isDeleted: false,
+        organizationId: orgId,
+        status: BatchStatus.GENERATING as never,
+      },
+    });
+
+    if (finalized.count !== 1) {
+      const currentBatch = await this.findScopedBatch(batchId, orgId);
+      if (currentBatch.status === BatchStatus.CANCELLED) {
+        return this.summaryService.toBatchSummary(currentBatch);
+      }
+      throw new BadRequestException(
+        `Batch ${batchId} changed state while processing`,
+      );
+    }
+
+    const updatedBatch = await this.findScopedBatch(batchId, orgId);
 
     this.logger.log(`Batch processing complete: ${batchId}`, {
       batchId,
@@ -114,13 +147,18 @@ export class BatchGenerationProcessingService {
       failedCount,
       status: finalStatus,
     });
-    await options?.onBatchCompleted?.({
-      batchId,
-      completedCount,
-      failedCount,
-      status: finalStatus,
-      totalCount,
-    });
+    await this.invokeLifecycleCallback(
+      'onBatchCompleted',
+      () =>
+        options?.onBatchCompleted?.({
+          batchId,
+          completedCount,
+          failedCount,
+          status: finalStatus,
+          totalCount,
+        }),
+      { batchId },
+    );
     return this.summaryService.toBatchSummary(updatedBatch);
   }
 
@@ -131,10 +169,14 @@ export class BatchGenerationProcessingService {
     batchConfig: BatchConfig,
     batchItems: BatchItemFull[],
     options?: BatchProcessOptions,
-  ): Promise<{ completedCount: number; failedCount: number }> {
+  ): Promise<BatchProcessingCounts> {
     let completedCount = 0;
     let failedCount = 0;
     for (let i = 0; i < batchItems.length; i++) {
+      if (!(await this.isBatchGenerating(batchId, orgId))) {
+        return { cancelled: true, completedCount, failedCount };
+      }
+
       const item = batchItems[i];
 
       if (item.status !== BatchItemStatus.PENDING) {
@@ -150,15 +192,20 @@ export class BatchGenerationProcessingService {
             ? topics[i % topics.length]
             : `${item.format} content`;
 
-        await options?.onItemStarted?.({
-          batchId,
-          completedCount,
-          failedCount,
-          index: i,
-          item,
-          topic,
-          totalCount: batchConfig.totalCount ?? batchItems.length,
-        });
+        await this.invokeLifecycleCallback(
+          'onItemStarted',
+          () =>
+            options?.onItemStarted?.({
+              batchId,
+              completedCount,
+              failedCount,
+              index: i,
+              item,
+              topic,
+              totalCount: batchConfig.totalCount ?? batchItems.length,
+            }),
+          { batchId, itemId: item._id },
+        );
 
         const generated = await this.contentGeneratorService.generateContent(
           orgId,
@@ -198,17 +245,22 @@ export class BatchGenerationProcessingService {
         item.status = BatchItemStatus.COMPLETED;
         completedCount++;
 
-        await options?.onItemCompleted?.({
-          batchId,
-          completedCount,
-          failedCount,
-          index: i,
-          item,
-          postId,
-          previewText: item.caption,
-          topic,
-          totalCount: batchConfig.totalCount ?? batchItems.length,
-        });
+        await this.invokeLifecycleCallback(
+          'onItemCompleted',
+          () =>
+            options?.onItemCompleted?.({
+              batchId,
+              completedCount,
+              failedCount,
+              index: i,
+              item,
+              postId,
+              previewText: item.caption,
+              topic,
+              totalCount: batchConfig.totalCount ?? batchItems.length,
+            }),
+          { batchId, itemId: item._id },
+        );
       } catch (error: unknown) {
         item.status = BatchItemStatus.FAILED;
         item.error = error instanceof Error ? error.message : 'Unknown error';
@@ -220,21 +272,70 @@ export class BatchGenerationProcessingService {
         });
 
         const topics = batchConfig.topics ?? [];
-        await options?.onItemFailed?.({
-          batchId,
-          completedCount,
-          error: item.error,
-          failedCount,
-          index: i,
-          item,
-          topic:
-            topics.length > 0
-              ? topics[i % topics.length]
-              : `${item.format} content`,
-          totalCount: batchConfig.totalCount ?? batchItems.length,
-        });
+        await this.invokeLifecycleCallback(
+          'onItemFailed',
+          () =>
+            options?.onItemFailed?.({
+              batchId,
+              completedCount,
+              error: item.error,
+              failedCount,
+              index: i,
+              item,
+              topic:
+                topics.length > 0
+                  ? topics[i % topics.length]
+                  : `${item.format} content`,
+              totalCount: batchConfig.totalCount ?? batchItems.length,
+            }),
+          { batchId, itemId: item._id },
+        );
       }
     }
-    return { completedCount, failedCount };
+    return { cancelled: false, completedCount, failedCount };
+  }
+
+  private async findScopedBatch(
+    batchId: string,
+    orgId: string,
+  ): Promise<BatchWithConfig> {
+    return (await findOrThrow(
+      this.prisma.batch,
+      { where: { id: batchId, isDeleted: false, organizationId: orgId } },
+      'Batch',
+      batchId,
+    )) as BatchWithConfig;
+  }
+
+  private async isBatchGenerating(
+    batchId: string,
+    orgId: string,
+  ): Promise<boolean> {
+    const batch = await this.prisma.batch.findFirst({
+      select: { status: true },
+      where: {
+        id: batchId,
+        isDeleted: false,
+        organizationId: orgId,
+      },
+    });
+    return batch?.status === BatchStatus.GENERATING;
+  }
+
+  private async invokeLifecycleCallback(
+    callbackName: string,
+    callback: (() => Promise<void> | void) | undefined,
+    context: Record<string, unknown>,
+  ): Promise<void> {
+    if (!callback) return;
+
+    try {
+      await callback();
+    } catch (error: unknown) {
+      this.logger.error(`Batch lifecycle callback ${callbackName} failed`, {
+        ...context,
+        error,
+      });
+    }
   }
 }

--- a/apps/server/api/src/services/batch-generation/batch-generation-review.service.ts
+++ b/apps/server/api/src/services/batch-generation/batch-generation-review.service.ts
@@ -139,10 +139,8 @@ export class BatchGenerationReviewService {
     ]);
 
     return {
-      items: await Promise.all(
-        batches.map((b) =>
-          this.summaryService.toBatchSummary(b as BatchWithConfig),
-        ),
+      items: await this.summaryService.toBatchSummaries(
+        batches as BatchWithConfig[],
       ),
       total,
     };
@@ -273,10 +271,23 @@ export class BatchGenerationReviewService {
         });
       }
 
-      return (await transaction.batch.update({
+      const batchUpdate = await transaction.batch.updateMany({
         data: { items: batchItems as never },
-        where: { id: batchId },
-      })) as BatchWithConfig;
+        where: { id: batchId, isDeleted: false, organizationId: orgId },
+      });
+      if (batchUpdate.count !== 1) {
+        throw new NotFoundException({
+          message: `Batch ${batchId} disappeared before approval completed`,
+        });
+      }
+
+      const updated = await transaction.batch.findFirst({
+        where: { id: batchId, isDeleted: false, organizationId: orgId },
+      });
+      if (!updated) {
+        throw new NotFoundException('Batch', batchId);
+      }
+      return updated as BatchWithConfig;
     });
 
     this.logger.log(`Approved ${itemIds.length} items in batch ${batchId}`, {
@@ -368,10 +379,19 @@ export class BatchGenerationReviewService {
       );
     }
 
-    const updatedBatch = (await this.prisma.batch.update({
+    const batchUpdate = await this.prisma.batch.updateMany({
       data: { items: batchItems as never },
-      where: { id: batchId },
-    })) as BatchWithConfig;
+      where: { id: batchId, isDeleted: false, organizationId: orgId },
+    });
+    if (batchUpdate.count !== 1) {
+      throw new NotFoundException('Batch', batchId);
+    }
+    const updatedBatch = (await findOrThrow(
+      this.prisma.batch,
+      { where: { id: batchId, isDeleted: false, organizationId: orgId } },
+      'Batch',
+      batchId,
+    )) as BatchWithConfig;
 
     this.logger.log(`Rejected ${itemIds.length} items in batch ${batchId}`, {
       batchId,
@@ -445,10 +465,19 @@ export class BatchGenerationReviewService {
       );
     }
 
-    const updatedBatch = (await this.prisma.batch.update({
+    const batchUpdate = await this.prisma.batch.updateMany({
       data: { items: batchItems as never },
-      where: { id: batchId },
-    })) as BatchWithConfig;
+      where: { id: batchId, isDeleted: false, organizationId: orgId },
+    });
+    if (batchUpdate.count !== 1) {
+      throw new NotFoundException('Batch', batchId);
+    }
+    const updatedBatch = (await findOrThrow(
+      this.prisma.batch,
+      { where: { id: batchId, isDeleted: false, organizationId: orgId } },
+      'Batch',
+      batchId,
+    )) as BatchWithConfig;
 
     this.logger.log(
       `Requested changes for ${itemIds.length} items in batch ${batchId}`,
@@ -477,13 +506,22 @@ export class BatchGenerationReviewService {
           : item.status,
     }));
 
-    const updatedBatch = (await this.prisma.batch.update({
+    const batchUpdate = await this.prisma.batch.updateMany({
       data: {
         items: batchItems as never,
         status: BatchStatus.CANCELLED as never,
       },
-      where: { id: batchId },
-    })) as BatchWithConfig;
+      where: { id: batchId, isDeleted: false, organizationId: orgId },
+    });
+    if (batchUpdate.count !== 1) {
+      throw new NotFoundException('Batch', batchId);
+    }
+    const updatedBatch = (await findOrThrow(
+      this.prisma.batch,
+      { where: { id: batchId, isDeleted: false, organizationId: orgId } },
+      'Batch',
+      batchId,
+    )) as BatchWithConfig;
 
     this.logger.log(`Batch cancelled: ${batchId}`, { batchId });
 
@@ -511,12 +549,25 @@ export class BatchGenerationReviewService {
       batchId,
     );
 
-    const updatedBatch = (await this.prisma.batch.update({
+    const batchUpdate = await this.prisma.batch.updateMany({
       data: {
         status: dto.status as never,
       },
-      where: { id: batchRecord.id },
-    })) as BatchWithConfig;
+      where: {
+        id: batchRecord.id,
+        isDeleted: false,
+        organizationId: orgId,
+      },
+    });
+    if (batchUpdate.count !== 1) {
+      throw new NotFoundException('Batch', batchId);
+    }
+    const updatedBatch = (await findOrThrow(
+      this.prisma.batch,
+      { where: { id: batchId, isDeleted: false, organizationId: orgId } },
+      'Batch',
+      batchId,
+    )) as BatchWithConfig;
 
     return this.summaryService.toBatchSummary(updatedBatch);
   }

--- a/apps/server/api/src/services/batch-generation/batch-generation-review.service.ts
+++ b/apps/server/api/src/services/batch-generation/batch-generation-review.service.ts
@@ -1,0 +1,523 @@
+import { PublishApprovalsService } from '@api/collections/publish-approvals/services/publish-approvals.service';
+import { NotFoundException } from '@api/helpers/exceptions/http/not-found.exception';
+import {
+  type BatchItemFull,
+  type BatchWithConfig,
+  cloneBatchItems,
+  type ReviewInboxItemSummary,
+  type ReviewInboxSummary,
+} from '@api/services/batch-generation/batch-generation.types';
+import { BatchGenerationSummaryService } from '@api/services/batch-generation/batch-generation-summary.service';
+import { UpdateBatchDto } from '@api/services/batch-generation/dto/update-batch.dto';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import { findOrThrow } from '@api/shared/utils/find-or-throw/find-or-throw.util';
+import { BatchItemStatus, BatchStatus, PostStatus } from '@genfeedai/enums';
+import type { IBatchSummary, IPublishApproval } from '@genfeedai/interfaces';
+import { AgentArtifactReferenceService } from '@genfeedai/server';
+import { LoggerService } from '@libs/logger/logger.service';
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class BatchGenerationReviewService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly logger: LoggerService,
+    private readonly agentArtifactReferenceService: AgentArtifactReferenceService,
+    private readonly publishApprovalsService: PublishApprovalsService,
+    private readonly summaryService: BatchGenerationSummaryService,
+  ) {}
+
+  async getReviewInboxSummary(
+    orgId: string,
+    brandId?: string,
+    limit = 5,
+  ): Promise<ReviewInboxSummary> {
+    const batches = (await this.prisma.batch.findMany({
+      where: {
+        isDeleted: false,
+        organizationId: orgId,
+        ...(brandId ? { brandId } : {}),
+      },
+    })) as BatchWithConfig[];
+
+    let approvedCount = 0;
+    let rejectedCount = 0;
+    let changesRequestedCount = 0;
+    let pendingCount = 0;
+    let readyCount = 0;
+    const readyItems: ReviewInboxItemSummary[] = [];
+
+    for (const batch of batches) {
+      const batchItems = cloneBatchItems(batch.items);
+      for (const item of batchItems) {
+        const decision = item.reviewDecision;
+        const status = item.status;
+
+        if (decision === 'approved') {
+          approvedCount++;
+        } else if (decision === 'rejected') {
+          rejectedCount++;
+        } else if (decision === 'request_changes') {
+          changesRequestedCount++;
+        } else if (
+          status === BatchItemStatus.GENERATING ||
+          status === BatchItemStatus.PENDING
+        ) {
+          pendingCount++;
+        } else if (status === BatchItemStatus.COMPLETED && !decision) {
+          readyCount++;
+          readyItems.push({
+            batchId: batch.id,
+            createdAt: item.createdAt ?? batch.createdAt.toISOString(),
+            format: item.format,
+            id: item._id,
+            mediaUrl: item.mediaUrl,
+            platform: item.platform,
+            postId: item.postId,
+            reviewDecision: undefined,
+            status: item.status,
+            summary:
+              item.caption ??
+              item.prompt ??
+              `${item.format.charAt(0).toUpperCase()}${item.format.slice(1)} ready for review`,
+          });
+        }
+      }
+    }
+
+    // Sort ready items by createdAt desc, take limit
+    readyItems.sort(
+      (a, b) =>
+        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+    );
+    const recentItems = readyItems.slice(0, Math.max(1, Math.min(limit, 10)));
+
+    return {
+      approvedCount,
+      changesRequestedCount,
+      pendingCount,
+      readyCount,
+      recentItems,
+      rejectedCount,
+    };
+  }
+
+  async getBatch(batchId: string, orgId: string): Promise<IBatchSummary> {
+    const batch = (await findOrThrow(
+      this.prisma.batch,
+      { where: { id: batchId, isDeleted: false, organizationId: orgId } },
+      'Batch',
+      batchId,
+    )) as BatchWithConfig;
+
+    return this.summaryService.toBatchSummary(batch);
+  }
+
+  async getBatches(
+    orgId: string,
+    query?: { status?: BatchStatus; limit?: number; offset?: number },
+  ): Promise<{ items: IBatchSummary[]; total: number }> {
+    const limit = Math.min(query?.limit ?? 20, 100);
+    const offset = query?.offset ?? 0;
+
+    const where: Record<string, unknown> = {
+      isDeleted: false,
+      organizationId: orgId,
+    };
+    if (query?.status) {
+      where.status = query.status;
+    }
+
+    const [batches, total] = await Promise.all([
+      this.prisma.batch.findMany({
+        orderBy: { createdAt: 'desc' },
+        skip: offset,
+        take: limit,
+        where: where as never,
+      }),
+      this.prisma.batch.count({ where: where as never }),
+    ]);
+
+    return {
+      items: await Promise.all(
+        batches.map((b) =>
+          this.summaryService.toBatchSummary(b as BatchWithConfig),
+        ),
+      ),
+      total,
+    };
+  }
+
+  async approveItems(
+    batchId: string,
+    itemIds: string[],
+    orgId: string,
+    createdByUserId: string,
+  ): Promise<IBatchSummary> {
+    const batchRecord = await findOrThrow(
+      this.prisma.batch,
+      { where: { id: batchId, isDeleted: false, organizationId: orgId } },
+      'Batch',
+      batchId,
+    );
+
+    const itemIdSet = new Set(itemIds);
+    const reviewedAt = new Date().toISOString();
+
+    const batchItems = cloneBatchItems(batchRecord.items);
+    const selectedPostIds = this.getSelectedPostIds(batchItems, itemIdSet);
+    const updatedBatch = await this.prisma.$transaction(async (transaction) => {
+      const versionPinIds = new Map<string, string>();
+      const publishApprovals = new Map<string, IPublishApproval>();
+
+      for (const postId of selectedPostIds) {
+        const item = batchItems.find(
+          (candidate) => candidate.postId === postId,
+        );
+        if (item?.scheduledDate) {
+          const approval =
+            await this.publishApprovalsService.createForCurrentPost({
+              actorUserId: createdByUserId,
+              mode: 'scheduled',
+              organizationId: orgId,
+              postId,
+              provenance: {
+                batchId,
+                reviewItemId: item._id,
+                surface: 'review-queue',
+              },
+              transaction,
+            });
+          publishApprovals.set(postId, approval);
+          versionPinIds.set(postId, approval.artifactVersionPinId);
+        } else {
+          const versionPin =
+            await this.agentArtifactReferenceService.createOrReuseVersionPin({
+              createdByUserId,
+              reference: {
+                ...(batchRecord.brandId
+                  ? { brandId: batchRecord.brandId }
+                  : {}),
+                kind: 'post',
+                organizationId: orgId,
+                recordId: postId,
+                serializer: 'post',
+              },
+              transaction,
+            });
+          versionPinIds.set(postId, versionPin.id);
+        }
+      }
+
+      const postIdsToSchedule: string[] = [];
+
+      for (const item of batchItems) {
+        if (
+          itemIdSet.has(item._id) &&
+          item.status === BatchItemStatus.COMPLETED
+        ) {
+          const versionPinId = item.postId
+            ? versionPinIds.get(item.postId)
+            : undefined;
+          item.reviewDecision = 'approved';
+          item.publishApproval = item.postId
+            ? publishApprovals.get(item.postId)
+            : undefined;
+          item.reviewFeedback = undefined;
+          item.versionPinId = versionPinId;
+          item.reviewedAt = reviewedAt;
+          item.reviewEvents = [
+            ...(item.reviewEvents ?? []),
+            {
+              decision: 'approved',
+              reviewedAt,
+              ...(versionPinId ? { versionPinId } : {}),
+            },
+          ];
+          if (item.postId && item.scheduledDate) {
+            postIdsToSchedule.push(item.postId);
+          }
+        }
+      }
+
+      const approvalUpdates = await Promise.all(
+        selectedPostIds.map((postId) =>
+          transaction.post.updateMany({
+            data: {
+              reviewDecision: 'APPROVED' as never,
+              reviewVersionPinId: versionPinIds.get(postId),
+              reviewedAt: new Date(reviewedAt),
+            },
+            where: {
+              id: postId,
+              isDeleted: false,
+              organizationId: orgId,
+            },
+          }),
+        ),
+      );
+      if (approvalUpdates.some((result) => result.count !== 1)) {
+        throw new NotFoundException({
+          message: 'A canonical Post disappeared before approval completed.',
+        });
+      }
+
+      if (postIdsToSchedule.length > 0) {
+        await transaction.post.updateMany({
+          data: { status: PostStatus.SCHEDULED as never },
+          where: {
+            id: { in: postIdsToSchedule },
+            isDeleted: false,
+            organizationId: orgId,
+          },
+        });
+      }
+
+      return (await transaction.batch.update({
+        data: { items: batchItems as never },
+        where: { id: batchId },
+      })) as BatchWithConfig;
+    });
+
+    this.logger.log(`Approved ${itemIds.length} items in batch ${batchId}`, {
+      batchId,
+      itemCount: itemIds.length,
+    });
+
+    return this.summaryService.toBatchSummary(updatedBatch);
+  }
+
+  private getSelectedPostIds(
+    batchItems: BatchItemFull[],
+    itemIdSet: Set<string>,
+  ): string[] {
+    return [
+      ...new Set(
+        batchItems
+          .filter(
+            (item) =>
+              itemIdSet.has(item._id) &&
+              item.status === BatchItemStatus.COMPLETED &&
+              Boolean(item.postId),
+          )
+          .flatMap((item) => (item.postId ? [item.postId] : [])),
+      ),
+    ];
+  }
+
+  async rejectItems(
+    batchId: string,
+    itemIds: string[],
+    orgId: string,
+    feedback?: string,
+    actorUserId?: string,
+  ): Promise<IBatchSummary> {
+    const batchRecord = await findOrThrow(
+      this.prisma.batch,
+      { where: { id: batchId, isDeleted: false, organizationId: orgId } },
+      'Batch',
+      batchId,
+    );
+
+    const itemIdSet = new Set(itemIds);
+    const postIdsToReject: string[] = [];
+    const reviewedAt = new Date().toISOString();
+
+    const batchItems = cloneBatchItems(batchRecord.items);
+
+    for (const item of batchItems) {
+      if (itemIdSet.has(item._id)) {
+        item.status = BatchItemStatus.SKIPPED;
+        item.reviewDecision = 'rejected';
+        item.reviewFeedback = feedback;
+        item.reviewedAt = reviewedAt;
+        item.reviewEvents = [
+          ...(item.reviewEvents ?? []),
+          { decision: 'rejected', feedback, reviewedAt },
+        ];
+        if (item.postId) {
+          postIdsToReject.push(item.postId);
+        }
+      }
+    }
+
+    if (postIdsToReject.length > 0) {
+      // Soft-delete rejected posts
+      await this.prisma.post.updateMany({
+        data: {
+          isDeleted: true,
+          reviewDecision: 'REJECTED' as never,
+          reviewedAt: new Date(reviewedAt),
+          reviewFeedback: feedback,
+        },
+        where: {
+          id: { in: postIdsToReject },
+          isDeleted: false,
+          organizationId: orgId,
+        },
+      });
+      await Promise.all(
+        postIdsToReject.map((postId) =>
+          this.publishApprovalsService.invalidatePost(
+            orgId,
+            postId,
+            'The review item was rejected.',
+            actorUserId,
+          ),
+        ),
+      );
+    }
+
+    const updatedBatch = (await this.prisma.batch.update({
+      data: { items: batchItems as never },
+      where: { id: batchId },
+    })) as BatchWithConfig;
+
+    this.logger.log(`Rejected ${itemIds.length} items in batch ${batchId}`, {
+      batchId,
+      itemCount: itemIds.length,
+    });
+
+    return this.summaryService.toBatchSummary(updatedBatch);
+  }
+
+  async requestChanges(
+    batchId: string,
+    itemIds: string[],
+    orgId: string,
+    feedback?: string,
+    actorUserId?: string,
+  ): Promise<IBatchSummary> {
+    const batchRecord = await findOrThrow(
+      this.prisma.batch,
+      { where: { id: batchId, isDeleted: false, organizationId: orgId } },
+      'Batch',
+      batchId,
+    );
+
+    const itemIdSet = new Set(itemIds);
+    const postIdsToKeepAsDraft: string[] = [];
+    const reviewedAt = new Date().toISOString();
+
+    const batchItems = cloneBatchItems(batchRecord.items);
+
+    for (const item of batchItems) {
+      if (
+        itemIdSet.has(item._id) &&
+        item.status === BatchItemStatus.COMPLETED
+      ) {
+        item.reviewDecision = 'request_changes';
+        item.reviewFeedback = feedback;
+        item.reviewedAt = reviewedAt;
+        item.reviewEvents = [
+          ...(item.reviewEvents ?? []),
+          { decision: 'request_changes', feedback, reviewedAt },
+        ];
+        if (item.postId) {
+          postIdsToKeepAsDraft.push(item.postId);
+        }
+      }
+    }
+
+    if (postIdsToKeepAsDraft.length > 0) {
+      await this.prisma.post.updateMany({
+        data: {
+          reviewDecision: 'REQUEST_CHANGES' as never,
+          reviewedAt: new Date(reviewedAt),
+          reviewFeedback: feedback,
+          status: PostStatus.DRAFT as never,
+        },
+        where: {
+          id: { in: postIdsToKeepAsDraft },
+          isDeleted: false,
+          organizationId: orgId,
+        },
+      });
+      await Promise.all(
+        postIdsToKeepAsDraft.map((postId) =>
+          this.publishApprovalsService.invalidatePost(
+            orgId,
+            postId,
+            'Changes were requested for the approved version.',
+            actorUserId,
+          ),
+        ),
+      );
+    }
+
+    const updatedBatch = (await this.prisma.batch.update({
+      data: { items: batchItems as never },
+      where: { id: batchId },
+    })) as BatchWithConfig;
+
+    this.logger.log(
+      `Requested changes for ${itemIds.length} items in batch ${batchId}`,
+      {
+        batchId,
+        itemCount: itemIds.length,
+      },
+    );
+
+    return this.summaryService.toBatchSummary(updatedBatch);
+  }
+
+  async cancelBatch(batchId: string, orgId: string): Promise<IBatchSummary> {
+    const batchRecord = await findOrThrow(
+      this.prisma.batch,
+      { where: { id: batchId, isDeleted: false, organizationId: orgId } },
+      'Batch',
+      batchId,
+    );
+
+    const batchItems = cloneBatchItems(batchRecord.items).map((item) => ({
+      ...item,
+      status:
+        item.status === BatchItemStatus.PENDING
+          ? BatchItemStatus.SKIPPED
+          : item.status,
+    }));
+
+    const updatedBatch = (await this.prisma.batch.update({
+      data: {
+        items: batchItems as never,
+        status: BatchStatus.CANCELLED as never,
+      },
+      where: { id: batchId },
+    })) as BatchWithConfig;
+
+    this.logger.log(`Batch cancelled: ${batchId}`, { batchId });
+
+    return this.summaryService.toBatchSummary(updatedBatch);
+  }
+
+  /**
+   * Update a batch by ID. Status transitions to CANCELLED are routed
+   * through cancelBatch() to preserve its guard (tenant-scoped existence
+   * check via findOrThrow) and cascade (marking pending items as skipped).
+   */
+  async updateBatch(
+    batchId: string,
+    dto: UpdateBatchDto,
+    orgId: string,
+  ): Promise<IBatchSummary> {
+    if (dto.status === BatchStatus.CANCELLED) {
+      return this.cancelBatch(batchId, orgId);
+    }
+
+    const batchRecord = await findOrThrow(
+      this.prisma.batch,
+      { where: { id: batchId, isDeleted: false, organizationId: orgId } },
+      'Batch',
+      batchId,
+    );
+
+    const updatedBatch = (await this.prisma.batch.update({
+      data: {
+        status: dto.status as never,
+      },
+      where: { id: batchRecord.id },
+    })) as BatchWithConfig;
+
+    return this.summaryService.toBatchSummary(updatedBatch);
+  }
+}

--- a/apps/server/api/src/services/batch-generation/batch-generation-summary.service.ts
+++ b/apps/server/api/src/services/batch-generation/batch-generation-summary.service.ts
@@ -1,0 +1,215 @@
+import { PublishApprovalsService } from '@api/collections/publish-approvals/services/publish-approvals.service';
+import {
+  type BatchConfig,
+  type BatchWithConfig,
+  cloneBatchItems,
+} from '@api/services/batch-generation/batch-generation.types';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import { BatchItemStatus, BatchStatus } from '@genfeedai/enums';
+import type { IBatchSummary } from '@genfeedai/interfaces';
+import { Injectable } from '@nestjs/common';
+
+type PostAnalyticsSummary = {
+  avgEngagementRate: number;
+  totalComments: number;
+  totalLikes: number;
+  totalSaves: number;
+  totalShares: number;
+  totalViews: number;
+};
+
+type LinkedPostAnalytics = {
+  engagementRate: number;
+  postId: string;
+  totalComments: number;
+  totalLikes: number;
+  totalSaves: number;
+  totalShares: number;
+  totalViews: number;
+};
+
+@Injectable()
+export class BatchGenerationSummaryService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly publishApprovalsService: PublishApprovalsService,
+  ) {}
+
+  async toBatchSummary(batch: BatchWithConfig): Promise<IBatchSummary> {
+    const batchConfig = (batch.config ?? {}) as BatchConfig;
+    const batchItems = cloneBatchItems(batch.items);
+
+    const pendingCount = batchItems.filter(
+      (item) =>
+        item.status === BatchItemStatus.PENDING ||
+        item.status === BatchItemStatus.GENERATING,
+    ).length;
+
+    const postIds = batchItems
+      .map((item) => item.postId)
+      .filter((id): id is string => Boolean(id));
+
+    const linkedPosts =
+      postIds.length > 0
+        ? await this.prisma.post.findMany({
+            select: {
+              externalId: true,
+              generationId: true,
+              id: true,
+              lastAttemptAt: true,
+              promptUsed: true,
+              publishedAt: true,
+              retryCount: true,
+              reviewDecision: true,
+              reviewedAt: true,
+              reviewFeedback: true,
+              reviewVersionPinId: true,
+              publishApproval: true,
+              status: true,
+              url: true,
+            },
+            where: {
+              id: { in: postIds },
+              isDeleted: false,
+              organizationId: batch.organizationId,
+            },
+          })
+        : [];
+
+    const linkedAnalytics =
+      postIds.length > 0
+        ? await this.prisma.postAnalytics.findMany({
+            select: {
+              engagementRate: true,
+              postId: true,
+              totalComments: true,
+              totalLikes: true,
+              totalSaves: true,
+              totalShares: true,
+              totalViews: true,
+            },
+            where: {
+              organizationId: batch.organizationId,
+              postId: { in: postIds },
+            },
+          })
+        : [];
+
+    const analyticsMap = this.buildAnalyticsMap(linkedAnalytics);
+    const linkedPostMap = new Map(linkedPosts.map((post) => [post.id, post]));
+
+    return {
+      brandId: batch.brandId ?? '',
+      completedAt: batchConfig.completedAt,
+      completedCount: batchConfig.completedCount ?? 0,
+      contentMix: {
+        carouselPercent: batchConfig.contentMix?.carouselPercent ?? 10,
+        imagePercent: batchConfig.contentMix?.imagePercent ?? 60,
+        reelPercent: batchConfig.contentMix?.reelPercent ?? 5,
+        storyPercent: batchConfig.contentMix?.storyPercent ?? 0,
+        videoPercent: batchConfig.contentMix?.videoPercent ?? 25,
+      },
+      createdAt: batch.createdAt.toISOString(),
+      failedCount: batchConfig.failedCount ?? 0,
+      id: batch.id,
+      items: batchItems.map((item) => {
+        const linkedPost = item.postId
+          ? linkedPostMap.get(item.postId)
+          : undefined;
+        const analytics = item.postId
+          ? analyticsMap.get(item.postId)
+          : undefined;
+
+        return {
+          batchId: batch.id,
+          caption: item.caption,
+          createdAt: item.createdAt ?? batch.createdAt.toISOString(),
+          error: item.error,
+          format: item.format,
+          gateOverallScore: item.gateOverallScore,
+          gateReasons: item.gateReasons ?? [],
+          id: item._id,
+          mediaUrl: item.mediaUrl,
+          opportunitySourceType: item.opportunitySourceType,
+          opportunityTopic: item.opportunityTopic,
+          platform: item.platform,
+          postAvgEngagementRate: analytics?.avgEngagementRate,
+          postExternalId: linkedPost?.externalId ?? undefined,
+          postGenerationId: linkedPost?.generationId ?? undefined,
+          postId: item.postId,
+          postLastAttemptAt: linkedPost?.lastAttemptAt?.toISOString(),
+          postPromptUsed: linkedPost?.promptUsed ?? undefined,
+          postPublishedAt: linkedPost?.publishedAt?.toISOString(),
+          postRetryCount: linkedPost?.retryCount,
+          postStatus: linkedPost?.status
+            ? String(linkedPost.status)
+            : undefined,
+          postTotalComments: analytics?.totalComments,
+          postTotalLikes: analytics?.totalLikes,
+          postTotalSaves: analytics?.totalSaves,
+          postTotalShares: analytics?.totalShares,
+          postTotalViews: analytics?.totalViews,
+          postUrl: linkedPost?.url ?? undefined,
+          prompt: item.prompt,
+          reviewDecision: item.reviewDecision,
+          reviewEvents: (item.reviewEvents ?? []).map((event) => ({
+            decision: event.decision,
+            feedback: event.feedback,
+            reviewedAt: event.reviewedAt,
+            versionPinId: event.versionPinId,
+          })),
+          reviewedAt: item.reviewedAt,
+          reviewFeedback: item.reviewFeedback,
+          publishApproval:
+            item.publishApproval ??
+            (linkedPost?.publishApproval
+              ? this.publishApprovalsService.toPublicInterface(
+                  linkedPost.publishApproval,
+                )
+              : undefined),
+          scheduledDate: item.scheduledDate,
+          sourceActionId: item.sourceActionId,
+          sourceWorkflowId: item.sourceWorkflowId,
+          sourceWorkflowName: item.sourceWorkflowName,
+          status: item.status,
+          versionPinId:
+            item.versionPinId ?? linkedPost?.reviewVersionPinId ?? undefined,
+        };
+      }),
+      pendingCount,
+      platforms: batchConfig.platforms ?? [],
+      status: String(batch.status) as BatchStatus,
+      totalCount: batchConfig.totalCount ?? batchItems.length,
+    };
+  }
+
+  private buildAnalyticsMap(
+    linkedAnalytics: LinkedPostAnalytics[],
+  ): Map<string, PostAnalyticsSummary> {
+    const analyticsMap = new Map<string, PostAnalyticsSummary>();
+    for (const row of linkedAnalytics) {
+      const existing = analyticsMap.get(row.postId);
+      if (!existing) {
+        analyticsMap.set(row.postId, {
+          avgEngagementRate: row.engagementRate,
+          totalComments: row.totalComments,
+          totalLikes: row.totalLikes,
+          totalSaves: row.totalSaves,
+          totalShares: row.totalShares,
+          totalViews: row.totalViews,
+        });
+      } else {
+        analyticsMap.set(row.postId, {
+          avgEngagementRate:
+            (existing.avgEngagementRate + row.engagementRate) / 2,
+          totalComments: Math.max(existing.totalComments, row.totalComments),
+          totalLikes: Math.max(existing.totalLikes, row.totalLikes),
+          totalSaves: Math.max(existing.totalSaves, row.totalSaves),
+          totalShares: Math.max(existing.totalShares, row.totalShares),
+          totalViews: Math.max(existing.totalViews, row.totalViews),
+        });
+      }
+    }
+    return analyticsMap;
+  }
+}

--- a/apps/server/api/src/services/batch-generation/batch-generation-summary.service.ts
+++ b/apps/server/api/src/services/batch-generation/batch-generation-summary.service.ts
@@ -10,6 +10,7 @@ import type { IBatchSummary } from '@genfeedai/interfaces';
 import { Injectable } from '@nestjs/common';
 
 type PostAnalyticsSummary = {
+  analyticsRows: number;
   avgEngagementRate: number;
   totalComments: number;
   totalLikes: number;
@@ -36,18 +37,24 @@ export class BatchGenerationSummaryService {
   ) {}
 
   async toBatchSummary(batch: BatchWithConfig): Promise<IBatchSummary> {
-    const batchConfig = (batch.config ?? {}) as BatchConfig;
-    const batchItems = cloneBatchItems(batch.items);
+    const [summary] = await this.toBatchSummaries([batch]);
+    return summary;
+  }
 
-    const pendingCount = batchItems.filter(
-      (item) =>
-        item.status === BatchItemStatus.PENDING ||
-        item.status === BatchItemStatus.GENERATING,
-    ).length;
-
-    const postIds = batchItems
-      .map((item) => item.postId)
-      .filter((id): id is string => Boolean(id));
+  async toBatchSummaries(batches: BatchWithConfig[]): Promise<IBatchSummary[]> {
+    const batchItemsById = new Map(
+      batches.map((batch) => [batch.id, cloneBatchItems(batch.items)]),
+    );
+    const postIds = [
+      ...new Set(
+        [...batchItemsById.values()]
+          .flat()
+          .flatMap((item) => (item.postId ? [item.postId] : [])),
+      ),
+    ];
+    const organizationIds = [
+      ...new Set(batches.map((batch) => batch.organizationId)),
+    ];
 
     const linkedPosts =
       postIds.length > 0
@@ -71,7 +78,7 @@ export class BatchGenerationSummaryService {
             where: {
               id: { in: postIds },
               isDeleted: false,
-              organizationId: batch.organizationId,
+              organizationId: { in: organizationIds },
             },
           })
         : [];
@@ -89,7 +96,8 @@ export class BatchGenerationSummaryService {
               totalViews: true,
             },
             where: {
-              organizationId: batch.organizationId,
+              isDeleted: false,
+              organizationId: { in: organizationIds },
               postId: { in: postIds },
             },
           })
@@ -98,89 +106,99 @@ export class BatchGenerationSummaryService {
     const analyticsMap = this.buildAnalyticsMap(linkedAnalytics);
     const linkedPostMap = new Map(linkedPosts.map((post) => [post.id, post]));
 
-    return {
-      brandId: batch.brandId ?? '',
-      completedAt: batchConfig.completedAt,
-      completedCount: batchConfig.completedCount ?? 0,
-      contentMix: {
-        carouselPercent: batchConfig.contentMix?.carouselPercent ?? 10,
-        imagePercent: batchConfig.contentMix?.imagePercent ?? 60,
-        reelPercent: batchConfig.contentMix?.reelPercent ?? 5,
-        storyPercent: batchConfig.contentMix?.storyPercent ?? 0,
-        videoPercent: batchConfig.contentMix?.videoPercent ?? 25,
-      },
-      createdAt: batch.createdAt.toISOString(),
-      failedCount: batchConfig.failedCount ?? 0,
-      id: batch.id,
-      items: batchItems.map((item) => {
-        const linkedPost = item.postId
-          ? linkedPostMap.get(item.postId)
-          : undefined;
-        const analytics = item.postId
-          ? analyticsMap.get(item.postId)
-          : undefined;
+    return batches.map((batch) => {
+      const batchConfig = (batch.config ?? {}) as BatchConfig;
+      const batchItems = batchItemsById.get(batch.id) ?? [];
+      const pendingCount = batchItems.filter(
+        (item) =>
+          item.status === BatchItemStatus.PENDING ||
+          item.status === BatchItemStatus.GENERATING,
+      ).length;
 
-        return {
-          batchId: batch.id,
-          caption: item.caption,
-          createdAt: item.createdAt ?? batch.createdAt.toISOString(),
-          error: item.error,
-          format: item.format,
-          gateOverallScore: item.gateOverallScore,
-          gateReasons: item.gateReasons ?? [],
-          id: item._id,
-          mediaUrl: item.mediaUrl,
-          opportunitySourceType: item.opportunitySourceType,
-          opportunityTopic: item.opportunityTopic,
-          platform: item.platform,
-          postAvgEngagementRate: analytics?.avgEngagementRate,
-          postExternalId: linkedPost?.externalId ?? undefined,
-          postGenerationId: linkedPost?.generationId ?? undefined,
-          postId: item.postId,
-          postLastAttemptAt: linkedPost?.lastAttemptAt?.toISOString(),
-          postPromptUsed: linkedPost?.promptUsed ?? undefined,
-          postPublishedAt: linkedPost?.publishedAt?.toISOString(),
-          postRetryCount: linkedPost?.retryCount,
-          postStatus: linkedPost?.status
-            ? String(linkedPost.status)
-            : undefined,
-          postTotalComments: analytics?.totalComments,
-          postTotalLikes: analytics?.totalLikes,
-          postTotalSaves: analytics?.totalSaves,
-          postTotalShares: analytics?.totalShares,
-          postTotalViews: analytics?.totalViews,
-          postUrl: linkedPost?.url ?? undefined,
-          prompt: item.prompt,
-          reviewDecision: item.reviewDecision,
-          reviewEvents: (item.reviewEvents ?? []).map((event) => ({
-            decision: event.decision,
-            feedback: event.feedback,
-            reviewedAt: event.reviewedAt,
-            versionPinId: event.versionPinId,
-          })),
-          reviewedAt: item.reviewedAt,
-          reviewFeedback: item.reviewFeedback,
-          publishApproval:
-            item.publishApproval ??
-            (linkedPost?.publishApproval
-              ? this.publishApprovalsService.toPublicInterface(
-                  linkedPost.publishApproval,
-                )
-              : undefined),
-          scheduledDate: item.scheduledDate,
-          sourceActionId: item.sourceActionId,
-          sourceWorkflowId: item.sourceWorkflowId,
-          sourceWorkflowName: item.sourceWorkflowName,
-          status: item.status,
-          versionPinId:
-            item.versionPinId ?? linkedPost?.reviewVersionPinId ?? undefined,
-        };
-      }),
-      pendingCount,
-      platforms: batchConfig.platforms ?? [],
-      status: String(batch.status) as BatchStatus,
-      totalCount: batchConfig.totalCount ?? batchItems.length,
-    };
+      return {
+        brandId: batch.brandId ?? '',
+        completedAt: batchConfig.completedAt,
+        completedCount: batchConfig.completedCount ?? 0,
+        contentMix: {
+          carouselPercent: batchConfig.contentMix?.carouselPercent ?? 10,
+          imagePercent: batchConfig.contentMix?.imagePercent ?? 60,
+          reelPercent: batchConfig.contentMix?.reelPercent ?? 5,
+          storyPercent: batchConfig.contentMix?.storyPercent ?? 0,
+          videoPercent: batchConfig.contentMix?.videoPercent ?? 25,
+        },
+        createdAt: batch.createdAt.toISOString(),
+        failedCount: batchConfig.failedCount ?? 0,
+        id: batch.id,
+        items: batchItems.map((item) => {
+          const linkedPost = item.postId
+            ? linkedPostMap.get(item.postId)
+            : undefined;
+          const analytics = item.postId
+            ? analyticsMap.get(item.postId)
+            : undefined;
+
+          return {
+            batchId: batch.id,
+            caption: item.caption,
+            createdAt: item.createdAt ?? batch.createdAt.toISOString(),
+            error: item.error,
+            format: item.format,
+            gateOverallScore: item.gateOverallScore,
+            gateReasons: item.gateReasons ?? [],
+            id: item._id,
+            mediaUrl: item.mediaUrl,
+            opportunitySourceType: item.opportunitySourceType,
+            opportunityTopic: item.opportunityTopic,
+            platform: item.platform,
+            postAvgEngagementRate: analytics?.avgEngagementRate,
+            postExternalId: linkedPost?.externalId ?? undefined,
+            postGenerationId: linkedPost?.generationId ?? undefined,
+            postId: item.postId,
+            postLastAttemptAt: linkedPost?.lastAttemptAt?.toISOString(),
+            postPromptUsed: linkedPost?.promptUsed ?? undefined,
+            postPublishedAt: linkedPost?.publishedAt?.toISOString(),
+            postRetryCount: linkedPost?.retryCount,
+            postStatus: linkedPost?.status
+              ? String(linkedPost.status)
+              : undefined,
+            postTotalComments: analytics?.totalComments,
+            postTotalLikes: analytics?.totalLikes,
+            postTotalSaves: analytics?.totalSaves,
+            postTotalShares: analytics?.totalShares,
+            postTotalViews: analytics?.totalViews,
+            postUrl: linkedPost?.url ?? undefined,
+            prompt: item.prompt,
+            reviewDecision: item.reviewDecision,
+            reviewEvents: (item.reviewEvents ?? []).map((event) => ({
+              decision: event.decision,
+              feedback: event.feedback,
+              reviewedAt: event.reviewedAt,
+              versionPinId: event.versionPinId,
+            })),
+            reviewedAt: item.reviewedAt,
+            reviewFeedback: item.reviewFeedback,
+            publishApproval:
+              item.publishApproval ??
+              (linkedPost?.publishApproval
+                ? this.publishApprovalsService.toPublicInterface(
+                    linkedPost.publishApproval,
+                  )
+                : undefined),
+            scheduledDate: item.scheduledDate,
+            sourceActionId: item.sourceActionId,
+            sourceWorkflowId: item.sourceWorkflowId,
+            sourceWorkflowName: item.sourceWorkflowName,
+            status: item.status,
+            versionPinId:
+              item.versionPinId ?? linkedPost?.reviewVersionPinId ?? undefined,
+          };
+        }),
+        pendingCount,
+        platforms: batchConfig.platforms ?? [],
+        status: String(batch.status) as BatchStatus,
+        totalCount: batchConfig.totalCount ?? batchItems.length,
+      };
+    });
   }
 
   private buildAnalyticsMap(
@@ -191,6 +209,7 @@ export class BatchGenerationSummaryService {
       const existing = analyticsMap.get(row.postId);
       if (!existing) {
         analyticsMap.set(row.postId, {
+          analyticsRows: 1,
           avgEngagementRate: row.engagementRate,
           totalComments: row.totalComments,
           totalLikes: row.totalLikes,
@@ -199,9 +218,13 @@ export class BatchGenerationSummaryService {
           totalViews: row.totalViews,
         });
       } else {
+        const analyticsRows = existing.analyticsRows + 1;
         analyticsMap.set(row.postId, {
+          analyticsRows,
           avgEngagementRate:
-            (existing.avgEngagementRate + row.engagementRate) / 2,
+            (existing.avgEngagementRate * existing.analyticsRows +
+              row.engagementRate) /
+            analyticsRows,
           totalComments: Math.max(existing.totalComments, row.totalComments),
           totalLikes: Math.max(existing.totalLikes, row.totalLikes),
           totalSaves: Math.max(existing.totalSaves, row.totalSaves),

--- a/apps/server/api/src/services/batch-generation/batch-generation.module.ts
+++ b/apps/server/api/src/services/batch-generation/batch-generation.module.ts
@@ -5,6 +5,10 @@ import { PostsModule } from '@api/collections/posts/posts.module';
 import { PublishApprovalsModule } from '@api/collections/publish-approvals/publish-approvals.module';
 import { BatchGenerationController } from '@api/services/batch-generation/batch-generation.controller';
 import { BatchGenerationService } from '@api/services/batch-generation/batch-generation.service';
+import { BatchGenerationCreationService } from '@api/services/batch-generation/batch-generation-creation.service';
+import { BatchGenerationProcessingService } from '@api/services/batch-generation/batch-generation-processing.service';
+import { BatchGenerationReviewService } from '@api/services/batch-generation/batch-generation-review.service';
+import { BatchGenerationSummaryService } from '@api/services/batch-generation/batch-generation-summary.service';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import {
   AgentArtifactReferenceService,
@@ -29,7 +33,11 @@ import { forwardRef, Module } from '@nestjs/common';
   ],
   providers: [
     AgentArtifactReferenceService,
+    BatchGenerationCreationService,
+    BatchGenerationProcessingService,
+    BatchGenerationReviewService,
     BatchGenerationService,
+    BatchGenerationSummaryService,
     { provide: SERVER_TOKENS.logger, useExisting: LoggerService },
     { provide: SERVER_TOKENS.prisma, useExisting: PrismaService },
   ],

--- a/apps/server/api/src/services/batch-generation/batch-generation.service.spec.ts
+++ b/apps/server/api/src/services/batch-generation/batch-generation.service.spec.ts
@@ -4,6 +4,10 @@ import { PostsService } from '@api/collections/posts/services/posts.service';
 import { PublishApprovalsService } from '@api/collections/publish-approvals/services/publish-approvals.service';
 import { NotFoundException } from '@api/helpers/exceptions/http/not-found.exception';
 import { BatchGenerationService } from '@api/services/batch-generation/batch-generation.service';
+import { BatchGenerationCreationService } from '@api/services/batch-generation/batch-generation-creation.service';
+import { BatchGenerationProcessingService } from '@api/services/batch-generation/batch-generation-processing.service';
+import { BatchGenerationReviewService } from '@api/services/batch-generation/batch-generation-review.service';
+import { BatchGenerationSummaryService } from '@api/services/batch-generation/batch-generation-summary.service';
 import { CacheService } from '@api/services/cache/services/cache.service';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { BatchItemStatus, BatchStatus, ContentFormat } from '@genfeedai/enums';
@@ -84,7 +88,11 @@ describe('BatchGenerationService approval version pins', () => {
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
+        BatchGenerationCreationService,
+        BatchGenerationProcessingService,
+        BatchGenerationReviewService,
         BatchGenerationService,
+        BatchGenerationSummaryService,
         {
           provide: AgentArtifactReferenceService,
           useValue: artifactReferenceService,

--- a/apps/server/api/src/services/batch-generation/batch-generation.service.spec.ts
+++ b/apps/server/api/src/services/batch-generation/batch-generation.service.spec.ts
@@ -22,6 +22,7 @@ describe('BatchGenerationService approval version pins', () => {
   let batchDelegate: {
     findFirst: ReturnType<typeof vi.fn>;
     update: ReturnType<typeof vi.fn>;
+    updateMany: ReturnType<typeof vi.fn>;
   };
   let postDelegate: {
     findMany: ReturnType<typeof vi.fn>;
@@ -62,6 +63,13 @@ describe('BatchGenerationService approval version pins', () => {
           items: data.items,
         }),
       ),
+      updateMany: vi.fn().mockImplementation(({ data }) => {
+        batchDelegate.findFirst.mockResolvedValue({
+          ...batchRecord,
+          ...data,
+        });
+        return Promise.resolve({ count: 1 });
+      }),
     };
     postDelegate = {
       findMany: vi.fn().mockResolvedValue([]),
@@ -131,9 +139,6 @@ describe('BatchGenerationService approval version pins', () => {
       status: BatchItemStatus.COMPLETED,
     };
     batchDelegate.findFirst.mockResolvedValue(createBatchRecord([item]));
-    batchDelegate.update.mockImplementation(({ data }) =>
-      Promise.resolve({ ...createBatchRecord([]), items: data.items }),
-    );
 
     const result = await service.approveItems(
       'batch-1',
@@ -170,7 +175,8 @@ describe('BatchGenerationService approval version pins', () => {
       },
     });
 
-    const persistedItems = batchDelegate.update.mock.calls[0]?.[0].data.items;
+    const persistedItems =
+      batchDelegate.updateMany.mock.calls[0]?.[0].data.items;
     expect(persistedItems).toEqual([
       expect.objectContaining({
         reviewDecision: 'approved',
@@ -212,7 +218,7 @@ describe('BatchGenerationService approval version pins', () => {
     ).rejects.toThrow('Canonical Post changed.');
 
     expect(postDelegate.updateMany).not.toHaveBeenCalled();
-    expect(batchDelegate.update).not.toHaveBeenCalled();
+    expect(batchDelegate.updateMany).not.toHaveBeenCalled();
   });
 
   it('rolls back Post reference state when the batch approval write fails', async () => {
@@ -237,7 +243,9 @@ describe('BatchGenerationService approval version pins', () => {
       }),
     };
     const transactionBatch = {
+      findFirst: vi.fn(),
       update: vi.fn().mockRejectedValue(new Error('batch write failed')),
+      updateMany: vi.fn().mockRejectedValue(new Error('batch write failed')),
     };
     const transaction = {
       batch: transactionBatch,
@@ -270,7 +278,7 @@ describe('BatchGenerationService approval version pins', () => {
       }),
     );
     expect(postDelegate.updateMany).not.toHaveBeenCalled();
-    expect(batchDelegate.update).not.toHaveBeenCalled();
+    expect(batchDelegate.updateMany).not.toHaveBeenCalled();
   });
 
   it('maps a missing canonical Post to the API NotFoundException convention', async () => {
@@ -295,7 +303,7 @@ describe('BatchGenerationService approval version pins', () => {
       detail: 'A canonical Post disappeared before approval completed.',
       title: 'Resource Not Found',
     });
-    expect(batchDelegate.update).not.toHaveBeenCalled();
+    expect(batchDelegate.updateMany).not.toHaveBeenCalled();
   });
 
   it('preserves legacy approval behavior for items without a canonical Post', async () => {
@@ -320,7 +328,7 @@ describe('BatchGenerationService approval version pins', () => {
       artifactReferenceService.createOrReuseVersionPin,
     ).not.toHaveBeenCalled();
     expect(postDelegate.updateMany).not.toHaveBeenCalled();
-    expect(batchDelegate.update).toHaveBeenCalledWith({
+    expect(batchDelegate.updateMany).toHaveBeenCalledWith({
       data: {
         items: [
           expect.objectContaining({
@@ -329,7 +337,11 @@ describe('BatchGenerationService approval version pins', () => {
           }),
         ],
       },
-      where: { id: 'batch-1' },
+      where: {
+        id: 'batch-1',
+        isDeleted: false,
+        organizationId: 'org-1',
+      },
     });
   });
 

--- a/apps/server/api/src/services/batch-generation/batch-generation.service.ts
+++ b/apps/server/api/src/services/batch-generation/batch-generation.service.ts
@@ -1,1403 +1,147 @@
-import { BrandsService } from '@api/collections/brands/services/brands.service';
-import { ContentGeneratorService } from '@api/collections/content-intelligence/services/content-generator.service';
-import { PostsService } from '@api/collections/posts/services/posts.service';
-import { PublishApprovalsService } from '@api/collections/publish-approvals/services/publish-approvals.service';
 import { HandleErrors } from '@api/helpers/decorators/error-handler.decorator';
-import { NotFoundException } from '@api/helpers/exceptions/http/not-found.exception';
-import { runIdempotent } from '@api/helpers/utils/idempotency/idempotency.util';
-import { ReviewBatchItemFormat } from '@api/services/batch-generation/constants/review-batch-item-format.constant';
+import type {
+  BatchProcessOptions,
+  ReviewInboxSummary,
+} from '@api/services/batch-generation/batch-generation.types';
+import { BatchGenerationCreationService } from '@api/services/batch-generation/batch-generation-creation.service';
+import { BatchGenerationProcessingService } from '@api/services/batch-generation/batch-generation-processing.service';
+import { BatchGenerationReviewService } from '@api/services/batch-generation/batch-generation-review.service';
 import { CreateBatchDto } from '@api/services/batch-generation/dto/create-batch.dto';
 import { CreateManualReviewBatchDto } from '@api/services/batch-generation/dto/create-manual-review-batch.dto';
 import { UpdateBatchDto } from '@api/services/batch-generation/dto/update-batch.dto';
-import type { ContentMixConfig } from '@api/services/batch-generation/schemas/batch.schema';
-import { CacheService } from '@api/services/cache/services/cache.service';
-import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
-import { findOrThrow } from '@api/shared/utils/find-or-throw/find-or-throw.util';
-import {
-  BatchItemStatus,
-  BatchStatus,
-  ContentFormat,
-  PostStatus,
-} from '@genfeedai/enums';
-import type {
-  IBatchSummary,
-  IPublishApproval,
-  ManualReviewBatchItem,
-} from '@genfeedai/interfaces';
-import type { Batch } from '@genfeedai/prisma';
-import { AgentArtifactReferenceService } from '@genfeedai/server';
-import { LoggerService } from '@libs/logger/logger.service';
-import { BadRequestException, Injectable } from '@nestjs/common';
+import { BatchStatus } from '@genfeedai/enums';
+import type { IBatchSummary } from '@genfeedai/interfaces';
+import { Injectable } from '@nestjs/common';
 
-interface BatchItem {
-  format: ContentFormat;
-  status: BatchItemStatus;
-  platform?: string;
-  scheduledDate?: string;
-}
-
-interface BatchItemFull extends BatchItem {
-  _id: string;
-  caption?: string;
-  prompt?: string;
-  postId?: string;
-  mediaUrl?: string;
-  error?: string;
-  reviewDecision?: 'approved' | 'rejected' | 'request_changes';
-  reviewFeedback?: string;
-  reviewedAt?: string;
-  reviewEvents?: Array<{
-    decision: 'approved' | 'rejected' | 'request_changes';
-    feedback?: string;
-    reviewedAt: string;
-    versionPinId?: string;
-  }>;
-  gateOverallScore?: number;
-  gateReasons?: string[];
-  opportunitySourceType?: 'trend' | 'event' | 'evergreen';
-  opportunityTopic?: string;
-  creativeVersion?: string;
-  hookVersion?: string;
-  contentRunId?: string;
-  variantId?: string;
-  scheduleSlot?: string;
-  publishIntent?: string;
-  sourceActionId?: string;
-  sourceWorkflowId?: string;
-  sourceWorkflowName?: string;
-  createdAt?: string;
-  versionPinId?: string;
-  publishApproval?: IPublishApproval;
-}
-
-type BatchConfig = {
-  contentMix?: ContentMixConfig;
-  dateRangeStart?: string;
-  dateRangeEnd?: string;
-  platforms?: string[];
-  topics?: string[];
-  completedCount?: number;
-  failedCount?: number;
-  totalCount?: number;
-  completedAt?: string;
-  source?: string;
-  style?: string;
-};
-
-type BatchWithConfig = Batch & {
-  config: BatchConfig;
-  items: BatchItemFull[];
-};
-
-interface BatchProcessItemContext {
-  batchId: string;
-  completedCount: number;
-  error?: string;
-  failedCount: number;
-  index: number;
-  item: BatchItemFull;
-  postId?: string;
-  previewText?: string;
-  topic: string;
-  totalCount: number;
-}
-
-interface BatchProcessOptions {
-  onBatchCompleted?: (params: {
-    batchId: string;
-    completedCount: number;
-    failedCount: number;
-    status: BatchStatus;
-    totalCount: number;
-  }) => Promise<void> | void;
-  onBatchStarted?: (params: {
-    batchId: string;
-    totalCount: number;
-  }) => Promise<void> | void;
-  onItemCompleted?: (params: BatchProcessItemContext) => Promise<void> | void;
-  onItemFailed?: (params: BatchProcessItemContext) => Promise<void> | void;
-  onItemStarted?: (params: BatchProcessItemContext) => Promise<void> | void;
-}
-
-export interface ReviewInboxItemSummary {
-  batchId: string;
-  createdAt: string;
-  format: string;
-  id: string;
-  mediaUrl?: string;
-  platform?: string;
-  postId?: string;
-  reviewDecision?: 'approved' | 'rejected' | 'request_changes';
-  status: string;
-  summary: string;
-}
-
-export interface ReviewInboxSummary {
-  approvedCount: number;
-  changesRequestedCount: number;
-  pendingCount: number;
-  readyCount: number;
-  recentItems: ReviewInboxItemSummary[];
-  rejectedCount: number;
-}
+export type {
+  ReviewInboxItemSummary,
+  ReviewInboxSummary,
+} from '@api/services/batch-generation/batch-generation.types';
 
 @Injectable()
 export class BatchGenerationService {
   constructor(
-    private readonly prisma: PrismaService,
-    private readonly logger: LoggerService,
-    private readonly brandsService: BrandsService,
-    private readonly postsService: PostsService,
-    private readonly contentGeneratorService: ContentGeneratorService,
-    private readonly cacheService: CacheService,
-    private readonly agentArtifactReferenceService: AgentArtifactReferenceService,
-    private readonly publishApprovalsService: PublishApprovalsService,
+    private readonly creationService: BatchGenerationCreationService,
+    private readonly processingService: BatchGenerationProcessingService,
+    private readonly reviewService: BatchGenerationReviewService,
   ) {}
 
-  private cloneBatchItems(items: Batch['items']): BatchItemFull[] {
-    return ((items ?? []) as unknown as BatchItemFull[]).map((item) => ({
-      ...item,
-    }));
-  }
-
   @HandleErrors('create batch', 'batch-generation')
-  async createBatch(
+  createBatch(
     dto: CreateBatchDto,
     userId: string,
     orgId: string,
     idempotencyKey?: string,
   ): Promise<IBatchSummary> {
-    if (idempotencyKey) {
-      return runIdempotent(this.cacheService, idempotencyKey, () =>
-        this.doCreateBatch(dto, userId, orgId),
-      );
-    }
-
-    return this.doCreateBatch(dto, userId, orgId);
-  }
-
-  private async doCreateBatch(
-    dto: CreateBatchDto,
-    userId: string,
-    orgId: string,
-  ): Promise<IBatchSummary> {
-    // Verify brand exists and belongs to org
-    const brand = await this.brandsService.findOne({
-      _id: dto.brandId,
-      isDeleted: false,
-      organization: orgId,
-    });
-
-    if (!brand) {
-      throw new NotFoundException('Brand', dto.brandId);
-    }
-
-    const contentMix: ContentMixConfig = dto.contentMix ?? {
-      carouselPercent: 10,
-      imagePercent: 60,
-      reelPercent: 5,
-      storyPercent: 0,
-      videoPercent: 25,
-    };
-
-    const dateRangeStart = new Date(dto.dateRange.start);
-    const dateRangeEnd = new Date(dto.dateRange.end);
-
-    const items = this.generateContentPlan(
-      dto.count,
-      contentMix,
-      dto.platforms,
-      dto.topics ?? [],
-      dateRangeStart,
-      dateRangeEnd,
-    );
-
-    const config: BatchConfig = {
-      completedCount: 0,
-      contentMix,
-      dateRangeEnd: dateRangeEnd.toISOString(),
-      dateRangeStart: dateRangeStart.toISOString(),
-      failedCount: 0,
-      platforms: dto.platforms,
-      style: dto.style,
-      topics: dto.topics ?? [],
-      totalCount: dto.count,
-    };
-
-    const batch = (await this.prisma.batch.create({
-      data: {
-        brandId: dto.brandId,
-        config: config as never,
-        isDeleted: false,
-        items: items as never,
-        organizationId: orgId,
-        status: BatchStatus.PENDING as never,
-        userId,
-      },
-    })) as BatchWithConfig;
-
-    this.logger.log(`Batch created: ${batch.id}`, {
-      batchId: batch.id,
-      count: dto.count,
-      orgId,
-    });
-
-    return this.toBatchSummary(batch);
+    return this.creationService.createBatch(dto, userId, orgId, idempotencyKey);
   }
 
   @HandleErrors('create manual review batch', 'batch-generation')
-  async createManualReviewBatch(
+  createManualReviewBatch(
     dto: CreateManualReviewBatchDto,
     userId: string,
     orgId: string,
     idempotencyKey?: string,
   ): Promise<IBatchSummary> {
-    if (idempotencyKey) {
-      return runIdempotent(this.cacheService, idempotencyKey, () =>
-        this.doCreateManualReviewBatch(dto, userId, orgId),
-      );
-    }
-
-    return this.doCreateManualReviewBatch(dto, userId, orgId);
-  }
-
-  private async doCreateManualReviewBatch(
-    dto: CreateManualReviewBatchDto,
-    userId: string,
-    orgId: string,
-  ): Promise<IBatchSummary> {
-    const brand = await this.brandsService.findOne({
-      _id: dto.brandId,
-      isDeleted: false,
-      organization: orgId,
-    });
-
-    if (!brand) {
-      throw new NotFoundException('Brand', dto.brandId);
-    }
-
-    // Validate that all supplied ingredientIds belong to the caller's org
-    const ingredientIds = dto.items
-      .map((item) => item.ingredientId)
-      .filter((id): id is string => typeof id === 'string' && id.length > 0);
-
-    if (ingredientIds.length > 0) {
-      const uniqueIngredientIds = Array.from(new Set(ingredientIds));
-      const ownedIngredients = await this.prisma.ingredient.findMany({
-        select: { id: true },
-        where: {
-          id: { in: uniqueIngredientIds },
-          isDeleted: false,
-          organizationId: orgId,
-        },
-      });
-
-      if (ownedIngredients.length !== uniqueIngredientIds.length) {
-        throw new BadRequestException(
-          'One or more ingredient IDs do not belong to this organization',
-        );
-      }
-    }
-
-    const items: ManualReviewBatchItem[] = [];
-    const batchItems: BatchItemFull[] = [];
-
-    // Collect all ingredient IDs from the batch and validate ownership up-front
-    // to prevent cross-tenant data access (MEDIUM: cross-tenant ingredient ID trust).
-    const ingredientIdsToValidate = dto.items
-      .map((item) => item.ingredientId)
-      .filter((id): id is string => Boolean(id));
-
-    if (ingredientIdsToValidate.length > 0) {
-      const ownedIngredients = await this.prisma.ingredient.findMany({
-        select: { id: true },
-        where: {
-          id: { in: ingredientIdsToValidate },
-          isDeleted: false,
-          organizationId: orgId,
-        },
-      });
-
-      const ownedIngredientIdSet = new Set(ownedIngredients.map((i) => i.id));
-      const unauthorized = ingredientIdsToValidate.filter(
-        (id) => !ownedIngredientIdSet.has(id),
-      );
-
-      if (unauthorized.length > 0) {
-        throw new NotFoundException(
-          `Ingredient(s): ${unauthorized.join(', ')}`,
-        );
-      }
-    }
-
-    for (const reviewItem of dto.items) {
-      const contentRunId = reviewItem.contentRunId
-        ? String(reviewItem.contentRunId)
-        : undefined;
-      const post = await this.postsService.create({
-        brand: dto.brandId,
-        contentRunId,
-        creativeVersion: reviewItem.creativeVersion,
-        description:
-          reviewItem.caption ??
-          reviewItem.prompt ??
-          'Review this asset before publishing',
-        hookVersion: reviewItem.hookVersion,
-        ingredients: reviewItem.ingredientId ? [reviewItem.ingredientId] : [],
-        label: reviewItem.label ?? `Review ${reviewItem.format} draft`,
-        organization: orgId,
-        platform: reviewItem.platform as never,
-        publishIntent: reviewItem.publishIntent,
-        promptUsed: reviewItem.prompt,
-        scheduleSlot: reviewItem.scheduleSlot,
-        sourceActionId: reviewItem.sourceActionId,
-        sourceWorkflowId: reviewItem.sourceWorkflowId,
-        sourceWorkflowName: reviewItem.sourceWorkflowName,
-        status: PostStatus.DRAFT,
-        user: userId,
-        variantId: reviewItem.variantId,
-      } as never);
-
-      const postId = String((post as Record<string, unknown>).id ?? post.id);
-
-      batchItems.push({
-        _id: crypto.randomUUID(),
-        caption: reviewItem.caption,
-        contentRunId,
-        creativeVersion: reviewItem.creativeVersion,
-        format: reviewItem.format as ContentFormat,
-        gateOverallScore: reviewItem.gateOverallScore,
-        gateReasons: reviewItem.gateReasons ?? [],
-        hookVersion: reviewItem.hookVersion,
-        mediaUrl: reviewItem.mediaUrl,
-        opportunitySourceType: reviewItem.opportunitySourceType,
-        opportunityTopic: reviewItem.opportunityTopic,
-        platform: reviewItem.platform,
-        postId,
-        publishIntent: reviewItem.publishIntent,
-        prompt: reviewItem.prompt,
-        reviewEvents: [],
-        scheduleSlot: reviewItem.scheduleSlot,
-        sourceActionId: reviewItem.sourceActionId,
-        sourceWorkflowId: reviewItem.sourceWorkflowId,
-        sourceWorkflowName: reviewItem.sourceWorkflowName,
-        status: BatchItemStatus.COMPLETED,
-        variantId: reviewItem.variantId,
-      });
-    }
-
-    const config: BatchConfig = {
-      completedAt: new Date().toISOString(),
-      completedCount: batchItems.length,
-      contentMix: {
-        carouselPercent: 0,
-        imagePercent: 0,
-        reelPercent: 0,
-        storyPercent: 0,
-        videoPercent: 0,
-      },
-      failedCount: 0,
-      platforms: Array.from(
-        new Set(
-          dto.items.flatMap((item) => (item.platform ? [item.platform] : [])),
-        ),
-      ),
-      source: 'manual',
-      topics: [],
-      totalCount: batchItems.length,
-    };
-
-    const batch = (await this.prisma.batch.create({
-      data: {
-        brandId: dto.brandId,
-        config: config as never,
-        isDeleted: false,
-        items: batchItems as never,
-        organizationId: orgId,
-        status: BatchStatus.COMPLETED as never,
-        userId,
-      },
-    })) as BatchWithConfig;
-
-    this.logger.log(`Manual review batch created: ${batch.id}`, {
-      batchId: batch.id,
-      itemCount: batchItems.length,
+    return this.creationService.createManualReviewBatch(
+      dto,
+      userId,
       orgId,
-    });
-
-    // Update posts with reviewBatchId / reviewItemId
-    await Promise.all(
-      batchItems.map(async (item) => {
-        if (!item.postId) return;
-
-        await this.prisma.post.updateMany({
-          data: {
-            reviewBatchId: batch.id,
-            reviewItemId: item._id,
-          },
-          where: {
-            id: item.postId,
-            isDeleted: false,
-            organizationId: orgId,
-          },
-        });
-      }),
+      idempotencyKey,
     );
-
-    return this.toBatchSummary(batch);
   }
 
   @HandleErrors('get review inbox summary', 'batch-generation')
-  async getReviewInboxSummary(
+  getReviewInboxSummary(
     orgId: string,
     brandId?: string,
     limit = 5,
   ): Promise<ReviewInboxSummary> {
-    const batches = (await this.prisma.batch.findMany({
-      where: {
-        isDeleted: false,
-        organizationId: orgId,
-        ...(brandId ? { brandId } : {}),
-      },
-    })) as BatchWithConfig[];
-
-    let approvedCount = 0;
-    let rejectedCount = 0;
-    let changesRequestedCount = 0;
-    let pendingCount = 0;
-    let readyCount = 0;
-    const readyItems: ReviewInboxItemSummary[] = [];
-
-    for (const batch of batches) {
-      const batchItems = this.cloneBatchItems(batch.items);
-      for (const item of batchItems) {
-        const decision = item.reviewDecision;
-        const status = item.status;
-
-        if (decision === 'approved') {
-          approvedCount++;
-        } else if (decision === 'rejected') {
-          rejectedCount++;
-        } else if (decision === 'request_changes') {
-          changesRequestedCount++;
-        } else if (
-          status === BatchItemStatus.GENERATING ||
-          status === BatchItemStatus.PENDING
-        ) {
-          pendingCount++;
-        } else if (status === BatchItemStatus.COMPLETED && !decision) {
-          readyCount++;
-          readyItems.push({
-            batchId: batch.id,
-            createdAt: item.createdAt ?? batch.createdAt.toISOString(),
-            format: item.format,
-            id: item._id,
-            mediaUrl: item.mediaUrl,
-            platform: item.platform,
-            postId: item.postId,
-            reviewDecision: undefined,
-            status: item.status,
-            summary:
-              item.caption ??
-              item.prompt ??
-              `${item.format.charAt(0).toUpperCase()}${item.format.slice(1)} ready for review`,
-          });
-        }
-      }
-    }
-
-    // Sort ready items by createdAt desc, take limit
-    readyItems.sort(
-      (a, b) =>
-        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
-    );
-    const recentItems = readyItems.slice(0, Math.max(1, Math.min(limit, 10)));
-
-    return {
-      approvedCount,
-      changesRequestedCount,
-      pendingCount,
-      readyCount,
-      recentItems,
-      rejectedCount,
-    };
+    return this.reviewService.getReviewInboxSummary(orgId, brandId, limit);
   }
 
   @HandleErrors('process batch', 'batch-generation')
-  async processBatch(
+  processBatch(
     batchId: string,
     orgId: string,
     options?: BatchProcessOptions,
   ): Promise<IBatchSummary> {
-    // Idempotency guard: atomically transition PENDING → GENERATING.
-    // If two concurrent calls race, exactly one updateMany will match (count=1);
-    // the other gets count=0 and exits early, preventing duplicate processing.
-    const claimed = await this.prisma.batch.updateMany({
-      data: { status: BatchStatus.GENERATING as never },
-      where: {
-        id: batchId,
-        isDeleted: false,
-        organizationId: orgId,
-        status: BatchStatus.PENDING as never,
-      },
-    });
-
-    if (claimed.count === 0) {
-      // Either the batch doesn't exist for this org, or it's already being processed.
-      const existing = await this.prisma.batch.findFirst({
-        where: { id: batchId, isDeleted: false, organizationId: orgId },
-      });
-      if (!existing) {
-        throw new NotFoundException('Batch', batchId);
-      }
-      // Already generating or completed — return early without re-processing.
-      throw new BadRequestException(
-        `Batch ${batchId} is already being processed (status: ${String(existing.status)})`,
-      );
-    }
-
-    const batchRecord = await findOrThrow(
-      this.prisma.batch,
-      { where: { id: batchId, isDeleted: false, organizationId: orgId } },
-      'Batch',
-      batchId,
-    );
-
-    const batchConfig = (batchRecord.config ?? {}) as BatchConfig;
-    const batchItems = this.cloneBatchItems(batchRecord.items);
-
-    await options?.onBatchStarted?.({
-      batchId,
-      totalCount: batchConfig.totalCount ?? batchItems.length,
-    });
-
-    let completedCount = 0;
-    let failedCount = 0;
-
-    for (let i = 0; i < batchItems.length; i++) {
-      const item = batchItems[i];
-
-      if (item.status !== BatchItemStatus.PENDING) {
-        continue;
-      }
-
-      try {
-        item.status = BatchItemStatus.GENERATING;
-
-        const topics = batchConfig.topics ?? [];
-        const topic =
-          topics.length > 0
-            ? topics[i % topics.length]
-            : `${item.format} content`;
-
-        await options?.onItemStarted?.({
-          batchId,
-          completedCount,
-          failedCount,
-          index: i,
-          item,
-          topic,
-          totalCount: batchConfig.totalCount ?? batchItems.length,
-        });
-
-        const generated = await this.contentGeneratorService.generateContent(
-          orgId,
-          {
-            additionalContext: batchConfig.style
-              ? [batchConfig.style]
-              : undefined,
-            brandId: batchRecord.brandId ?? undefined,
-            platform: item.platform as never,
-            topic,
-            variationsCount: 1,
-          },
-        );
-
-        const content = generated[0];
-        item.prompt = content?.content ?? topic;
-        item.caption = content?.content ?? '';
-
-        // Create a draft post as placeholder
-        const post = await this.postsService.create({
-          brand: batchRecord.brandId,
-          credential: undefined as never,
-          description: item.caption,
-          ingredients: [],
-          label: `Batch: ${topic}`,
-          organization: orgId,
-          platform: item.platform as never,
-          scheduledDate: item.scheduledDate
-            ? new Date(item.scheduledDate)
-            : undefined,
-          status: PostStatus.DRAFT,
-          user: batchRecord.userId,
-        } as never);
-
-        const postId = String((post as Record<string, unknown>).id ?? post.id);
-        item.postId = postId;
-        item.status = BatchItemStatus.COMPLETED;
-        completedCount++;
-
-        await options?.onItemCompleted?.({
-          batchId,
-          completedCount,
-          failedCount,
-          index: i,
-          item,
-          postId,
-          previewText: item.caption,
-          topic,
-          totalCount: batchConfig.totalCount ?? batchItems.length,
-        });
-      } catch (error: unknown) {
-        item.status = BatchItemStatus.FAILED;
-        item.error = error instanceof Error ? error.message : 'Unknown error';
-        failedCount++;
-
-        this.logger.error(`Batch item ${item._id} failed: ${item.error}`, {
-          batchId,
-          itemId: item._id,
-        });
-
-        const topics = batchConfig.topics ?? [];
-        await options?.onItemFailed?.({
-          batchId,
-          completedCount,
-          error: item.error,
-          failedCount,
-          index: i,
-          item,
-          topic:
-            topics.length > 0
-              ? topics[i % topics.length]
-              : `${item.format} content`,
-          totalCount: batchConfig.totalCount ?? batchItems.length,
-        });
-      }
-    }
-
-    const totalCount = batchConfig.totalCount ?? batchItems.length;
-    let finalStatus: BatchStatus;
-    let completedAt: string | undefined;
-
-    if (failedCount === 0 && completedCount === totalCount) {
-      finalStatus = BatchStatus.COMPLETED;
-      completedAt = new Date().toISOString();
-    } else if (completedCount > 0) {
-      finalStatus = BatchStatus.PARTIAL;
-    } else {
-      finalStatus = BatchStatus.FAILED;
-    }
-
-    const updatedConfig: BatchConfig = {
-      ...batchConfig,
-      completedAt,
-      completedCount,
-      failedCount,
-    };
-
-    const updatedBatch = (await this.prisma.batch.update({
-      data: {
-        config: updatedConfig as never,
-        items: batchItems as never,
-        status: finalStatus as never,
-      },
-      where: { id: batchId },
-    })) as BatchWithConfig;
-
-    this.logger.log(`Batch processing complete: ${batchId}`, {
-      batchId,
-      completedCount,
-      failedCount,
-      status: finalStatus,
-    });
-
-    await options?.onBatchCompleted?.({
-      batchId,
-      completedCount,
-      failedCount,
-      status: finalStatus,
-      totalCount,
-    });
-
-    return this.toBatchSummary(updatedBatch);
+    return this.processingService.processBatch(batchId, orgId, options);
   }
 
   @HandleErrors('get batch', 'batch-generation')
-  async getBatch(batchId: string, orgId: string): Promise<IBatchSummary> {
-    const batch = (await findOrThrow(
-      this.prisma.batch,
-      { where: { id: batchId, isDeleted: false, organizationId: orgId } },
-      'Batch',
-      batchId,
-    )) as BatchWithConfig;
-
-    return this.toBatchSummary(batch);
+  getBatch(batchId: string, orgId: string): Promise<IBatchSummary> {
+    return this.reviewService.getBatch(batchId, orgId);
   }
 
   @HandleErrors('get batches', 'batch-generation')
-  async getBatches(
+  getBatches(
     orgId: string,
     query?: { status?: BatchStatus; limit?: number; offset?: number },
   ): Promise<{ items: IBatchSummary[]; total: number }> {
-    const limit = Math.min(query?.limit ?? 20, 100);
-    const offset = query?.offset ?? 0;
-
-    const where: Record<string, unknown> = {
-      isDeleted: false,
-      organizationId: orgId,
-    };
-    if (query?.status) {
-      where.status = query.status;
-    }
-
-    const [batches, total] = await Promise.all([
-      this.prisma.batch.findMany({
-        orderBy: { createdAt: 'desc' },
-        skip: offset,
-        take: limit,
-        where: where as never,
-      }),
-      this.prisma.batch.count({ where: where as never }),
-    ]);
-
-    return {
-      items: await Promise.all(
-        batches.map((b) => this.toBatchSummary(b as BatchWithConfig)),
-      ),
-      total,
-    };
+    return this.reviewService.getBatches(orgId, query);
   }
 
   @HandleErrors('approve items', 'batch-generation')
-  async approveItems(
+  approveItems(
     batchId: string,
     itemIds: string[],
     orgId: string,
     createdByUserId: string,
   ): Promise<IBatchSummary> {
-    const batchRecord = await findOrThrow(
-      this.prisma.batch,
-      { where: { id: batchId, isDeleted: false, organizationId: orgId } },
-      'Batch',
+    return this.reviewService.approveItems(
       batchId,
+      itemIds,
+      orgId,
+      createdByUserId,
     );
-
-    const itemIdSet = new Set(itemIds);
-    const reviewedAt = new Date().toISOString();
-
-    const batchItems = this.cloneBatchItems(batchRecord.items);
-    const selectedPostIds = [
-      ...new Set(
-        batchItems
-          .filter(
-            (item) =>
-              itemIdSet.has(item._id) &&
-              item.status === BatchItemStatus.COMPLETED &&
-              Boolean(item.postId),
-          )
-          .flatMap((item) => (item.postId ? [item.postId] : [])),
-      ),
-    ];
-    const updatedBatch = await this.prisma.$transaction(async (transaction) => {
-      const versionPinIds = new Map<string, string>();
-      const publishApprovals = new Map<string, IPublishApproval>();
-
-      for (const postId of selectedPostIds) {
-        const item = batchItems.find(
-          (candidate) => candidate.postId === postId,
-        );
-        if (item?.scheduledDate) {
-          const approval =
-            await this.publishApprovalsService.createForCurrentPost({
-              actorUserId: createdByUserId,
-              mode: 'scheduled',
-              organizationId: orgId,
-              postId,
-              provenance: {
-                batchId,
-                reviewItemId: item._id,
-                surface: 'review-queue',
-              },
-              transaction,
-            });
-          publishApprovals.set(postId, approval);
-          versionPinIds.set(postId, approval.artifactVersionPinId);
-        } else {
-          const versionPin =
-            await this.agentArtifactReferenceService.createOrReuseVersionPin({
-              createdByUserId,
-              reference: {
-                ...(batchRecord.brandId
-                  ? { brandId: batchRecord.brandId }
-                  : {}),
-                kind: 'post',
-                organizationId: orgId,
-                recordId: postId,
-                serializer: 'post',
-              },
-              transaction,
-            });
-          versionPinIds.set(postId, versionPin.id);
-        }
-      }
-
-      const postIdsToSchedule: string[] = [];
-
-      for (const item of batchItems) {
-        if (
-          itemIdSet.has(item._id) &&
-          item.status === BatchItemStatus.COMPLETED
-        ) {
-          const versionPinId = item.postId
-            ? versionPinIds.get(item.postId)
-            : undefined;
-          item.reviewDecision = 'approved';
-          item.publishApproval = item.postId
-            ? publishApprovals.get(item.postId)
-            : undefined;
-          item.reviewFeedback = undefined;
-          item.versionPinId = versionPinId;
-          item.reviewedAt = reviewedAt;
-          item.reviewEvents = [
-            ...(item.reviewEvents ?? []),
-            {
-              decision: 'approved',
-              reviewedAt,
-              ...(versionPinId ? { versionPinId } : {}),
-            },
-          ];
-          if (item.postId && item.scheduledDate) {
-            postIdsToSchedule.push(item.postId);
-          }
-        }
-      }
-
-      const approvalUpdates = await Promise.all(
-        selectedPostIds.map((postId) =>
-          transaction.post.updateMany({
-            data: {
-              reviewDecision: 'APPROVED' as never,
-              reviewVersionPinId: versionPinIds.get(postId),
-              reviewedAt: new Date(reviewedAt),
-            },
-            where: {
-              id: postId,
-              isDeleted: false,
-              organizationId: orgId,
-            },
-          }),
-        ),
-      );
-      if (approvalUpdates.some((result) => result.count !== 1)) {
-        throw new NotFoundException({
-          message: 'A canonical Post disappeared before approval completed.',
-        });
-      }
-
-      if (postIdsToSchedule.length > 0) {
-        await transaction.post.updateMany({
-          data: { status: PostStatus.SCHEDULED as never },
-          where: {
-            id: { in: postIdsToSchedule },
-            isDeleted: false,
-            organizationId: orgId,
-          },
-        });
-      }
-
-      return (await transaction.batch.update({
-        data: { items: batchItems as never },
-        where: { id: batchId },
-      })) as BatchWithConfig;
-    });
-
-    this.logger.log(`Approved ${itemIds.length} items in batch ${batchId}`, {
-      batchId,
-      itemCount: itemIds.length,
-    });
-
-    return this.toBatchSummary(updatedBatch);
   }
 
   @HandleErrors('reject items', 'batch-generation')
-  async rejectItems(
+  rejectItems(
     batchId: string,
     itemIds: string[],
     orgId: string,
     feedback?: string,
     actorUserId?: string,
   ): Promise<IBatchSummary> {
-    const batchRecord = await findOrThrow(
-      this.prisma.batch,
-      { where: { id: batchId, isDeleted: false, organizationId: orgId } },
-      'Batch',
+    return this.reviewService.rejectItems(
       batchId,
+      itemIds,
+      orgId,
+      feedback,
+      actorUserId,
     );
-
-    const itemIdSet = new Set(itemIds);
-    const postIdsToReject: string[] = [];
-    const reviewedAt = new Date().toISOString();
-
-    const batchItems = this.cloneBatchItems(batchRecord.items);
-
-    for (const item of batchItems) {
-      if (itemIdSet.has(item._id)) {
-        item.status = BatchItemStatus.SKIPPED;
-        item.reviewDecision = 'rejected';
-        item.reviewFeedback = feedback;
-        item.reviewedAt = reviewedAt;
-        item.reviewEvents = [
-          ...(item.reviewEvents ?? []),
-          { decision: 'rejected', feedback, reviewedAt },
-        ];
-        if (item.postId) {
-          postIdsToReject.push(item.postId);
-        }
-      }
-    }
-
-    if (postIdsToReject.length > 0) {
-      // Soft-delete rejected posts
-      await this.prisma.post.updateMany({
-        data: {
-          isDeleted: true,
-          reviewDecision: 'REJECTED' as never,
-          reviewedAt: new Date(reviewedAt),
-          reviewFeedback: feedback,
-        },
-        where: {
-          id: { in: postIdsToReject },
-          isDeleted: false,
-          organizationId: orgId,
-        },
-      });
-      await Promise.all(
-        postIdsToReject.map((postId) =>
-          this.publishApprovalsService.invalidatePost(
-            orgId,
-            postId,
-            'The review item was rejected.',
-            actorUserId,
-          ),
-        ),
-      );
-    }
-
-    const updatedBatch = (await this.prisma.batch.update({
-      data: { items: batchItems as never },
-      where: { id: batchId },
-    })) as BatchWithConfig;
-
-    this.logger.log(`Rejected ${itemIds.length} items in batch ${batchId}`, {
-      batchId,
-      itemCount: itemIds.length,
-    });
-
-    return this.toBatchSummary(updatedBatch);
   }
 
   @HandleErrors('request changes', 'batch-generation')
-  async requestChanges(
+  requestChanges(
     batchId: string,
     itemIds: string[],
     orgId: string,
     feedback?: string,
     actorUserId?: string,
   ): Promise<IBatchSummary> {
-    const batchRecord = await findOrThrow(
-      this.prisma.batch,
-      { where: { id: batchId, isDeleted: false, organizationId: orgId } },
-      'Batch',
+    return this.reviewService.requestChanges(
       batchId,
+      itemIds,
+      orgId,
+      feedback,
+      actorUserId,
     );
-
-    const itemIdSet = new Set(itemIds);
-    const postIdsToKeepAsDraft: string[] = [];
-    const reviewedAt = new Date().toISOString();
-
-    const batchItems = this.cloneBatchItems(batchRecord.items);
-
-    for (const item of batchItems) {
-      if (
-        itemIdSet.has(item._id) &&
-        item.status === BatchItemStatus.COMPLETED
-      ) {
-        item.reviewDecision = 'request_changes';
-        item.reviewFeedback = feedback;
-        item.reviewedAt = reviewedAt;
-        item.reviewEvents = [
-          ...(item.reviewEvents ?? []),
-          { decision: 'request_changes', feedback, reviewedAt },
-        ];
-        if (item.postId) {
-          postIdsToKeepAsDraft.push(item.postId);
-        }
-      }
-    }
-
-    if (postIdsToKeepAsDraft.length > 0) {
-      await this.prisma.post.updateMany({
-        data: {
-          reviewDecision: 'REQUEST_CHANGES' as never,
-          reviewedAt: new Date(reviewedAt),
-          reviewFeedback: feedback,
-          status: PostStatus.DRAFT as never,
-        },
-        where: {
-          id: { in: postIdsToKeepAsDraft },
-          isDeleted: false,
-          organizationId: orgId,
-        },
-      });
-      await Promise.all(
-        postIdsToKeepAsDraft.map((postId) =>
-          this.publishApprovalsService.invalidatePost(
-            orgId,
-            postId,
-            'Changes were requested for the approved version.',
-            actorUserId,
-          ),
-        ),
-      );
-    }
-
-    const updatedBatch = (await this.prisma.batch.update({
-      data: { items: batchItems as never },
-      where: { id: batchId },
-    })) as BatchWithConfig;
-
-    this.logger.log(
-      `Requested changes for ${itemIds.length} items in batch ${batchId}`,
-      {
-        batchId,
-        itemCount: itemIds.length,
-      },
-    );
-
-    return this.toBatchSummary(updatedBatch);
   }
 
   @HandleErrors('cancel batch', 'batch-generation')
-  async cancelBatch(batchId: string, orgId: string): Promise<IBatchSummary> {
-    const batchRecord = await findOrThrow(
-      this.prisma.batch,
-      { where: { id: batchId, isDeleted: false, organizationId: orgId } },
-      'Batch',
-      batchId,
-    );
-
-    const batchItems = this.cloneBatchItems(batchRecord.items).map((item) => ({
-      ...item,
-      status:
-        item.status === BatchItemStatus.PENDING
-          ? BatchItemStatus.SKIPPED
-          : item.status,
-    }));
-
-    const updatedBatch = (await this.prisma.batch.update({
-      data: {
-        items: batchItems as never,
-        status: BatchStatus.CANCELLED as never,
-      },
-      where: { id: batchId },
-    })) as BatchWithConfig;
-
-    this.logger.log(`Batch cancelled: ${batchId}`, { batchId });
-
-    return this.toBatchSummary(updatedBatch);
+  cancelBatch(batchId: string, orgId: string): Promise<IBatchSummary> {
+    return this.reviewService.cancelBatch(batchId, orgId);
   }
 
-  /**
-   * Update a batch by ID. Status transitions to CANCELLED are routed
-   * through cancelBatch() to preserve its guard (tenant-scoped existence
-   * check via findOrThrow) and cascade (marking pending items as skipped).
-   */
   @HandleErrors('update batch', 'batch-generation')
-  async updateBatch(
+  updateBatch(
     batchId: string,
     dto: UpdateBatchDto,
     orgId: string,
   ): Promise<IBatchSummary> {
-    if (dto.status === BatchStatus.CANCELLED) {
-      return this.cancelBatch(batchId, orgId);
-    }
-
-    const batchRecord = await findOrThrow(
-      this.prisma.batch,
-      { where: { id: batchId, isDeleted: false, organizationId: orgId } },
-      'Batch',
-      batchId,
-    );
-
-    const updatedBatch = (await this.prisma.batch.update({
-      data: {
-        status: dto.status as never,
-      },
-      where: { id: batchRecord.id },
-    })) as BatchWithConfig;
-
-    return this.toBatchSummary(updatedBatch);
-  }
-
-  private generateContentPlan(
-    count: number,
-    contentMix: ContentMixConfig,
-    platforms: string[],
-    _topics: string[],
-    dateRangeStart: Date,
-    dateRangeEnd: Date,
-  ): BatchItemFull[] {
-    const items: BatchItemFull[] = [];
-    const formatCounts = this.calculateFormatCounts(count, contentMix);
-    const timeSlots = this.distributeTimeSlots(
-      count,
-      dateRangeStart,
-      dateRangeEnd,
-    );
-
-    let index = 0;
-    const now = new Date().toISOString();
-    for (const [format, formatCount] of Object.entries(formatCounts)) {
-      for (let i = 0; i < formatCount; i++) {
-        items.push({
-          _id: crypto.randomUUID(),
-          createdAt: now,
-          format: format as ContentFormat,
-          platform: platforms[index % platforms.length],
-          scheduledDate: timeSlots[index]?.toISOString(),
-          status: BatchItemStatus.PENDING,
-        });
-        index++;
-      }
-    }
-
-    return items;
-  }
-
-  private calculateFormatCounts(
-    total: number,
-    contentMix: ContentMixConfig,
-  ): Record<string, number> {
-    const counts: Record<string, number> = {};
-    let remaining = total;
-
-    const formats: Array<{ key: ContentFormat; percent: number }> = [
-      { key: ContentFormat.IMAGE, percent: contentMix.imagePercent },
-      { key: ContentFormat.VIDEO, percent: contentMix.videoPercent },
-      { key: ContentFormat.CAROUSEL, percent: contentMix.carouselPercent },
-      { key: ContentFormat.REEL, percent: contentMix.reelPercent },
-      { key: ContentFormat.STORY, percent: contentMix.storyPercent },
-    ];
-
-    for (const format of formats) {
-      const count = Math.round((format.percent / 100) * total);
-      counts[format.key] = count;
-      remaining -= count;
-    }
-
-    if (remaining !== 0) {
-      const largest = formats.reduce((a, b) =>
-        a.percent >= b.percent ? a : b,
-      );
-      counts[largest.key] = (counts[largest.key] ?? 0) + remaining;
-    }
-
-    return counts;
-  }
-
-  private distributeTimeSlots(count: number, start: Date, end: Date): Date[] {
-    const slots: Date[] = [];
-    const totalMs = end.getTime() - start.getTime();
-    const interval = count > 1 ? totalMs / (count - 1) : 0;
-
-    for (let i = 0; i < count; i++) {
-      slots.push(new Date(start.getTime() + interval * i));
-    }
-
-    return slots;
-  }
-
-  private async toBatchSummary(batch: BatchWithConfig): Promise<IBatchSummary> {
-    const batchConfig = (batch.config ?? {}) as BatchConfig;
-    const batchItems = this.cloneBatchItems(batch.items);
-
-    const pendingCount = batchItems.filter(
-      (item) =>
-        item.status === BatchItemStatus.PENDING ||
-        item.status === BatchItemStatus.GENERATING,
-    ).length;
-
-    const postIds = batchItems
-      .map((item) => item.postId)
-      .filter((id): id is string => Boolean(id));
-
-    const linkedPosts =
-      postIds.length > 0
-        ? await this.prisma.post.findMany({
-            select: {
-              externalId: true,
-              generationId: true,
-              id: true,
-              lastAttemptAt: true,
-              promptUsed: true,
-              publishedAt: true,
-              retryCount: true,
-              reviewDecision: true,
-              reviewedAt: true,
-              reviewFeedback: true,
-              reviewVersionPinId: true,
-              publishApproval: true,
-              status: true,
-              url: true,
-            },
-            where: {
-              id: { in: postIds },
-              isDeleted: false,
-              organizationId: batch.organizationId,
-            },
-          })
-        : [];
-
-    const linkedAnalytics =
-      postIds.length > 0
-        ? await this.prisma.postAnalytics.findMany({
-            select: {
-              engagementRate: true,
-              postId: true,
-              totalComments: true,
-              totalLikes: true,
-              totalSaves: true,
-              totalShares: true,
-              totalViews: true,
-            },
-            where: {
-              organizationId: batch.organizationId,
-              postId: { in: postIds },
-            },
-          })
-        : [];
-
-    // Aggregate analytics by postId (take max for each metric)
-    const analyticsMap = new Map<
-      string,
-      {
-        avgEngagementRate: number;
-        totalComments: number;
-        totalLikes: number;
-        totalSaves: number;
-        totalShares: number;
-        totalViews: number;
-      }
-    >();
-    for (const row of linkedAnalytics) {
-      const existing = analyticsMap.get(row.postId);
-      if (!existing) {
-        analyticsMap.set(row.postId, {
-          avgEngagementRate: row.engagementRate,
-          totalComments: row.totalComments,
-          totalLikes: row.totalLikes,
-          totalSaves: row.totalSaves,
-          totalShares: row.totalShares,
-          totalViews: row.totalViews,
-        });
-      } else {
-        analyticsMap.set(row.postId, {
-          avgEngagementRate:
-            (existing.avgEngagementRate + row.engagementRate) / 2,
-          totalComments: Math.max(existing.totalComments, row.totalComments),
-          totalLikes: Math.max(existing.totalLikes, row.totalLikes),
-          totalSaves: Math.max(existing.totalSaves, row.totalSaves),
-          totalShares: Math.max(existing.totalShares, row.totalShares),
-          totalViews: Math.max(existing.totalViews, row.totalViews),
-        });
-      }
-    }
-
-    const linkedPostMap = new Map(linkedPosts.map((post) => [post.id, post]));
-
-    return {
-      brandId: batch.brandId ?? '',
-      completedAt: batchConfig.completedAt,
-      completedCount: batchConfig.completedCount ?? 0,
-      contentMix: {
-        carouselPercent: batchConfig.contentMix?.carouselPercent ?? 10,
-        imagePercent: batchConfig.contentMix?.imagePercent ?? 60,
-        reelPercent: batchConfig.contentMix?.reelPercent ?? 5,
-        storyPercent: batchConfig.contentMix?.storyPercent ?? 0,
-        videoPercent: batchConfig.contentMix?.videoPercent ?? 25,
-      },
-      createdAt: batch.createdAt.toISOString(),
-      failedCount: batchConfig.failedCount ?? 0,
-      id: batch.id,
-      items: batchItems.map((item) => {
-        const linkedPost = item.postId
-          ? linkedPostMap.get(item.postId)
-          : undefined;
-        const analytics = item.postId
-          ? analyticsMap.get(item.postId)
-          : undefined;
-
-        return {
-          batchId: batch.id,
-          caption: item.caption,
-          createdAt: item.createdAt ?? batch.createdAt.toISOString(),
-          error: item.error,
-          format: item.format,
-          gateOverallScore: item.gateOverallScore,
-          gateReasons: item.gateReasons ?? [],
-          id: item._id,
-          mediaUrl: item.mediaUrl,
-          opportunitySourceType: item.opportunitySourceType,
-          opportunityTopic: item.opportunityTopic,
-          platform: item.platform,
-          postAvgEngagementRate: analytics?.avgEngagementRate,
-          postExternalId: linkedPost?.externalId ?? undefined,
-          postGenerationId: linkedPost?.generationId ?? undefined,
-          postId: item.postId,
-          postLastAttemptAt: linkedPost?.lastAttemptAt?.toISOString(),
-          postPromptUsed: linkedPost?.promptUsed ?? undefined,
-          postPublishedAt: linkedPost?.publishedAt?.toISOString(),
-          postRetryCount: linkedPost?.retryCount,
-          postStatus: linkedPost?.status
-            ? String(linkedPost.status)
-            : undefined,
-          postTotalComments: analytics?.totalComments,
-          postTotalLikes: analytics?.totalLikes,
-          postTotalSaves: analytics?.totalSaves,
-          postTotalShares: analytics?.totalShares,
-          postTotalViews: analytics?.totalViews,
-          postUrl: linkedPost?.url ?? undefined,
-          prompt: item.prompt,
-          reviewDecision: item.reviewDecision,
-          reviewEvents: (item.reviewEvents ?? []).map((event) => ({
-            decision: event.decision,
-            feedback: event.feedback,
-            reviewedAt: event.reviewedAt,
-            versionPinId: event.versionPinId,
-          })),
-          reviewedAt: item.reviewedAt,
-          reviewFeedback: item.reviewFeedback,
-          publishApproval:
-            item.publishApproval ??
-            (linkedPost?.publishApproval
-              ? this.publishApprovalsService.toPublicInterface(
-                  linkedPost.publishApproval,
-                )
-              : undefined),
-          scheduledDate: item.scheduledDate,
-          sourceActionId: item.sourceActionId,
-          sourceWorkflowId: item.sourceWorkflowId,
-          sourceWorkflowName: item.sourceWorkflowName,
-          status: item.status,
-          versionPinId:
-            item.versionPinId ?? linkedPost?.reviewVersionPinId ?? undefined,
-        };
-      }),
-      pendingCount,
-      platforms: batchConfig.platforms ?? [],
-      status: String(batch.status) as BatchStatus,
-      totalCount: batchConfig.totalCount ?? batchItems.length,
-    };
+    return this.reviewService.updateBatch(batchId, dto, orgId);
   }
 }

--- a/apps/server/api/src/services/batch-generation/batch-generation.types.ts
+++ b/apps/server/api/src/services/batch-generation/batch-generation.types.ts
@@ -1,0 +1,122 @@
+import type { ContentMixConfig } from '@api/services/batch-generation/schemas/batch.schema';
+import { BatchItemStatus, BatchStatus, ContentFormat } from '@genfeedai/enums';
+import type { IPublishApproval } from '@genfeedai/interfaces';
+import type { Batch } from '@genfeedai/prisma';
+
+export interface BatchItem {
+  format: ContentFormat;
+  status: BatchItemStatus;
+  platform?: string;
+  scheduledDate?: string;
+}
+
+export interface BatchItemFull extends BatchItem {
+  _id: string;
+  caption?: string;
+  prompt?: string;
+  postId?: string;
+  mediaUrl?: string;
+  error?: string;
+  reviewDecision?: 'approved' | 'rejected' | 'request_changes';
+  reviewFeedback?: string;
+  reviewedAt?: string;
+  reviewEvents?: Array<{
+    decision: 'approved' | 'rejected' | 'request_changes';
+    feedback?: string;
+    reviewedAt: string;
+    versionPinId?: string;
+  }>;
+  gateOverallScore?: number;
+  gateReasons?: string[];
+  opportunitySourceType?: 'trend' | 'event' | 'evergreen';
+  opportunityTopic?: string;
+  creativeVersion?: string;
+  hookVersion?: string;
+  contentRunId?: string;
+  variantId?: string;
+  scheduleSlot?: string;
+  publishIntent?: string;
+  sourceActionId?: string;
+  sourceWorkflowId?: string;
+  sourceWorkflowName?: string;
+  createdAt?: string;
+  versionPinId?: string;
+  publishApproval?: IPublishApproval;
+}
+
+export type BatchConfig = {
+  contentMix?: ContentMixConfig;
+  dateRangeStart?: string;
+  dateRangeEnd?: string;
+  platforms?: string[];
+  topics?: string[];
+  completedCount?: number;
+  failedCount?: number;
+  totalCount?: number;
+  completedAt?: string;
+  source?: string;
+  style?: string;
+};
+
+export type BatchWithConfig = Batch & {
+  config: BatchConfig;
+  items: BatchItemFull[];
+};
+
+export interface BatchProcessItemContext {
+  batchId: string;
+  completedCount: number;
+  error?: string;
+  failedCount: number;
+  index: number;
+  item: BatchItemFull;
+  postId?: string;
+  previewText?: string;
+  topic: string;
+  totalCount: number;
+}
+
+export interface BatchProcessOptions {
+  onBatchCompleted?: (params: {
+    batchId: string;
+    completedCount: number;
+    failedCount: number;
+    status: BatchStatus;
+    totalCount: number;
+  }) => Promise<void> | void;
+  onBatchStarted?: (params: {
+    batchId: string;
+    totalCount: number;
+  }) => Promise<void> | void;
+  onItemCompleted?: (params: BatchProcessItemContext) => Promise<void> | void;
+  onItemFailed?: (params: BatchProcessItemContext) => Promise<void> | void;
+  onItemStarted?: (params: BatchProcessItemContext) => Promise<void> | void;
+}
+
+export interface ReviewInboxItemSummary {
+  batchId: string;
+  createdAt: string;
+  format: string;
+  id: string;
+  mediaUrl?: string;
+  platform?: string;
+  postId?: string;
+  reviewDecision?: 'approved' | 'rejected' | 'request_changes';
+  status: string;
+  summary: string;
+}
+
+export interface ReviewInboxSummary {
+  approvedCount: number;
+  changesRequestedCount: number;
+  pendingCount: number;
+  readyCount: number;
+  recentItems: ReviewInboxItemSummary[];
+  rejectedCount: number;
+}
+
+export function cloneBatchItems(items: Batch['items']): BatchItemFull[] {
+  return ((items ?? []) as unknown as BatchItemFull[]).map((item) => ({
+    ...item,
+  }));
+}


### PR DESCRIPTION
## Summary
- replace the 1,403-line batch generation service with a 147-line façade
- extract creation/manual-review setup, batch processing, review decisions/querying, and summary projection providers
- preserve approval/version-pin transactionality and tenant-scoped post updates
- consolidate duplicate manual-review ingredient ownership queries into one tenant-scoped validation
- keep the approval version-pin regression suite wired through the real extracted providers

## Size
- façade: 147 lines
- creation: 390 lines
- processing: 240 lines
- review: 523 lines
- summary: 215 lines
- largest method: 148 lines

## Verification
- `bunx biome check` on all changed batch-generation files
- public method inventory parity
- `git diff --check`
- staged gitleaks scan
- local tests/typecheck/build intentionally deferred to PR CI per workstation policy

Part of #1739.