### PR TITLE
fix(notifications): retry transient Resend email failures

### DIFF
--- a/apps/server/notifications/src/services/notification-handler.service.spec.ts
+++ b/apps/server/notifications/src/services/notification-handler.service.spec.ts
@@ -3,12 +3,26 @@ import { RedisService } from '@libs/redis/redis.service';
 import { Test, type TestingModule } from '@nestjs/testing';
 import { DiscordService } from '@notifications/services/discord/discord.service';
 import { NotificationHandlerService } from '@notifications/services/notification-handler.service';
-import { ResendService } from '@notifications/services/resend/resend.service';
+import {
+  ResendEmailDeliveryError,
+  ResendService,
+} from '@notifications/services/resend/resend.service';
+import { SlackService } from '@notifications/services/slack/slack.service';
+import { TelegramService } from '@notifications/services/telegram/telegram.service';
+
+type NotificationSubscriber = (message: unknown) => void;
+
+async function flushAsyncWork(): Promise<void> {
+  for (let iteration = 0; iteration < 10; iteration += 1) {
+    await Promise.resolve();
+  }
+}
 
 describe('NotificationHandlerService', () => {
   let service: NotificationHandlerService;
   let loggerService: LoggerService;
   let redisService: RedisService;
+  let subscriber: NotificationSubscriber | undefined;
 
   const mockLoggerService = {
     debug: vi.fn(),
@@ -31,7 +45,27 @@ describe('NotificationHandlerService', () => {
     sendEmail: vi.fn(),
   };
 
+  const mockSlackService = {
+    sendFile: vi.fn(),
+    sendMessage: vi.fn(),
+  };
+
+  const mockTelegramService = {
+    sendMessage: vi.fn(),
+    sendPhoto: vi.fn(),
+  };
+
   beforeEach(async () => {
+    vi.clearAllMocks();
+    subscriber = undefined;
+    mockRedisService.publish.mockResolvedValue(undefined);
+    mockRedisService.subscribe.mockImplementation(
+      async (_channel: string, handler: NotificationSubscriber) => {
+        subscriber = handler;
+      },
+    );
+    mockResendService.sendEmail.mockResolvedValue(null);
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         NotificationHandlerService,
@@ -51,6 +85,14 @@ describe('NotificationHandlerService', () => {
           provide: ResendService,
           useValue: mockResendService,
         },
+        {
+          provide: SlackService,
+          useValue: mockSlackService,
+        },
+        {
+          provide: TelegramService,
+          useValue: mockTelegramService,
+        },
       ],
     }).compile();
 
@@ -62,6 +104,10 @@ describe('NotificationHandlerService', () => {
     redisService = module.get(RedisService);
 
     loggerService.log('NotificationHandlerService initialized');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it('should be defined', () => {
@@ -76,6 +122,86 @@ describe('NotificationHandlerService', () => {
         'notifications',
         expect.any(Function),
       );
+    });
+
+    it('republishes transient email failures for retry', async () => {
+      let retryCallback: (() => void) | undefined;
+      const timeoutSpy = vi
+        .spyOn(globalThis, 'setTimeout')
+        .mockImplementation((callback) => {
+          retryCallback = callback as () => void;
+          return 1 as unknown as ReturnType<typeof setTimeout>;
+        });
+      mockResendService.sendEmail.mockRejectedValue(
+        new ResendEmailDeliveryError('Too many requests', {
+          providerCode: 'rate_limit_exceeded',
+          retryable: true,
+          statusCode: 429,
+        }),
+      );
+
+      await service.onModuleInit();
+      subscriber?.({
+        action: 'send_email',
+        payload: {
+          html: '<p>hello</p>',
+          subject: 'Subject',
+          to: 'test@example.com',
+        },
+        type: 'email',
+      });
+      await flushAsyncWork();
+
+      expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), 5000);
+      expect(retryCallback).toBeDefined();
+      retryCallback?.();
+      await flushAsyncWork();
+
+      expect(redisService.publish).toHaveBeenCalledWith(
+        'notifications',
+        expect.objectContaining({
+          action: 'send_email',
+          retryCount: 1,
+          type: 'email',
+        }),
+      );
+    });
+
+    it('surfaces permanent email failures without scheduling a retry', async () => {
+      const timeoutSpy = vi
+        .spyOn(globalThis, 'setTimeout')
+        .mockReturnValue(1 as unknown as ReturnType<typeof setTimeout>);
+      mockResendService.sendEmail.mockRejectedValue(
+        new ResendEmailDeliveryError('Invalid recipient', {
+          providerCode: 'validation_error',
+          retryable: false,
+          statusCode: 422,
+        }),
+      );
+
+      await service.onModuleInit();
+      subscriber?.({
+        action: 'send_email',
+        payload: {
+          html: '<p>hello</p>',
+          subject: 'Subject',
+          to: 'invalid',
+        },
+        type: 'email',
+      });
+      await flushAsyncWork();
+
+      expect(loggerService.error).toHaveBeenCalledWith(
+        'Failed to handle event email:send_email',
+        expect.any(ResendEmailDeliveryError),
+        expect.objectContaining({
+          providerCode: 'validation_error',
+          retryable: false,
+          statusCode: 422,
+        }),
+      );
+      expect(timeoutSpy).not.toHaveBeenCalled();
+      expect(redisService.publish).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/server/notifications/src/services/notification-handler.service.ts
+++ b/apps/server/notifications/src/services/notification-handler.service.ts
@@ -17,7 +17,10 @@ import {
   isNotificationEvent,
   type NotificationEvent,
 } from '@notifications/services/notification-handler.types';
-import { ResendService } from '@notifications/services/resend/resend.service';
+import {
+  ResendEmailDeliveryError,
+  ResendService,
+} from '@notifications/services/resend/resend.service';
 import { SlackService } from '@notifications/services/slack/slack.service';
 import { TelegramService } from '@notifications/services/telegram/telegram.service';
 
@@ -59,11 +62,24 @@ export class NotificationHandlerService implements OnModuleInit {
         try {
           await this.handleEvent(event);
         } catch (error: unknown) {
+          const resendDeliveryError =
+            error instanceof ResendEmailDeliveryError ? error : null;
           this.logger.error(
             `Failed to handle event ${event.type}:${event.action}`,
             error,
-            this.context,
+            resendDeliveryError
+              ? {
+                  ...this.context,
+                  providerCode: resendDeliveryError.providerCode,
+                  retryable: resendDeliveryError.retryable,
+                  statusCode: resendDeliveryError.statusCode,
+                }
+              : this.context,
           );
+
+          if (resendDeliveryError && !resendDeliveryError.retryable) {
+            return;
+          }
 
           const retryCount = event.retryCount ?? 0;
           if (retryCount < 3) {

--- a/apps/server/notifications/src/services/resend/resend.service.spec.ts
+++ b/apps/server/notifications/src/services/resend/resend.service.spec.ts
@@ -1,7 +1,10 @@
 import { LoggerService } from '@libs/logger/logger.service';
 import { Test, type TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@notifications/config/config.service';
-import { ResendService } from '@notifications/services/resend/resend.service';
+import {
+  ResendEmailDeliveryError,
+  ResendService,
+} from '@notifications/services/resend/resend.service';
 import { Resend } from 'resend';
 
 const mockSend = vi.fn();
@@ -119,5 +122,150 @@ describe('ResendService', () => {
       }),
       { idempotencyKey: 'crm/contacted/lead_1' },
     );
+  });
+
+  it('surfaces transient Resend failures as retryable delivery errors', async () => {
+    mockSend.mockResolvedValue({
+      data: null,
+      error: {
+        message: 'Too many requests',
+        name: 'rate_limit_exceeded',
+        statusCode: 429,
+      },
+    });
+
+    const delivery = service.sendEmail({
+      html: '<p>hello</p>',
+      subject: 'Subject',
+      to: 'test@example.com',
+    });
+
+    await expect(delivery).rejects.toMatchObject({
+      message: 'Too many requests',
+      name: ResendEmailDeliveryError.name,
+      providerCode: 'rate_limit_exceeded',
+      retryable: true,
+      statusCode: 429,
+    });
+    expect(loggerMock.error).toHaveBeenCalledWith(
+      'ResendService sendEmail failed',
+      expect.any(ResendEmailDeliveryError),
+      expect.objectContaining({
+        providerCode: 'rate_limit_exceeded',
+        retryable: true,
+        statusCode: 429,
+      }),
+    );
+  });
+
+  it('treats SDK-normalized network failures as retryable', async () => {
+    mockSend.mockResolvedValue({
+      data: null,
+      error: {
+        message: 'Unable to fetch data',
+        name: 'application_error',
+        statusCode: null,
+      },
+    });
+
+    await expect(
+      service.sendEmail({
+        html: '<p>hello</p>',
+        subject: 'Subject',
+        to: 'test@example.com',
+      }),
+    ).rejects.toMatchObject({
+      providerCode: 'application_error',
+      retryable: true,
+      statusCode: null,
+    });
+  });
+
+  it('retries concurrent requests that reuse an in-flight idempotency key', async () => {
+    mockSend.mockResolvedValue({
+      data: null,
+      error: {
+        message: 'The original request is still in progress',
+        name: 'concurrent_idempotent_requests',
+        statusCode: 409,
+      },
+    });
+
+    await expect(
+      service.sendEmail({
+        html: '<p>hello</p>',
+        idempotencyKey: 'workflow-status/workflow_1/completed',
+        subject: 'Subject',
+        to: 'test@example.com',
+      }),
+    ).rejects.toMatchObject({
+      providerCode: 'concurrent_idempotent_requests',
+      retryable: true,
+      statusCode: 409,
+    });
+  });
+
+  it('surfaces permanent Resend failures without marking them retryable', async () => {
+    mockSend.mockResolvedValue({
+      data: null,
+      error: {
+        message: 'Invalid recipient',
+        name: 'validation_error',
+        statusCode: 422,
+      },
+    });
+
+    await expect(
+      service.sendEmail({
+        html: '<p>hello</p>',
+        subject: 'Subject',
+        to: 'invalid',
+      }),
+    ).rejects.toMatchObject({
+      message: 'Invalid recipient',
+      providerCode: 'validation_error',
+      retryable: false,
+      statusCode: 422,
+    });
+  });
+
+  it('does not retry quota failures that cannot recover within the retry window', async () => {
+    mockSend.mockResolvedValue({
+      data: null,
+      error: {
+        message: 'Monthly quota exceeded',
+        name: 'monthly_quota_exceeded',
+        statusCode: 429,
+      },
+    });
+
+    await expect(
+      service.sendEmail({
+        html: '<p>hello</p>',
+        subject: 'Subject',
+        to: 'test@example.com',
+      }),
+    ).rejects.toMatchObject({
+      providerCode: 'monthly_quota_exceeded',
+      retryable: false,
+      statusCode: 429,
+    });
+  });
+
+  it('surfaces thrown transport failures as retryable delivery errors', async () => {
+    mockSend.mockRejectedValue(new Error('socket closed'));
+
+    await expect(
+      service.sendEmail({
+        html: '<p>hello</p>',
+        subject: 'Subject',
+        to: 'test@example.com',
+      }),
+    ).rejects.toMatchObject({
+      message: 'socket closed',
+      providerCode: null,
+      retryable: true,
+      statusCode: null,
+    });
   });
 });

--- a/apps/server/notifications/src/services/resend/resend.service.ts
+++ b/apps/server/notifications/src/services/resend/resend.service.ts
@@ -2,7 +2,7 @@ import { LoggerService } from '@libs/logger/logger.service';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@notifications/config/config.service';
-import { Resend } from 'resend';
+import { type ErrorResponse, Resend } from 'resend';
 
 export interface ResendEmailPayload {
   readonly to: string;
@@ -12,6 +12,71 @@ export interface ResendEmailPayload {
   readonly from?: string;
   readonly replyTo?: string;
   readonly idempotencyKey?: string;
+}
+
+export interface ResendEmailDeliveryErrorOptions {
+  readonly providerCode: ErrorResponse['name'] | null;
+  readonly retryable: boolean;
+  readonly statusCode: number | null;
+}
+
+export class ResendEmailDeliveryError extends Error {
+  readonly providerCode: ErrorResponse['name'] | null;
+  readonly retryable: boolean;
+  readonly statusCode: number | null;
+
+  constructor(message: string, options: ResendEmailDeliveryErrorOptions) {
+    super(message);
+    this.name = ResendEmailDeliveryError.name;
+    this.providerCode = options.providerCode;
+    this.retryable = options.retryable;
+    this.statusCode = options.statusCode;
+  }
+
+  static fromResponse(error: ErrorResponse): ResendEmailDeliveryError {
+    return new ResendEmailDeliveryError(error.message, {
+      providerCode: error.name,
+      retryable: isRetryableResendFailure(error),
+      statusCode: error.statusCode,
+    });
+  }
+
+  static fromCause(error: unknown): ResendEmailDeliveryError {
+    return new ResendEmailDeliveryError(
+      error instanceof Error ? error.message : 'Resend email delivery failed',
+      {
+        providerCode: null,
+        retryable: true,
+        statusCode: null,
+      },
+    );
+  }
+}
+
+function isRetryableResendFailure(error: ErrorResponse): boolean {
+  if (
+    error.name === 'daily_quota_exceeded' ||
+    error.name === 'monthly_quota_exceeded'
+  ) {
+    return false;
+  }
+
+  if (
+    error.name === 'concurrent_idempotent_requests' ||
+    error.name === 'rate_limit_exceeded'
+  ) {
+    return true;
+  }
+
+  const statusCode = error.statusCode;
+
+  return (
+    statusCode === null ||
+    statusCode === 408 ||
+    statusCode === 425 ||
+    statusCode === 429 ||
+    statusCode >= 500
+  );
 }
 
 @Injectable()
@@ -36,9 +101,8 @@ export class ResendService {
       return null;
     }
 
-    const resend = new Resend(this.configService.get('RESEND_API_KEY') || '');
-
     try {
+      const resend = new Resend(this.configService.get('RESEND_API_KEY') || '');
       const response = await resend.emails.send(
         {
           from:
@@ -58,8 +122,7 @@ export class ResendService {
       );
 
       if (response.error) {
-        this.loggerService.error(`${url} failed`, response.error);
-        return null;
+        throw ResendEmailDeliveryError.fromResponse(response.error);
       }
 
       this.loggerService.log(`${url} success`, {
@@ -70,8 +133,19 @@ export class ResendService {
 
       return response.data?.id ?? null;
     } catch (error: unknown) {
-      this.loggerService.error(`${url} failed`, error);
-      return null;
+      const deliveryError =
+        error instanceof ResendEmailDeliveryError
+          ? error
+          : ResendEmailDeliveryError.fromCause(error);
+
+      this.loggerService.error(`${url} failed`, error, {
+        provider: 'resend',
+        providerCode: deliveryError.providerCode,
+        retryable: deliveryError.retryable,
+        statusCode: deliveryError.statusCode,
+      });
+
+      throw deliveryError;
     }
   }
 }


### PR DESCRIPTION
## Summary

- Propagate Resend delivery failures as typed errors instead of returning `null`.
- Preserve the existing notification subscriber as the retry owner and republish transient failures through its three-attempt retry path.
- Classify validation, authentication, quota, and other permanent 4xx failures as non-retryable while retrying network failures, 5xx responses, rate limits, and concurrent idempotency requests.
- Include Resend provider code, status, and retryability in failure logs.

## Root cause

`ResendService.sendEmail()` logged both SDK response errors and thrown transport errors, then returned `null`. `NotificationHandlerService` only schedules a retry when email handling throws, so every Resend failure was indistinguishable from a successful notification.

## Scope

This keeps the current Redis pub/sub producer and notification-service boundary intact. Moving email delivery to BullMQ or an outbox remains the separate durability follow-up described in the issue.

## Validation

- `biome check` on the four changed notification files
- `git diff --check`
- staged `gitleaks protect --staged --redact --no-banner`
- commit hooks: staged Biome, secretlint, and UI control guard
- focused Resend and notification-handler tests added; local tests, typechecks, builds, compilation, and E2E were intentionally not run per workstation policy and are delegated to PR CI

Closes #1607