### PR TITLE
fix(app): restore workspace activity and task view accessibility

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/tasks/issues-list.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/tasks/issues-list.test.tsx
@@ -1,0 +1,52 @@
+import '@testing-library/jest-dom/vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import IssuesList from './issues-list';
+
+const mocks = vi.hoisted(() => ({
+  list: vi.fn(),
+}));
+
+vi.mock('@hooks/auth/use-authed-service/use-authed-service', () => ({
+  useAuthedService: () => async () => ({
+    list: mocks.list,
+  }),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock('./issue-overlay', () => ({
+  default: () => null,
+}));
+
+vi.mock('./issue-overlay-controls', () => ({
+  openIssueOverlay: vi.fn(),
+}));
+
+describe('IssuesList view controls', () => {
+  beforeEach(() => {
+    mocks.list.mockReset();
+    mocks.list.mockResolvedValue([]);
+  });
+
+  it('names the view controls and exposes their selected state', async () => {
+    render(<IssuesList />);
+
+    expect(await screen.findByText('No tasks found')).toBeVisible();
+
+    const listView = screen.getByRole('button', { name: 'List view' });
+    const kanbanView = screen.getByRole('button', { name: 'Kanban view' });
+
+    expect(screen.getByRole('group', { name: 'Task view' })).toBeVisible();
+    expect(listView).toHaveAttribute('aria-pressed', 'true');
+    expect(kanbanView).toHaveAttribute('aria-pressed', 'false');
+
+    fireEvent.click(kanbanView);
+
+    expect(listView).toHaveAttribute('aria-pressed', 'false');
+    expect(kanbanView).toHaveAttribute('aria-pressed', 'true');
+  });
+});

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/tasks/issues-list.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/tasks/issues-list.test.tsx
@@ -4,13 +4,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import IssuesList from './issues-list';
 
 const mocks = vi.hoisted(() => ({
+  getService: vi.fn(),
   list: vi.fn(),
 }));
 
 vi.mock('@hooks/auth/use-authed-service/use-authed-service', () => ({
-  useAuthedService: () => async () => ({
-    list: mocks.list,
-  }),
+  useAuthedService: () => mocks.getService,
 }));
 
 vi.mock('next/navigation', () => ({
@@ -28,8 +27,10 @@ vi.mock('./issue-overlay-controls', () => ({
 
 describe('IssuesList view controls', () => {
   beforeEach(() => {
+    mocks.getService.mockReset();
     mocks.list.mockReset();
     mocks.list.mockResolvedValue([]);
+    mocks.getService.mockResolvedValue({ list: mocks.list });
   });
 
   it('names the view controls and exposes their selected state', async () => {

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/tasks/issues-list.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/tasks/issues-list.tsx
@@ -411,8 +411,11 @@ export default function IssuesList() {
               ))}
             </SelectContent>
           </Select>
-          <div className="flex rounded border border-white/10">
+          <fieldset className="flex rounded border border-white/10">
+            <legend className="sr-only">Task view</legend>
             <Button
+              aria-pressed={viewMode === 'list'}
+              ariaLabel="List view"
               variant={ButtonVariant.GHOST}
               size={ButtonSize.ICON}
               className={cn(
@@ -425,9 +428,11 @@ export default function IssuesList() {
                 dispatch({ type: 'SET_VIEW_MODE', payload: 'list' })
               }
             >
-              <HiOutlineListBullet className="size-4" />
+              <HiOutlineListBullet aria-hidden="true" className="size-4" />
             </Button>
             <Button
+              aria-pressed={viewMode === 'kanban'}
+              ariaLabel="Kanban view"
               variant={ButtonVariant.GHOST}
               size={ButtonSize.ICON}
               className={cn(
@@ -440,9 +445,9 @@ export default function IssuesList() {
                 dispatch({ type: 'SET_VIEW_MODE', payload: 'kanban' })
               }
             >
-              <HiOutlineViewColumns className="size-4" />
+              <HiOutlineViewColumns aria-hidden="true" className="size-4" />
             </Button>
-          </div>
+          </fieldset>
         </div>
       </div>
 

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/use-workspace-page-content.ts
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/use-workspace-page-content.ts
@@ -572,7 +572,7 @@ export function useWorkspacePageContent({
   const sectionCopy = SECTION_COPY[section];
   const shouldShowComposer = false;
   const shouldShowInbox = section === 'overview' || section === 'inbox';
-  const shouldShowHistory = false;
+  const shouldShowHistory = section === 'activity';
   const shouldShowSectionSnapshot = section === 'inbox';
 
   return {

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.test.tsx
@@ -288,6 +288,21 @@ describe('WorkspacePageContent', () => {
     ]);
   });
 
+  it('renders the activity empty state on the dedicated activity page', async () => {
+    mocks.list.mockResolvedValue([]);
+
+    render(<WorkspacePageContent section="activity" />);
+
+    await waitFor(() => {
+      expect(mocks.list).toHaveBeenCalledWith({});
+    });
+
+    expect(screen.getByTestId('workspace-activity')).toBeInTheDocument();
+    expect(
+      screen.getByText('Activity will appear here once tasks start running.'),
+    ).toBeVisible();
+  });
+
   it('loads inbox tasks, opens the inspector, and executes task actions', async () => {
     render(<WorkspacePageContent section="inbox" defaultInboxView="unread" />);
 


### PR DESCRIPTION
## Summary

- restore the dedicated Workspace Activity table and existing empty-state contract
- give Tasks list/Kanban controls semantic grouping, distinct accessible names, and selected state
- add focused regressions for both browser-proven defects

Closes #1769

## Verification

- `bunx biome check` on all four changed files
- `bun run design:lint` (0 errors; existing unused-token warnings only)
- focused Secretlint on changed files
- `git diff --check` and staged diff check
- commit hooks: Secretlint, Biome staged config, UI control guard, bespoke-card guard
- no local tests, typechecks, builds, or E2E per workstation policy; PR CI is authoritative