### PR TITLE
fix(feature-flags): preserve OSS defaults for shell rollout

### DIFF
--- a/packages/hooks/feature-flags/provider/FeatureFlagProvider.test.tsx
+++ b/packages/hooks/feature-flags/provider/FeatureFlagProvider.test.tsx
@@ -55,6 +55,34 @@ describe('FeatureFlagProvider', () => {
     expect(status).toEqual({ isConfigured: false, isReady: true });
   });
 
+  it('keeps public defaults unconfigured when only server overrides are provided', () => {
+    let status: {
+      flags: Record<string, unknown>;
+      isConfigured: boolean;
+    } | null = null;
+
+    function Probe() {
+      const ctx = useFeatureFlagContext();
+      status = { flags: ctx.flags, isConfigured: ctx.isConfigured };
+      return <span>override content</span>;
+    }
+
+    render(
+      <FeatureFlagProvider
+        defaults={{}}
+        overrides={{ conversation_shell: true }}
+      >
+        <Probe />
+      </FeatureFlagProvider>,
+    );
+
+    expect(screen.getByText('override content')).toBeDefined();
+    expect(status).toEqual({
+      flags: { conversation_shell: true },
+      isConfigured: false,
+    });
+  });
+
   it('renders children when no config is provided', () => {
     render(
       <FeatureFlagProvider defaults={{}}>

--- a/packages/hooks/feature-flags/provider/FeatureFlagProvider.tsx
+++ b/packages/hooks/feature-flags/provider/FeatureFlagProvider.tsx
@@ -48,9 +48,10 @@ export function FeatureFlagProvider({
   const value = useMemo<FeatureFlagContextValue>(
     () => ({
       flags: { ...resolvedDefaults.flags, ...overrides },
-      isConfigured:
-        resolvedDefaults.isConfigured ||
-        (overrides !== undefined && Object.keys(overrides).length > 0),
+      // Server-resolved overrides are independent from public defaults. In
+      // particular, the conversation shell rollout must not make unrelated
+      // OSS feature flags fail closed when no public defaults are configured.
+      isConfigured: resolvedDefaults.isConfigured,
       isReady: ready,
     }),
     [overrides, ready, resolvedDefaults],

--- a/packages/hooks/feature-flags/use-feature-flag/use-feature-flag.test.ts
+++ b/packages/hooks/feature-flags/use-feature-flag/use-feature-flag.test.ts
@@ -47,6 +47,25 @@ describe('useFeatureFlag', () => {
     expect(result.current).toBe(true);
   });
 
+  it('keeps ordinary OSS flags on when only the conversation shell override is configured', () => {
+    function Wrapper({ children }: { children: ReactNode }) {
+      return createElement(
+        FeatureFlagProvider,
+        {
+          defaults: {},
+          overrides: { conversation_shell: true },
+        },
+        children,
+      );
+    }
+
+    const { result } = renderHook(() => useFeatureFlag('analytics'), {
+      wrapper: Wrapper,
+    });
+
+    expect(result.current).toBe(true);
+  });
+
   it('fails the conversation shell closed when no provider is configured', () => {
     const { result } = renderHook(() => useFeatureFlag('conversation_shell'));
 


### PR DESCRIPTION
## Summary

- keep public feature-default configuration independent from server-resolved overrides
- preserve ordinary OSS features as default-on when only the conversation shell rollout is resolved
- add focused provider and hook regressions

## QA

- Brave route sweep before the fix: all sampled gated product routes rendered Feature Unavailable
- Brave route sweep after the fix: Messages, Workflows, Orchestration, Studio, Analytics, Library, Workspace, Research, Remix/Posts, Compose, Editor, settings, and organization overview rendered their actual surfaces
- Studio Image -> Video canonical navigation round-trip verified
- local tests/typechecks/builds intentionally not run per workstation policy; PR CI is the verification source