### PR TITLE
fix(app): require source selection for remix entry

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/remix/page.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/remix/page.test.tsx
@@ -58,16 +58,14 @@ describe('PostsRemixPage', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('preserves the existing no-input Trend Remix entry', async () => {
-    const page = await PostsRemixPage({
-      searchParams: Promise.resolve({ thread: 'thread-1' }),
-    });
+  it('renders the Library source picker when Remix has no source intent', async () => {
+    const page = await PostsRemixPage({});
 
     render(page);
 
-    expect(screen.getByTestId('trend-remix-surface')).toBeInTheDocument();
-    expect(
-      screen.queryByTestId('library-remix-surface'),
-    ).not.toBeInTheDocument();
+    expect(screen.getByTestId('library-remix-surface')).toHaveTextContent(
+      'none:none',
+    );
+    expect(screen.queryByTestId('trend-remix-surface')).not.toBeInTheDocument();
   });
 });

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/remix/page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/remix/page.tsx
@@ -34,7 +34,12 @@ export default async function PostsRemixPage({
   const threadId = resolvedSearchParams.thread;
 
   if (typeof sourceArtifact !== 'string' || !sourceArtifact.trim()) {
-    return <TrendRemixPage />;
+    return (
+      <LibraryRemixSurface
+        sourceArtifact={null}
+        threadId={typeof threadId === 'string' ? threadId : null}
+      />
+    );
   }
 
   return (


### PR DESCRIPTION
## Summary
- route the no-query Remix app entry to the existing Library source-selection surface
- retain legacy trend Remix generation only when legacy source/trend intent is present
- preserve typed Library Remix sources and active thread context

## Regression coverage
- no-input `/posts/remix` renders the Library Remix surface instead of legacy generation
- existing typed Library and legacy trend intent tests remain in place

## Browser QA
Authenticated Brave against `http://genfeed.localhost:3000`:
- direct no-query Remix route renders `Start a Remix from Library`
- no credential error or generation side effect occurs
- `Choose a source` opens the Library picker with Images, Videos, and GIFs

Local tests/typechecks/builds intentionally not run per workstation policy; PR CI is the verification gate.