### PR TITLE
fix(docs): harden Nextra layout prerender patch

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -26,7 +26,7 @@
     "format:fix": "prettier --write .",
     "lint": "biome check app components content tests mdx-components.tsx next.config.mjs package.json tsconfig.json types styles README.md",
     "start": "next start",
-    "test": "bun test ./tests",
+    "test": "vitest run tests/nextra-layout-patch.test.ts",
     "type-check": "tsc --noEmit"
   },
   "version": "0.0.0"

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -24,9 +24,9 @@
     "dev:portless": "portless run --name docs.genfeed bun run dev:direct",
     "format:check": "prettier --check .",
     "format:fix": "prettier --write .",
-    "lint": "biome check app components content tests mdx-components.tsx next.config.mjs package.json tsconfig.json types styles README.md",
+    "lint": "biome check app components content tests mdx-components.tsx next.config.mjs vitest.config.ts package.json tsconfig.json types styles README.md",
     "start": "next start",
-    "test": "vitest run tests/nextra-layout-patch.test.ts",
+    "test": "vitest run --config vitest.config.ts",
     "type-check": "tsc --noEmit"
   },
   "version": "0.0.0"

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -26,7 +26,7 @@
     "format:fix": "prettier --write .",
     "lint": "biome check app components content tests mdx-components.tsx next.config.mjs package.json tsconfig.json types styles README.md",
     "start": "next start",
-    "test": "bun test ./tests/**/*.test.ts",
+    "test": "bun test ./tests",
     "type-check": "tsc --noEmit"
   },
   "version": "0.0.0"

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -24,8 +24,9 @@
     "dev:portless": "portless run --name docs.genfeed bun run dev:direct",
     "format:check": "prettier --check .",
     "format:fix": "prettier --write .",
-    "lint": "biome check app components content mdx-components.tsx next.config.mjs package.json tsconfig.json types styles README.md",
+    "lint": "biome check app components content tests mdx-components.tsx next.config.mjs package.json tsconfig.json types styles README.md",
     "start": "next start",
+    "test": "bun test ./tests/**/*.test.ts",
     "type-check": "tsc --noEmit"
   },
   "version": "0.0.0"

--- a/apps/docs/tests/nextra-layout-patch.test.ts
+++ b/apps/docs/tests/nextra-layout-patch.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'bun:test';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const themeDist = path.dirname(
+  fileURLToPath(import.meta.resolve('nextra-theme-docs')),
+);
+
+function readThemeFile(fileName: string): string {
+  return fs.readFileSync(path.join(themeDist, fileName), 'utf8');
+}
+
+describe('Nextra docs layout prerender patch', () => {
+  it('validates the complete layout props object', () => {
+    const layout = readThemeFile('layout.js');
+
+    expect(layout).toContain('LayoutPropsSchema.safeParse(t0)');
+    expect(layout).not.toContain('LayoutPropsSchema.safeParse(themeConfig)');
+  });
+
+  it('keeps validated children out of the theme config', () => {
+    const layout = readThemeFile('layout.js');
+    const schema = readThemeFile('schemas.js');
+    const schemaTypes = readThemeFile('schemas.d.mts');
+
+    expect(layout).toMatch(/banner,\s+children,\s+\.\.\.rest/);
+    expect(schema).toContain('children: reactNode,');
+    expect(schema).not.toContain('children: reactNode.optional()');
+    expect(schemaTypes).toContain(
+      'children: z.ZodCustom<react.ReactNode, react.ReactNode>',
+    );
+  });
+});

--- a/apps/docs/tests/nextra-layout-patch.test.ts
+++ b/apps/docs/tests/nextra-layout-patch.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it } from 'bun:test';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
 
 const themeDist = path.dirname(
   fileURLToPath(import.meta.resolve('nextra-theme-docs')),

--- a/apps/docs/vitest.config.ts
+++ b/apps/docs/vitest.config.ts
@@ -1,0 +1,11 @@
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  root: fileURLToPath(new URL('.', import.meta.url)),
+  test: {
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+    name: '@genfeedai/docs',
+  },
+});

--- a/patches/nextra-theme-docs@4.6.1.patch
+++ b/patches/nextra-theme-docs@4.6.1.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/layout.js b/dist/layout.js
-index 57a511faacf75820f822be305d66c61494ca998a..f2cfdba105b424a61ca79dc584e7bf922dfaf54d 100644
+index 57a511faacf75820f822be305d66c61494ca998a..32aece3ee852164d1a0b27be978ab6d20fec76a6 100644
 --- a/dist/layout.js
 +++ b/dist/layout.js
 @@ -23,16 +23,16 @@ const Layout = (t0) => {
@@ -22,28 +22,10 @@ index 57a511faacf75820f822be305d66c61494ca998a..f2cfdba105b424a61ca79dc584e7bf92
      $[4] = data;
    } else {
      data = $[4];
-diff --git a/dist/schemas.d.mts b/dist/schemas.d.mts
-index ab0104e9095be0d138c9b04d84f3a4e0d821c0fa..e0c6d34184b5bfe8a6284ef5c0ebf11c0b779c87 100644
---- a/dist/schemas.d.mts
-+++ b/dist/schemas.d.mts
-@@ -5,6 +5,6 @@
- declare const LayoutPropsSchema: z.ZodObject<{
-     banner: z.ZodOptional<z.ZodCustom<react.ReactNode, react.ReactNode>>;
--    children: z.ZodCustom<react.ReactNode, react.ReactNode>;
-+    children: z.ZodOptional<z.ZodCustom<react.ReactNode, react.ReactNode>>;
-     copyPageButton: z.ZodDefault<z.ZodBoolean>;
-     darkMode: z.ZodDefault<z.ZodBoolean>;
-     docsRepositoryBase: z.ZodDefault<z.ZodString>;
-diff --git a/dist/schemas.js b/dist/schemas.js
-index 060d0b98b76515e4f0a1cd9edb3c3f5d31597540..f17054ec71086d81f8242282a5e0bb42adbcb657 100644
---- a/dist/schemas.js
-+++ b/dist/schemas.js
-@@ -65,7 +65,7 @@ const LayoutPropsSchema = z.strictObject({
-   banner: reactNode.optional().meta({
-     description: "Rendered [`<Banner>` component](/docs/built-ins/banner). E.g. `<Banner {...bannerProps} />`"
-   }),
--  children: reactNode,
-+  children: reactNode.optional(),
-   copyPageButton: z.boolean().default(true).meta({
-     description: "Hide/show copy page content button."
-   }),
+@@ -51,5 +51,6 @@ const Layout = (t0) => {
+       nextThemes,
+       banner,
++      children,
+       ...rest
+     } = data);
+     $[5] = data;


### PR DESCRIPTION
## Summary
- complete the Nextra 4.6.1 layout backport by validating the full props object and extracting the validated `children` before constructing theme config
- remove the earlier optional-`children` schema workaround so the runtime and generated type contract stay strict
- add focused docs-workspace regression coverage that inspects the installed patched package in CI

## Root cause
Nextra 4.6.1 destructures `children` before validating the remaining `themeConfig` against a strict schema that still requires `children`. The first fixes in #1458/#1475 stopped the prerender exception, but together they left `children` optional and allowed validated children to flow into shared theme state. This patch aligns the compiled package with the upstream repair semantics.

## Verification
- `biome check apps/docs/package.json apps/docs/tests/nextra-layout-patch.test.ts`
- `git diff --check`
- `jq empty apps/docs/package.json`
- applied the Bun patch to the pristine Nextra 4.6.1 `dist/layout.js` and verified target blob `32aece3ee852164d1a0b27be978ab6d20fec76a6`
- staged filename scan and `gitleaks git --staged --redact=100 --no-banner`
- `https://docs.genfeed.ai/guides/asset-prompting-guide` currently returns HTTP 200
- local tests, typechecks, and builds intentionally not run per MacBook policy; PR CI provides executable test/build evidence

Closes #1419
