### PR TITLE
Fix Workflow Autopilot and Configuration route boundaries

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/autopilot/page.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/autopilot/page.test.tsx
@@ -1,0 +1,42 @@
+import { redirect } from 'next/navigation';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import LegacyWorkflowAutopilotPage from './page';
+
+vi.mock('next/navigation', () => ({
+  redirect: vi.fn((url: string) => {
+    throw new Error(`redirect:${url}`);
+  }),
+}));
+
+describe('LegacyWorkflowAutopilotPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('redirects exactly once to the scoped canonical capability without loading a workflow id', async () => {
+    await expect(
+      LegacyWorkflowAutopilotPage({
+        params: Promise.resolve({
+          brandSlug: 'moonrise',
+          orgSlug: 'acme',
+        }),
+        searchParams: Promise.resolve({
+          thread: 'thread-1',
+        }),
+      }),
+    ).rejects.toThrow(
+      'redirect:/acme/moonrise/orchestration/autopilot?thread=thread-1',
+    );
+
+    expect(redirect).toHaveBeenCalledTimes(1);
+    expect(redirect).toHaveBeenCalledWith(
+      '/acme/moonrise/orchestration/autopilot?thread=thread-1',
+    );
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/autopilot/page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/autopilot/page.tsx
@@ -1,0 +1,30 @@
+import { APP_ROUTES } from '@genfeedai/constants';
+import { redirect } from 'next/navigation';
+import {
+  buildLegacyWorkflowRouteRedirect,
+  type LegacyWorkflowRouteSearchParams,
+} from '../legacy-workflow-route';
+
+interface LegacyWorkflowAutopilotPageProps {
+  params: Promise<{ brandSlug: string; orgSlug: string }>;
+  searchParams: Promise<LegacyWorkflowRouteSearchParams>;
+}
+
+export default async function LegacyWorkflowAutopilotPage({
+  params,
+  searchParams,
+}: LegacyWorkflowAutopilotPageProps) {
+  const [{ brandSlug, orgSlug }, resolvedSearchParams] = await Promise.all([
+    params,
+    searchParams,
+  ]);
+
+  redirect(
+    buildLegacyWorkflowRouteRedirect({
+      brandSlug,
+      destination: APP_ROUTES.ORCHESTRATION.AUTOPILOT,
+      orgSlug,
+      searchParams: resolvedSearchParams,
+    }),
+  );
+}

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/configuration/page.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/configuration/page.test.tsx
@@ -1,0 +1,43 @@
+import { redirect } from 'next/navigation';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import LegacyWorkflowConfigurationPage from './page';
+
+vi.mock('next/navigation', () => ({
+  redirect: vi.fn((url: string) => {
+    throw new Error(`redirect:${url}`);
+  }),
+}));
+
+describe('LegacyWorkflowConfigurationPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('redirects exactly once to the scoped canonical capability without loading a workflow id', async () => {
+    await expect(
+      LegacyWorkflowConfigurationPage({
+        params: Promise.resolve({
+          brandSlug: 'moonrise',
+          orgSlug: 'acme',
+        }),
+        searchParams: Promise.resolve({
+          overlay: 'workflow-picker',
+          thread: 'thread-1',
+        }),
+      }),
+    ).rejects.toThrow(
+      'redirect:/acme/moonrise/orchestration/configuration?overlay=workflow-picker&thread=thread-1',
+    );
+
+    expect(redirect).toHaveBeenCalledTimes(1);
+    expect(redirect).toHaveBeenCalledWith(
+      '/acme/moonrise/orchestration/configuration?overlay=workflow-picker&thread=thread-1',
+    );
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/configuration/page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/configuration/page.tsx
@@ -1,0 +1,30 @@
+import { APP_ROUTES } from '@genfeedai/constants';
+import { redirect } from 'next/navigation';
+import {
+  buildLegacyWorkflowRouteRedirect,
+  type LegacyWorkflowRouteSearchParams,
+} from '../legacy-workflow-route';
+
+interface LegacyWorkflowConfigurationPageProps {
+  params: Promise<{ brandSlug: string; orgSlug: string }>;
+  searchParams: Promise<LegacyWorkflowRouteSearchParams>;
+}
+
+export default async function LegacyWorkflowConfigurationPage({
+  params,
+  searchParams,
+}: LegacyWorkflowConfigurationPageProps) {
+  const [{ brandSlug, orgSlug }, resolvedSearchParams] = await Promise.all([
+    params,
+    searchParams,
+  ]);
+
+  redirect(
+    buildLegacyWorkflowRouteRedirect({
+      brandSlug,
+      destination: APP_ROUTES.ORCHESTRATION.CONFIGURATION,
+      orgSlug,
+      searchParams: resolvedSearchParams,
+    }),
+  );
+}

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/legacy-workflow-route.test.ts
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/legacy-workflow-route.test.ts
@@ -1,0 +1,46 @@
+import { APP_ROUTES } from '@genfeedai/constants';
+import { describe, expect, it } from 'vitest';
+import { buildLegacyWorkflowRouteRedirect } from './legacy-workflow-route';
+
+describe('buildLegacyWorkflowRouteRedirect', () => {
+  it('preserves route scope and opaque conversation-shell state', () => {
+    expect(
+      buildLegacyWorkflowRouteRedirect({
+        brandSlug: 'moonrise',
+        destination: APP_ROUTES.ORCHESTRATION.AUTOPILOT,
+        orgSlug: 'acme',
+        searchParams: {
+          filter: 'active',
+          overlay: 'workflow-picker',
+          overlayRef: 'workflow:workflow-1',
+          thread: 'thread-1',
+        },
+      }),
+    ).toBe(
+      '/acme/moonrise/orchestration/autopilot?filter=active&overlay=workflow-picker&overlayRef=workflow%3Aworkflow-1&thread=thread-1',
+    );
+  });
+
+  it('preserves repeated query values deterministically', () => {
+    expect(
+      buildLegacyWorkflowRouteRedirect({
+        brandSlug: 'moonrise',
+        destination: APP_ROUTES.ORCHESTRATION.CONFIGURATION,
+        orgSlug: 'acme',
+        searchParams: { panel: ['model', 'publishing'] },
+      }),
+    ).toBe(
+      '/acme/moonrise/orchestration/configuration?panel=model&panel=publishing',
+    );
+  });
+
+  it('does not add an empty query string', () => {
+    expect(
+      buildLegacyWorkflowRouteRedirect({
+        brandSlug: 'moonrise',
+        destination: APP_ROUTES.ORCHESTRATION.AUTOPILOT,
+        orgSlug: 'acme',
+      }),
+    ).toBe('/acme/moonrise/orchestration/autopilot');
+  });
+});

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/legacy-workflow-route.ts
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workflows/legacy-workflow-route.ts
@@ -1,0 +1,49 @@
+import { type APP_ROUTES, createBrandAppRoute } from '@genfeedai/constants';
+
+export type LegacyWorkflowRouteSearchParams = Readonly<
+  Record<string, string | readonly string[] | undefined>
+>;
+
+interface BuildLegacyWorkflowRouteRedirectOptions {
+  brandSlug: string;
+  destination:
+    | typeof APP_ROUTES.ORCHESTRATION.AUTOPILOT
+    | typeof APP_ROUTES.ORCHESTRATION.CONFIGURATION;
+  orgSlug: string;
+  searchParams?: LegacyWorkflowRouteSearchParams;
+}
+
+/**
+ * Keeps old workflow navigation links inside their existing route scope while
+ * handing authorization and the capability to its canonical orchestration
+ * owner. Opaque product and conversation-shell query parameters survive the
+ * compatibility redirect.
+ */
+export function buildLegacyWorkflowRouteRedirect({
+  brandSlug,
+  destination,
+  orgSlug,
+  searchParams = {},
+}: BuildLegacyWorkflowRouteRedirectOptions): string {
+  const preservedSearchParams = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(searchParams)) {
+    if (value === undefined) {
+      continue;
+    }
+
+    if (typeof value === 'string') {
+      preservedSearchParams.set(key, value);
+      continue;
+    }
+
+    for (const item of value) {
+      preservedSearchParams.append(key, item);
+    }
+  }
+
+  const query = preservedSearchParams.toString();
+  const destinationWithQuery = query ? `${destination}?${query}` : destination;
+
+  return createBrandAppRoute(orgSlug, brandSlug, destinationWithQuery);
+}

--- a/apps/app/packages/config/workflows-menu-items.config.test.ts
+++ b/apps/app/packages/config/workflows-menu-items.config.test.ts
@@ -30,4 +30,22 @@ describe('WORKFLOWS_MENU_ITEMS', () => {
       expect(item.solid).toBeDefined();
     }
   });
+
+  it.each([
+    ['Autopilot', '/orchestration/autopilot', '/workflows/autopilot'],
+    [
+      'Configuration',
+      '/orchestration/configuration',
+      '/workflows/configuration',
+    ],
+  ])('uses the canonical orchestration route for %s and only matches its legacy workflow alias', (label, canonicalHref, legacyHref) => {
+    const item = WORKFLOWS_MENU_ITEMS.find(
+      (menuItem) => menuItem.label === label,
+    );
+
+    expect(item).toMatchObject({ href: canonicalHref });
+    expect(item?.matchPaths).toEqual(
+      expect.arrayContaining([canonicalHref, legacyHref]),
+    );
+  });
 });

--- a/apps/app/packages/config/workflows-menu-items.config.ts
+++ b/apps/app/packages/config/workflows-menu-items.config.ts
@@ -43,7 +43,7 @@ export const WORKFLOWS_MENU_ITEMS: MenuItemConfig[] = [
   },
   {
     group: '',
-    href: APP_ROUTES.WORKFLOWS.AUTOPILOT,
+    href: APP_ROUTES.ORCHESTRATION.AUTOPILOT,
     label: 'Autopilot',
     matchPaths: [
       APP_ROUTES.WORKFLOWS.AUTOPILOT,
@@ -55,7 +55,7 @@ export const WORKFLOWS_MENU_ITEMS: MenuItemConfig[] = [
   },
   {
     group: '',
-    href: APP_ROUTES.WORKFLOWS.CONFIGURATION,
+    href: APP_ROUTES.ORCHESTRATION.CONFIGURATION,
     label: 'Configuration',
     matchPaths: [
       APP_ROUTES.WORKFLOWS.CONFIGURATION,

--- a/packages/constants/src/routes.constant.ts
+++ b/packages/constants/src/routes.constant.ts
@@ -202,7 +202,9 @@ export const APP_ROUTES = {
     ROOT: '/tasks',
   },
   WORKFLOWS: {
+    /** @deprecated Use ORCHESTRATION.AUTOPILOT. Retained for legacy deep links. */
     AUTOPILOT: '/workflows/autopilot',
+    /** @deprecated Use ORCHESTRATION.CONFIGURATION. Retained for legacy deep links. */
     CONFIGURATION: '/workflows/configuration',
     EXECUTIONS: '/workflows/executions',
     NEW: '/workflows/new',


### PR DESCRIPTION
## Summary

- route Workflow Autopilot and Configuration navigation to their existing canonical orchestration owners
- keep both legacy workflow deep links as scoped server redirects that preserve conversation-shell and opaque query state
- prevent the generic workflow editor from interpreting `autopilot` and `configuration` as workflow IDs, eliminating the four repeated route-shaped API requests and their blocking 404 errors
- add focused coverage for canonical menu ownership, legacy fallback redirects, organization/brand scope, query preservation, single redirects, and zero data requests

## Related issue

Closes #1772

Refs #1670
Refs #1773

## Scope

This restores the two legacy workflow URLs through existing orchestration contracts; it adds no API endpoint and does not change deterministic workflow execution. The legacy constants remain deprecated compatibility aliases so old deep links and menu active-state matching continue to work.

The canonical Agent Configuration hydration/service-state repair remains isolated in #1773's active worktree to avoid overlapping ownership. This PR only fixes the Workflow Configuration route/API boundary.

QA source: `/tmp/genfeed-qa-20260715/report.md`.

## Verification

- `biome check <9 changed files>` — passed with no warnings
- `bun run check:pages-boundary` — passed
- `git diff --cached --check` — passed
- `gitleaks git --staged --no-banner --redact --exit-code 1` — no leaks
- pre-commit staged gates — Biome, secretlint, UI control guard, and bespoke-card guard passed
- local tests, typechecks, builds, compilation, E2E, and app processes intentionally not run per repository machine policy; PR CI is the executable verification source

Post-deploy browser observation should confirm both legacy URLs land on their scoped canonical orchestration routes with no `/v1/workflows/autopilot` or `/v1/workflows/configuration` request and no route-shaped 404 debug overlay.

## Screenshots

Not applicable; this is a route ownership and compatibility redirect fix with no visual UI change.

## Checklist

- [x] I reviewed the final diff for unrelated changes.
- [x] I ran the relevant focused checks or documented why they were left to CI.
- [x] No documentation change is needed; the route constants carry compatibility deprecations and the canonical route inventory already names orchestration ownership.
- [x] Migrations, release steps, and external configuration changes are not applicable.
- [x] I did not include secrets, credentials, personal data, customer data, or generated build output.
