### PR TITLE
fix(analytics): defer hook remix video loading

### DIFF
--- a/packages/pages/trends/list/components/HookRemixModal.test.tsx
+++ b/packages/pages/trends/list/components/HookRemixModal.test.tsx
@@ -1,8 +1,154 @@
-import { describe, expect, it } from 'vitest';
-import Module from './HookRemixModal.tsx';
+import '@testing-library/jest-dom/vitest';
+import type { ITrendVideo } from '@genfeedai/interfaces';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, waitFor } from '@testing-library/react';
+import type { ChangeEvent, ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import HookRemixModal from './HookRemixModal';
 
-describe('HookRemixModal.tsx', () => {
-  it('exports a component', () => {
-    expect(Module).toBeDefined();
+const mocks = vi.hoisted(() => ({
+  closeModal: vi.fn(),
+  createHookRemix: vi.fn(),
+  findAllVideos: vi.fn(),
+  getHookRemixInstance: vi.fn(() => 'hook-remix-service'),
+  getLegacyIngredientsInstance: vi.fn(() => 'legacy-video-service'),
+  getVideosInstance: vi.fn(() => 'videos-service'),
+  openModal: vi.fn(),
+}));
+
+vi.mock('@contexts/user/brand-context/brand-context', () => ({
+  useBrand: () => ({
+    brandId: 'brand-1',
+    brands: [{ id: 'brand-1', label: 'Default Brand' }],
+  }),
+}));
+
+vi.mock('@helpers/ui/modal/modal.helper', () => ({
+  closeModal: mocks.closeModal,
+  openModal: mocks.openModal,
+}));
+
+vi.mock('@hooks/auth/use-authed-service/use-authed-service', () => ({
+  useAuthedService: (factory: (token: string) => unknown) => async () => {
+    const service = factory('test-token');
+
+    return service === 'videos-service' || service === 'legacy-video-service'
+      ? { findAll: mocks.findAllVideos }
+      : { createHookRemix: mocks.createHookRemix };
+  },
+}));
+
+vi.mock('@services/content/ingredients.service', () => ({
+  IngredientsService: { getInstance: mocks.getLegacyIngredientsInstance },
+}));
+
+vi.mock('@services/ingredients/videos.service', () => ({
+  VideosService: { getInstance: mocks.getVideosInstance },
+}));
+
+vi.mock('@services/hook-remix/hook-remix.service', () => ({
+  HookRemixService: { getInstance: mocks.getHookRemixInstance },
+}));
+
+vi.mock('@ui/modals/actions/ModalActions', () => ({
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@ui/modals/modal/Modal', () => ({
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@ui/primitives/button', () => ({
+  Button: ({
+    isDisabled,
+    label,
+    onClick,
+  }: {
+    isDisabled?: boolean;
+    label?: ReactNode;
+    onClick?: () => void;
+  }) => (
+    <button disabled={isDisabled} onClick={onClick} type="button">
+      {label}
+    </button>
+  ),
+}));
+
+vi.mock('@ui/primitives/field', () => ({
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@ui/primitives/select', () => ({
+  SelectField: ({
+    children,
+    isDisabled,
+    name,
+    onChange,
+    value,
+  }: {
+    children: ReactNode;
+    isDisabled?: boolean;
+    name: string;
+    onChange?: (event: ChangeEvent<HTMLSelectElement>) => void;
+    value?: string;
+  }) => (
+    <select disabled={isDisabled} name={name} onChange={onChange} value={value}>
+      {children}
+    </select>
+  ),
+}));
+
+vi.mock('@ui/primitives/slider', () => ({
+  Slider: () => <div data-testid="slider" />,
+}));
+
+const trendVideo: ITrendVideo = {
+  creatorHandle: 'creator',
+  engagementRate: 0,
+  id: 'trend-video-1',
+  platform: 'tiktok',
+  velocity: 0,
+  viralScore: 0,
+};
+
+describe('HookRemixModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.findAllVideos.mockResolvedValue([]);
+  });
+
+  it('does not fetch CTA clips while the modal is closed', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <HookRemixModal isOpen={false} video={null} />
+      </QueryClientProvider>,
+    );
+
+    await Promise.resolve();
+
+    expect(mocks.getLegacyIngredientsInstance).not.toHaveBeenCalled();
+    expect(mocks.getVideosInstance).not.toHaveBeenCalled();
+    expect(mocks.findAllVideos).not.toHaveBeenCalled();
+  });
+
+  it('loads CTA clips from the canonical videos service when opened', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <HookRemixModal isOpen video={trendVideo} />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(mocks.getVideosInstance).toHaveBeenCalledWith('test-token');
+      expect(mocks.findAllVideos).toHaveBeenCalledWith({ brand: 'brand-1' });
+    });
   });
 });

--- a/packages/pages/trends/list/components/HookRemixModal.tsx
+++ b/packages/pages/trends/list/components/HookRemixModal.tsx
@@ -1,18 +1,14 @@
 'use client';
 
 import { useBrand } from '@contexts/user/brand-context/brand-context';
-import {
-  ButtonSize,
-  ButtonVariant,
-  IngredientCategory,
-} from '@genfeedai/enums';
+import { ButtonSize, ButtonVariant } from '@genfeedai/enums';
 import type { IIngredient } from '@genfeedai/interfaces';
 import { closeModal, openModal } from '@helpers/ui/modal/modal.helper';
 import { useAuthedService } from '@hooks/auth/use-authed-service/use-authed-service';
 import type { ModalHookRemixProps } from '@props/trends/hook-remix.props';
-import { IngredientsService } from '@services/content/ingredients.service';
 import { logger } from '@services/core/logger.service';
 import { HookRemixService } from '@services/hook-remix/hook-remix.service';
+import { VideosService } from '@services/ingredients/videos.service';
 import { useQuery } from '@tanstack/react-query';
 import ModalActions from '@ui/modals/actions/ModalActions';
 import Modal from '@ui/modals/modal/Modal';
@@ -46,7 +42,6 @@ function getIngredientOptionLabel(ingredient: IIngredient): string {
 export default function HookRemixModal({
   video,
   isOpen,
-  openKey,
   onSubmit,
   onClose,
 }: ModalHookRemixProps) {
@@ -64,7 +59,7 @@ export default function HookRemixModal({
   onSubmitRef.current = onSubmit;
 
   const getVideoIngredientsService = useAuthedService((token: string) =>
-    IngredientsService.getInstance(IngredientCategory.VIDEO, token),
+    VideosService.getInstance(token),
   );
 
   const getHookRemixService = useAuthedService((token: string) =>
@@ -75,7 +70,7 @@ export default function HookRemixModal({
   const { data: videoIngredients = [], isLoading: isLoadingClips } = useQuery<
     IIngredient[]
   >({
-    enabled: Boolean(selectedBrandId),
+    enabled: Boolean(isOpen && selectedBrandId),
     queryFn: async () => {
       if (!selectedBrandId) {
         return [];


### PR DESCRIPTION
## Summary

- stop the always-mounted Hook Remix dialog from loading CTA clips while closed
- use the canonical `VideosService` so the opened dialog calls `/videos`, not the singular `/video` collection
- replace the placeholder export test with focused closed/open query regressions

## QA evidence

- Brave reproduction on Analytics Trends: the page opened the error-debug dialog for `GET /v1/video?brand=...` before any remix interaction
- boundary trace: `AnalyticsTrends` always mounts `HookRemixModal`; its query was enabled by the selected brand alone and constructed `IngredientsService` from `IngredientCategory.VIDEO` (`video`)
- the leaderboard’s separate canonical `/videos` query already degrades to an empty state and is unchanged
- no local tests/typechecks/builds run per workstation policy; PR CI is the verification source
- local dev servers remain stopped under the disk gate