### PR TITLE
fix(ui): resolve specific shell breadcrumbs

### DIFF
--- a/packages/contexts/ui/sidebar-navigation-context.test.tsx
+++ b/packages/contexts/ui/sidebar-navigation-context.test.tsx
@@ -40,6 +40,35 @@ describe('SidebarNavigationProvider', () => {
     expect(screen.getByText('Dashboard')).toBeInTheDocument();
   });
 
+  it.each([
+    ['/acme/brand/studio/video', '/studio', '/studio/video', 'Video'],
+    [
+      '/acme/brand/analytics/insights',
+      '/analytics',
+      '/analytics/insights',
+      'Insights',
+    ],
+    ['/acme/brand/workspace/inbox', '/workspace', '/workspace/inbox', 'Inbox'],
+    ['/acme/brand/compose/post', '/compose', '/compose/post', 'Post'],
+  ])('prefers the most specific match for %s', (pathname, rootPath, childPath, childLabel) => {
+    pathnameState.value = pathname;
+
+    renderNavigation([
+      {
+        href: `${rootPath}/overview`,
+        label: 'Overview',
+        matchPaths: [rootPath],
+      },
+      {
+        href: childPath,
+        label: childLabel,
+        matchPaths: [childPath],
+      },
+    ]);
+
+    expect(screen.getByText(childLabel)).toBeInTheDocument();
+  });
+
   it('ignores task-context query parameters when matching menu hrefs', () => {
     pathnameState.value = '/acme/brand/library/images';
 

--- a/packages/contexts/ui/sidebar-navigation-context.tsx
+++ b/packages/contexts/ui/sidebar-navigation-context.tsx
@@ -140,6 +140,14 @@ export function SidebarNavigationProvider({
   // Derive active group + page from pathname
   const { derivedGroupId, derivedPageLabel } = useMemo(() => {
     const normalizedPathname = stripOrgPrefix(pathname ?? '');
+    let bestMatch:
+      | {
+          derivedGroupId: string;
+          derivedPageLabel: string;
+          specificity: number;
+        }
+      | undefined;
+
     for (const g of groups) {
       for (const item of g.items) {
         if (!item.href) {
@@ -148,18 +156,31 @@ export function SidebarNavigationProvider({
         // Respect isExactMatch so a root item (e.g. General at `/settings`)
         // doesn't greedily prefix-match every subpage (`/settings/members`).
         const candidatePaths = [item.href, ...(item.matchPaths ?? [])];
-        const matches = candidatePaths.some((candidatePath) => {
+        for (const candidatePath of candidatePaths) {
           const candidatePathname =
             candidatePath.split('?')[0] ?? candidatePath;
-          return item.isExactMatch
+          const matches = item.isExactMatch
             ? normalizedPathname === candidatePathname
             : isPathActive(candidatePath, pathname);
-        });
-        if (matches) {
-          return { derivedGroupId: g.group, derivedPageLabel: item.label };
+
+          if (
+            matches &&
+            (!bestMatch || candidatePathname.length > bestMatch.specificity)
+          ) {
+            bestMatch = {
+              derivedGroupId: g.group,
+              derivedPageLabel: item.label,
+              specificity: candidatePathname.length,
+            };
+          }
         }
       }
     }
+
+    if (bestMatch) {
+      return bestMatch;
+    }
+
     return {
       derivedGroupId: groups[0]?.group ?? '',
       derivedPageLabel: '',


### PR DESCRIPTION
## Summary
- choose the most specific matching menu route when deriving shared-shell breadcrumbs
- preserve exact-match behavior and stable menu-order ties
- cover the four browser-observed regressions across Studio, Analytics, Workspace, and Compose

## QA evidence
Authenticated Brave QA showed root menu match paths winning before their specific child entries: Studio/Image on Video, Analytics/Overview on Insights, Workspace/Dashboard on Inbox, and Compose/Article on Post.

## Validation
- bunx biome check --write on the two changed files
- bun run design:lint (0 errors; 9 pre-existing unused-token warnings)
- local tests/typechecks/builds intentionally not run; GitHub CI is the validation authority