### PR TITLE
Fix Analytics Insights provider fallback and Trends video loading

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/trends/analytics-trends.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/trends/analytics-trends.test.tsx
@@ -20,6 +20,7 @@ const mocks = vi.hoisted(() => ({
   loggerInfo: vi.fn(),
   open: vi.fn(),
   push: vi.fn(),
+  viralVideoProps: vi.fn(),
 }));
 
 vi.mock('@contexts/user/brand-context/brand-context', () => ({
@@ -136,33 +137,35 @@ vi.mock('@ui/analytics/trends', () => ({
       ))}
     </section>
   ),
-  ViralVideoLeaderboard: ({
-    onTimeframeChange,
-    onVideoClick,
-    timeframe,
-    videos,
-  }: {
+  ViralVideoLeaderboard: (props: {
     onTimeframeChange: (timeframe: Timeframe.D7) => void;
     onVideoClick: (video: Record<string, unknown>) => void;
     timeframe: string;
-    videos: Array<{ title: string }>;
-  }) => (
-    <section>
-      <div>Video timeframe: {timeframe}</div>
-      <button type="button" onClick={() => onTimeframeChange(Timeframe.D7)}>
-        Last 7 Days
-      </button>
-      {videos.map((video) => (
+    videos: Array<{ creatorHandle: string; title: string }>;
+  }) => {
+    mocks.viralVideoProps(props);
+
+    return (
+      <section>
+        <div>Video timeframe: {props.timeframe}</div>
         <button
-          key={video.title}
           type="button"
-          onClick={() => onVideoClick(video)}
+          onClick={() => props.onTimeframeChange(Timeframe.D7)}
         >
-          Open {video.title}
+          Last 7 Days
         </button>
-      ))}
-    </section>
-  ),
+        {props.videos.map((video) => (
+          <button
+            key={video.title}
+            type="button"
+            onClick={() => props.onVideoClick(video)}
+          >
+            Open {video.title}
+          </button>
+        ))}
+      </section>
+    );
+  },
 }));
 
 vi.mock('@ui/card/Card', () => ({
@@ -483,19 +486,34 @@ describe('AnalyticsTrends', () => {
 
     renderAnalyticsTrends();
 
-    expect(await screen.findByText('video-wi')).toBeInTheDocument();
-    expect(screen.getByText('@Your brand')).toBeInTheDocument();
-    expect(screen.getByText('0.0%')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(mocks.viralVideoProps).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          videos: [
+            expect.objectContaining({
+              creatorHandle: 'Your brand',
+              engagementRate: 0,
+              platform: 'genfeed',
+              title: 'video-wi',
+              viralScore: 0,
+              views: 0,
+            }),
+          ],
+        }),
+      );
+    });
   });
 
-  it('renders the recoverable empty state when the videos collection is empty', async () => {
+  it('supplies a recoverable empty collection when no videos exist', async () => {
     mocks.findAllVideos.mockResolvedValue([]);
 
     renderAnalyticsTrends();
 
-    expect(
-      await screen.findByText('No viral videos found'),
-    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(mocks.viralVideoProps).toHaveBeenLastCalledWith(
+        expect.objectContaining({ videos: [] }),
+      );
+    });
     expect(mocks.loggerError).not.toHaveBeenCalledWith(
       'Failed to fetch analytics videos',
       expect.anything(),

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/trends/analytics-trends.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/trends/analytics-trends.test.tsx
@@ -1,19 +1,21 @@
 import '@testing-library/jest-dom/vitest';
 import { Platform, Timeframe } from '@genfeedai/enums';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import type { ReactNode } from 'react';
+import { type ReactNode, StrictMode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import AnalyticsTrends from './analytics-trends';
 
 const mocks = vi.hoisted(() => ({
   cacheGet: vi.fn(),
   cacheSet: vi.fn(),
+  findAllVideos: vi.fn(),
   getTrendsDiscovery: vi.fn(),
   getTrendingHashtags: vi.fn(),
   getTrendingSounds: vi.fn(),
   getTrendingTopics: vi.fn(),
   getTrendsService: vi.fn(),
-  getViralVideos: vi.fn(),
+  getVideosService: vi.fn(),
   loggerError: vi.fn(),
   loggerInfo: vi.fn(),
   open: vi.fn(),
@@ -40,7 +42,18 @@ vi.mock('@helpers/formatting/format/format.helper', () => ({
 }));
 
 vi.mock('@hooks/auth/use-authed-service/use-authed-service', () => ({
-  useAuthedService: () => mocks.getTrendsService,
+  useAuthedService: (factory: (token: string) => unknown) => {
+    const service = factory('mock-token');
+    return service === 'videos-service'
+      ? mocks.getVideosService
+      : mocks.getTrendsService;
+  },
+}));
+
+vi.mock('@services/ingredients/videos.service', () => ({
+  VideosService: {
+    getInstance: vi.fn(() => 'videos-service'),
+  },
 }));
 
 vi.mock('@pages/trends/list/components/HookRemixModal', () => ({
@@ -253,16 +266,21 @@ function makeTrend(overrides: Record<string, unknown> = {}) {
 
 function makeVideo(overrides: Record<string, unknown> = {}) {
   return {
-    creatorHandle: 'creator',
-    engagementRate: 8.5,
+    brand: { label: 'Creator' },
+    createdAt: '2026-07-15T08:00:00.000Z',
+    evaluation: {
+      actualPerformance: {
+        engagementRate: 8.5,
+        views: 100_000,
+      },
+      externalContent: { platform: Platform.TIKTOK },
+      scores: { engagement: { viralityPotential: 91 } },
+    },
     id: 'video-1',
-    platform: Platform.TIKTOK,
-    publishedAt: '2026-05-19T08:00:00.000Z',
-    title: 'Launch hook',
-    velocity: 42,
-    videoUrl: 'https://example.test/video',
-    viralScore: 91,
-    views: 100_000,
+    ingredientUrl: 'https://example.test/video',
+    metadataLabel: 'Launch hook',
+    publishedAt: new Date().toISOString(),
+    thumbnailUrl: 'https://example.test/thumbnail',
     ...overrides,
   };
 }
@@ -301,14 +319,18 @@ function configureSuccessfulService() {
       topic: 'Carousel hooks',
     }),
   ]);
-  mocks.getViralVideos.mockResolvedValue([
+  mocks.findAllVideos.mockResolvedValue([
     makeVideo(),
     makeVideo({
+      brand: undefined,
+      evaluation: {
+        actualPerformance: { engagementRate: 0, views: 0 },
+        externalContent: { platform: Platform.YOUTUBE },
+        scores: { engagement: { viralityPotential: 44 } },
+      },
       id: undefined,
-      platform: Platform.YOUTUBE,
-      title: 'External video',
-      videoUrl: 'https://example.test/external-video',
-      viralScore: 44,
+      ingredientUrl: 'https://example.test/external-video',
+      metadataLabel: 'External video',
     }),
   ]);
   mocks.getTrendingHashtags.mockResolvedValue([
@@ -330,12 +352,27 @@ describe('AnalyticsTrends', () => {
       getTrendingHashtags: mocks.getTrendingHashtags,
       getTrendingSounds: mocks.getTrendingSounds,
       getTrendingTopics: mocks.getTrendingTopics,
-      getViralVideos: mocks.getViralVideos,
+    });
+    mocks.getVideosService.mockResolvedValue({
+      findAll: mocks.findAllVideos,
     });
   });
 
+  function renderAnalyticsTrends(isStrictMode: boolean = false) {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const content = <AnalyticsTrends />;
+
+    return render(
+      <QueryClientProvider client={queryClient}>
+        {isStrictMode ? <StrictMode>{content}</StrictMode> : content}
+      </QueryClientProvider>,
+    );
+  }
+
   it('loads trend surfaces and routes interactive trend content', async () => {
-    render(<AnalyticsTrends />);
+    renderAnalyticsTrends();
 
     expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
       'Social Media Trends',
@@ -351,10 +388,16 @@ describe('AnalyticsTrends', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Last 7 Days' }));
     await waitFor(() => {
-      expect(mocks.getViralVideos).toHaveBeenCalledWith({
-        limit: 12,
-        timeframe: Timeframe.D7,
-      });
+      expect(mocks.findAllVideos).toHaveBeenLastCalledWith(
+        {
+          brand: 'brand-1',
+          lightweight: true,
+          limit: 12,
+          sort: 'createdAt: -1',
+        },
+        expect.any(AbortSignal),
+      );
+      expect(mocks.findAllVideos).toHaveBeenCalledTimes(1);
     });
 
     fireEvent.click(screen.getByRole('button', { name: 'Open Launch hook' }));
@@ -385,11 +428,11 @@ describe('AnalyticsTrends', () => {
   it('renders empty topic copy and falls back to cached videos, hashtags, and sounds', async () => {
     mocks.getTrendsDiscovery.mockResolvedValue({ trends: [] });
     mocks.getTrendingTopics.mockRejectedValue(new Error('topics failed'));
-    mocks.getViralVideos.mockRejectedValue(new Error('videos failed'));
+    mocks.findAllVideos.mockRejectedValue(new Error('videos failed'));
     mocks.getTrendingHashtags.mockRejectedValue(new Error('hashtags failed'));
     mocks.getTrendingSounds.mockRejectedValue(new Error('sounds failed'));
     mocks.cacheGet.mockImplementation((key: string) => {
-      if (key.startsWith('viral:')) {
+      if (key.startsWith('videos:')) {
         return [makeVideo({ id: 'cached-video', title: 'Cached video' })];
       }
       if (key.startsWith('hashtags:')) {
@@ -401,7 +444,7 @@ describe('AnalyticsTrends', () => {
       return null;
     });
 
-    render(<AnalyticsTrends />);
+    renderAnalyticsTrends();
 
     expect(
       await screen.findByText('No trending topics available.'),
@@ -413,7 +456,7 @@ describe('AnalyticsTrends', () => {
       error: expect.any(Error),
     });
     expect(mocks.loggerError).toHaveBeenCalledWith(
-      'Failed to fetch viral videos',
+      'Failed to fetch analytics videos',
       { error: expect.any(Error) },
     );
     expect(mocks.loggerError).toHaveBeenCalledWith(
@@ -424,5 +467,52 @@ describe('AnalyticsTrends', () => {
       'Failed to fetch trending sounds',
       { error: expect.any(Error) },
     );
+  });
+
+  it('normalizes videos with missing analytics data into a safe empty-metric row', async () => {
+    mocks.findAllVideos.mockResolvedValue([
+      makeVideo({
+        brand: undefined,
+        evaluation: undefined,
+        id: 'video-without-analytics',
+        metadataLabel: undefined,
+        provider: undefined,
+        publishedAt: undefined,
+      }),
+    ]);
+
+    renderAnalyticsTrends();
+
+    expect(await screen.findByText('video-wi')).toBeInTheDocument();
+    expect(screen.getByText('@Your brand')).toBeInTheDocument();
+    expect(screen.getByText('0.0%')).toBeInTheDocument();
+  });
+
+  it('renders the recoverable empty state when the videos collection is empty', async () => {
+    mocks.findAllVideos.mockResolvedValue([]);
+
+    renderAnalyticsTrends();
+
+    expect(
+      await screen.findByText('No viral videos found'),
+    ).toBeInTheDocument();
+    expect(mocks.loggerError).not.toHaveBeenCalledWith(
+      'Failed to fetch analytics videos',
+      expect.anything(),
+    );
+  });
+
+  it('deduplicates the canonical videos request across a Strict Mode remount', async () => {
+    mocks.findAllVideos.mockReturnValue(new Promise(() => undefined));
+
+    const view = renderAnalyticsTrends(true);
+
+    await waitFor(() => {
+      expect(mocks.findAllVideos).toHaveBeenCalledTimes(1);
+    });
+
+    const requestSignal = mocks.findAllVideos.mock.calls[0]?.[1] as AbortSignal;
+    view.unmount();
+    expect(requestSignal.aborted).toBe(true);
   });
 });

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/trends/useAnalyticsTrends.ts
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/trends/useAnalyticsTrends.ts
@@ -2,20 +2,25 @@ import { useBrandId } from '@contexts/user/brand-context/brand-context';
 import { useOptionalAnalyticsContext } from '@genfeedai/contexts/analytics/analytics-context';
 import { Platform, Timeframe } from '@genfeedai/enums';
 import type {
+  IBrand,
   ITrend,
   ITrendHashtag,
   ITrendPlaybook,
   ITrendSound,
   ITrendVideo,
+  IVideo,
 } from '@genfeedai/interfaces';
 import type { ICreatorWatchlist } from '@genfeedai/interfaces/analytics/creator-watchlist.interface';
 import type { ITrendPlatformConfig } from '@genfeedai/interfaces/analytics/platform-config.interface';
+import type { Video } from '@genfeedai/models/ingredients/video.model';
 import { createLocalStorageCache } from '@helpers/data/cache/cache.helper';
 import { formatDate } from '@helpers/formatting/date/date.helper';
 import { useAuthedService } from '@hooks/auth/use-authed-service/use-authed-service';
 import type { TrendItem } from '@props/trends/trends-page.props';
 import { logger } from '@services/core/logger.service';
+import { VideosService } from '@services/ingredients/videos.service';
 import { TrendsService } from '@services/social/trends.service';
+import { useQuery } from '@tanstack/react-query';
 import { PLATFORM_CONFIGS } from '@ui-constants/platform.constant';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
@@ -30,6 +35,39 @@ const TRENDS_PLATFORMS: ITrendPlatformConfig[] = [
 
 const TRENDS_CACHE_TTL = 30 * 60 * 1000;
 const trendsCache = createLocalStorageCache({ prefix: 'trends:' });
+const VIDEO_TIMEFRAME_MS = {
+  [Timeframe.H24]: 24 * 60 * 60 * 1000,
+  [Timeframe.H72]: 72 * 60 * 60 * 1000,
+  [Timeframe.D7]: 7 * 24 * 60 * 60 * 1000,
+} as const;
+
+export function normalizeAnalyticsVideo(video: Video): ITrendVideo {
+  const ingredient = video as IVideo;
+  const evaluation = ingredient.evaluation;
+  const actualPerformance = evaluation?.actualPerformance;
+  const engagementScores = evaluation?.scores?.engagement;
+  const brand =
+    typeof ingredient.brand === 'object'
+      ? (ingredient.brand as IBrand)
+      : undefined;
+
+  return {
+    creatorHandle: brand?.label || 'Your brand',
+    description: video.metadataDescription || undefined,
+    engagementRate: actualPerformance?.engagementRate ?? 0,
+    id: video.id || '',
+    platform:
+      evaluation?.externalContent?.platform || ingredient.provider || 'genfeed',
+    publishedAt: ingredient.publishedAt || video.createdAt,
+    thumbnailUrl: video.thumbnailUrl,
+    title: video.metadataLabel || video.id?.slice(0, 8) || 'Untitled video',
+    velocity: actualPerformance?.engagement ?? 0,
+    videoUrl: video.ingredientUrl,
+    viralScore:
+      engagementScores?.viralityPotential ?? evaluation?.overallScore ?? 0,
+    views: actualPerformance?.views ?? 0,
+  };
+}
 
 export function useAnalyticsTrends() {
   const brandId = useBrandId();
@@ -39,12 +77,14 @@ export function useAnalyticsTrends() {
   const getTrendsService = useAuthedService((token: string) =>
     TrendsService.getInstance(token),
   );
+  const getVideosService = useAuthedService((token: string) =>
+    VideosService.getInstance(token),
+  );
 
   const [tiktokTrends, setTiktokTrends] = useState<ITrend[]>([]);
   const [youtubeTrends, setYoutubeTrends] = useState<ITrend[]>([]);
   const [twitterTrends, setTwitterTrends] = useState<ITrend[]>([]);
   const [instagramTrends, setInstagramTrends] = useState<ITrend[]>([]);
-  const [viralVideos, setViralVideos] = useState<ITrendVideo[]>([]);
   const [creators, setCreators] = useState<ICreatorWatchlist[]>([]);
   const [playbooks, setPlaybooks] = useState<ITrendPlaybook[]>([]);
 
@@ -55,7 +95,6 @@ export function useAnalyticsTrends() {
   // New state for hashtags and sounds
   const [trendingHashtags, setTrendingHashtags] = useState<ITrendHashtag[]>([]);
   const [trendingSounds, setTrendingSounds] = useState<ITrendSound[]>([]);
-  const [isLoadingVideos, setIsLoadingVideos] = useState(true);
   const [isLoadingHashtags, setIsLoadingHashtags] = useState(true);
   const [isLoadingSounds, setIsLoadingSounds] = useState(true);
 
@@ -88,6 +127,54 @@ export function useAnalyticsTrends() {
   );
 
   const [remixVideo, setRemixVideo] = useState<ITrendVideo | null>(null);
+
+  const videoCacheKey = `videos:${brandId}`;
+  const { data: analyticsVideos = [], isLoading: isLoadingVideos } = useQuery<
+    ITrendVideo[]
+  >({
+    enabled: Boolean(brandId),
+    queryKey: ['analytics-trends-videos', brandId],
+    queryFn: async ({ signal }) => {
+      const service = await getVideosService();
+      signal.throwIfAborted();
+
+      try {
+        const videos = await service.findAll(
+          {
+            brand: brandId,
+            lightweight: true,
+            limit: 12,
+            sort: 'createdAt: -1',
+          },
+          signal,
+        );
+        const normalizedVideos = videos.map(normalizeAnalyticsVideo);
+
+        trendsCache.set(videoCacheKey, normalizedVideos, TRENDS_CACHE_TTL);
+        logger.info('Fetched analytics videos', {
+          count: normalizedVideos.length,
+        });
+        return normalizedVideos;
+      } catch (error) {
+        if (signal.aborted) {
+          throw error;
+        }
+
+        logger.error('Failed to fetch analytics videos', { error });
+        return (trendsCache.get(videoCacheKey) as ITrendVideo[] | null) ?? [];
+      }
+    },
+    retry: false,
+    staleTime: TRENDS_CACHE_TTL,
+  });
+  const viralVideos = useMemo(() => {
+    const cutoff = Date.now() - VIDEO_TIMEFRAME_MS[videoTimeframe];
+
+    return analyticsVideos.filter((video) => {
+      const publishedAt = new Date(video.publishedAt ?? 0).getTime();
+      return Number.isFinite(publishedAt) && publishedAt >= cutoff;
+    });
+  }, [analyticsVideos, videoTimeframe]);
 
   // Fetch trending topics from our TrendsService
   useEffect(() => {
@@ -152,45 +239,6 @@ export function useAnalyticsTrends() {
     findTrends();
     return () => controller.abort();
   }, [getTrendsService]);
-
-  // Fetch viral videos from backend
-  useEffect(() => {
-    const controller = new AbortController();
-
-    const fetchViralVideos = async () => {
-      setIsLoadingVideos(true);
-      try {
-        const service = await getTrendsService();
-        const videos = await service.getViralVideos({
-          limit: 12,
-          timeframe: videoTimeframe,
-        });
-        setViralVideos(videos);
-        trendsCache.set(
-          `viral:${brandId}:${videoTimeframe}`,
-          videos,
-          TRENDS_CACHE_TTL,
-        );
-        logger.info('Fetched viral videos', { count: videos.length });
-      } catch (error) {
-        if ((error as Error).name === 'AbortError') {
-          return;
-        }
-        logger.error('Failed to fetch viral videos', { error });
-        const cv = trendsCache.get(`viral:${brandId}:${videoTimeframe}`) as
-          | ITrendVideo[]
-          | null;
-        if (cv) {
-          setViralVideos(cv);
-        }
-      } finally {
-        setIsLoadingVideos(false);
-      }
-    };
-
-    fetchViralVideos();
-    return () => controller.abort();
-  }, [brandId, getTrendsService, videoTimeframe]);
 
   // Fetch trending hashtags from backend
   useEffect(() => {

--- a/apps/server/api/src/collections/insights/insights.module.ts
+++ b/apps/server/api/src/collections/insights/insights.module.ts
@@ -10,20 +10,16 @@ import { InsightsService } from '@api/collections/insights/services/insights.ser
 import { ModelsModule } from '@api/collections/models/models.module';
 import { CreditsGuard } from '@api/helpers/guards/credits/credits.guard';
 import { CreditsInterceptor } from '@api/helpers/interceptors/credits/credits.interceptor';
-import { ByokModule } from '@api/services/byok/byok.module';
-import { ReplicateModule } from '@api/services/integrations/replicate/replicate.module';
-import { ConfigModule } from '@libs/config/config.module';
+import { LlmDispatcherModule } from '@api/services/integrations/llm/llm-dispatcher.module';
 import { forwardRef, Module } from '@nestjs/common';
 
 @Module({
   controllers: [InsightsController],
   exports: [InsightsService],
   imports: [
-    forwardRef(() => ByokModule),
-    forwardRef(() => ConfigModule),
     forwardRef(() => CreditsModule),
+    forwardRef(() => LlmDispatcherModule),
     forwardRef(() => ModelsModule),
-    forwardRef(() => ReplicateModule),
   ],
   providers: [InsightsService, CreditsGuard, CreditsInterceptor],
 })

--- a/apps/server/api/src/collections/insights/insights.module.ts
+++ b/apps/server/api/src/collections/insights/insights.module.ts
@@ -10,13 +10,17 @@ import { InsightsService } from '@api/collections/insights/services/insights.ser
 import { ModelsModule } from '@api/collections/models/models.module';
 import { CreditsGuard } from '@api/helpers/guards/credits/credits.guard';
 import { CreditsInterceptor } from '@api/helpers/interceptors/credits/credits.interceptor';
+import { ByokModule } from '@api/services/byok/byok.module';
 import { LlmDispatcherModule } from '@api/services/integrations/llm/llm-dispatcher.module';
+import { ConfigModule } from '@libs/config/config.module';
 import { forwardRef, Module } from '@nestjs/common';
 
 @Module({
   controllers: [InsightsController],
   exports: [InsightsService],
   imports: [
+    forwardRef(() => ByokModule),
+    forwardRef(() => ConfigModule),
     forwardRef(() => CreditsModule),
     forwardRef(() => LlmDispatcherModule),
     forwardRef(() => ModelsModule),

--- a/apps/server/api/src/collections/insights/services/insights.service.spec.ts
+++ b/apps/server/api/src/collections/insights/services/insights.service.spec.ts
@@ -1,17 +1,28 @@
 import { InsightsService } from '@api/collections/insights/services/insights.service';
 import type { ModelsService } from '@api/collections/models/services/models.service';
+import type { LlmDispatcherService } from '@api/services/integrations/llm/llm-dispatcher.service';
 import type { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import type { LoggerService } from '@libs/logger/logger.service';
-import type { ReplicateService } from '@server/services/integrations/replicate/services/replicate.service';
 
 type MockInsightDelegate = {
+  create: ReturnType<typeof vi.fn>;
+  findMany: ReturnType<typeof vi.fn>;
   findFirst: ReturnType<typeof vi.fn>;
   update: ReturnType<typeof vi.fn>;
 };
 
-describe('InsightsService.update', () => {
+describe('InsightsService', () => {
   let service: InsightsService;
   let delegate: MockInsightDelegate;
+  let llmDispatcherService: {
+    chatCompletion: ReturnType<typeof vi.fn>;
+  };
+  let logger: {
+    debug: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+    log: ReturnType<typeof vi.fn>;
+    warn: ReturnType<typeof vi.fn>;
+  };
 
   const existing = {
     data: { forecast: { value: 42 }, isRead: false },
@@ -22,22 +33,53 @@ describe('InsightsService.update', () => {
 
   beforeEach(() => {
     delegate = {
+      create: vi.fn().mockImplementation(({ data }) => ({
+        createdAt: new Date('2026-07-15T00:00:00.000Z'),
+        id: 'generated-insight',
+        isDeleted: false,
+        ...data,
+      })),
+      findMany: vi.fn().mockResolvedValue([]),
       findFirst: vi.fn().mockResolvedValue(existing),
       update: vi
         .fn()
         .mockImplementation(({ data }) => ({ ...existing, ...data })),
     };
+    llmDispatcherService = {
+      chatCompletion: vi.fn().mockResolvedValue({
+        choices: [
+          {
+            message: {
+              content: JSON.stringify({
+                insights: [
+                  {
+                    actionableSteps: ['Publish the follow-up'],
+                    confidence: 82,
+                    description: 'The current series is gaining momentum.',
+                    impact: 'high',
+                    relatedMetrics: ['reach'],
+                    title: 'Continue the series',
+                    type: 'opportunity',
+                  },
+                ],
+              }),
+            },
+          },
+        ],
+      }),
+    };
+    logger = {
+      debug: vi.fn(),
+      error: vi.fn(),
+      log: vi.fn(),
+      warn: vi.fn(),
+    };
 
     service = new InsightsService(
       { insight: delegate } as unknown as PrismaService,
-      {
-        debug: vi.fn(),
-        error: vi.fn(),
-        log: vi.fn(),
-        warn: vi.fn(),
-      } as unknown as LoggerService,
+      logger as unknown as LoggerService,
       {} as unknown as ModelsService,
-      {} as unknown as ReplicateService,
+      llmDispatcherService as unknown as LlmDispatcherService,
     );
   });
 
@@ -45,45 +87,121 @@ describe('InsightsService.update', () => {
     vi.clearAllMocks();
   });
 
-  it('merges isRead into the data blob while preserving other keys', async () => {
-    await service.update('insight-1', 'org-1', { isRead: true });
+  describe('getInsights', () => {
+    it('uses the authenticated LLM dispatcher and persists generated insights in organization scope', async () => {
+      const result = await service.getInsights('org-1', 1);
 
-    expect(delegate.update).toHaveBeenCalledWith({
-      data: { data: { forecast: { value: 42 }, isRead: true } },
-      where: { id: 'insight-1' },
+      expect(llmDispatcherService.chatCompletion).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messages: [expect.objectContaining({ role: 'user' })],
+          model: 'anthropic/claude-sonnet-4-5',
+        }),
+        'org-1',
+      );
+      expect(delegate.findMany).toHaveBeenCalledWith({
+        orderBy: { createdAt: 'desc' },
+        where: { isDeleted: false, organizationId: 'org-1' },
+      });
+      expect(delegate.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({ organizationId: 'org-1' }),
+      });
+      expect(result).toHaveLength(1);
+    });
+
+    it('returns an empty recoverable read when no insights are generated', async () => {
+      llmDispatcherService.chatCompletion.mockResolvedValue({
+        choices: [{ message: { content: '{"insights":[]}' } }],
+      });
+
+      await expect(service.getInsights('org-1', 5)).resolves.toEqual([]);
+    });
+
+    it('returns existing insights when the provider is unavailable', async () => {
+      const storedInsight = {
+        ...existing,
+        data: {
+          confidence: 75,
+          description: 'Stored insight',
+          impact: 'medium',
+          isDismissed: false,
+          isRead: false,
+          title: 'Stored insight',
+        },
+      };
+      delegate.findMany.mockResolvedValue([storedInsight]);
+      llmDispatcherService.chatCompletion.mockRejectedValue(
+        new Error('upstream body includes api_key=secret-value'),
+      );
+
+      await expect(service.getInsights('org-1', 2)).resolves.toEqual([
+        storedInsight,
+      ]);
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Insight generation provider unavailable',
+        {
+          organizationId: 'org-1',
+          providerStatus: 'unavailable',
+        },
+      );
+      expect(JSON.stringify(logger.warn.mock.calls)).not.toContain(
+        'secret-value',
+      );
+    });
+
+    it('does not call a provider when enough active insights already exist', async () => {
+      delegate.findMany.mockResolvedValue([
+        { ...existing, id: 'insight-1' },
+        { ...existing, id: 'insight-2' },
+      ]);
+
+      const result = await service.getInsights('org-1', 2);
+
+      expect(result).toHaveLength(2);
+      expect(llmDispatcherService.chatCompletion).not.toHaveBeenCalled();
     });
   });
 
-  it('merges isDismissed into the data blob', async () => {
-    await service.update('insight-1', 'org-1', { isDismissed: true });
+  describe('update', () => {
+    it('merges isRead into the data blob while preserving other keys', async () => {
+      await service.update('insight-1', 'org-1', { isRead: true });
 
-    expect(delegate.update).toHaveBeenCalledWith({
-      data: {
-        data: { forecast: { value: 42 }, isDismissed: true, isRead: false },
-      },
-      where: { id: 'insight-1' },
-    });
-  });
-
-  it('applies both flags at once', async () => {
-    await service.update('insight-1', 'org-1', {
-      isDismissed: true,
-      isRead: true,
+      expect(delegate.update).toHaveBeenCalledWith({
+        data: { data: { forecast: { value: 42 }, isRead: true } },
+        where: { id: 'insight-1' },
+      });
     });
 
-    expect(delegate.update).toHaveBeenCalledWith({
-      data: {
-        data: { forecast: { value: 42 }, isDismissed: true, isRead: true },
-      },
-      where: { id: 'insight-1' },
+    it('merges isDismissed into the data blob', async () => {
+      await service.update('insight-1', 'org-1', { isDismissed: true });
+
+      expect(delegate.update).toHaveBeenCalledWith({
+        data: {
+          data: { forecast: { value: 42 }, isDismissed: true, isRead: false },
+        },
+        where: { id: 'insight-1' },
+      });
     });
-  });
 
-  it('throws when the insight is not found', async () => {
-    delegate.findFirst.mockResolvedValue(null);
+    it('applies both flags at once', async () => {
+      await service.update('insight-1', 'org-1', {
+        isDismissed: true,
+        isRead: true,
+      });
 
-    await expect(
-      service.update('missing', 'org-1', { isRead: true }),
-    ).rejects.toThrow('Insight not found');
+      expect(delegate.update).toHaveBeenCalledWith({
+        data: {
+          data: { forecast: { value: 42 }, isDismissed: true, isRead: true },
+        },
+        where: { id: 'insight-1' },
+      });
+    });
+
+    it('throws when the insight is not found', async () => {
+      delegate.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.update('missing', 'org-1', { isRead: true }),
+      ).rejects.toThrow('Insight not found');
+    });
   });
 });

--- a/apps/server/api/src/collections/insights/services/insights.service.ts
+++ b/apps/server/api/src/collections/insights/services/insights.service.ts
@@ -8,14 +8,19 @@ import { DEFAULT_TEXT_MODEL } from '@api/constants/default-text-model.constant';
 import { HandleErrors } from '@api/helpers/decorators/error-handler.decorator';
 import { JsonParserUtil } from '@api/helpers/utils/json-parser.util';
 import { calculateEstimatedTextCredits } from '@api/helpers/utils/text-pricing/text-pricing.util';
+import { LlmDispatcherService } from '@api/services/integrations/llm/llm-dispatcher.service';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { Timeframe } from '@genfeedai/enums';
 import { LoggerService } from '@libs/logger/logger.service';
-import { BadRequestException, Injectable } from '@nestjs/common';
-import { ReplicateService } from '@server/services/integrations/replicate/services/replicate.service';
+import {
+  BadRequestException,
+  Injectable,
+  ServiceUnavailableException,
+} from '@nestjs/common';
 
 type Forecast = ForecastDocument;
 type Insight = InsightDocument;
+const INSIGHTS_TEXT_MODEL = 'anthropic/claude-sonnet-4-5';
 
 type InsightData = {
   actionableSteps?: string[];
@@ -43,7 +48,7 @@ export class InsightsService {
     private readonly prisma: PrismaService,
     private readonly logger: LoggerService,
     private readonly modelsService: ModelsService,
-    private readonly replicateService: ReplicateService,
+    private readonly llmDispatcherService: LlmDispatcherService,
   ) {}
 
   private readObjectRecord(value: unknown): Record<string, unknown> {
@@ -236,11 +241,20 @@ export class InsightsService {
         return existingInsights as unknown as Insight[];
       }
 
-      const newInsights = await this.generateInsights(
-        organizationId,
-        limit - existingInsights.length,
-        onBilling,
-      );
+      let newInsights: Insight[];
+      try {
+        newInsights = await this.generateInsights(
+          organizationId,
+          limit - existingInsights.length,
+          onBilling,
+        );
+      } catch (error: unknown) {
+        if (!(error instanceof ServiceUnavailableException)) {
+          throw error;
+        }
+
+        return existingInsights as unknown as Insight[];
+      }
 
       return [...(existingInsights as unknown as Insight[]), ...newInsights];
     } catch (error: unknown) {
@@ -368,9 +382,10 @@ Probability is % chance of going viral (>100k views).
 Return ONLY valid JSON. Do not include any text before or after the JSON.`;
 
       const input = { max_completion_tokens: 1024, prompt };
-      const response = await this.replicateService.generateTextCompletionSync(
-        DEFAULT_TEXT_MODEL,
-        input,
+      const response = await this.generateTextCompletion(
+        prompt,
+        input.max_completion_tokens,
+        organizationId,
       );
       onBilling?.(await this.calculateDefaultTextCharge(input, response));
 
@@ -425,9 +440,10 @@ Return ONLY valid JSON with this structure. Do not include any text before or af
 }`;
 
       const input = { max_completion_tokens: 1024, prompt };
-      const response = await this.replicateService.generateTextCompletionSync(
-        DEFAULT_TEXT_MODEL,
-        input,
+      const response = await this.generateTextCompletion(
+        prompt,
+        input.max_completion_tokens,
+        organizationId,
       );
       onBilling?.(await this.calculateDefaultTextCharge(input, response));
 
@@ -485,9 +501,10 @@ Return ONLY valid JSON with this structure. Do not include any text before or af
 Provide 5-7 optimal time slots.`;
 
       const input = { max_completion_tokens: 1024, prompt };
-      const response = await this.replicateService.generateTextCompletionSync(
-        DEFAULT_TEXT_MODEL,
-        input,
+      const response = await this.generateTextCompletion(
+        prompt,
+        input.max_completion_tokens,
+        organizationId,
       );
       onBilling?.(await this.calculateDefaultTextCharge(input, response));
 
@@ -574,9 +591,10 @@ Impact: high, medium, low
 Confidence: 0-100`;
 
     const input = { max_completion_tokens: 2048, prompt };
-    const response = await this.replicateService.generateTextCompletionSync(
-      DEFAULT_TEXT_MODEL,
-      input,
+    const response = await this.generateTextCompletion(
+      prompt,
+      input.max_completion_tokens,
+      organizationId,
     );
     onBilling?.(await this.calculateDefaultTextCharge(input, response));
 
@@ -614,6 +632,34 @@ Confidence: 0-100`;
     }
 
     return savedInsights;
+  }
+
+  private async generateTextCompletion(
+    prompt: string,
+    maxTokens: number,
+    organizationId: string,
+  ): Promise<string> {
+    try {
+      const response = await this.llmDispatcherService.chatCompletion(
+        {
+          max_tokens: maxTokens,
+          messages: [{ content: prompt, role: 'user' }],
+          model: INSIGHTS_TEXT_MODEL,
+          temperature: 0.2,
+        },
+        organizationId,
+      );
+
+      return response.choices?.[0]?.message?.content?.trim() ?? '';
+    } catch {
+      this.logger.warn('Insight generation provider unavailable', {
+        organizationId,
+        providerStatus: 'unavailable',
+      });
+      throw new ServiceUnavailableException(
+        'Analytics insight generation is temporarily unavailable',
+      );
+    }
   }
 
   private async calculateDefaultTextCharge(

--- a/packages/hooks/data/analytics/use-insights/use-insights.ts
+++ b/packages/hooks/data/analytics/use-insights/use-insights.ts
@@ -90,9 +90,9 @@ export function useInsights({
     refetch: refetchInsights,
   } = useQuery<Insight[]>({
     queryKey: insightsQueryKey,
-    queryFn: async () => {
+    queryFn: async ({ signal }) => {
       const service = await getInsightsService();
-      return service.getInsights();
+      return service.getInsights(undefined, signal);
     },
     enabled,
   });
@@ -105,7 +105,7 @@ export function useInsights({
     refetch: refetchContent,
   } = useQuery<ContentInsightsData>({
     queryKey: contentQueryKey,
-    queryFn: async () => {
+    queryFn: async ({ signal }) => {
       const service = await getPredictiveService();
       const range =
         dateRange.startDate && dateRange.endDate
@@ -115,7 +115,10 @@ export function useInsights({
             }
           : undefined;
 
-      return (await service.getContentInsights(range)) as ContentInsightsData;
+      return (await service.getContentInsights(
+        range,
+        signal,
+      )) as ContentInsightsData;
     },
     enabled,
   });

--- a/packages/services/analytics/insights.service.test.ts
+++ b/packages/services/analytics/insights.service.test.ts
@@ -27,6 +27,19 @@ vi.mock('@genfeedai/constants', () => ({ ITEMS_PER_PAGE: 20 }));
 
 describe('InsightsService', () => {
   const mockToken = 'test-token-123';
+  type MockInsightsHttpClient = {
+    get: ReturnType<typeof vi.fn>;
+  };
+
+  function getHttpClient(
+    service: ReturnType<typeof InsightsService.getInstance>,
+  ): MockInsightsHttpClient {
+    return (
+      service as unknown as {
+        instance: MockInsightsHttpClient;
+      }
+    ).instance;
+  }
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -61,5 +74,45 @@ describe('InsightsService', () => {
     InsightsService.clearInstance(mockToken);
     const inst2 = InsightsService.getInstance(mockToken);
     expect(inst1).not.toBe(inst2);
+  });
+
+  it('returns a successful insights collection and forwards cancellation', async () => {
+    const service = InsightsService.getInstance(mockToken);
+    const controller = new AbortController();
+    getHttpClient(service).get.mockResolvedValue({
+      data: {
+        data: [
+          {
+            attributes: {
+              actionableSteps: [],
+              category: 'opportunity',
+              confidence: 80,
+              createdAt: '2026-07-15T00:00:00.000Z',
+              description: 'Continue the series',
+              impact: 'high',
+              isRead: false,
+              relatedMetrics: [],
+              title: 'Momentum is increasing',
+            },
+            id: 'insight-1',
+            type: 'insights',
+          },
+        ],
+      },
+    });
+
+    const result = await service.getInsights(15, controller.signal);
+
+    expect(result).toHaveLength(1);
+    expect(getHttpClient(service).get).toHaveBeenCalledWith('?limit=15', {
+      signal: controller.signal,
+    });
+  });
+
+  it('returns an empty insights collection without treating it as an error', async () => {
+    const service = InsightsService.getInstance(mockToken);
+    getHttpClient(service).get.mockResolvedValue({ data: { data: [] } });
+
+    await expect(service.getInsights()).resolves.toEqual([]);
   });
 });

--- a/packages/services/analytics/insights.service.ts
+++ b/packages/services/analytics/insights.service.ts
@@ -32,10 +32,13 @@ class InsightsServiceClass extends HTTPBaseService {
   /**
    * Get AI-generated insights
    */
-  async getInsights(limit: number = ITEMS_PER_PAGE): Promise<Insight[]> {
+  async getInsights(
+    limit: number = ITEMS_PER_PAGE,
+    signal?: AbortSignal,
+  ): Promise<Insight[]> {
     try {
       return await this.instance
-        .get<JsonApiResponseDocument>(`?limit=${limit}`)
+        .get<JsonApiResponseDocument>(`?limit=${limit}`, { signal })
         .then((res) => {
           const data = deserializeCollection<IInsightResponse>(res.data);
           logger.info('Insights retrieved', { count: data.length });
@@ -185,7 +188,7 @@ export class PredictiveAnalyticsService {
     );
   }
 
-  async getContentInsights(range?: IDateRange) {
+  async getContentInsights(range?: IDateRange, signal?: AbortSignal) {
     const url = this.buildUrl('/insights', {
       end: range?.end,
       start: range?.start,
@@ -193,7 +196,7 @@ export class PredictiveAnalyticsService {
 
     return this.request(
       url,
-      { method: 'GET' },
+      { method: 'GET', signal },
       'Failed to get content insights',
     );
   }


### PR DESCRIPTION
Closes #1771

## Summary
- route Analytics Insights generation through the organization-aware LLM dispatcher and degrade provider-unavailable reads to stored or empty data without exposing provider errors
- load Trends videos through the canonical brand-scoped videos collection, normalize missing analytics fields, filter timeframes locally, and share one cancellable request across remounts
- forward query cancellation through Insights clients and add focused client/server regressions for success, empty, unavailable, missing-data, duplicate-request, cancellation, and normalized-error paths

## Verification
- targeted Biome checks passed (one pre-existing static-only-class warning)
- staged secretlint and UI/control guards passed in the commit hook
- `git diff --check` passed
- executable tests/typechecks/builds intentionally deferred to PR CI per workstation policy