### PR TITLE
fix(agent): hydrate scoped configuration settings

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/configuration/agent-configuration-page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/configuration/agent-configuration-page.tsx
@@ -1,28 +1,171 @@
 'use client';
 
 import { useBrand } from '@contexts/user/brand-context/brand-context';
-import { type AgentApiConfig, AgentSettings } from '@genfeedai/agent';
-import { useAuthIdentity } from '@genfeedai/hooks/auth/use-auth-identity/use-auth-identity';
-import { resolveAuthToken } from '@helpers/auth/auth.helper';
+import { getBrandOrganizationSlug } from '@contexts/user/brand-context/brand-context.helpers';
+import { useCurrentUser } from '@contexts/user/user-context/user-context';
+import {
+  type AgentGenerationPriority,
+  AgentSettings,
+  type AgentSettingsValues,
+} from '@genfeedai/agent';
+import { AlertCategory } from '@genfeedai/enums';
+import { useAuthedService } from '@hooks/auth/use-authed-service/use-authed-service';
+import { User } from '@models/auth/user.model';
+import { logger } from '@services/core/logger.service';
+import { UsersService } from '@services/organization/users.service';
+import { BrandsService } from '@services/social/brands.service';
+import Alert from '@ui/feedback/alert/Alert';
 import Container from '@ui/layout/container/Container';
-import { useMemo } from 'react';
+import Loading from '@ui/loading/default/Loading';
+import { Button } from '@ui/primitives/button';
+import { useParams } from 'next/navigation';
+import { type ReactElement, useCallback, useMemo } from 'react';
 import { HiOutlineCog6Tooth } from 'react-icons/hi2';
 
-export default function AgentConfigurationPage() {
-  const { getToken } = useAuthIdentity();
-  const { brandId } = useBrand();
+const DEFAULT_GENERATION_PRIORITY: AgentGenerationPriority = 'balanced';
 
-  const apiConfig = useMemo<AgentApiConfig>(
-    () => ({
-      baseUrl: process.env.NEXT_PUBLIC_API_ENDPOINT ?? '',
-      getToken: async (options) => resolveAuthToken(getToken, options),
-    }),
-    [getToken],
+interface ConfigurationErrorStateProps {
+  actionLabel: string;
+  message: string;
+  onRetry: () => Promise<void>;
+}
+
+function ConfigurationErrorState({
+  actionLabel,
+  message,
+  onRetry,
+}: ConfigurationErrorStateProps): ReactElement {
+  return (
+    <div className="space-y-4">
+      <Alert type={AlertCategory.ERROR}>{message}</Alert>
+      <Button label={actionLabel} onClick={() => void onRetry()} />
+    </div>
   );
+}
+
+export default function AgentConfigurationPage(): ReactElement {
+  const params = useParams<{ brandSlug: string; orgSlug: string }>();
+  const { brandId, isReady, refreshBrands, selectedBrand } = useBrand();
+  const { currentUser, isLoading, mutateUser, refetchUser } = useCurrentUser();
+  const getBrandsService = useAuthedService((token: string) =>
+    BrandsService.getInstance(token),
+  );
+  const getUsersService = useAuthedService((token: string) =>
+    UsersService.getInstance(token),
+  );
+
+  const selectedBrandId = selectedBrand?.id ?? '';
+  const isScopeMatch = Boolean(
+    selectedBrandId &&
+      selectedBrandId === brandId &&
+      selectedBrand?.slug === params.brandSlug &&
+      getBrandOrganizationSlug(selectedBrand) === params.orgSlug,
+  );
+
+  const initialSettings = useMemo<AgentSettingsValues>(
+    () => ({
+      defaultModel: selectedBrand?.agentConfig?.defaultModel ?? '',
+      generationPriority:
+        currentUser?.settings?.generationPriority ??
+        DEFAULT_GENERATION_PRIORITY,
+      persona: selectedBrand?.agentConfig?.persona ?? '',
+    }),
+    [
+      currentUser?.settings?.generationPriority,
+      selectedBrand?.agentConfig?.defaultModel,
+      selectedBrand?.agentConfig?.persona,
+    ],
+  );
+
+  const isDefaultState =
+    selectedBrand?.agentConfig?.defaultModel == null &&
+    selectedBrand?.agentConfig?.persona == null &&
+    currentUser?.settings?.generationPriority == null;
+
+  const handleSave = useCallback(
+    async (settings: AgentSettingsValues): Promise<void> => {
+      if (!currentUser || !isScopeMatch || !selectedBrandId) {
+        throw new Error('Agent configuration scope is unavailable');
+      }
+
+      try {
+        const [brandsService, usersService] = await Promise.all([
+          getBrandsService(),
+          getUsersService(),
+        ]);
+
+        await Promise.all([
+          brandsService.updateAgentConfig(selectedBrandId, {
+            defaultModel: settings.defaultModel || undefined,
+            persona: settings.persona || undefined,
+          }),
+          usersService.patchSettings(currentUser.id, {
+            generationPriority: settings.generationPriority,
+          }),
+        ]);
+
+        await refreshBrands();
+        mutateUser(
+          new User({
+            ...currentUser,
+            settings: {
+              ...currentUser.settings,
+              generationPriority: settings.generationPriority,
+            },
+          }),
+        );
+      } catch (error) {
+        logger.error('Failed to save agent configuration', error);
+        throw error;
+      }
+    },
+    [
+      currentUser,
+      getBrandsService,
+      getUsersService,
+      isScopeMatch,
+      mutateUser,
+      refreshBrands,
+      selectedBrandId,
+    ],
+  );
+
+  let content: ReactElement;
+
+  if (!isReady || isLoading) {
+    content = (
+      <Loading isFullSize={false} message="Loading agent configuration" />
+    );
+  } else if (!isScopeMatch) {
+    content = (
+      <ConfigurationErrorState
+        actionLabel="Reload brand access"
+        message="Agent configuration is unavailable for this brand. Return to an authorized brand or reload your access."
+        onRetry={refreshBrands}
+      />
+    );
+  } else if (!currentUser) {
+    content = (
+      <ConfigurationErrorState
+        actionLabel="Retry settings"
+        message="Your settings could not be loaded. Retry before editing agent configuration."
+        onRetry={refetchUser}
+      />
+    );
+  } else {
+    content = (
+      <AgentSettings
+        key={`${selectedBrandId}:${currentUser.id}`}
+        initialSettings={initialSettings}
+        isDefaultState={isDefaultState}
+        onSave={handleSave}
+      />
+    );
+  }
 
   return (
     <Container label="Agent Configuration" icon={<HiOutlineCog6Tooth />}>
-      <AgentSettings apiConfig={apiConfig} brandId={brandId} />
+      {content}
     </Container>
   );
 }

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/configuration/page.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/configuration/page.test.tsx
@@ -96,7 +96,7 @@ describe('AgentConfigurationPage', () => {
   it('hydrates from protected brand context and the canonical current user', () => {
     render(<AgentConfigurationPage />);
 
-    expect(screen.getByRole('button', { name: /^Fast\b/ })).toHaveAttribute(
+    expect(screen.getByRole('button', { name: /^Fast/ })).toHaveAttribute(
       'aria-pressed',
       'true',
     );
@@ -198,7 +198,7 @@ describe('AgentConfigurationPage', () => {
     expect(screen.getByRole('status')).toHaveTextContent(
       'No model, persona, or generation priority overrides are saved yet.',
     );
-    expect(screen.getByRole('button', { name: /^Balanced\b/ })).toHaveAttribute(
+    expect(screen.getByRole('button', { name: /^Balanced/ })).toHaveAttribute(
       'aria-pressed',
       'true',
     );
@@ -207,7 +207,7 @@ describe('AgentConfigurationPage', () => {
   it('saves through canonical scoped services and refreshes hydrated context', async () => {
     render(<AgentConfigurationPage />);
 
-    fireEvent.click(screen.getByRole('button', { name: /^Budget\b/ }));
+    fireEvent.click(screen.getByRole('button', { name: /^Budget/ }));
     fireEvent.change(screen.getByRole('textbox', { name: 'Agent persona' }), {
       target: { value: 'Stay concise.' },
     });

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/configuration/page.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/configuration/page.test.tsx
@@ -1,5 +1,233 @@
+import { useBrand } from '@contexts/user/brand-context/brand-context';
+import { useCurrentUser } from '@contexts/user/user-context/user-context';
+import { useAuthedService } from '@hooks/auth/use-authed-service/use-authed-service';
+import { UsersService } from '@services/organization/users.service';
+import { BrandsService } from '@services/social/brands.service';
 import { assertSourceHasExport } from '@shared/pages/sourceContractTestUtils';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { useParams } from 'next/navigation';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import AgentConfigurationPage from './agent-configuration-page';
 
 assertSourceHasExport(
   'app/(protected)/[orgSlug]/[brandSlug]/orchestration/configuration/page.tsx',
 );
+
+vi.mock('@contexts/user/brand-context/brand-context', () => ({
+  useBrand: vi.fn(),
+}));
+
+vi.mock('@contexts/user/user-context/user-context', () => ({
+  useCurrentUser: vi.fn(),
+}));
+
+vi.mock('@hooks/auth/use-authed-service/use-authed-service', () => ({
+  useAuthedService: vi.fn(),
+}));
+
+vi.mock('@services/core/logger.service', () => ({
+  logger: { error: vi.fn() },
+}));
+
+vi.mock('@services/social/brands.service', () => ({
+  BrandsService: { getInstance: vi.fn() },
+}));
+
+vi.mock('@services/organization/users.service', () => ({
+  UsersService: { getInstance: vi.fn() },
+}));
+
+vi.mock('next/navigation', () => ({
+  useParams: vi.fn(),
+}));
+
+describe('AgentConfigurationPage', () => {
+  const fetchMock = vi.fn();
+  const updateAgentConfig = vi.fn().mockResolvedValue(undefined);
+  const patchSettings = vi.fn().mockResolvedValue(undefined);
+  const refreshBrands = vi.fn().mockResolvedValue(undefined);
+  const refetchUser = vi.fn().mockResolvedValue(undefined);
+  const mutateUser = vi.fn();
+  const selectedBrand = {
+    agentConfig: {
+      defaultModel: 'anthropic/claude-sonnet-4-5-20250929',
+      persona: 'Use the brand voice.',
+    },
+    id: 'brand-db-id',
+    organization: { id: 'org-db-id', slug: 'acme' },
+    slug: 'launchpad',
+  };
+  const currentUser = {
+    id: 'user-db-id',
+    settings: { generationPriority: 'speed' },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = fetchMock as typeof fetch;
+    vi.mocked(useParams).mockReturnValue({
+      brandSlug: 'launchpad',
+      orgSlug: 'acme',
+    });
+    vi.mocked(useBrand).mockReturnValue({
+      brandId: 'brand-db-id',
+      isReady: true,
+      refreshBrands,
+      selectedBrand,
+    } as never);
+    vi.mocked(useCurrentUser).mockReturnValue({
+      currentUser,
+      isLoading: false,
+      mutateUser,
+      refetchUser,
+    } as never);
+    vi.mocked(useAuthedService).mockImplementation(
+      (factory: (token: string) => unknown) => async () => factory('token'),
+    );
+    vi.mocked(BrandsService.getInstance).mockReturnValue({
+      updateAgentConfig,
+    } as never);
+    vi.mocked(UsersService.getInstance).mockReturnValue({
+      patchSettings,
+    } as never);
+  });
+
+  it('hydrates from protected brand context and the canonical current user', () => {
+    render(<AgentConfigurationPage />);
+
+    expect(screen.getByRole('button', { name: /^Fast\b/ })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+    expect(screen.getByRole('textbox', { name: 'Agent persona' })).toHaveValue(
+      'Use the brand voice.',
+    );
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('does not expose editable defaults while scoped hydration is pending', () => {
+    vi.mocked(useBrand).mockReturnValue({
+      isReady: false,
+      refreshBrands,
+    } as never);
+    vi.mocked(useCurrentUser).mockReturnValue({
+      currentUser: null,
+      isLoading: true,
+      mutateUser,
+      refetchUser,
+    } as never);
+
+    render(<AgentConfigurationPage />);
+
+    expect(
+      screen.getByRole('status', { name: 'Loading agent configuration' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Save Settings' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('normalizes missing brand access (403) without a refetch', () => {
+    vi.mocked(useBrand).mockReturnValue({
+      brandId: '',
+      isReady: true,
+      refreshBrands,
+      selectedBrand: undefined,
+    } as never);
+
+    render(<AgentConfigurationPage />);
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Agent configuration is unavailable for this brand.',
+    );
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(
+      screen.queryByRole('button', { name: 'Save Settings' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('normalizes a missing user settings record (404) to a recoverable state', () => {
+    vi.mocked(useCurrentUser).mockReturnValue({
+      currentUser: null,
+      isLoading: false,
+      mutateUser,
+      refetchUser,
+    } as never);
+
+    render(<AgentConfigurationPage />);
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Your settings could not be loaded.',
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Retry settings' }));
+    expect(refetchUser).toHaveBeenCalledOnce();
+  });
+
+  it('fails closed when route and protected context scopes do not match', () => {
+    vi.mocked(useParams).mockReturnValue({
+      brandSlug: 'another-brand',
+      orgSlug: 'acme',
+    });
+
+    render(<AgentConfigurationPage />);
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Agent configuration is unavailable for this brand.',
+    );
+    expect(updateAgentConfig).not.toHaveBeenCalled();
+    expect(patchSettings).not.toHaveBeenCalled();
+  });
+
+  it('renders explicit defaults only after authoritative empty state hydrates', () => {
+    vi.mocked(useBrand).mockReturnValue({
+      brandId: 'brand-db-id',
+      isReady: true,
+      refreshBrands,
+      selectedBrand: { ...selectedBrand, agentConfig: undefined },
+    } as never);
+    vi.mocked(useCurrentUser).mockReturnValue({
+      currentUser: { ...currentUser, settings: undefined },
+      isLoading: false,
+      mutateUser,
+      refetchUser,
+    } as never);
+
+    render(<AgentConfigurationPage />);
+
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'No model, persona, or generation priority overrides are saved yet.',
+    );
+    expect(screen.getByRole('button', { name: /^Balanced\b/ })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+  });
+
+  it('saves through canonical scoped services and refreshes hydrated context', async () => {
+    render(<AgentConfigurationPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: /^Budget\b/ }));
+    fireEvent.change(screen.getByRole('textbox', { name: 'Agent persona' }), {
+      target: { value: 'Stay concise.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save Settings' }));
+
+    await waitFor(() => {
+      expect(updateAgentConfig).toHaveBeenCalledWith('brand-db-id', {
+        defaultModel: 'anthropic/claude-sonnet-4-5-20250929',
+        persona: 'Stay concise.',
+      });
+      expect(patchSettings).toHaveBeenCalledWith('user-db-id', {
+        generationPriority: 'cost',
+      });
+    });
+    expect(mutateUser).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'user-db-id',
+        settings: expect.objectContaining({ generationPriority: 'cost' }),
+      }),
+    );
+    expect(refreshBrands).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/agent/src/components/AgentSettings.spec.tsx
+++ b/packages/agent/src/components/AgentSettings.spec.tsx
@@ -1,52 +1,108 @@
 import { AgentSettings } from '@genfeedai/agent/components/AgentSettings';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 describe('AgentSettings', () => {
+  const onSave = vi.fn().mockResolvedValue(undefined);
+
   beforeEach(() => {
-    global.fetch = vi.fn().mockImplementation((url: string) => {
-      if (url.includes('/brands/')) {
-        return Promise.resolve({
-          json: async () => ({
-            data: { attributes: { agentConfig: {} } },
-          }),
-          ok: true,
-        });
-      }
-
-      return Promise.resolve({
-        json: async () => ({
-          data: { attributes: { generationPriority: 'balanced' } },
-        }),
-        ok: true,
-      });
-    }) as typeof fetch;
+    vi.clearAllMocks();
   });
 
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  it('describes Auto as the default routing path', async () => {
+  it('hydrates controls from authoritative settings', () => {
     render(
       <AgentSettings
-        apiConfig={{
-          baseUrl: 'https://example.com',
-          getToken: vi.fn().mockResolvedValue('token'),
+        initialSettings={{
+          defaultModel: 'anthropic/claude-sonnet-4-5-20250929',
+          generationPriority: 'speed',
+          persona: 'Write like a pragmatic founder.',
         }}
-        brandId="brand-1"
+        onSave={onSave}
       />,
     );
 
-    await waitFor(() => {
-      expect(screen.getByText('Default Model Override')).toBeInTheDocument();
-    });
-
+    expect(screen.getByRole('button', { name: /^Fast\b/ })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
     expect(
-      screen.getByText(
-        'Leave this on Auto to use brand defaults and OpenRouter auto-routing for new threads.',
-      ),
-    ).toBeInTheDocument();
+      screen.getByRole('button', { name: /Claude Sonnet 4.5/i }),
+    ).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('textbox', { name: 'Agent persona' })).toHaveValue(
+      'Write like a pragmatic founder.',
+    );
+  });
+
+  it('labels authoritative empty settings as defaults', () => {
+    render(
+      <AgentSettings
+        initialSettings={{
+          defaultModel: '',
+          generationPriority: 'balanced',
+          persona: '',
+        }}
+        isDefaultState
+        onSave={onSave}
+      />,
+    );
+
+    expect(screen.getByRole('status')).toHaveTextContent(
+      'No model, persona, or generation priority overrides are saved yet.',
+    );
+    expect(screen.getByRole('button', { name: /^Balanced\b/ })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+  });
+
+  it('saves the edited values through the provided boundary', async () => {
+    render(
+      <AgentSettings
+        initialSettings={{
+          defaultModel: '',
+          generationPriority: 'balanced',
+          persona: '',
+        }}
+        onSave={onSave}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /^Budget\b/ }));
+    fireEvent.change(screen.getByRole('textbox', { name: 'Agent persona' }), {
+      target: { value: 'Keep every answer crisp.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Save Settings' }));
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith({
+        defaultModel: '',
+        generationPriority: 'cost',
+        persona: 'Keep every answer crisp.',
+      });
+    });
+    expect(screen.getByRole('status')).toHaveTextContent('Settings saved');
+  });
+
+  it('keeps the form editable and reports a recoverable save failure', async () => {
+    onSave.mockRejectedValueOnce(new Error('save failed'));
+
+    render(
+      <AgentSettings
+        initialSettings={{
+          defaultModel: '',
+          generationPriority: 'balanced',
+          persona: '',
+        }}
+        onSave={onSave}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save Settings' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Failed to save settings',
+    );
+    expect(screen.getByRole('button', { name: 'Save Settings' })).toBeEnabled();
   });
 });

--- a/packages/agent/src/components/AgentSettings.spec.tsx
+++ b/packages/agent/src/components/AgentSettings.spec.tsx
@@ -22,7 +22,7 @@ describe('AgentSettings', () => {
       />,
     );
 
-    expect(screen.getByRole('button', { name: /^Fast\b/ })).toHaveAttribute(
+    expect(screen.getByRole('button', { name: /^Fast/ })).toHaveAttribute(
       'aria-pressed',
       'true',
     );
@@ -50,7 +50,7 @@ describe('AgentSettings', () => {
     expect(screen.getByRole('status')).toHaveTextContent(
       'No model, persona, or generation priority overrides are saved yet.',
     );
-    expect(screen.getByRole('button', { name: /^Balanced\b/ })).toHaveAttribute(
+    expect(screen.getByRole('button', { name: /^Balanced/ })).toHaveAttribute(
       'aria-pressed',
       'true',
     );
@@ -68,7 +68,7 @@ describe('AgentSettings', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: /^Budget\b/ }));
+    fireEvent.click(screen.getByRole('button', { name: /^Budget/ }));
     fireEvent.change(screen.getByRole('textbox', { name: 'Agent persona' }), {
       target: { value: 'Keep every answer crisp.' },
     });

--- a/packages/agent/src/components/AgentSettings.tsx
+++ b/packages/agent/src/components/AgentSettings.tsx
@@ -7,7 +7,6 @@ import {
   type ChangeEvent,
   type ReactElement,
   useCallback,
-  useEffect,
   useState,
 } from 'react';
 import {
@@ -91,19 +90,6 @@ export function AgentSettings({
   const [hasPersistedOverrides, setHasPersistedOverrides] = useState(
     !isDefaultState,
   );
-
-  useEffect(() => {
-    setSelectedModel(initialSettings.defaultModel);
-    setPersona(initialSettings.persona);
-    setGenerationPriority(initialSettings.generationPriority);
-    setHasPersistedOverrides(!isDefaultState);
-    setSaveStatus('idle');
-  }, [
-    initialSettings.defaultModel,
-    initialSettings.generationPriority,
-    initialSettings.persona,
-    isDefaultState,
-  ]);
 
   const handleSave = useCallback(async () => {
     setIsSaving(true);

--- a/packages/agent/src/components/AgentSettings.tsx
+++ b/packages/agent/src/components/AgentSettings.tsx
@@ -1,10 +1,15 @@
 import { AGENT_MODELS } from '@genfeedai/agent/constants/agent-models.constant';
-import type { AgentApiConfig } from '@genfeedai/agent/services/agent-api.service';
 import { ButtonSize, ButtonVariant, CostTier } from '@genfeedai/enums';
 import { cn } from '@helpers/formatting/cn/cn.util';
 import { Button } from '@ui/primitives/button';
 import { Textarea } from '@ui/primitives/textarea';
-import { type ReactElement, useCallback, useEffect, useState } from 'react';
+import {
+  type ChangeEvent,
+  type ReactElement,
+  useCallback,
+  useEffect,
+  useState,
+} from 'react';
 import {
   HiOutlineBolt,
   HiOutlineCheck,
@@ -14,20 +19,22 @@ import {
   HiOutlineTrophy,
 } from 'react-icons/hi2';
 
+export type AgentGenerationPriority = 'quality' | 'balanced' | 'speed' | 'cost';
+
+export interface AgentSettingsValues {
+  defaultModel: string;
+  generationPriority: AgentGenerationPriority;
+  persona: string;
+}
+
 interface AgentSettingsProps {
-  apiConfig: AgentApiConfig;
-  brandId?: string;
+  initialSettings: AgentSettingsValues;
+  isDefaultState?: boolean;
+  onSave: (settings: AgentSettingsValues) => Promise<void>;
 }
-
-interface BrandAgentConfig {
-  defaultModel?: string;
-  persona?: string;
-}
-
-type GenerationPriority = 'quality' | 'balanced' | 'speed' | 'cost';
 
 interface PriorityOption {
-  key: GenerationPriority;
+  key: AgentGenerationPriority;
   label: string;
   description: string;
   icon: ReactElement;
@@ -67,137 +74,88 @@ const COST_TIER_COLORS: Record<CostTier, string> = {
 };
 
 export function AgentSettings({
-  apiConfig,
-  brandId,
+  initialSettings,
+  isDefaultState = false,
+  onSave,
 }: AgentSettingsProps): ReactElement {
-  const [selectedModel, setSelectedModel] = useState<string>('');
-  const [persona, setPersona] = useState('');
+  const [selectedModel, setSelectedModel] = useState(
+    initialSettings.defaultModel,
+  );
+  const [persona, setPersona] = useState(initialSettings.persona);
   const [generationPriority, setGenerationPriority] =
-    useState<GenerationPriority>('quality');
+    useState<AgentGenerationPriority>(initialSettings.generationPriority);
   const [isSaving, setIsSaving] = useState(false);
   const [saveStatus, setSaveStatus] = useState<'idle' | 'success' | 'error'>(
     'idle',
   );
-  const [isLoading, setIsLoading] = useState(true);
+  const [hasPersistedOverrides, setHasPersistedOverrides] = useState(
+    !isDefaultState,
+  );
 
   useEffect(() => {
-    const controller = new AbortController();
-
-    async function fetchConfig(): Promise<void> {
-      try {
-        const token = await apiConfig.getToken();
-        const headers = {
-          Authorization: token ? `Bearer ${token}` : '',
-          'Content-Type': 'application/json',
-        };
-
-        // Fetch brand config and user settings in parallel
-        const [brandRes, settingsRes] = await Promise.all([
-          brandId
-            ? fetch(`${apiConfig.baseUrl}/brands/${brandId}`, {
-                headers,
-                signal: controller.signal,
-              })
-            : Promise.resolve(null),
-          fetch(`${apiConfig.baseUrl}/users/me/settings`, {
-            headers,
-            signal: controller.signal,
-          }),
-        ]);
-
-        if (brandRes?.ok) {
-          const json = await brandRes.json();
-          const agentConfig: BrandAgentConfig | undefined =
-            json?.data?.attributes?.agentConfig;
-          if (agentConfig?.defaultModel) {
-            setSelectedModel(agentConfig.defaultModel);
-          }
-          if (agentConfig?.persona) {
-            setPersona(agentConfig.persona);
-          }
-        }
-
-        if (settingsRes.ok) {
-          const json = await settingsRes.json();
-          const priority = json?.data?.attributes?.generationPriority;
-          if (priority) {
-            setGenerationPriority(priority as GenerationPriority);
-          }
-        }
-      } catch {
-        // Silently fail — settings will use defaults
-      } finally {
-        if (!controller.signal.aborted) {
-          setIsLoading(false);
-        }
-      }
-    }
-
-    fetchConfig();
-    return () => controller.abort();
-  }, [apiConfig, brandId]);
+    setSelectedModel(initialSettings.defaultModel);
+    setPersona(initialSettings.persona);
+    setGenerationPriority(initialSettings.generationPriority);
+    setHasPersistedOverrides(!isDefaultState);
+    setSaveStatus('idle');
+  }, [
+    initialSettings.defaultModel,
+    initialSettings.generationPriority,
+    initialSettings.persona,
+    isDefaultState,
+  ]);
 
   const handleSave = useCallback(async () => {
     setIsSaving(true);
     setSaveStatus('idle');
 
     try {
-      const token = await apiConfig.getToken();
-      const headers = {
-        Authorization: token ? `Bearer ${token}` : '',
-        'Content-Type': 'application/json',
-      };
-
-      // Save brand config and user settings in parallel
-      const requests: Promise<Response>[] = [];
-
-      if (brandId) {
-        requests.push(
-          fetch(`${apiConfig.baseUrl}/brands/${brandId}/agent-config`, {
-            body: JSON.stringify({
-              defaultModel: selectedModel || undefined,
-              persona: persona || undefined,
-            }),
-            headers,
-            method: 'PATCH',
-          }),
-        );
-      }
-
-      requests.push(
-        fetch(`${apiConfig.baseUrl}/users/me/settings`, {
-          body: JSON.stringify({ generationPriority }),
-          headers,
-          method: 'PATCH',
-        }),
-      );
-
-      const results = await Promise.all(requests);
-      const allOk = results.every((r) => r.ok);
-
-      if (allOk) {
-        setSaveStatus('success');
-        setTimeout(() => setSaveStatus('idle'), 2000);
-      } else {
-        setSaveStatus('error');
-      }
+      await onSave({
+        defaultModel: selectedModel,
+        generationPriority,
+        persona,
+      });
+      setHasPersistedOverrides(true);
+      setSaveStatus('success');
     } catch {
       setSaveStatus('error');
     } finally {
       setIsSaving(false);
     }
-  }, [apiConfig, brandId, selectedModel, persona, generationPriority]);
+  }, [generationPriority, onSave, persona, selectedModel]);
 
-  if (isLoading) {
-    return (
-      <div className="flex items-center justify-center py-12">
-        <div className="size-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
-      </div>
-    );
-  }
+  const handlePriorityChange = useCallback(
+    (priority: AgentGenerationPriority) => {
+      setGenerationPriority(priority);
+      setSaveStatus('idle');
+    },
+    [],
+  );
+
+  const handleModelChange = useCallback((model: string) => {
+    setSelectedModel(model);
+    setSaveStatus('idle');
+  }, []);
+
+  const handlePersonaChange = useCallback(
+    (event: ChangeEvent<HTMLTextAreaElement>) => {
+      setPersona(event.target.value);
+      setSaveStatus('idle');
+    },
+    [],
+  );
 
   return (
     <div className="space-y-8">
+      {!hasPersistedOverrides && (
+        <p
+          className="rounded bg-white/[0.02] px-4 py-3 text-xs text-muted-foreground"
+          role="status"
+        >
+          No model, persona, or generation priority overrides are saved yet.
+          These defaults become persisted only after you save.
+        </p>
+      )}
       {/* Generation Priority */}
       <section>
         <h3 className="mb-1 text-sm font-semibold text-foreground">
@@ -210,9 +168,10 @@ export function AgentSettings({
           {GENERATION_PRIORITY_OPTIONS.map((option) => (
             <Button
               key={option.key}
+              aria-pressed={generationPriority === option.key}
               variant={ButtonVariant.UNSTYLED}
               withWrapper={false}
-              onClick={() => setGenerationPriority(option.key)}
+              onClick={() => handlePriorityChange(option.key)}
               className={cn(
                 'flex items-center gap-3 border px-4 py-3 text-left transition-colors',
                 generationPriority === option.key
@@ -259,9 +218,10 @@ export function AgentSettings({
           {AGENT_MODELS.map((model) => (
             <Button
               key={model.key}
+              aria-pressed={selectedModel === model.key}
               variant={ButtonVariant.UNSTYLED}
               withWrapper={false}
-              onClick={() => setSelectedModel(model.key)}
+              onClick={() => handleModelChange(model.key)}
               className={cn(
                 'flex items-center gap-3 border px-4 py-3 text-left transition-colors',
                 selectedModel === model.key
@@ -309,8 +269,9 @@ export function AgentSettings({
         </p>
         <div className="relative">
           <Textarea
+            aria-label="Agent persona"
             value={persona}
-            onChange={(e) => setPersona(e.target.value)}
+            onChange={handlePersonaChange}
             placeholder="Customize your agent's personality and instructions..."
             maxLength={5000}
             rows={6}
@@ -334,10 +295,14 @@ export function AgentSettings({
           {isSaving ? 'Saving...' : 'Save Settings'}
         </Button>
         {saveStatus === 'success' && (
-          <span className="text-xs text-green-400">Settings saved</span>
+          <span className="text-xs text-success" role="status">
+            Settings saved
+          </span>
         )}
         {saveStatus === 'error' && (
-          <span className="text-xs text-red-400">Failed to save</span>
+          <span className="text-xs text-destructive" role="alert">
+            Failed to save settings
+          </span>
         )}
       </div>
     </div>

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -12,7 +12,11 @@ export { AgentOnboardingChecklist } from '@genfeedai/agent/components/AgentOnboa
 export { AgentOutputsPanel } from '@genfeedai/agent/components/AgentOutputsPanel';
 export { AgentOverlay } from '@genfeedai/agent/components/AgentOverlay';
 export { AgentPanel } from '@genfeedai/agent/components/AgentPanel';
-export { AgentSettings } from '@genfeedai/agent/components/AgentSettings';
+export {
+  type AgentGenerationPriority,
+  AgentSettings,
+  type AgentSettingsValues,
+} from '@genfeedai/agent/components/AgentSettings';
 export { AgentSidebar } from '@genfeedai/agent/components/AgentSidebar';
 export { AgentSidebarContent } from '@genfeedai/agent/components/AgentSidebarContent';
 export { AgentStrategyConfig } from '@genfeedai/agent/components/AgentStrategyConfig';


### PR DESCRIPTION
## Summary

- hydrate Agent Configuration from the validated protected-route brand context and canonical current-user settings
- remove the redundant brand refetch and nonexistent users/me/settings read from the shared AgentSettings component
- fail closed on loading, missing access, missing user settings, and route/context scope mismatch before rendering editable controls
- preserve parallel brand/user save semantics through BrandsService.updateAgentConfig and UsersService.patchSettings with currentUser.id
- add focused coverage for hydration, 403/404 normalization, loading safety, scope mismatch, explicit defaults, and save behavior

## Optimization target and approach

Target: one authorized hydration path, zero redundant reads, and no editable state before authority is known.

I considered repairing the two raw fetch URLs inside the shared component, but that would retain duplicate auth, scope, serialization, and deployment-mode logic. This PR instead keeps scope and persistence in the app route container while AgentSettings renders typed state and emits a typed save callback.

## Verification

- scoped Biome check: passed
- design-system lint/check: passed (existing DESIGN.md warnings only)
- package API surface check: passed
- staged and committed diff secret scans: passed with gitleaks
- commit hooks: secretlint, UI control guard, bespoke-card guard, and staged Biome passed
- focused regression tests added; executable tests, typechecks, and builds are delegated to PR CI per local machine policy
- full check:ui-guards remains locally unavailable because its existing nested-card checker crashes while loading the absent TypeScript runtime; PR CI is authoritative

## QA

Reproduction evidence is recorded in issue #1773 from /tmp/genfeed-qa-20260715/report.md. After CI, browser re-verify /default/default/orchestration/configuration for successful hydration, no brand or users/me/settings load requests, fail-closed loading/error states, and successful save/reload.

Closes #1773
Part of #1670