### PR TITLE
fix(brands): normalize ownership on create

### DIFF
--- a/apps/server/api/src/collections/brands/services/brands.service.spec.ts
+++ b/apps/server/api/src/collections/brands/services/brands.service.spec.ts
@@ -15,6 +15,7 @@ import { BrandKitAssetsService } from '@api/collections/brands/services/brand-ki
 import { BrandKitDraftService } from '@api/collections/brands/services/brand-kit-draft.service';
 import type { BrandRelocationService } from '@api/collections/brands/services/brand-relocation.service';
 import { BrandsService } from '@api/collections/brands/services/brands.service';
+import { CACHE_PATTERNS } from '@api/common/constants/cache-patterns.constants';
 import { CacheInvalidationService } from '@api/common/services/cache-invalidation.service';
 import { BrandScraperService } from '@api/services/brand-scraper/brand-scraper.service';
 import { CacheService } from '@api/services/cache/services/cache.service';
@@ -108,6 +109,73 @@ describe('BrandsService', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+  });
+
+  describe('create', () => {
+    const createBrandDto = {
+      backgroundColor: '#000000',
+      fontFamily: 'MONTSERRAT_BLACK',
+      isSelected: true,
+      label: 'Default Brand',
+      primaryColor: '#000000',
+      secondaryColor: '#FFFFFF',
+      slug: 'default-brand',
+    };
+
+    it('maps controller metadata aliases to canonical Prisma foreign keys', async () => {
+      delegate.create.mockResolvedValue({
+        ...createBrandDto,
+        id: 'brand-1',
+        organizationId: 'org-1',
+        userId: 'user-1',
+      });
+
+      await service.create({
+        ...createBrandDto,
+        organization: 'org-1',
+        user: 'user-1',
+      });
+
+      const createInput = delegate.create.mock.calls[0]?.[0] as {
+        data: Record<string, unknown>;
+      };
+      expect(createInput.data).toMatchObject({
+        organizationId: 'org-1',
+        userId: 'user-1',
+      });
+      expect(createInput.data).not.toHaveProperty('organization');
+      expect(createInput.data).not.toHaveProperty('user');
+      expect(cacheInvalidationService.invalidate).toHaveBeenCalledWith(
+        CACHE_PATTERNS.BRANDS_LIST('org-1'),
+      );
+    });
+
+    it('prefers canonical foreign keys over legacy metadata aliases', async () => {
+      delegate.create.mockResolvedValue({
+        ...createBrandDto,
+        id: 'brand-1',
+        organizationId: 'org-canonical',
+        userId: 'user-canonical',
+      });
+
+      await service.create({
+        ...createBrandDto,
+        organization: 'org-legacy',
+        organizationId: 'org-canonical',
+        user: 'user-legacy',
+        userId: 'user-canonical',
+      });
+
+      const createInput = delegate.create.mock.calls[0]?.[0] as {
+        data: Record<string, unknown>;
+      };
+      expect(createInput.data).toMatchObject({
+        organizationId: 'org-canonical',
+        userId: 'user-canonical',
+      });
+      expect(createInput.data).not.toHaveProperty('organization');
+      expect(createInput.data).not.toHaveProperty('user');
+    });
   });
 
   it('resolves legacy mongo ids before selecting a brand', async () => {

--- a/apps/server/api/src/collections/brands/services/brands.service.ts
+++ b/apps/server/api/src/collections/brands/services/brands.service.ts
@@ -75,6 +75,14 @@ export class BrandsService extends BaseService<
       userId?: string;
     },
   ): Promise<BrandDocument> {
+    const { organization, organizationId, user, userId, ...brandFields } =
+      createBrandDto;
+    const resolvedOrganizationId =
+      organizationId ??
+      (typeof organization === 'string' ? organization : undefined);
+    const resolvedUserId =
+      userId ?? (typeof user === 'string' ? user : undefined);
+
     this.logger.debug('Creating brand', {
       label: createBrandDto.label,
       operation: 'create',
@@ -82,16 +90,18 @@ export class BrandsService extends BaseService<
       slug: createBrandDto.slug,
     });
 
-    const orgId =
-      (createBrandDto.organizationId as string) ??
-      (createBrandDto.organization as string);
-
-    const brand = await super.create(createBrandDto);
+    const brand = await super.create({
+      ...brandFields,
+      ...(resolvedOrganizationId
+        ? { organizationId: resolvedOrganizationId }
+        : {}),
+      ...(resolvedUserId ? { userId: resolvedUserId } : {}),
+    } as CreateBrandDto);
 
     // Invalidate brand list cache so the new brand is immediately visible
-    if (orgId) {
+    if (resolvedOrganizationId) {
       await this.cacheInvalidationService.invalidate(
-        CACHE_PATTERNS.BRANDS_LIST(orgId),
+        CACHE_PATTERNS.BRANDS_LIST(resolvedOrganizationId),
       );
     }
     // Also bust the shared brands tag (covers user-scoped list keys from @Cache decorator)


### PR DESCRIPTION
## Summary

- normalize legacy controller ownership aliases to Prisma `organizationId` and `userId` before brand creation
- prefer canonical scalar foreign keys when both canonical and legacy fields are present
- preserve brand-list cache invalidation against the resolved organization
- add focused regressions for the local first-brand bootstrap failure and canonical precedence

## QA evidence

- Brave/local API reproduction: a new user’s `POST /v1/brands` returned 400 because Prisma received scalar strings in nested `organization` and `user` relation fields
- static boundary verification confirms only canonical scalar foreign keys now reach `BaseService.create`
- outbound response still uses `BrandSerializer` in `BrandsController`
- no local tests/typechecks/builds run per workstation policy; PR CI is the verification source
- local dev servers remain stopped under the disk gate