### PR TITLE
fix(auth): deduplicate concurrent token exchanges

### DIFF
--- a/packages/auth-client/src/client.test.ts
+++ b/packages/auth-client/src/client.test.ts
@@ -18,11 +18,39 @@ vi.mock('better-auth/react', () => ({
   })),
 }));
 
-import { getBetterAuthToken } from './client';
+import {
+  clearBetterAuthTokenCache,
+  getBetterAuthToken,
+  getBetterAuthTokenContextKey,
+  signOut,
+} from './client';
+
+function createDeferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+
+  return { promise, resolve };
+}
+
+function createJwt(exp: number): string {
+  const encode = (value: object): string =>
+    btoa(JSON.stringify(value))
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/g, '');
+
+  return `${encode({ alg: 'HS256', typ: 'JWT' })}.${encode({ exp })}.signature`;
+}
 
 describe('getBetterAuthToken', () => {
   beforeEach(() => {
     fetchMock.mockReset();
+    clearBetterAuthTokenCache();
   });
 
   it('reads a direct token response from Better Auth fetch', async () => {
@@ -41,5 +69,193 @@ describe('getBetterAuthToken', () => {
     fetchMock.mockResolvedValue({ data: null });
 
     await expect(getBetterAuthToken()).resolves.toBeNull();
+  });
+
+  it('coalesces a protected-route burst into one token exchange', async () => {
+    const deferred = createDeferred<{ token: string }>();
+    fetchMock.mockReturnValue(deferred.promise);
+
+    const callers = Array.from({ length: 64 }, () =>
+      getBetterAuthToken('session-1:user-1:org-1'),
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    deferred.resolve({ token: 'shared-token' });
+
+    await expect(Promise.all(callers)).resolves.toEqual(
+      Array.from({ length: 64 }, () => 'shared-token'),
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('reuses a valid cached token within its safe lifetime', async () => {
+    fetchMock.mockResolvedValue({ token: 'cached-token' });
+
+    await expect(getBetterAuthToken('session-1:user-1:org-1')).resolves.toBe(
+      'cached-token',
+    );
+    await expect(getBetterAuthToken('session-1:user-1:org-1')).resolves.toBe(
+      'cached-token',
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not reuse a token close to its JWT expiry', async () => {
+    const expiringToken = createJwt(Math.floor(Date.now() / 1000) + 1);
+    const freshToken = createJwt(Math.floor(Date.now() / 1000) + 120);
+    fetchMock
+      .mockResolvedValueOnce({ token: expiringToken })
+      .mockResolvedValueOnce({ token: freshToken });
+
+    await getBetterAuthToken('session-1:user-1:org-1');
+    await expect(getBetterAuthToken('session-1:user-1:org-1')).resolves.toBe(
+      freshToken,
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('isolates cached tokens by authenticated session and organization', async () => {
+    const firstContext = getBetterAuthTokenContextKey({
+      organizationId: 'org-1',
+      sessionId: 'session-1',
+      userId: 'user-1',
+    });
+    const nextSessionContext = getBetterAuthTokenContextKey({
+      organizationId: 'org-1',
+      sessionId: 'session-2',
+      userId: 'user-1',
+    });
+    const nextOrganizationContext = getBetterAuthTokenContextKey({
+      organizationId: 'org-2',
+      sessionId: 'session-2',
+      userId: 'user-1',
+    });
+    fetchMock
+      .mockResolvedValueOnce({ token: 'session-1-token' })
+      .mockResolvedValueOnce({ token: 'session-2-token' })
+      .mockResolvedValueOnce({ token: 'org-2-token' });
+
+    await expect(getBetterAuthToken(firstContext)).resolves.toBe(
+      'session-1-token',
+    );
+    await expect(getBetterAuthToken(nextSessionContext)).resolves.toBe(
+      'session-2-token',
+    );
+    await expect(getBetterAuthToken(nextOrganizationContext)).resolves.toBe(
+      'org-2-token',
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('invalidates cached and in-flight tokens for an auth context', async () => {
+    const firstExchange = createDeferred<{ token: string }>();
+    fetchMock
+      .mockReturnValueOnce(firstExchange.promise)
+      .mockResolvedValueOnce({ token: 'replacement-token' });
+
+    const invalidated = getBetterAuthToken('session-1:user-1:org-1');
+    clearBetterAuthTokenCache('session-1:user-1:org-1');
+    firstExchange.resolve({ token: 'invalidated-token' });
+
+    await expect(invalidated).resolves.toBeNull();
+    await expect(getBetterAuthToken('session-1:user-1:org-1')).resolves.toBe(
+      'replacement-token',
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('invalidates all cached tokens when the session signs out', async () => {
+    fetchMock
+      .mockResolvedValueOnce({ token: 'signed-in-token' })
+      .mockResolvedValueOnce({ token: 'next-session-token' });
+
+    await getBetterAuthToken('session-1:user-1:org-1');
+    await signOut();
+    await expect(getBetterAuthToken('session-1:user-1:org-1')).resolves.toBe(
+      'next-session-token',
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('shares a failed exchange and coalesces the next retry wave', async () => {
+    fetchMock
+      .mockRejectedValueOnce(new Error('rate limited'))
+      .mockResolvedValueOnce({ token: 'recovered-token' });
+
+    const failedWave = await Promise.allSettled(
+      Array.from({ length: 44 }, () =>
+        getBetterAuthToken('session-1:user-1:org-1'),
+      ),
+    );
+
+    expect(failedWave).toHaveLength(44);
+    expect(failedWave.every((result) => result.status === 'rejected')).toBe(
+      true,
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await expect(
+      Promise.all(
+        Array.from({ length: 44 }, () =>
+          getBetterAuthToken('session-1:user-1:org-1'),
+        ),
+      ),
+    ).resolves.toEqual(Array.from({ length: 44 }, () => 'recovered-token'));
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('coalesces concurrent forced refreshes', async () => {
+    const refreshExchange = createDeferred<{ token: string }>();
+    fetchMock
+      .mockResolvedValueOnce({ token: 'cached-token' })
+      .mockReturnValueOnce(refreshExchange.promise);
+
+    await getBetterAuthToken('session-1:user-1:org-1');
+    const firstRefresh = getBetterAuthToken('session-1:user-1:org-1', {
+      forceRefresh: true,
+    });
+    const secondRefresh = getBetterAuthToken('session-1:user-1:org-1', {
+      forceRefresh: true,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    refreshExchange.resolve({ token: 'fresh-token' });
+
+    await expect(Promise.all([firstRefresh, secondRefresh])).resolves.toEqual([
+      'fresh-token',
+      'fresh-token',
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not let one consumer cancellation abort the shared exchange', async () => {
+    const deferred = createDeferred<{ token: string }>();
+    const controller = new AbortController();
+    fetchMock.mockReturnValue(deferred.promise);
+
+    const cancelledConsumer = getBetterAuthToken('session-1:user-1:org-1', {
+      signal: controller.signal,
+    });
+    const activeConsumer = getBetterAuthToken('session-1:user-1:org-1');
+
+    controller.abort();
+
+    await expect(cancelledConsumer).rejects.toMatchObject({
+      name: 'AbortError',
+    });
+
+    deferred.resolve({ token: 'shared-token' });
+
+    await expect(activeConsumer).resolves.toBe('shared-token');
+    await expect(getBetterAuthToken('session-1:user-1:org-1')).resolves.toBe(
+      'shared-token',
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/auth-client/src/client.ts
+++ b/packages/auth-client/src/client.ts
@@ -54,6 +54,8 @@ export interface BetterAuthTokenRequestOptions {
   template?: string;
 }
 
+const DEFAULT_TOKEN_REQUEST_OPTIONS: BetterAuthTokenRequestOptions = {};
+
 interface BetterAuthTokenCacheEntry {
   expiresAt: number;
   promise?: Promise<string | null>;
@@ -166,25 +168,48 @@ function extractBetterAuthToken(response: unknown): string | null {
     : null;
 }
 
+function getInFlightTokenPromise(
+  cacheEntry: BetterAuthTokenCacheEntry | undefined,
+): Promise<string | null> | null {
+  if (!cacheEntry) {
+    return null;
+  }
+
+  return cacheEntry.promise ?? null;
+}
+
+function getUnexpiredToken(
+  cacheEntry: BetterAuthTokenCacheEntry | undefined,
+): string | null {
+  if (!cacheEntry) {
+    return null;
+  }
+  if (!cacheEntry.token) {
+    return null;
+  }
+  if (cacheEntry.expiresAt <= Date.now()) {
+    return null;
+  }
+
+  return cacheEntry.token;
+}
+
 function getReusableTokenPromise(
   cacheKey: string,
   isForceRefresh: boolean,
 ): Promise<string | null> | null {
-  const cachedEntry = betterAuthTokenCache.get(cacheKey);
+  const cacheEntry = betterAuthTokenCache.get(cacheKey);
+  const inFlightPromise = getInFlightTokenPromise(cacheEntry);
 
-  if (cachedEntry?.promise) {
-    return cachedEntry.promise;
+  if (inFlightPromise) {
+    return inFlightPromise;
   }
-
-  if (
-    isForceRefresh ||
-    !cachedEntry?.token ||
-    cachedEntry.expiresAt <= Date.now()
-  ) {
+  if (isForceRefresh) {
     return null;
   }
 
-  return Promise.resolve(cachedEntry.token);
+  const token = getUnexpiredToken(cacheEntry);
+  return token ? Promise.resolve(token) : null;
 }
 
 function cacheResolvedToken(
@@ -257,14 +282,14 @@ function createBetterAuthTokenExchange(
  */
 export function getBetterAuthToken(
   contextKey = DEFAULT_TOKEN_CONTEXT_KEY,
-  options?: BetterAuthTokenRequestOptions,
+  options = DEFAULT_TOKEN_REQUEST_OPTIONS,
 ): Promise<string | null> {
-  const cacheKey = getBetterAuthTokenCacheKey(contextKey, options?.template);
+  const cacheKey = getBetterAuthTokenCacheKey(contextKey, options.template);
   const tokenPromise =
-    getReusableTokenPromise(cacheKey, options?.forceRefresh === true) ??
+    getReusableTokenPromise(cacheKey, options.forceRefresh === true) ??
     createBetterAuthTokenExchange(cacheKey);
 
-  return waitForTokenConsumer(tokenPromise, options?.signal);
+  return waitForTokenConsumer(tokenPromise, options.signal);
 }
 
 export function clearBetterAuthTokenCache(contextKey?: string): void {

--- a/packages/auth-client/src/client.ts
+++ b/packages/auth-client/src/client.ts
@@ -166,6 +166,85 @@ function extractBetterAuthToken(response: unknown): string | null {
     : null;
 }
 
+function getReusableTokenPromise(
+  cacheKey: string,
+  isForceRefresh: boolean,
+): Promise<string | null> | null {
+  const cachedEntry = betterAuthTokenCache.get(cacheKey);
+
+  if (cachedEntry?.promise) {
+    return cachedEntry.promise;
+  }
+
+  if (
+    isForceRefresh ||
+    !cachedEntry?.token ||
+    cachedEntry.expiresAt <= Date.now()
+  ) {
+    return null;
+  }
+
+  return Promise.resolve(cachedEntry.token);
+}
+
+function cacheResolvedToken(
+  cacheKey: string,
+  cacheEntry: BetterAuthTokenCacheEntry,
+  token: string | null,
+): string | null {
+  if (betterAuthTokenCache.get(cacheKey) !== cacheEntry) {
+    return null;
+  }
+
+  if (!token) {
+    betterAuthTokenCache.delete(cacheKey);
+    return null;
+  }
+
+  cacheEntry.expiresAt = getJwtAwareExpiry(token);
+  cacheEntry.token = token;
+  return token;
+}
+
+function deleteTokenCacheEntry(
+  cacheKey: string,
+  cacheEntry: BetterAuthTokenCacheEntry,
+): void {
+  if (betterAuthTokenCache.get(cacheKey) === cacheEntry) {
+    betterAuthTokenCache.delete(cacheKey);
+  }
+}
+
+function clearInFlightTokenPromise(
+  cacheKey: string,
+  cacheEntry: BetterAuthTokenCacheEntry,
+): void {
+  if (betterAuthTokenCache.get(cacheKey) === cacheEntry) {
+    cacheEntry.promise = undefined;
+  }
+}
+
+function createBetterAuthTokenExchange(
+  cacheKey: string,
+): Promise<string | null> {
+  const cacheEntry: BetterAuthTokenCacheEntry = { expiresAt: 0 };
+  const exchange = authClient
+    .$fetch<{ token: string }>('/token', { method: 'GET' })
+    .then(extractBetterAuthToken)
+    .then((token) => cacheResolvedToken(cacheKey, cacheEntry, token))
+    .catch((error: unknown) => {
+      deleteTokenCacheEntry(cacheKey, cacheEntry);
+      throw error;
+    })
+    .finally(() => {
+      clearInFlightTokenPromise(cacheKey, cacheEntry);
+    });
+
+  cacheEntry.promise = exchange;
+  betterAuthTokenCache.set(cacheKey, cacheEntry);
+  return exchange;
+}
+
 /**
  * Retrieves a Bearer JWT minted by the Better Auth `jwt` plugin via its server
  * `GET /token` endpoint (the jwt *client* plugin only exposes `jwks`, not a
@@ -181,57 +260,11 @@ export function getBetterAuthToken(
   options?: BetterAuthTokenRequestOptions,
 ): Promise<string | null> {
   const cacheKey = getBetterAuthTokenCacheKey(contextKey, options?.template);
-  const cachedEntry = betterAuthTokenCache.get(cacheKey);
+  const tokenPromise =
+    getReusableTokenPromise(cacheKey, options?.forceRefresh === true) ??
+    createBetterAuthTokenExchange(cacheKey);
 
-  if (cachedEntry?.promise) {
-    return waitForTokenConsumer(cachedEntry.promise, options?.signal);
-  }
-
-  if (
-    !options?.forceRefresh &&
-    cachedEntry?.token &&
-    cachedEntry.expiresAt > Date.now()
-  ) {
-    return waitForTokenConsumer(
-      Promise.resolve(cachedEntry.token),
-      options?.signal,
-    );
-  }
-
-  const nextEntry: BetterAuthTokenCacheEntry = { expiresAt: 0 };
-  const exchange = authClient
-    .$fetch<{ token: string }>('/token', { method: 'GET' })
-    .then(extractBetterAuthToken)
-    .then((token) => {
-      if (betterAuthTokenCache.get(cacheKey) !== nextEntry) {
-        return null;
-      }
-
-      if (!token) {
-        betterAuthTokenCache.delete(cacheKey);
-        return null;
-      }
-
-      nextEntry.expiresAt = getJwtAwareExpiry(token);
-      nextEntry.token = token;
-      return token;
-    })
-    .catch((error: unknown) => {
-      if (betterAuthTokenCache.get(cacheKey) === nextEntry) {
-        betterAuthTokenCache.delete(cacheKey);
-      }
-      throw error;
-    })
-    .finally(() => {
-      if (betterAuthTokenCache.get(cacheKey) === nextEntry) {
-        nextEntry.promise = undefined;
-      }
-    });
-
-  nextEntry.promise = exchange;
-  betterAuthTokenCache.set(cacheKey, nextEntry);
-
-  return waitForTokenConsumer(exchange, options?.signal);
+  return waitForTokenConsumer(tokenPromise, options?.signal);
 }
 
 export function clearBetterAuthTokenCache(contextKey?: string): void {

--- a/packages/auth-client/src/client.ts
+++ b/packages/auth-client/src/client.ts
@@ -32,10 +32,118 @@ export const {
   requestPasswordReset,
   resetPassword,
   signIn,
-  signOut,
   signUp,
   useSession,
 } = authClient;
+
+const TOKEN_CACHE_TTL_MS = 30_000;
+const TOKEN_EXPIRY_SKEW_MS = 5_000;
+const DEFAULT_TOKEN_CONTEXT_KEY = '__default__';
+const DEFAULT_TOKEN_TEMPLATE_KEY = '__default__';
+const TOKEN_CACHE_KEY_SEPARATOR = '\u0001';
+
+export interface BetterAuthTokenContext {
+  organizationId: string | null;
+  sessionId: string | null;
+  userId: string | null;
+}
+
+export interface BetterAuthTokenRequestOptions {
+  forceRefresh?: boolean;
+  signal?: AbortSignal;
+  template?: string;
+}
+
+interface BetterAuthTokenCacheEntry {
+  expiresAt: number;
+  promise?: Promise<string | null>;
+  token?: string;
+}
+
+const betterAuthTokenCache = new Map<string, BetterAuthTokenCacheEntry>();
+
+export function getBetterAuthTokenContextKey(
+  context: BetterAuthTokenContext,
+): string {
+  return [
+    context.sessionId ?? 'no-session',
+    context.userId ?? 'anonymous',
+    context.organizationId ?? 'no-org',
+  ].join(TOKEN_CACHE_KEY_SEPARATOR);
+}
+
+function getBetterAuthTokenCacheKey(
+  contextKey: string,
+  template?: string,
+): string {
+  return [contextKey, template ?? DEFAULT_TOKEN_TEMPLATE_KEY].join(
+    TOKEN_CACHE_KEY_SEPARATOR,
+  );
+}
+
+function getJwtAwareExpiry(token: string): number {
+  const fallbackExpiry = Date.now() + TOKEN_CACHE_TTL_MS;
+  const payload = token.split('.')[1];
+
+  if (!payload) {
+    return fallbackExpiry;
+  }
+
+  try {
+    const normalizedPayload = payload
+      .replace(/-/g, '+')
+      .replace(/_/g, '/')
+      .padEnd(Math.ceil(payload.length / 4) * 4, '=');
+    const decodedPayload = atob(normalizedPayload);
+    const parsed = JSON.parse(decodedPayload) as { exp?: number };
+
+    if (typeof parsed.exp !== 'number') {
+      return fallbackExpiry;
+    }
+
+    return Math.min(
+      fallbackExpiry,
+      Math.max(Date.now(), parsed.exp * 1000 - TOKEN_EXPIRY_SKEW_MS),
+    );
+  } catch {
+    return fallbackExpiry;
+  }
+}
+
+function waitForTokenConsumer(
+  promise: Promise<string | null>,
+  signal?: AbortSignal,
+): Promise<string | null> {
+  if (!signal) {
+    return promise;
+  }
+
+  return new Promise<string | null>((resolve, reject) => {
+    if (signal.aborted) {
+      reject(new DOMException('Token request aborted', 'AbortError'));
+      return;
+    }
+
+    const handleAbort = (): void => {
+      reject(new DOMException('Token request aborted', 'AbortError'));
+    };
+    const cleanup = (): void => {
+      signal.removeEventListener('abort', handleAbort);
+    };
+
+    signal.addEventListener('abort', handleAbort, { once: true });
+    promise.then(
+      (token) => {
+        cleanup();
+        resolve(token);
+      },
+      (error: unknown) => {
+        cleanup();
+        reject(error);
+      },
+    );
+  });
+}
 
 function extractBetterAuthToken(response: unknown): string | null {
   if (!response || typeof response !== 'object') {
@@ -63,11 +171,89 @@ function extractBetterAuthToken(response: unknown): string | null {
  * `GET /token` endpoint (the jwt *client* plugin only exposes `jwks`, not a
  * `token()` action in 1.6.x — so we call `$fetch` directly). Non-hook, so it is
  * safe to call from the token choke point in `@genfeedai/helpers` and other
- * non-React contexts. Returns `null` when there is no active session.
+ * non-React contexts. Concurrent callers share one session-scoped exchange and
+ * valid results are cached for at most 30 seconds. A consumer abort only stops
+ * that consumer's wait; it never aborts the shared exchange. Returns `null`
+ * when there is no active session or the context was invalidated in flight.
  */
-export async function getBetterAuthToken(): Promise<string | null> {
-  const response = await authClient.$fetch<{ token: string }>('/token', {
-    method: 'GET',
-  });
-  return extractBetterAuthToken(response);
+export function getBetterAuthToken(
+  contextKey = DEFAULT_TOKEN_CONTEXT_KEY,
+  options?: BetterAuthTokenRequestOptions,
+): Promise<string | null> {
+  const cacheKey = getBetterAuthTokenCacheKey(contextKey, options?.template);
+  const cachedEntry = betterAuthTokenCache.get(cacheKey);
+
+  if (cachedEntry?.promise) {
+    return waitForTokenConsumer(cachedEntry.promise, options?.signal);
+  }
+
+  if (
+    !options?.forceRefresh &&
+    cachedEntry?.token &&
+    cachedEntry.expiresAt > Date.now()
+  ) {
+    return waitForTokenConsumer(
+      Promise.resolve(cachedEntry.token),
+      options?.signal,
+    );
+  }
+
+  const nextEntry: BetterAuthTokenCacheEntry = { expiresAt: 0 };
+  const exchange = authClient
+    .$fetch<{ token: string }>('/token', { method: 'GET' })
+    .then(extractBetterAuthToken)
+    .then((token) => {
+      if (betterAuthTokenCache.get(cacheKey) !== nextEntry) {
+        return null;
+      }
+
+      if (!token) {
+        betterAuthTokenCache.delete(cacheKey);
+        return null;
+      }
+
+      nextEntry.expiresAt = getJwtAwareExpiry(token);
+      nextEntry.token = token;
+      return token;
+    })
+    .catch((error: unknown) => {
+      if (betterAuthTokenCache.get(cacheKey) === nextEntry) {
+        betterAuthTokenCache.delete(cacheKey);
+      }
+      throw error;
+    })
+    .finally(() => {
+      if (betterAuthTokenCache.get(cacheKey) === nextEntry) {
+        nextEntry.promise = undefined;
+      }
+    });
+
+  nextEntry.promise = exchange;
+  betterAuthTokenCache.set(cacheKey, nextEntry);
+
+  return waitForTokenConsumer(exchange, options?.signal);
+}
+
+export function clearBetterAuthTokenCache(contextKey?: string): void {
+  if (!contextKey) {
+    betterAuthTokenCache.clear();
+    return;
+  }
+
+  const cacheKeyPrefix = `${contextKey}${TOKEN_CACHE_KEY_SEPARATOR}`;
+  for (const cacheKey of betterAuthTokenCache.keys()) {
+    if (cacheKey.startsWith(cacheKeyPrefix)) {
+      betterAuthTokenCache.delete(cacheKey);
+    }
+  }
+}
+
+export async function signOut(
+  ...args: Parameters<typeof authClient.signOut>
+): Promise<Awaited<ReturnType<typeof authClient.signOut>>> {
+  try {
+    return await authClient.signOut(...args);
+  } finally {
+    clearBetterAuthTokenCache();
+  }
 }

--- a/packages/auth-client/src/session.ts
+++ b/packages/auth-client/src/session.ts
@@ -2,7 +2,12 @@
 
 import { useCallback } from 'react';
 
-import { authClient, getBetterAuthToken } from './client';
+import {
+  authClient,
+  type BetterAuthTokenRequestOptions,
+  getBetterAuthToken,
+  getBetterAuthTokenContextKey,
+} from './client';
 
 /**
  * Provider-neutral auth identity shape consumed by the app's token choke
@@ -10,10 +15,7 @@ import { authClient, getBetterAuthToken } from './client';
  * from the concrete auth client.
  */
 export interface AuthIdentity {
-  getToken: (opts?: {
-    forceRefresh?: boolean;
-    template?: string;
-  }) => Promise<string | null>;
+  getToken: (opts?: BetterAuthTokenRequestOptions) => Promise<string | null>;
   isLoaded: boolean;
   isSignedIn: boolean;
   orgId: string | null;
@@ -35,17 +37,27 @@ interface BetterAuthSessionShape {
  */
 export function useBetterAuthIdentity(): AuthIdentity {
   const { data, isPending } = authClient.useSession();
-
-  const getToken = useCallback(() => getBetterAuthToken(), []);
-
   const session = data?.session as BetterAuthSessionShape | undefined;
+  const organizationId = session?.activeOrganizationId ?? null;
+  const sessionId = session?.id ?? null;
+  const userId = data?.user?.id ?? null;
+  const tokenContextKey = getBetterAuthTokenContextKey({
+    organizationId,
+    sessionId,
+    userId,
+  });
+  const getToken = useCallback(
+    (options?: BetterAuthTokenRequestOptions) =>
+      getBetterAuthToken(tokenContextKey, options),
+    [tokenContextKey],
+  );
 
   return {
     getToken,
     isLoaded: !isPending,
     isSignedIn: Boolean(data?.session),
-    orgId: session?.activeOrganizationId ?? null,
-    sessionId: session?.id ?? null,
-    userId: data?.user?.id ?? null,
+    orgId: organizationId,
+    sessionId,
+    userId,
   };
 }

--- a/packages/auth-client/src/session.ts
+++ b/packages/auth-client/src/session.ts
@@ -1,10 +1,11 @@
 'use client';
 
-import { useCallback } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 import {
   authClient,
   type BetterAuthTokenRequestOptions,
+  clearBetterAuthTokenCache,
   getBetterAuthToken,
   getBetterAuthTokenContextKey,
 } from './client';
@@ -46,6 +47,17 @@ export function useBetterAuthIdentity(): AuthIdentity {
     sessionId,
     userId,
   });
+  const previousTokenContextKeyRef = useRef(tokenContextKey);
+
+  useEffect(() => {
+    const previousTokenContextKey = previousTokenContextKeyRef.current;
+    previousTokenContextKeyRef.current = tokenContextKey;
+
+    if (previousTokenContextKey !== tokenContextKey) {
+      clearBetterAuthTokenCache(previousTokenContextKey);
+    }
+  }, [tokenContextKey]);
+
   const getToken = useCallback(
     (options?: BetterAuthTokenRequestOptions) =>
       getBetterAuthToken(tokenContextKey, options),

--- a/packages/contexts/providers/protected-providers/protected-providers.test.tsx
+++ b/packages/contexts/providers/protected-providers/protected-providers.test.tsx
@@ -179,4 +179,42 @@ describe('ProtectedProviders', () => {
       expect(screen.getByTestId('child')).toHaveTextContent('playwright-auth');
     });
   });
+
+  it('acquires a fresh token when the authenticated session changes', async () => {
+    const firstGetToken = vi.fn().mockResolvedValue('session-1-token');
+    const secondGetToken = vi.fn().mockResolvedValue('session-2-token');
+    useAuthMock.mockReturnValue({
+      getToken: firstGetToken,
+      isLoaded: true,
+      isSignedIn: true,
+      orgId: 'org-1',
+      sessionId: 'session-1',
+      userId: 'user-1',
+    });
+
+    const { rerender } = render(
+      <ProtectedProviders>
+        <span data-testid="child">session-token</span>
+      </ProtectedProviders>,
+    );
+
+    await waitFor(() => expect(firstGetToken).toHaveBeenCalledTimes(1));
+
+    useAuthMock.mockReturnValue({
+      getToken: secondGetToken,
+      isLoaded: true,
+      isSignedIn: true,
+      orgId: 'org-1',
+      sessionId: 'session-2',
+      userId: 'user-1',
+    });
+    rerender(
+      <ProtectedProviders>
+        <span data-testid="child">session-token</span>
+      </ProtectedProviders>,
+    );
+
+    await waitFor(() => expect(secondGetToken).toHaveBeenCalledTimes(1));
+    expect(firstGetToken).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/contexts/providers/protected-providers/protected-providers.tsx
+++ b/packages/contexts/providers/protected-providers/protected-providers.tsx
@@ -38,6 +38,8 @@ export function ProtectedAuthGate({ children }: LayoutProps): ReactNode {
     getToken,
     isLoaded: isAuthLoaded,
     isSignedIn,
+    orgId,
+    sessionId,
     userId,
   } = useAuthIdentity();
   const playwrightAuth = getPlaywrightAuthState();
@@ -47,7 +49,12 @@ export function ProtectedAuthGate({ children }: LayoutProps): ReactNode {
   const effectiveUserId = userId ?? playwrightAuth?.userId ?? null;
   const [hasJwtToken, setHasJwtToken] = useState(false);
 
-  const sessionKey = `${effectiveUserId ?? 'none'}:${effectiveIsSignedIn ? 'in' : 'out'}`;
+  const sessionKey = [
+    sessionId ?? 'no-session',
+    effectiveUserId ?? 'none',
+    orgId ?? playwrightAuth?.orgId ?? 'no-org',
+    effectiveIsSignedIn ? 'in' : 'out',
+  ].join(':');
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentional trigger — sessionKey changes drive cache clear
   useEffect(() => {

--- a/packages/contexts/providers/protected-providers/protected-providers.tsx
+++ b/packages/contexts/providers/protected-providers/protected-providers.tsx
@@ -12,7 +12,6 @@ import {
   resolveAuthToken,
 } from '@genfeedai/helpers/auth/auth.helper';
 import { useAuthIdentity } from '@genfeedai/hooks/auth/use-auth-identity/use-auth-identity';
-import { clearTokenCache } from '@genfeedai/hooks/auth/use-authed-service/use-authed-service';
 import type { LayoutProps } from '@genfeedai/props/layout/layout.props';
 import type { ProtectedBootstrapData } from '@genfeedai/props/layout/protected-bootstrap.props';
 import { AccessStateProvider } from '@providers/access-state/access-state.provider';
@@ -55,11 +54,6 @@ export function ProtectedAuthGate({ children }: LayoutProps): ReactNode {
     orgId ?? playwrightAuth?.orgId ?? 'no-org',
     effectiveIsSignedIn ? 'in' : 'out',
   ].join(':');
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional trigger — sessionKey changes drive cache clear
-  useEffect(() => {
-    clearTokenCache();
-  }, [sessionKey]);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: sessionKey as a change trigger for auth token refresh
   useEffect(() => {

--- a/packages/contexts/user/brand-context/useBrandProviderState.ts
+++ b/packages/contexts/user/brand-context/useBrandProviderState.ts
@@ -25,10 +25,7 @@ import {
   useState,
 } from 'react';
 import { loadClientProtectedBootstrap } from '../../providers/protected-bootstrap/client-protected-bootstrap';
-import {
-  clearContextTokenCache,
-  useContextAuthedService,
-} from '../internal/context-authed-service';
+import { useContextAuthedService } from '../internal/context-authed-service';
 import {
   BRAND_CONTEXT_CACHE_TTL_MS,
   getBrandEntityId,
@@ -389,7 +386,6 @@ export function useBrandProviderState({
 
   useEffect(() => {
     if (effectiveIsAuthLoaded && !effectiveIsSignedIn) {
-      clearContextTokenCache();
       clearAllServiceInstances();
       startTransition(() => {
         setBrandId('');

--- a/packages/contexts/user/internal/context-authed-service.ts
+++ b/packages/contexts/user/internal/context-authed-service.ts
@@ -1,6 +1,5 @@
 'use client';
 
-import { clearBetterAuthTokenCache } from '@genfeedai/auth-client';
 import { useAuthIdentity } from '@genfeedai/hooks/auth/use-auth-identity/use-auth-identity';
 import { resolveRequiredAuthToken } from '@helpers/auth/auth.helper';
 import { useCallback, useEffect, useRef } from 'react';
@@ -17,10 +16,6 @@ export class ContextAuthenticationTokenUnavailableError extends Error {
     super('Authentication token unavailable');
     this.name = 'ContextAuthenticationTokenUnavailableError';
   }
-}
-
-export function clearContextTokenCache(): void {
-  clearBetterAuthTokenCache();
 }
 
 export function useContextAuthedService<T>(

--- a/packages/contexts/user/internal/context-authed-service.ts
+++ b/packages/contexts/user/internal/context-authed-service.ts
@@ -1,5 +1,6 @@
 'use client';
 
+import { clearBetterAuthTokenCache } from '@genfeedai/auth-client';
 import { useAuthIdentity } from '@genfeedai/hooks/auth/use-auth-identity/use-auth-identity';
 import { resolveAuthToken } from '@helpers/auth/auth.helper';
 import { useCallback, useEffect, useRef } from 'react';
@@ -101,13 +102,14 @@ function getCachedToken(
 
 export function clearContextTokenCache(): void {
   tokenCache.clear();
+  clearBetterAuthTokenCache();
 }
 
 export function useContextAuthedService<T>(
   factory: (token: string) => T,
   template?: string,
 ) {
-  const { getToken, orgId, userId } = useAuthIdentity();
+  const { getToken, orgId, sessionId, userId } = useAuthIdentity();
   const factoryRef = useRef(factory);
   const getTokenRef = useRef(
     getToken as (opts?: TokenOptions) => Promise<string | null>,
@@ -120,7 +122,11 @@ export function useContextAuthedService<T>(
     ) => Promise<string | null>;
   }, [factory, getToken]);
 
-  const identityKey = `${userId ?? 'anonymous'}:${orgId ?? 'no-org'}`;
+  const identityKey = [
+    sessionId ?? 'no-session',
+    userId ?? 'anonymous',
+    orgId ?? 'no-org',
+  ].join(IDENTITY_CACHE_KEY_SEPARATOR);
 
   return useCallback(
     async (options?: { forceRefresh?: boolean }) => {

--- a/packages/contexts/user/internal/context-authed-service.ts
+++ b/packages/contexts/user/internal/context-authed-service.ts
@@ -2,17 +2,9 @@
 
 import { clearBetterAuthTokenCache } from '@genfeedai/auth-client';
 import { useAuthIdentity } from '@genfeedai/hooks/auth/use-auth-identity/use-auth-identity';
-import { resolveAuthToken } from '@helpers/auth/auth.helper';
+import { resolveRequiredAuthToken } from '@helpers/auth/auth.helper';
 import { useCallback, useEffect, useRef } from 'react';
 
-const tokenCache = new Map<
-  string,
-  { expiresAt: number; promise: Promise<string> }
->();
-
-const TOKEN_CACHE_TTL_MS = 30_000;
-const TOKEN_EXPIRY_SKEW_MS = 5_000;
-const DEFAULT_TOKEN_CACHE_KEY = '__default__';
 const IDENTITY_CACHE_KEY_SEPARATOR = '\u0001';
 
 interface TokenOptions {
@@ -27,81 +19,7 @@ export class ContextAuthenticationTokenUnavailableError extends Error {
   }
 }
 
-function getJwtAwareExpiry(token: string): number {
-  const fallbackExpiry = Date.now() + TOKEN_CACHE_TTL_MS;
-  const payload = token.split('.')[1];
-
-  if (!payload) {
-    return fallbackExpiry;
-  }
-
-  try {
-    const normalizedPayload = payload
-      .replace(/-/g, '+')
-      .replace(/_/g, '/')
-      .padEnd(Math.ceil(payload.length / 4) * 4, '=');
-
-    const decodedPayload = atob(normalizedPayload);
-    const parsed = JSON.parse(decodedPayload) as { exp?: number };
-
-    if (typeof parsed.exp !== 'number') {
-      return fallbackExpiry;
-    }
-
-    return Math.min(
-      fallbackExpiry,
-      Math.max(Date.now(), parsed.exp * 1000 - TOKEN_EXPIRY_SKEW_MS),
-    );
-  } catch {
-    return fallbackExpiry;
-  }
-}
-
-function getCachedToken(
-  getTokenFn: (opts?: TokenOptions) => Promise<string | null>,
-  identityKey: string,
-  options?: TokenOptions,
-): Promise<string> {
-  const cacheKey = [
-    identityKey,
-    options?.template ?? DEFAULT_TOKEN_CACHE_KEY,
-  ].join(IDENTITY_CACHE_KEY_SEPARATOR);
-  const tokenOptions =
-    options?.template || options?.forceRefresh ? options : undefined;
-  const cached = !options?.forceRefresh ? tokenCache.get(cacheKey) : undefined;
-
-  if (cached && cached.expiresAt > Date.now()) {
-    return cached.promise;
-  }
-
-  const promise = resolveAuthToken(getTokenFn, tokenOptions).then((token) => {
-    if (!token) {
-      tokenCache.delete(cacheKey);
-      throw new ContextAuthenticationTokenUnavailableError();
-    }
-
-    const cachedEntry = tokenCache.get(cacheKey);
-    if (cachedEntry?.promise === promise) {
-      cachedEntry.expiresAt = getJwtAwareExpiry(token);
-    }
-
-    return token;
-  });
-
-  tokenCache.set(cacheKey, {
-    expiresAt: Date.now() + TOKEN_CACHE_TTL_MS,
-    promise,
-  });
-
-  promise.catch(() => {
-    tokenCache.delete(cacheKey);
-  });
-
-  return promise;
-}
-
 export function clearContextTokenCache(): void {
-  tokenCache.clear();
   clearBetterAuthTokenCache();
 }
 
@@ -128,12 +46,18 @@ export function useContextAuthedService<T>(
     orgId ?? 'no-org',
   ].join(IDENTITY_CACHE_KEY_SEPARATOR);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: identityKey intentionally refreshes consumers after auth scope changes
   return useCallback(
     async (options?: { forceRefresh?: boolean }) => {
-      const token = await getCachedToken(getTokenRef.current, identityKey, {
-        forceRefresh: options?.forceRefresh,
-        template,
-      });
+      const tokenOptions =
+        template || options?.forceRefresh
+          ? { forceRefresh: options?.forceRefresh, template }
+          : undefined;
+      const token = await resolveRequiredAuthToken(
+        getTokenRef.current,
+        tokenOptions,
+        () => new ContextAuthenticationTokenUnavailableError(),
+      );
 
       return factoryRef.current(token);
     },

--- a/packages/helpers/src/auth/auth.helper.test.ts
+++ b/packages/helpers/src/auth/auth.helper.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { resolveAuthToken } from './auth.helper';
+import { resolveAuthToken, resolveRequiredAuthToken } from './auth.helper';
 
 describe('resolveAuthToken', () => {
   beforeEach(() => {
@@ -34,5 +34,17 @@ describe('resolveAuthToken', () => {
     await expect(resolveAuthToken(getToken)).resolves.toBe('playwright-token');
 
     expect(getToken).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws the boundary-specific error when no token is available', async () => {
+    const getToken = vi.fn().mockResolvedValue(null);
+
+    await expect(
+      resolveRequiredAuthToken(
+        getToken,
+        undefined,
+        () => new Error('Authentication token unavailable'),
+      ),
+    ).rejects.toThrow('Authentication token unavailable');
   });
 });

--- a/packages/helpers/src/auth/auth.helper.test.ts
+++ b/packages/helpers/src/auth/auth.helper.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { resolveAuthToken } from './auth.helper';
+
+describe('resolveAuthToken', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('uses the provider token getter as the single acquisition choke point', async () => {
+    const controller = new AbortController();
+    const getToken = vi.fn().mockResolvedValue('provider-token');
+
+    await expect(
+      resolveAuthToken(getToken, {
+        forceRefresh: true,
+        signal: controller.signal,
+        template: 'genfeed-jwt',
+      }),
+    ).resolves.toBe('provider-token');
+
+    expect(getToken).toHaveBeenCalledTimes(1);
+    expect(getToken).toHaveBeenCalledWith({
+      forceRefresh: true,
+      signal: controller.signal,
+      template: 'genfeed-jwt',
+    });
+  });
+
+  it('falls back to the Playwright token when the provider has no token', async () => {
+    const getToken = vi.fn().mockResolvedValue(null);
+    localStorage.setItem('__better_auth_client_jwt', 'playwright-token');
+
+    await expect(resolveAuthToken(getToken)).resolves.toBe('playwright-token');
+
+    expect(getToken).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/helpers/src/auth/auth.helper.ts
+++ b/packages/helpers/src/auth/auth.helper.ts
@@ -31,6 +31,7 @@ export interface PlaywrightAuthState {
 
 export type AuthTokenGetter = (opts?: {
   forceRefresh?: boolean;
+  signal?: AbortSignal;
   template?: string;
 }) => Promise<string | null>;
 
@@ -87,15 +88,11 @@ export async function resolveAuthToken(
   getToken: AuthTokenGetter,
   opts?: {
     forceRefresh?: boolean;
+    signal?: AbortSignal;
     template?: string;
   },
 ): Promise<string | null> {
-  const { getBetterAuthToken } = await import('@genfeedai/auth-client');
-  return (
-    (await getBetterAuthToken()) ??
-    (await getToken(opts)) ??
-    getPlaywrightJwtToken()
-  );
+  return (await getToken(opts)) ?? getPlaywrightJwtToken();
 }
 
 export function hasPlaywrightJwtToken(): boolean {

--- a/packages/helpers/src/auth/auth.helper.ts
+++ b/packages/helpers/src/auth/auth.helper.ts
@@ -29,11 +29,15 @@ export interface PlaywrightAuthState {
   userId: string | null;
 }
 
-export type AuthTokenGetter = (opts?: {
+export interface AuthTokenOptions {
   forceRefresh?: boolean;
   signal?: AbortSignal;
   template?: string;
-}) => Promise<string | null>;
+}
+
+export type AuthTokenGetter = (
+  opts?: AuthTokenOptions,
+) => Promise<string | null>;
 
 const PLAYWRIGHT_JWT_STORAGE_KEYS = [
   '__better_auth_client_jwt',
@@ -86,13 +90,23 @@ export function getPlaywrightJwtToken(): string | null {
 
 export async function resolveAuthToken(
   getToken: AuthTokenGetter,
-  opts?: {
-    forceRefresh?: boolean;
-    signal?: AbortSignal;
-    template?: string;
-  },
+  opts?: AuthTokenOptions,
 ): Promise<string | null> {
   return (await getToken(opts)) ?? getPlaywrightJwtToken();
+}
+
+export async function resolveRequiredAuthToken(
+  getToken: AuthTokenGetter,
+  opts: AuthTokenOptions | undefined,
+  createError: () => Error,
+): Promise<string> {
+  const token = await resolveAuthToken(getToken, opts);
+
+  if (!token) {
+    throw createError();
+  }
+
+  return token;
 }
 
 export function hasPlaywrightJwtToken(): boolean {

--- a/packages/hooks/auth/use-authed-service/use-authed-service.test.ts
+++ b/packages/hooks/auth/use-authed-service/use-authed-service.test.ts
@@ -22,6 +22,7 @@ describe('useAuthedService', () => {
     typeof vi.fn
   >;
   let orgIdMock: string | null = 'org-123';
+  let sessionIdMock: string | null = 'session-123';
   let userIdMock: string | null = 'user-123';
 
   function createJwt(exp: number): string {
@@ -38,6 +39,7 @@ describe('useAuthedService', () => {
     vi.clearAllMocks();
     clearTokenCache();
     orgIdMock = 'org-123';
+    sessionIdMock = 'session-123';
     userIdMock = 'user-123';
     mockResolveAuthToken.mockImplementation(async (getToken, opts) =>
       getToken(opts),
@@ -45,6 +47,7 @@ describe('useAuthedService', () => {
     mockUseAuthIdentity.mockReturnValue({
       getToken: getTokenMock,
       orgId: orgIdMock,
+      sessionId: sessionIdMock,
       userId: userIdMock,
     });
   });
@@ -163,6 +166,7 @@ describe('useAuthedService', () => {
     mockUseAuthIdentity.mockReturnValue({
       getToken: getTokenMock,
       orgId: orgIdMock,
+      sessionId: sessionIdMock,
       userId: userIdMock,
     });
 
@@ -172,5 +176,33 @@ describe('useAuthedService', () => {
     expect(getTokenMock).toHaveBeenCalledTimes(2);
     expect(mockService).toHaveBeenNthCalledWith(1, 'jwt-token-user-1');
     expect(mockService).toHaveBeenNthCalledWith(2, 'jwt-token-user-2');
+  });
+
+  it('does not reuse a cached token across session rotations', async () => {
+    const mockService = vi.fn();
+    getTokenMock
+      .mockResolvedValueOnce('jwt-token-session-1')
+      .mockResolvedValueOnce('jwt-token-session-2');
+
+    const { result, rerender } = renderHook(() =>
+      useAuthedService(mockService),
+    );
+
+    await result.current();
+
+    sessionIdMock = 'session-456';
+    mockUseAuthIdentity.mockReturnValue({
+      getToken: getTokenMock,
+      orgId: orgIdMock,
+      sessionId: sessionIdMock,
+      userId: userIdMock,
+    });
+
+    rerender();
+    await result.current();
+
+    expect(getTokenMock).toHaveBeenCalledTimes(2);
+    expect(mockService).toHaveBeenNthCalledWith(1, 'jwt-token-session-1');
+    expect(mockService).toHaveBeenNthCalledWith(2, 'jwt-token-session-2');
   });
 });

--- a/packages/hooks/auth/use-authed-service/use-authed-service.test.ts
+++ b/packages/hooks/auth/use-authed-service/use-authed-service.test.ts
@@ -1,8 +1,8 @@
-import { resolveAuthToken } from '@helpers/auth/auth.helper';
 import {
-  clearTokenCache,
-  useAuthedService,
-} from '@hooks/auth/use-authed-service/use-authed-service';
+  resolveAuthToken,
+  resolveRequiredAuthToken,
+} from '@helpers/auth/auth.helper';
+import { useAuthedService } from '@hooks/auth/use-authed-service/use-authed-service';
 import { renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -14,6 +14,7 @@ vi.mock('@hooks/auth/use-auth-identity/use-auth-identity', () => ({
 
 vi.mock('@helpers/auth/auth.helper', () => ({
   resolveAuthToken: vi.fn(),
+  resolveRequiredAuthToken: vi.fn(),
 }));
 
 describe('useAuthedService', () => {
@@ -21,34 +22,25 @@ describe('useAuthedService', () => {
   const mockResolveAuthToken = resolveAuthToken as unknown as ReturnType<
     typeof vi.fn
   >;
-  let orgIdMock: string | null = 'org-123';
-  let sessionIdMock: string | null = 'session-123';
-  let userIdMock: string | null = 'user-123';
-
-  function createJwt(exp: number): string {
-    const encode = (value: object): string =>
-      btoa(JSON.stringify(value))
-        .replace(/\+/g, '-')
-        .replace(/\//g, '_')
-        .replace(/=+$/g, '');
-
-    return `${encode({ alg: 'HS256', typ: 'JWT' })}.${encode({ exp })}.signature`;
-  }
+  const mockResolveRequiredAuthToken =
+    resolveRequiredAuthToken as unknown as ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    clearTokenCache();
-    orgIdMock = 'org-123';
-    sessionIdMock = 'session-123';
-    userIdMock = 'user-123';
     mockResolveAuthToken.mockImplementation(async (getToken, opts) =>
       getToken(opts),
     );
+    mockResolveRequiredAuthToken.mockImplementation(
+      async (getToken, opts, createError) => {
+        const token = await mockResolveAuthToken(getToken, opts);
+        if (!token) {
+          throw createError();
+        }
+        return token;
+      },
+    );
     mockUseAuthIdentity.mockReturnValue({
       getToken: getTokenMock,
-      orgId: orgIdMock,
-      sessionId: sessionIdMock,
-      userId: userIdMock,
     });
   });
 
@@ -112,25 +104,6 @@ describe('useAuthedService', () => {
     expect(mockService).toHaveBeenCalledWith('playwright-jwt');
   });
 
-  it('does not reuse a token that is already near expiry', async () => {
-    const mockService = vi.fn();
-    const nearExpiryToken = createJwt(Math.floor(Date.now() / 1000) + 1);
-    const refreshedToken = createJwt(Math.floor(Date.now() / 1000) + 120);
-
-    getTokenMock
-      .mockResolvedValueOnce(nearExpiryToken)
-      .mockResolvedValueOnce(refreshedToken);
-
-    const { result } = renderHook(() => useAuthedService(mockService));
-
-    await result.current();
-    await result.current();
-
-    expect(getTokenMock).toHaveBeenCalledTimes(2);
-    expect(mockService).toHaveBeenNthCalledWith(1, nearExpiryToken);
-    expect(mockService).toHaveBeenNthCalledWith(2, refreshedToken);
-  });
-
   it('supports forcing a fresh token lookup', async () => {
     const mockService = vi.fn();
     getTokenMock
@@ -148,61 +121,5 @@ describe('useAuthedService', () => {
       template: undefined,
     });
     expect(mockService).toHaveBeenNthCalledWith(2, 'fresh-token');
-  });
-
-  it('does not reuse a cached token across auth identity changes', async () => {
-    const mockService = vi.fn();
-    getTokenMock
-      .mockResolvedValueOnce('jwt-token-user-1')
-      .mockResolvedValueOnce('jwt-token-user-2');
-
-    const { result, rerender } = renderHook(() =>
-      useAuthedService(mockService),
-    );
-
-    await result.current();
-
-    userIdMock = 'user-456';
-    mockUseAuthIdentity.mockReturnValue({
-      getToken: getTokenMock,
-      orgId: orgIdMock,
-      sessionId: sessionIdMock,
-      userId: userIdMock,
-    });
-
-    rerender();
-    await result.current();
-
-    expect(getTokenMock).toHaveBeenCalledTimes(2);
-    expect(mockService).toHaveBeenNthCalledWith(1, 'jwt-token-user-1');
-    expect(mockService).toHaveBeenNthCalledWith(2, 'jwt-token-user-2');
-  });
-
-  it('does not reuse a cached token across session rotations', async () => {
-    const mockService = vi.fn();
-    getTokenMock
-      .mockResolvedValueOnce('jwt-token-session-1')
-      .mockResolvedValueOnce('jwt-token-session-2');
-
-    const { result, rerender } = renderHook(() =>
-      useAuthedService(mockService),
-    );
-
-    await result.current();
-
-    sessionIdMock = 'session-456';
-    mockUseAuthIdentity.mockReturnValue({
-      getToken: getTokenMock,
-      orgId: orgIdMock,
-      sessionId: sessionIdMock,
-      userId: userIdMock,
-    });
-
-    rerender();
-    await result.current();
-
-    expect(getTokenMock).toHaveBeenCalledTimes(2);
-    expect(mockService).toHaveBeenNthCalledWith(1, 'jwt-token-session-1');
-    expect(mockService).toHaveBeenNthCalledWith(2, 'jwt-token-session-2');
   });
 });

--- a/packages/hooks/auth/use-authed-service/use-authed-service.ts
+++ b/packages/hooks/auth/use-authed-service/use-authed-service.ts
@@ -112,7 +112,7 @@ export function useAuthedService<T>(
   factory: (token: string) => T,
   template?: string,
 ) {
-  const { getToken, orgId, userId } = useAuthIdentity();
+  const { getToken, orgId, sessionId, userId } = useAuthIdentity();
 
   // Store factory in ref to avoid callback recreation
   const factoryRef = useRef(factory);
@@ -130,7 +130,11 @@ export function useAuthedService<T>(
     ) => Promise<string | null>;
   }, [factory, getToken]);
 
-  const identityKey = `${userId ?? 'anonymous'}:${orgId ?? 'no-org'}`;
+  const identityKey = [
+    sessionId ?? 'no-session',
+    userId ?? 'anonymous',
+    orgId ?? 'no-org',
+  ].join(IDENTITY_CACHE_KEY_SEPARATOR);
 
   return useCallback(
     async (options?: { forceRefresh?: boolean }) => {

--- a/packages/hooks/auth/use-authed-service/use-authed-service.ts
+++ b/packages/hooks/auth/use-authed-service/use-authed-service.ts
@@ -1,22 +1,9 @@
 'use client';
 
-import { resolveAuthToken } from '@helpers/auth/auth.helper';
+import { resolveRequiredAuthToken } from '@helpers/auth/auth.helper';
 import { useAuthIdentity } from '@hooks/auth/use-auth-identity/use-auth-identity';
 import { useCallback, useEffect, useRef } from 'react';
 
-/**
- * Module-level token cache shared across all useAuthedService instances.
- * Deduplicates concurrent getToken() calls and reuses recent tokens (30s TTL).
- * Prevents auth-provider rate-limiting when multiple providers fetch in parallel.
- */
-const tokenCache = new Map<
-  string,
-  { promise: Promise<string>; expiresAt: number }
->();
-
-const TOKEN_CACHE_TTL_MS = 30_000;
-const TOKEN_EXPIRY_SKEW_MS = 5_000;
-const DEFAULT_TOKEN_CACHE_KEY = '__default__';
 const IDENTITY_CACHE_KEY_SEPARATOR = '\u0001';
 
 interface TokenOptions {
@@ -28,83 +15,6 @@ export class AuthenticationTokenUnavailableError extends Error {
   constructor() {
     super('Authentication token unavailable');
     this.name = 'AuthenticationTokenUnavailableError';
-  }
-}
-
-function getCachedToken(
-  getTokenFn: (opts?: TokenOptions) => Promise<string | null>,
-  identityKey: string,
-  options?: TokenOptions,
-): Promise<string> {
-  const cacheKey = [
-    identityKey,
-    options?.template ?? DEFAULT_TOKEN_CACHE_KEY,
-  ].join(IDENTITY_CACHE_KEY_SEPARATOR);
-  const tokenOptions =
-    options?.template || options?.forceRefresh ? options : undefined;
-  const cached = !options?.forceRefresh ? tokenCache.get(cacheKey) : undefined;
-  if (cached && cached.expiresAt > Date.now()) {
-    return cached.promise;
-  }
-
-  const promise = resolveAuthToken(getTokenFn, tokenOptions).then((token) => {
-    if (!token) {
-      tokenCache.delete(cacheKey);
-      throw new AuthenticationTokenUnavailableError();
-    }
-
-    const cachedEntry = tokenCache.get(cacheKey);
-    if (cachedEntry?.promise === promise) {
-      cachedEntry.expiresAt = getJwtAwareExpiry(token);
-    }
-
-    return token;
-  });
-  tokenCache.set(cacheKey, {
-    expiresAt: Date.now() + TOKEN_CACHE_TTL_MS,
-    promise,
-  });
-
-  // Clear on failure so next call retries
-  promise.catch(() => {
-    tokenCache.delete(cacheKey);
-  });
-
-  return promise;
-}
-
-/** @internal Exposed for test cleanup only */
-export function clearTokenCache(): void {
-  tokenCache.clear();
-}
-
-function getJwtAwareExpiry(token: string): number {
-  const fallbackExpiry = Date.now() + TOKEN_CACHE_TTL_MS;
-  const payload = token.split('.')[1];
-
-  if (!payload) {
-    return fallbackExpiry;
-  }
-
-  try {
-    const normalizedPayload = payload
-      .replace(/-/g, '+')
-      .replace(/_/g, '/')
-      .padEnd(Math.ceil(payload.length / 4) * 4, '=');
-
-    const decodedPayload = atob(normalizedPayload);
-    const parsed = JSON.parse(decodedPayload) as { exp?: number };
-
-    if (typeof parsed.exp !== 'number') {
-      return fallbackExpiry;
-    }
-
-    return Math.min(
-      fallbackExpiry,
-      Math.max(Date.now(), parsed.exp * 1000 - TOKEN_EXPIRY_SKEW_MS),
-    );
-  } catch {
-    return fallbackExpiry;
   }
 }
 
@@ -136,12 +46,18 @@ export function useAuthedService<T>(
     orgId ?? 'no-org',
   ].join(IDENTITY_CACHE_KEY_SEPARATOR);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: identityKey intentionally refreshes consumers after auth scope changes
   return useCallback(
     async (options?: { forceRefresh?: boolean }) => {
-      const token = await getCachedToken(getTokenRef.current, identityKey, {
-        forceRefresh: options?.forceRefresh,
-        template,
-      });
+      const tokenOptions =
+        template || options?.forceRefresh
+          ? { forceRefresh: options?.forceRefresh, template }
+          : undefined;
+      const token = await resolveRequiredAuthToken(
+        getTokenRef.current,
+        tokenOptions,
+        () => new AuthenticationTokenUnavailableError(),
+      );
       return factoryRef.current(token);
     },
     [identityKey, template],


### PR DESCRIPTION
## Summary

- coalesce Better Auth token acquisition at the shared auth-client choke point, keyed by session, user, organization, and token template
- reuse only safely valid JWTs, invalidate on context/sign-out changes, and coalesce forced refresh and post-failure retry waves
- isolate caller cancellation from the shared exchange while preserving server-side organization and brand authorization
- add focused coverage matching the 64-request Studio burst and 44-request Analytics retry wave, plus caching, expiry, invalidation, sign-out, session rotation, cancellation, and protected-gate refresh

## Verification

- Biome check: passed on all 11 changed files
- staged Secretlint and Gitleaks commit-range scan: passed
- git diff --check: passed
- PR CI: all exact-head checks passed, including typecheck, build, app, API, package, extension, web/desktop/mobile, server service, guards, and security checks
- local tests, typechecks, builds, E2E, and app processes intentionally not run per repository MacBook policy

Closes #1765
