### PR TITLE
fix(agent): keep disabled prompt bar opaque

### DIFF
--- a/packages/agent/src/components/AgentChatInput.spec.tsx
+++ b/packages/agent/src/components/AgentChatInput.spec.tsx
@@ -70,6 +70,15 @@ describe('AgentChatInput', () => {
     expect(screen.getByTestId('agent-chat-input-shell')).toBeTruthy();
   });
 
+  it('keeps the prompt shell opaque when disabled', () => {
+    render(<AgentChatInput disabled onSend={vi.fn()} />);
+
+    const shell = screen.getByTestId('agent-chat-input-shell');
+
+    expect(shell).toHaveClass('bg-card');
+    expect(shell).not.toHaveClass('opacity-50');
+  });
+
   it('renders the stop action within the shell footer when a run is active', () => {
     render(<AgentChatInput onSend={vi.fn()} onStop={vi.fn()} showStop />);
 

--- a/packages/agent/src/components/AgentChatInput.tsx
+++ b/packages/agent/src/components/AgentChatInput.tsx
@@ -153,7 +153,6 @@ export function AgentChatInput({
       <PromptBarShell
         className={cn(
           'overflow-hidden rounded-xl border border-border bg-card shadow-border transition-[border-color,box-shadow] focus-within:border-foreground/[0.18] focus-within:shadow-border-strong',
-          disabled && 'opacity-50',
           isDragActive && 'ring-1 ring-primary/40',
         )}
         data-testid="agent-chat-input-shell"


### PR DESCRIPTION
## Summary

- keep the disabled agent prompt-bar shell visually opaque
- preserve disabled interaction semantics
- add focused regression coverage for the shell classes

Closes #1791

## Verification

- `git diff --cached --check`
- staged gitleaks scan: no leaks
- Biome check on the two changed files
- local tests/typechecks/builds intentionally not run; GitHub CI is the verification lane