### PR TITLE
fix(app): resolve protected route QA defects

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/messages/messages-page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/messages/messages-page.tsx
@@ -150,8 +150,10 @@ function isAbortLike(error: unknown): boolean {
     (error instanceof DOMException && error.name === 'AbortError') ||
     (typeof error === 'object' &&
       error !== null &&
-      'name' in error &&
-      (error as { name?: string }).name === 'CanceledError')
+      (('name' in error &&
+        (error as { name?: string }).name === 'CanceledError') ||
+        ('isCancelled' in error &&
+          (error as { isCancelled?: boolean }).isCancelled === true)))
   );
 }
 

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/[type]/StudioPageContent.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/[type]/StudioPageContent.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import StudioPageContent from './StudioPageContent';
@@ -13,28 +13,44 @@ const navigationState = vi.hoisted(() => ({
 
 const enabledCategoriesState = vi.hoisted(() => ({
   defaultCategory: 'video',
+  enabledCategories: ['image', 'video'],
   isEnabled: vi.fn(() => false),
   isLoading: false,
 }));
 
 vi.mock('next/navigation', () => ({
   useParams: () => ({ type: navigationState.type }),
+  usePathname: () => `/default/default/studio/${navigationState.type}`,
   useRouter: () => ({
+    prefetch: vi.fn(),
     replace: replaceMock,
   }),
   useSearchParams: () => ({
     get: (key: string) => (key === 'type' ? navigationState.searchType : null),
+    toString: () => '',
   }),
 }));
 
 vi.mock(
   '@hooks/data/organization/use-enabled-categories/use-enabled-categories',
   () => ({
+    STUDIO_CATEGORY_CONFIG: [
+      { category: 'image', param: 'image' },
+      { category: 'video', param: 'video' },
+      { category: 'music', param: 'music' },
+      { category: 'avatar', param: 'avatar' },
+    ],
     categoryToParam: (category: string) => category,
     paramToCategory: (param?: string | null) => param ?? 'image',
     useEnabledCategories: () => enabledCategoriesState,
   }),
 );
+
+vi.mock('@hooks/navigation/use-org-url', () => ({
+  useOrgUrl: () => ({
+    href: (path: string) => `/default/default${path}`,
+  }),
+}));
 
 vi.mock('@pages/studio/generate', () => ({
   default: () => <div data-testid="studio-generate-layout" />,
@@ -54,6 +70,7 @@ describe('StudioPageContent', () => {
     navigationState.type = 'image';
     navigationState.searchType = null;
     enabledCategoriesState.defaultCategory = 'video';
+    enabledCategoriesState.enabledCategories = ['image', 'video'];
     enabledCategoriesState.isEnabled.mockReturnValue(false);
     enabledCategoriesState.isLoading = false;
   });
@@ -61,6 +78,20 @@ describe('StudioPageContent', () => {
   it('should render without crashing', () => {
     const { container } = render(<StudioPageContent />);
     expect(container.firstChild).toBeInTheDocument();
+  });
+
+  it('renders direct navigation for enabled Studio modes', () => {
+    render(<StudioPageContent />);
+
+    expect(screen.getByRole('link', { name: 'Image' })).toHaveAttribute(
+      'href',
+      '/default/default/studio/image',
+    );
+    expect(screen.getByRole('link', { name: 'Video' })).toHaveAttribute(
+      'href',
+      '/default/default/studio/video',
+    );
+    expect(screen.queryByRole('link', { name: 'Music' })).toBeNull();
   });
 
   it('resets redirect guard when category changes so redirects can fire again', async () => {

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/[type]/StudioPageContent.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/[type]/StudioPageContent.tsx
@@ -4,10 +4,13 @@ import type { IngredientCategory } from '@genfeedai/enums';
 import {
   categoryToParam,
   paramToCategory,
+  STUDIO_CATEGORY_CONFIG,
   useEnabledCategories,
 } from '@hooks/data/organization/use-enabled-categories/use-enabled-categories';
+import { useOrgUrl } from '@hooks/navigation/use-org-url';
 import StudioGenerateLayout from '@pages/studio/generate';
 import LazyLoadingFallback from '@ui/loading/fallback/LazyLoadingFallback';
+import Tabs from '@ui/navigation/tabs/Tabs';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { Suspense, useCallback, useEffect, useMemo, useRef } from 'react';
 import StudioWorkspaceSurfaceAdapter from '../studio-workspace-surface-adapter';
@@ -15,10 +18,12 @@ import GenerationFeatureGuard from './GenerationFeatureGuard';
 
 function StudioPageContentInner() {
   const { replace } = useRouter();
+  const { href } = useOrgUrl();
   const params = useParams<{ type?: string }>();
   const searchParams = useSearchParams();
   const requestedType = searchParams.get('type');
-  const { isEnabled, defaultCategory, isLoading } = useEnabledCategories();
+  const { enabledCategories, isEnabled, defaultCategory, isLoading } =
+    useEnabledCategories();
   const hasRedirectedRef = useRef(false);
 
   // Derive category from URL (single source of truth)
@@ -59,9 +64,31 @@ function StudioPageContentInner() {
     [replace],
   );
 
+  const navigationItems = useMemo(
+    () =>
+      STUDIO_CATEGORY_CONFIG.filter(({ category }) =>
+        enabledCategories.includes(category),
+      ).map(({ category, param }) => ({
+        href: href(`/studio/${param}`),
+        id: param,
+        label: `${category.charAt(0).toUpperCase()}${category.slice(1)}`,
+        matchMode: 'exact' as const,
+      })),
+    [enabledCategories, href],
+  );
+
   return (
     <div className="flex h-full flex-col">
       <StudioWorkspaceSurfaceAdapter mode={category} />
+      <div className="shrink-0 border-border border-b px-4 py-2">
+        <Tabs
+          items={navigationItems}
+          activeTab={categoryToParam(category)}
+          fullWidth={false}
+          size="sm"
+          variant="pills"
+        />
+      </div>
       <div className="min-h-0 flex-1">
         <GenerationFeatureGuard category={category}>
           <StudioGenerateLayout

--- a/packages/agent/src/hooks/use-agent-dashboard-persistence.spec.tsx
+++ b/packages/agent/src/hooks/use-agent-dashboard-persistence.spec.tsx
@@ -1,0 +1,37 @@
+import type { AgentUIBlock } from '@genfeedai/interfaces';
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useAgentDashboardPersistence } from './use-agent-dashboard-persistence';
+
+describe('useAgentDashboardPersistence', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does not persist an unchanged default dashboard on mount', async () => {
+    vi.useFakeTimers();
+    const persistState = vi.fn().mockResolvedValue(undefined);
+    const localSnapshot = {
+      blocks: [] as AgentUIBlock[],
+      isAgentModified: false,
+    };
+
+    renderHook(() =>
+      useAgentDashboardPersistence({
+        blocks: localSnapshot.blocks,
+        currentUser: { id: 'user-1' },
+        getLocalSnapshot: () => localSnapshot,
+        hydrateState: vi.fn(),
+        isAgentModified: localSnapshot.isAgentModified,
+        persistState,
+        scope: 'brand',
+      }),
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(701);
+    });
+
+    expect(persistState).not.toHaveBeenCalled();
+  });
+});

--- a/packages/agent/src/hooks/use-agent-dashboard-persistence.ts
+++ b/packages/agent/src/hooks/use-agent-dashboard-persistence.ts
@@ -96,9 +96,12 @@ export function useAgentDashboardPersistence({
       (localSnapshot.blocks.length > 0 || localSnapshot.isAgentModified)
     ) {
       hydrateState(localSnapshot);
-      lastPersistedSnapshotRef.current = JSON.stringify(localSnapshot);
     }
 
+    // Treat the resolved local state as the persistence baseline even when it
+    // is empty. Otherwise the default dashboard is immediately PATCHed back
+    // to the API on mount despite the user not changing anything.
+    lastPersistedSnapshotRef.current = JSON.stringify(localSnapshot);
     hasResolvedPersistenceRef.current = true;
   }, [currentUser, disabled, getLocalSnapshot, hydrateState, scope]);
 

--- a/packages/services/core/base.service.test.ts
+++ b/packages/services/core/base.service.test.ts
@@ -101,6 +101,7 @@ import type { IServiceSerializer } from '@genfeedai/interfaces/utils/error.inter
 import { PagesService } from '@services/content/pages.service';
 // Import after mocks
 import { BaseService } from '@services/core/base.service';
+import { logger } from '@services/core/logger.service';
 
 // Create a concrete implementation for testing
 class TestModel {
@@ -822,6 +823,14 @@ describe('BaseService', () => {
   });
 
   describe('error handling', () => {
+    it('preserves silent request cancellations without logging or wrapping', async () => {
+      const cancellation = { isCancelled: true, silent: true };
+      service.getInstanceForTest().get.mockRejectedValue(cancellation);
+
+      await expect(service.findAll()).rejects.toBe(cancellation);
+      expect(logger.error).not.toHaveBeenCalled();
+    });
+
     it('should handle network errors', async () => {
       service
         .getInstanceForTest()

--- a/packages/services/core/base.service.ts
+++ b/packages/services/core/base.service.ts
@@ -26,6 +26,15 @@ export type { JsonApiResponseDocument } from '@services/core/json-api';
 
 const serviceInstances = new ServiceInstanceManager<BaseService<unknown>>();
 
+function isCancelledRequest(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'isCancelled' in error &&
+    error.isCancelled === true
+  );
+}
+
 /**
  * Base service class for API operations with type-safe request payloads.
  *
@@ -259,6 +268,13 @@ export abstract class BaseService<
     try {
       return await promise;
     } catch (error) {
+      // The interceptor marks request cancellations as silent control flow.
+      // Preserve that marker so callers can ignore stale requests without a
+      // misleading 500 log or a generic structured error wrapper.
+      if (isCancelledRequest(error)) {
+        throw error;
+      }
+
       this.handleOperationError(operation, error);
     }
   }


### PR DESCRIPTION
## Summary
- preserve silent HTTP cancellations so Messages does not surface a fake 500 after a successful retry
- treat the initial empty dashboard as the Analytics persistence baseline
- add feature-aware Studio generation mode navigation for direct Image/Video switching

## Regression coverage
- BaseService cancellation remains unwrapped and unlogged
- unchanged default dashboard does not persist on mount
- enabled Studio modes render scoped route links

## Browser QA
Authenticated Brave against `http://genfeed.localhost:3000`:
- Studio Image -> Video -> Image passed
- Analytics emitted no settings PATCH after a 2-second settle
- Messages returned HTTP 200 and rendered without page/console errors

Local tests/typechecks/builds intentionally not run per workstation policy; PR CI is the verification gate.