### PR TITLE
fix(release): repair production E2E gate

### DIFF
--- a/apps/server/api/src/seeds/self-hosted-seed.service.spec.ts
+++ b/apps/server/api/src/seeds/self-hosted-seed.service.spec.ts
@@ -23,7 +23,7 @@ describe('SelfHostedSeedService', () => {
       findFirst: ReturnType<typeof vi.fn>;
       update: ReturnType<typeof vi.fn>;
     };
-    role: { findMany: ReturnType<typeof vi.fn> };
+    role: { upsert: ReturnType<typeof vi.fn> };
   };
   let service: SelfHostedSeedService;
 
@@ -41,10 +41,10 @@ describe('SelfHostedSeedService', () => {
         }),
       },
       role: {
-        findMany: vi.fn().mockResolvedValue([
-          { id: 'role_user', key: 'user' },
-          { id: 'role_owner', key: 'owner' },
-        ]),
+        upsert: vi.fn().mockResolvedValue({
+          id: 'role_owner',
+          key: 'owner',
+        }),
       },
     };
     const logger = {
@@ -63,6 +63,16 @@ describe('SelfHostedSeedService', () => {
   it('backfills an active owner member when the default workspace already exists', async () => {
     await service.onApplicationBootstrap();
 
+    expect(prisma.role.upsert).toHaveBeenCalledWith({
+      create: {
+        key: 'owner',
+        label: 'Owner',
+      },
+      update: {
+        isDeleted: false,
+      },
+      where: { key: 'owner' },
+    });
     expect(prisma.member.create).toHaveBeenCalledWith({
       data: {
         isActive: true,

--- a/apps/server/api/src/seeds/self-hosted-seed.service.ts
+++ b/apps/server/api/src/seeds/self-hosted-seed.service.ts
@@ -119,21 +119,16 @@ export class SelfHostedSeedService implements OnApplicationBootstrap {
       return;
     }
 
-    const roles = await this.prisma.role.findMany({
-      where: {
-        isDeleted: false,
-        key: {
-          in: [MemberRole.OWNER, MemberRole.ADMIN, MemberRole.USER],
-        },
+    const role = await this.prisma.role.upsert({
+      create: {
+        key: MemberRole.OWNER,
+        label: 'Owner',
       },
+      update: {
+        isDeleted: false,
+      },
+      where: { key: MemberRole.OWNER },
     });
-    const role = [MemberRole.OWNER, MemberRole.ADMIN, MemberRole.USER]
-      .map((key) => roles.find((candidate) => candidate.key === key))
-      .find(Boolean);
-
-    if (!role) {
-      throw new Error('No owner, admin, or user role found for default member');
-    }
 
     await this.prisma.member.create({
       data: {

--- a/playwright/e2e/tests/core/automation-loop.spec.ts
+++ b/playwright/e2e/tests/core/automation-loop.spec.ts
@@ -39,14 +39,11 @@ test.describe('Core Automation Loop', () => {
       automationPage.getByRole('link', { name: 'New Workflow' }).first(),
     ).toHaveAttribute('href', /\/workflows\/new$/);
     await expect(
-      automationPage.getByRole('link', { name: 'Workflows' }).first(),
-    ).toBeVisible();
-    await expect(
       automationPage.getByRole('link', { name: 'Templates' }).first(),
     ).toBeVisible();
     await expect(
-      automationPage.getByRole('link', { name: 'Runs' }).first(),
-    ).toBeVisible();
+      automationPage.getByRole('link', { name: 'Autopilot' }).first(),
+    ).toHaveAttribute('href', /\/orchestration\/autopilot$/);
     await expect(
       automationPage
         .getByText('No workflows yet')

--- a/playwright/e2e/tests/core/content-loop.spec.ts
+++ b/playwright/e2e/tests/core/content-loop.spec.ts
@@ -167,13 +167,18 @@ test.describe('Core Content Loop', () => {
     await authenticatedPage.goto(
       `/analytics/posts?postId=${String(contentLoopPost.id)}`,
     );
+    await expect(authenticatedPage).toHaveURL(
+      new RegExp(`analytics/posts\\?postId=${String(contentLoopPost.id)}`),
+    );
+    const postDetail = authenticatedPage.getByRole('dialog', {
+      name: 'Post detail',
+    });
+    await expect(postDetail).toBeVisible();
     await expect(
-      authenticatedPage.getByRole('heading', { name: 'Top Posts' }),
+      postDetail.getByRole('heading', { name: 'Post detail' }),
     ).toBeVisible();
     await expect(
-      authenticatedPage.getByText(
-        'Focused on a single post from the loop. Open the post detail to remix, or ask the agent for the next step.',
-      ),
+      postDetail.getByRole('button', { name: 'Open page' }),
     ).toBeVisible();
   });
 });

--- a/playwright/e2e/tests/shell/page-context-contract.spec.ts
+++ b/playwright/e2e/tests/shell/page-context-contract.spec.ts
@@ -25,22 +25,17 @@ const CONTRACTS: PageContextContract[] = [
     route: `${BRAND_BASE}/workspace/overview`,
     currentApp: 'workspace',
     sectionLabel: 'Workspace',
-    sidebarLabels: ['Dashboard', 'Inbox', 'Tasks', 'Activity'],
+    pageLabels: ['Dashboard'],
   },
   {
     route: `${BRAND_BASE}/library/images`,
     currentApp: 'library',
-    sectionLabel: 'Library',
-    sidebarLabels: ['Videos', 'Images', 'Voices', 'Music'],
+    sectionLabel: 'Workspace',
   },
   {
     route: `${BRAND_BASE}/studio/image`,
     currentApp: 'studio',
-    sectionLabel: 'Studio',
-    // Studio nav lists generation types (Image/Video/Avatar/Music/Batch). The old
-    // 'Library' entry only matched the section-header text back when the studio
-    // shell mislabeled its section 'Library'; that header is now 'Studio'.
-    sidebarLabels: ['Image', 'Video', 'Batch'],
+    sectionLabel: 'Workspace',
   },
   {
     route: `${BRAND_BASE}/posts/scheduled`,


### PR DESCRIPTION
## Summary

- make self-hosted bootstrap upsert the canonical owner role before creating the default membership
- align shell and workflow E2E contracts with the default-on agent-first canvas
- assert analytics post selection through the new in-context detail overlay

## Release evidence

- repairs the failures from [Daily Production Deploy run 29385718739](https://github.com/genfeedai/genfeed.ai/actions/runs/29385718739)
- blocked Deploy ECS run: [29385735429](https://github.com/genfeedai/genfeed.ai/actions/runs/29385735429)
- closes #1767

## Verification

- `bunx biome check` on all five changed files
- staged Secretlint, Biome, and UI control guard passed
- `git diff --check`
- tests, typechecks, builds, and E2E intentionally deferred to GitHub Actions per local machine policy