### PR TITLE
fix(billing): reconcile initial subscription credits

### DIFF
--- a/apps/server/api/src/collections/credits/services/credits.utils.service.spec.ts
+++ b/apps/server/api/src/collections/credits/services/credits.utils.service.spec.ts
@@ -269,7 +269,7 @@ describe('CreditsUtilsService', () => {
 
     // #1398: the yearly subscription reset path relies on this reference
     // being persisted on the transaction row — otherwise
-    // StripeWebhookSupportService#hasSubscriptionInvoiceCreditGrant can
+    // StripeWebhookSupportService#hasSubscriptionCreditGrant can
     // never find a match and a replayed invoice.paid double-resets credits.
     it('persists a referenceId/referenceType on the reset transaction when options are passed', async () => {
       const service = buildService();

--- a/apps/server/api/src/endpoints/webhooks/stripe/handlers/stripe-invoice-webhook.handler.spec.ts
+++ b/apps/server/api/src/endpoints/webhooks/stripe/handlers/stripe-invoice-webhook.handler.spec.ts
@@ -2,6 +2,7 @@ import { CreditsUtilsService } from '@api/collections/credits/services/credits.u
 import { UsersService } from '@api/collections/users/services/users.service';
 import { AccessBootstrapCacheService } from '@api/common/services/access-bootstrap-cache.service';
 import { StripeInvoiceWebhookHandler } from '@api/endpoints/webhooks/stripe/handlers/stripe-invoice-webhook.handler';
+import { StripeSubscriptionCreditReconcilerService } from '@api/endpoints/webhooks/stripe/handlers/stripe-subscription-credit-reconciler.service';
 import { StripeWebhookSupportService } from '@api/endpoints/webhooks/stripe/handlers/stripe-webhook-support.service';
 import { ByokBillingStatus, SubscriptionTier } from '@genfeedai/enums';
 import { SUBSCRIPTIONS_SERVICE } from '@genfeedai/interfaces/billing';
@@ -29,7 +30,7 @@ describe('StripeInvoiceWebhookHandler', () => {
   const usersService = { findOne: vi.fn(), patch: vi.fn() };
   const accessBootstrapCacheService = { invalidateForUser: vi.fn() };
   const supportService = {
-    hasSubscriptionInvoiceCreditGrant: vi.fn().mockResolvedValue(false),
+    hasSubscriptionCreditGrant: vi.fn().mockResolvedValue(false),
     isUniqueConstraintError: vi.fn().mockReturnValue(false),
     markOnboardingComplete: vi.fn(),
     recordCreditsActivity: vi.fn(),
@@ -63,12 +64,13 @@ describe('StripeInvoiceWebhookHandler', () => {
     subscriptionsService.findOne.mockResolvedValue(monthlySubscription);
     subscriptionsService.patch.mockResolvedValue(monthlySubscription);
     supportService.resolveTierFromPriceId.mockReturnValue(null);
-    supportService.hasSubscriptionInvoiceCreditGrant.mockResolvedValue(false);
+    supportService.hasSubscriptionCreditGrant.mockResolvedValue(false);
     supportService.isUniqueConstraintError.mockReturnValue(false);
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         StripeInvoiceWebhookHandler,
+        StripeSubscriptionCreditReconcilerService,
         { provide: ConfigService, useValue: configService },
         { provide: LoggerService, useValue: loggerService },
         { provide: SUBSCRIPTIONS_SERVICE, useValue: subscriptionsService },
@@ -107,10 +109,10 @@ describe('StripeInvoiceWebhookHandler', () => {
         'monthly',
         expect.stringContaining('monthly'),
         expect.any(Date),
-        {
+        expect.objectContaining({
           referenceId: 'stripe-invoice:in_123',
           referenceType: 'stripe-invoice:subscription-grant',
-        },
+        }),
       );
       expect(supportService.setHasEverHadCredits).toHaveBeenCalledWith(
         'org_1',
@@ -142,10 +144,10 @@ describe('StripeInvoiceWebhookHandler', () => {
         500_000,
         'yearly',
         expect.stringContaining('yearly'),
-        {
+        expect.objectContaining({
           referenceId: 'stripe-invoice:in_123',
           referenceType: 'stripe-invoice:subscription-grant',
-        },
+        }),
       );
     });
 
@@ -173,10 +175,10 @@ describe('StripeInvoiceWebhookHandler', () => {
         'monthly',
         expect.stringContaining('monthly'),
         expect.any(Date),
-        {
+        expect.objectContaining({
           referenceId: 'stripe-invoice:in_123',
           referenceType: 'stripe-invoice:subscription-grant',
-        },
+        }),
       );
     });
 
@@ -204,10 +206,10 @@ describe('StripeInvoiceWebhookHandler', () => {
         'monthly',
         expect.stringContaining('monthly'),
         expect.any(Date),
-        {
+        expect.objectContaining({
           referenceId: 'stripe-invoice:in_123',
           referenceType: 'stripe-invoice:subscription-grant',
-        },
+        }),
       );
     });
 
@@ -233,10 +235,10 @@ describe('StripeInvoiceWebhookHandler', () => {
         96_000,
         'yearly',
         expect.stringContaining('yearly'),
-        {
+        expect.objectContaining({
           referenceId: 'stripe-invoice:in_123',
           referenceType: 'stripe-invoice:subscription-grant',
-        },
+        }),
       );
     });
 
@@ -295,10 +297,46 @@ describe('StripeInvoiceWebhookHandler', () => {
       expect(
         accessBootstrapCacheService.invalidateForUser,
       ).toHaveBeenCalledWith('user_1');
+      expect(
+        creditsUtilsService.addOrganizationCreditsWithExpiration,
+      ).toHaveBeenCalledWith(
+        'org_1',
+        35_000,
+        'monthly',
+        expect.stringContaining('monthly'),
+        expect.any(Date),
+        expect.objectContaining({
+          referenceId: 'stripe-subscription:sub_stripe_1',
+          referenceType: 'stripe-subscription:initial-grant',
+        }),
+      );
+    });
+
+    it('propagates credit reconciliation failures for Stripe retry', async () => {
+      const ledgerError = new Error('ledger unavailable');
+      creditsUtilsService.addOrganizationCreditsWithExpiration.mockRejectedValueOnce(
+        ledgerError,
+      );
+
+      await expect(
+        handler.handleInvoicePaid(
+          invoiceWith({
+            parent: {
+              subscription_details: { subscription: 'sub_stripe_1' },
+            },
+          }),
+          'test',
+        ),
+      ).rejects.toBe(ledgerError);
+
+      expect(loggerService.error).toHaveBeenCalledWith(
+        expect.stringContaining('failed to handle invoice paid'),
+        ledgerError,
+      );
     });
 
     it('#1398: skips a duplicate monthly grant when the invoice reference already exists', async () => {
-      supportService.hasSubscriptionInvoiceCreditGrant.mockResolvedValue(true);
+      supportService.hasSubscriptionCreditGrant.mockResolvedValue(true);
 
       await handler.handleInvoicePaid(
         invoiceWith({
@@ -309,12 +347,15 @@ describe('StripeInvoiceWebhookHandler', () => {
         'test',
       );
 
-      expect(
-        supportService.hasSubscriptionInvoiceCreditGrant,
-      ).toHaveBeenCalledWith('org_1', {
-        referenceId: 'stripe-invoice:in_123',
-        referenceType: 'stripe-invoice:subscription-grant',
-      });
+      expect(supportService.hasSubscriptionCreditGrant).toHaveBeenCalledWith(
+        'org_1',
+        {
+          reference: {
+            referenceId: 'stripe-invoice:in_123',
+            referenceType: 'stripe-invoice:subscription-grant',
+          },
+        },
+      );
       expect(
         creditsUtilsService.addOrganizationCreditsWithExpiration,
       ).not.toHaveBeenCalled();
@@ -329,7 +370,7 @@ describe('StripeInvoiceWebhookHandler', () => {
         ...monthlySubscription,
         type: 'yearly',
       });
-      supportService.hasSubscriptionInvoiceCreditGrant.mockResolvedValue(true);
+      supportService.hasSubscriptionCreditGrant.mockResolvedValue(true);
 
       await handler.handleInvoicePaid(
         invoiceWith({
@@ -398,10 +439,10 @@ describe('StripeInvoiceWebhookHandler', () => {
         500_000,
         'yearly',
         expect.stringContaining('yearly'),
-        {
+        expect.objectContaining({
           referenceId: 'stripe-invoice:in_123',
           referenceType: 'stripe-invoice:subscription-grant',
-        },
+        }),
       );
       expect(supportService.isUniqueConstraintError).toHaveBeenCalledWith(
         uniqueConstraintError,

--- a/apps/server/api/src/endpoints/webhooks/stripe/handlers/stripe-invoice-webhook.handler.ts
+++ b/apps/server/api/src/endpoints/webhooks/stripe/handlers/stripe-invoice-webhook.handler.ts
@@ -1,47 +1,30 @@
-import { CreditsUtilsService } from '@api/collections/credits/services/credits.utils.service';
 import { UsersService } from '@api/collections/users/services/users.service';
 import { AccessBootstrapCacheService } from '@api/common/services/access-bootstrap-cache.service';
+import { StripeSubscriptionCreditReconcilerService } from '@api/endpoints/webhooks/stripe/handlers/stripe-subscription-credit-reconciler.service';
 import { StripeWebhookSupportService } from '@api/endpoints/webhooks/stripe/handlers/stripe-webhook-support.service';
 import { extractInvoiceSubscriptionId } from '@api/endpoints/webhooks/stripe/stripe-webhook.util';
 import type { StripeInvoice } from '@api/services/integrations/stripe/services/stripe.service';
-import {
-  ActivityKey,
-  ActivitySource,
-  ByokBillingStatus,
-  SubscriptionPlan,
-} from '@genfeedai/enums';
+import { ActivitySource, ByokBillingStatus } from '@genfeedai/enums';
 import {
   type ISubscriptionOssReadModel,
   type ISubscriptionsService,
   SUBSCRIPTIONS_SERVICE,
 } from '@genfeedai/interfaces/billing';
-import { TIER_INCLUDED_MONTHLY_CREDITS } from '@genfeedai/pricing';
-import { ConfigService } from '@libs/config/config.service';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Inject, Injectable } from '@nestjs/common';
-
-/**
- * Durable reference type for subscription-invoice credit grants (#1398).
- * Scoped by `stripe-invoice:{invoice.id}` so a Stripe replay of the same
- * invoice (same or a fresh event id) can never re-grant credits, even after
- * the 24h Redis webhook-event dedup marker has expired.
- */
-const SUBSCRIPTION_INVOICE_CREDIT_REFERENCE_TYPE =
-  'stripe-invoice:subscription-grant';
 
 /** Handles invoice.paid / invoice.payment_failed Stripe webhook events. */
 @Injectable()
 export class StripeInvoiceWebhookHandler {
   constructor(
-    private readonly configService: ConfigService,
     private readonly loggerService: LoggerService,
 
     @Inject(SUBSCRIPTIONS_SERVICE)
     private readonly subscriptionsService: ISubscriptionsService,
-    private readonly creditsUtilsService: CreditsUtilsService,
     private readonly usersService: UsersService,
     private readonly accessBootstrapCacheService: AccessBootstrapCacheService,
     private readonly supportService: StripeWebhookSupportService,
+    private readonly creditReconciler: StripeSubscriptionCreditReconcilerService,
   ) {}
 
   async handleInvoicePaid(invoice: StripeInvoice, url: string): Promise<void> {
@@ -95,7 +78,20 @@ export class StripeInvoiceWebhookHandler {
         updatedSubscription,
       );
 
-      await this.allocateSubscriptionCredits(subscription, invoice, url);
+      await this.creditReconciler.reconcile({
+        billingReason: invoice.billing_reason,
+        invoiceId: invoice.id,
+        ...(invoice.period_end
+          ? { periodEnd: new Date(invoice.period_end * 1000) }
+          : {}),
+        ...(invoice.period_start
+          ? { periodStart: new Date(invoice.period_start * 1000) }
+          : {}),
+        stripeSubscriptionId,
+        subscription,
+        trigger: 'invoice.paid',
+        url,
+      });
 
       // Mark onboarding as completed server-side on first subscription payment
       if (invoice.billing_reason === 'subscription_create') {
@@ -108,173 +104,8 @@ export class StripeInvoiceWebhookHandler {
       });
     } catch (error: unknown) {
       this.loggerService.error(`${url} failed to handle invoice paid`, error);
+      throw error;
     }
-  }
-
-  /**
-   * Resolve the billing-period credit amount for a subscription.
-   *
-   * Tier-aware: Pro/Scale grant their configured monthly included credits
-   * (TIER_INCLUDED_MONTHLY_CREDITS — single source of truth in
-   * @genfeedai/pricing, matching the website plan cards); yearly grants 12x
-   * that. Tiers without a configured allotment (e.g. Enterprise) and any
-   * unresolved price fall back to the STRIPE_MONTHLY_CREDITS /
-   * STRIPE_YEARLY_CREDITS config values.
-   */
-  private resolvePlanCredits(
-    subscription: Pick<ISubscriptionOssReadModel, 'type' | 'stripePriceId'>,
-  ): number {
-    const tier = subscription.stripePriceId
-      ? this.supportService.resolveTierFromPriceId(subscription.stripePriceId)
-      : null;
-    const tierMonthlyCredits = tier
-      ? TIER_INCLUDED_MONTHLY_CREDITS[tier]
-      : undefined;
-
-    if (subscription.type === SubscriptionPlan.MONTHLY) {
-      return (
-        tierMonthlyCredits ??
-        (Number(this.configService.get('STRIPE_MONTHLY_CREDITS')) || 35_000)
-      );
-    }
-
-    if (subscription.type === SubscriptionPlan.YEARLY) {
-      return tierMonthlyCredits != null
-        ? tierMonthlyCredits * 12
-        : Number(this.configService.get('STRIPE_YEARLY_CREDITS')) || 500_000;
-    }
-
-    return 0;
-  }
-
-  /** Allocate billing-period credits based on the subscription plan's rollover policy. */
-  private async allocateSubscriptionCredits(
-    subscription: ISubscriptionOssReadModel,
-    invoice: StripeInvoice,
-    url: string,
-  ): Promise<void> {
-    const creditsToAdd = this.resolvePlanCredits(subscription);
-
-    if (creditsToAdd <= 0) {
-      return;
-    }
-
-    const organizationId = String(subscription.organization);
-    // #1398: durable Postgres-level dedup keyed on the invoice, covering
-    // BOTH rollover policies below. The Redis event-id marker only guards
-    // the 24h window immediately after the original webhook — this guards
-    // any later replay of the same invoice regardless of event id.
-    const creditReference = {
-      referenceId: `stripe-invoice:${invoice.id}`,
-      referenceType: SUBSCRIPTION_INVOICE_CREDIT_REFERENCE_TYPE,
-    };
-
-    if (
-      await this.supportService.hasSubscriptionInvoiceCreditGrant(
-        organizationId,
-        creditReference,
-      )
-    ) {
-      this.loggerService.log(
-        `${url} skipping duplicate subscription invoice credit grant`,
-        { invoiceId: invoice.id, organizationId, ...creditReference },
-      );
-      return;
-    }
-
-    // Handle different rollover policies based on subscription type
-    if (subscription.type === SubscriptionPlan.MONTHLY) {
-      // Monthly: 3-month rollover with expiration. The reference is also
-      // passed through to the transaction row as a race-condition backstop
-      // behind a unique index (P2002 is treated as a duplicate no-op below).
-      try {
-        await this.creditsUtilsService.addOrganizationCreditsWithExpiration(
-          organizationId,
-          creditsToAdd,
-          subscription.type,
-          `${subscription.type} subscription billing period`,
-          new Date(Date.now() + 90 * 24 * 60 * 60 * 1000), // 3 months from now
-          creditReference,
-        );
-      } catch (error: unknown) {
-        if (this.supportService.isUniqueConstraintError(error)) {
-          this.loggerService.log(
-            `${url} skipping duplicate subscription invoice credit grant`,
-            { invoiceId: invoice.id, organizationId, ...creditReference },
-          );
-          return;
-        }
-        throw error;
-      }
-    } else if (subscription.type === SubscriptionPlan.YEARLY) {
-      // Yearly: reset credits (no rollover). The reference is also passed
-      // through to the reset transaction row as a race-condition backstop
-      // behind the same unique index used by the monthly path above (P2002
-      // is treated as a duplicate no-op below) — symmetric protection to
-      // MONTHLY, since the pre-check alone cannot see a prior grant unless
-      // the reset transaction actually persists the reference (#1398).
-      try {
-        await this.creditsUtilsService.resetOrganizationCredits(
-          organizationId,
-          creditsToAdd,
-          subscription.type,
-          `${subscription.type} subscription billing period reset`,
-          creditReference,
-        );
-      } catch (error: unknown) {
-        if (this.supportService.isUniqueConstraintError(error)) {
-          this.loggerService.log(
-            `${url} skipping duplicate subscription invoice credit grant`,
-            { invoiceId: invoice.id, organizationId, ...creditReference },
-          );
-          return;
-        }
-        throw error;
-      }
-    }
-
-    // Log activity for credit handling
-    const activityKey =
-      subscription.type === SubscriptionPlan.MONTHLY
-        ? ActivityKey.CREDITS_ADD
-        : ActivityKey.CREDITS_RESET;
-
-    await this.supportService.recordCreditsActivity({
-      brandId: String(subscription.organization),
-      key: activityKey,
-      organizationId: String(subscription.organization),
-      source: ActivitySource.SUBSCRIPTION,
-      userId: String(subscription.user),
-      value: String(creditsToAdd),
-    });
-
-    const currentBalance =
-      await this.creditsUtilsService.getOrganizationCreditsBalance(
-        String(subscription.organization),
-      );
-
-    this.loggerService.log(
-      `${url} ${subscription.type} subscription credits processed`,
-      {
-        billingReason: invoice.billing_reason,
-        creditsAdded: creditsToAdd,
-        currentBalance,
-        organizationId: subscription.organization,
-        policy:
-          subscription.type === SubscriptionPlan.MONTHLY
-            ? '3-month rollover'
-            : 'reset only',
-        subscriptionType: subscription.type,
-      },
-    );
-
-    // Mark org as having received credits (used by frontend to hide setup card).
-    // hasEverHadCredits is persisted to OrganizationSetting and read from the DB
-    // on bootstrap (epic #735, Phase C — no legacy auth provider write-back).
-    await this.supportService.setHasEverHadCredits(
-      String(subscription.organization),
-      url,
-    );
   }
 
   private async markOnboardingCompleteFromInvoice(

--- a/apps/server/api/src/endpoints/webhooks/stripe/handlers/stripe-subscription-credit-reconciler.service.spec.ts
+++ b/apps/server/api/src/endpoints/webhooks/stripe/handlers/stripe-subscription-credit-reconciler.service.spec.ts
@@ -1,0 +1,303 @@
+import { CreditsUtilsService } from '@api/collections/credits/services/credits.utils.service';
+import { StripeSubscriptionCreditReconcilerService } from '@api/endpoints/webhooks/stripe/handlers/stripe-subscription-credit-reconciler.service';
+import { StripeWebhookSupportService } from '@api/endpoints/webhooks/stripe/handlers/stripe-webhook-support.service';
+import { SubscriptionPlan, SubscriptionTier } from '@genfeedai/enums';
+import { ConfigService } from '@libs/config/config.service';
+import { LoggerService } from '@libs/logger/logger.service';
+import { Test, type TestingModule } from '@nestjs/testing';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('StripeSubscriptionCreditReconcilerService', () => {
+  let service: StripeSubscriptionCreditReconcilerService;
+
+  const configService = { get: vi.fn() };
+  const loggerService = { log: vi.fn(), warn: vi.fn() };
+  const creditsUtilsService = {
+    addOrganizationCreditsWithExpiration: vi.fn(),
+    getOrganizationCreditsBalance: vi.fn(),
+    resetOrganizationCredits: vi.fn(),
+  };
+  const supportService = {
+    hasSubscriptionCreditGrant: vi.fn(),
+    isUniqueConstraintError: vi.fn(),
+    recordCreditsActivity: vi.fn(),
+    resolveTierFromPriceId: vi.fn(),
+    setHasEverHadCredits: vi.fn(),
+  };
+
+  const periodStart = new Date('2026-07-01T00:00:00.000Z');
+  const periodEnd = new Date('2026-08-01T00:00:00.000Z');
+  const monthlySubscription = {
+    id: 'sub_db_1',
+    organization: 'org_1',
+    stripePriceId: 'price_pro',
+    stripeSubscriptionId: 'sub_stripe_1',
+    type: SubscriptionPlan.MONTHLY,
+    user: 'user_1',
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    configService.get.mockReturnValue(undefined);
+    creditsUtilsService.getOrganizationCreditsBalance.mockResolvedValue(8_000);
+    supportService.hasSubscriptionCreditGrant.mockResolvedValue(false);
+    supportService.isUniqueConstraintError.mockReturnValue(false);
+    supportService.resolveTierFromPriceId.mockReturnValue(SubscriptionTier.PRO);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        StripeSubscriptionCreditReconcilerService,
+        { provide: ConfigService, useValue: configService },
+        { provide: LoggerService, useValue: loggerService },
+        { provide: CreditsUtilsService, useValue: creditsUtilsService },
+        { provide: StripeWebhookSupportService, useValue: supportService },
+      ],
+    }).compile();
+
+    service = module.get(StripeSubscriptionCreditReconcilerService);
+  });
+
+  it('allocates the initial monthly grant from subscription.created with a durable subscription key', async () => {
+    await expect(
+      service.reconcile({
+        billingReason: 'subscription_create',
+        periodEnd,
+        periodStart,
+        stripeSubscriptionId: 'sub_stripe_1',
+        subscription: monthlySubscription,
+        subscriptionStatus: 'active',
+        trigger: 'customer.subscription.created',
+        url: 'test',
+      }),
+    ).resolves.toBe(true);
+
+    expect(supportService.hasSubscriptionCreditGrant).toHaveBeenCalledWith(
+      'org_1',
+      {
+        legacyPeriod: {
+          end: periodEnd,
+          source: SubscriptionPlan.MONTHLY,
+          start: periodStart,
+        },
+        reference: {
+          referenceId: 'stripe-subscription:sub_stripe_1',
+          referenceType: 'stripe-subscription:initial-grant',
+        },
+      },
+    );
+    expect(
+      creditsUtilsService.addOrganizationCreditsWithExpiration,
+    ).toHaveBeenCalledWith(
+      'org_1',
+      8_000,
+      SubscriptionPlan.MONTHLY,
+      expect.stringContaining('monthly'),
+      expect.any(Date),
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          billingReason: 'subscription_create',
+          stripeSubscriptionId: 'sub_stripe_1',
+          trigger: 'customer.subscription.created',
+        }),
+        referenceId: 'stripe-subscription:sub_stripe_1',
+        referenceType: 'stripe-subscription:initial-grant',
+      }),
+    );
+    expect(loggerService.log).toHaveBeenCalledWith(
+      expect.stringContaining('subscription credits reconciled'),
+      expect.objectContaining({
+        outcome: 'allocated',
+        trigger: 'customer.subscription.created',
+      }),
+    );
+  });
+
+  it('recognizes the legacy invoice reference while converging invoice.paid on the initial key', async () => {
+    supportService.hasSubscriptionCreditGrant.mockResolvedValue(true);
+
+    await expect(
+      service.reconcile({
+        billingReason: 'subscription_create',
+        invoiceId: 'in_123',
+        periodEnd,
+        periodStart,
+        stripeSubscriptionId: 'sub_stripe_1',
+        subscription: monthlySubscription,
+        trigger: 'invoice.paid',
+        url: 'test',
+      }),
+    ).resolves.toBe(false);
+
+    expect(supportService.hasSubscriptionCreditGrant).toHaveBeenCalledWith(
+      'org_1',
+      {
+        legacyInvoiceReference: {
+          referenceId: 'stripe-invoice:in_123',
+          referenceType: 'stripe-invoice:subscription-grant',
+        },
+        legacyPeriod: {
+          end: periodEnd,
+          source: SubscriptionPlan.MONTHLY,
+          start: periodStart,
+        },
+        reference: {
+          referenceId: 'stripe-subscription:sub_stripe_1',
+          referenceType: 'stripe-subscription:initial-grant',
+        },
+      },
+    );
+    expect(
+      creditsUtilsService.addOrganizationCreditsWithExpiration,
+    ).not.toHaveBeenCalled();
+    expect(loggerService.log).toHaveBeenCalledWith(
+      expect.stringContaining('reconciliation skipped'),
+      expect.objectContaining({ outcome: 'existing_grant' }),
+    );
+  });
+
+  it('grants once when invoice.paid arrives before subscription.created', async () => {
+    const appliedReferences = new Set<string>();
+    supportService.hasSubscriptionCreditGrant.mockImplementation(
+      async (
+        _organizationId: string,
+        lookup: {
+          reference: { referenceId: string; referenceType: string };
+        },
+      ) =>
+        appliedReferences.has(
+          `${lookup.reference.referenceType}:${lookup.reference.referenceId}`,
+        ),
+    );
+    creditsUtilsService.addOrganizationCreditsWithExpiration.mockImplementation(
+      async (
+        _organizationId: string,
+        _credits: number,
+        _source: string,
+        _description: string,
+        _expiresAt: Date,
+        options: { referenceId: string; referenceType: string },
+      ) => {
+        appliedReferences.add(
+          `${options.referenceType}:${options.referenceId}`,
+        );
+      },
+    );
+
+    const invoiceResult = await service.reconcile({
+      billingReason: 'subscription_create',
+      invoiceId: 'in_early',
+      periodEnd,
+      periodStart,
+      stripeSubscriptionId: 'sub_stripe_1',
+      subscription: monthlySubscription,
+      trigger: 'invoice.paid',
+      url: 'test',
+    });
+    const subscriptionResult = await service.reconcile({
+      billingReason: 'subscription_create',
+      periodEnd,
+      periodStart,
+      stripeSubscriptionId: 'sub_stripe_1',
+      subscription: monthlySubscription,
+      subscriptionStatus: 'active',
+      trigger: 'customer.subscription.created',
+      url: 'test',
+    });
+
+    expect(invoiceResult).toBe(true);
+    expect(subscriptionResult).toBe(false);
+    expect(
+      creditsUtilsService.addOrganizationCreditsWithExpiration,
+    ).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps recurring cycle grants keyed by invoice id', async () => {
+    await service.reconcile({
+      billingReason: 'subscription_cycle',
+      invoiceId: 'in_cycle_1',
+      periodEnd,
+      periodStart,
+      stripeSubscriptionId: 'sub_stripe_1',
+      subscription: monthlySubscription,
+      trigger: 'invoice.paid',
+      url: 'test',
+    });
+
+    expect(supportService.hasSubscriptionCreditGrant).toHaveBeenCalledWith(
+      'org_1',
+      {
+        reference: {
+          referenceId: 'stripe-invoice:in_cycle_1',
+          referenceType: 'stripe-invoice:subscription-grant',
+        },
+      },
+    );
+  });
+
+  it('does not grant credits for an incomplete subscription.created event', async () => {
+    await expect(
+      service.reconcile({
+        billingReason: 'subscription_create',
+        periodEnd,
+        periodStart,
+        stripeSubscriptionId: 'sub_stripe_1',
+        subscription: monthlySubscription,
+        subscriptionStatus: 'incomplete',
+        trigger: 'customer.subscription.created',
+        url: 'test',
+      }),
+    ).resolves.toBe(false);
+
+    expect(supportService.hasSubscriptionCreditGrant).not.toHaveBeenCalled();
+    expect(
+      creditsUtilsService.addOrganizationCreditsWithExpiration,
+    ).not.toHaveBeenCalled();
+    expect(loggerService.log).toHaveBeenCalledWith(
+      expect.stringContaining('reconciliation skipped'),
+      expect.objectContaining({ outcome: 'ineligible_status' }),
+    );
+  });
+
+  it('treats a unique-index race as an observed duplicate no-op', async () => {
+    const uniqueConstraintError = { code: 'P2002' };
+    creditsUtilsService.addOrganizationCreditsWithExpiration.mockRejectedValue(
+      uniqueConstraintError,
+    );
+    supportService.isUniqueConstraintError.mockReturnValue(true);
+
+    await expect(
+      service.reconcile({
+        billingReason: 'subscription_create',
+        stripeSubscriptionId: 'sub_stripe_1',
+        subscription: monthlySubscription,
+        subscriptionStatus: 'active',
+        trigger: 'customer.subscription.created',
+        url: 'test',
+      }),
+    ).resolves.toBe(false);
+
+    expect(supportService.recordCreditsActivity).not.toHaveBeenCalled();
+    expect(loggerService.log).toHaveBeenCalledWith(
+      expect.stringContaining('reconciliation skipped'),
+      expect.objectContaining({ outcome: 'unique_constraint_race' }),
+    );
+  });
+
+  it('propagates credit ledger failures for webhook retry', async () => {
+    const ledgerError = new Error('ledger unavailable');
+    creditsUtilsService.addOrganizationCreditsWithExpiration.mockRejectedValue(
+      ledgerError,
+    );
+
+    await expect(
+      service.reconcile({
+        billingReason: 'subscription_create',
+        stripeSubscriptionId: 'sub_stripe_1',
+        subscription: monthlySubscription,
+        subscriptionStatus: 'active',
+        trigger: 'customer.subscription.created',
+        url: 'test',
+      }),
+    ).rejects.toBe(ledgerError);
+  });
+});

--- a/apps/server/api/src/endpoints/webhooks/stripe/handlers/stripe-subscription-credit-reconciler.service.ts
+++ b/apps/server/api/src/endpoints/webhooks/stripe/handlers/stripe-subscription-credit-reconciler.service.ts
@@ -37,6 +37,44 @@ type SubscriptionCreditReconciliationInput = {
   url: string;
 };
 
+type CreditReference = {
+  referenceId: string;
+  referenceType: string;
+};
+
+type CreditTransactionOptions = CreditReference & {
+  metadata: Record<string, unknown>;
+};
+
+type SubscriptionCreditReconciliationContext =
+  SubscriptionCreditReconciliationInput & {
+    creditReference: CreditReference;
+    creditsToAdd: number;
+    organizationId: string;
+  };
+
+type SubscriptionCreditGrantLookup = {
+  legacyInvoiceReference?: CreditReference;
+  legacyPeriod?: {
+    end: Date;
+    source: string;
+    start: Date;
+  };
+  reference: CreditReference;
+};
+
+type DuplicateLogDetails = {
+  billingReason: string;
+  invoiceId?: string;
+  organizationId: string;
+  outcome: 'existing_grant' | 'unique_constraint_race';
+  referenceId: string;
+  referenceType: string;
+  stripeSubscriptionId: string;
+  trigger: SubscriptionCreditTrigger;
+  url: string;
+};
+
 /**
  * Converges subscription.created and invoice.paid onto one durable initial
  * credit grant while preserving invoice-keyed grants for later billing cycles.
@@ -50,263 +88,402 @@ export class StripeSubscriptionCreditReconcilerService {
     private readonly supportService: StripeWebhookSupportService,
   ) {}
 
-  async reconcile({
-    billingReason,
-    invoiceId,
-    periodEnd,
-    periodStart,
-    stripeSubscriptionId,
-    subscription,
-    subscriptionStatus,
-    trigger,
-    url,
-  }: SubscriptionCreditReconciliationInput): Promise<boolean> {
-    const organizationId = subscription.organization
-      ? String(subscription.organization)
+  async reconcile(
+    input: SubscriptionCreditReconciliationInput,
+  ): Promise<boolean> {
+    const context = this.prepareContext(input);
+    return context ? await this.reconcileContext(context) : false;
+  }
+
+  private prepareContext(
+    input: SubscriptionCreditReconciliationInput,
+  ): SubscriptionCreditReconciliationContext | null {
+    const organizationId = input.subscription.organization
+      ? String(input.subscription.organization)
       : '';
 
-    if (!organizationId) {
-      this.loggerService.warn(
-        `${url} subscription credit reconciliation skipped`,
-        {
-          billingReason,
-          outcome: 'missing_organization',
-          stripeSubscriptionId,
-          trigger,
-        },
-      );
-      return false;
+    if (organizationId) {
+      return this.requireEligibleStatus({ ...input, organizationId });
     }
 
-    if (
-      trigger === 'customer.subscription.created' &&
-      (!subscriptionStatus ||
-        !ACTIVE_SUBSCRIPTION_STATUSES.has(subscriptionStatus))
-    ) {
-      this.loggerService.log(
-        `${url} subscription credit reconciliation skipped`,
-        {
-          billingReason,
-          organizationId,
-          outcome: 'ineligible_status',
-          status: subscriptionStatus,
-          stripeSubscriptionId,
-          trigger,
-        },
-      );
-      return false;
-    }
-
-    const creditsToAdd = this.resolvePlanCredits(subscription);
-    if (creditsToAdd <= 0) {
-      this.loggerService.warn(
-        `${url} subscription credit reconciliation skipped`,
-        {
-          billingReason,
-          organizationId,
-          outcome: 'no_credit_allocation',
-          stripeSubscriptionId,
-          subscriptionType: subscription.type,
-          trigger,
-        },
-      );
-      return false;
-    }
-
-    const creditReference =
-      billingReason === 'subscription_create'
-        ? {
-            referenceId: `stripe-subscription:${stripeSubscriptionId}`,
-            referenceType: SUBSCRIPTION_INITIAL_CREDIT_REFERENCE_TYPE,
-          }
-        : invoiceId
-          ? {
-              referenceId: `stripe-invoice:${invoiceId}`,
-              referenceType: SUBSCRIPTION_INVOICE_CREDIT_REFERENCE_TYPE,
-            }
-          : null;
-
-    if (!creditReference) {
-      this.loggerService.warn(
-        `${url} subscription credit reconciliation skipped`,
-        {
-          billingReason,
-          organizationId,
-          outcome: 'missing_invoice_id',
-          stripeSubscriptionId,
-          trigger,
-        },
-      );
-      return false;
-    }
-
-    const legacyInvoiceReference =
-      billingReason === 'subscription_create' && invoiceId
-        ? {
-            referenceId: `stripe-invoice:${invoiceId}`,
-            referenceType: SUBSCRIPTION_INVOICE_CREDIT_REFERENCE_TYPE,
-          }
-        : undefined;
-
-    if (
-      await this.supportService.hasSubscriptionCreditGrant(organizationId, {
-        ...(legacyInvoiceReference ? { legacyInvoiceReference } : {}),
-        ...(billingReason === 'subscription_create' &&
-        periodStart &&
-        periodEnd &&
-        subscription.type
-          ? {
-              legacyPeriod: {
-                end: periodEnd,
-                source: subscription.type,
-                start: periodStart,
-              },
-            }
-          : {}),
-        reference: creditReference,
-      })
-    ) {
-      this.logDuplicate({
-        billingReason,
-        invoiceId,
-        organizationId,
-        outcome: 'existing_grant',
-        referenceId: creditReference.referenceId,
-        referenceType: creditReference.referenceType,
-        stripeSubscriptionId,
-        trigger,
-        url,
-      });
-      return false;
-    }
-
-    const transactionOptions = {
-      metadata: {
-        billingReason,
-        ...(invoiceId ? { stripeInvoiceId: invoiceId } : {}),
-        ...(periodEnd ? { periodEnd: periodEnd.toISOString() } : {}),
-        ...(periodStart ? { periodStart: periodStart.toISOString() } : {}),
-        stripeSubscriptionId,
-        trigger,
+    this.loggerService.warn(
+      `${input.url} subscription credit reconciliation skipped`,
+      {
+        billingReason: input.billingReason,
+        outcome: 'missing_organization',
+        stripeSubscriptionId: input.stripeSubscriptionId,
+        trigger: input.trigger,
       },
-      ...creditReference,
-    };
+    );
+    return null;
+  }
+
+  private requireEligibleStatus(
+    context: SubscriptionCreditReconciliationInput & {
+      organizationId: string;
+    },
+  ): SubscriptionCreditReconciliationContext | null {
+    if (this.isEligibleStatus(context)) {
+      return this.requireCreditAllocation(context);
+    }
+
+    this.loggerService.log(
+      `${context.url} subscription credit reconciliation skipped`,
+      {
+        billingReason: context.billingReason,
+        organizationId: context.organizationId,
+        outcome: 'ineligible_status',
+        status: context.subscriptionStatus,
+        stripeSubscriptionId: context.stripeSubscriptionId,
+        trigger: context.trigger,
+      },
+    );
+    return null;
+  }
+
+  private isEligibleStatus(
+    context: SubscriptionCreditReconciliationInput,
+  ): boolean {
+    if (context.trigger === 'invoice.paid') {
+      return true;
+    }
+
+    return Boolean(
+      context.subscriptionStatus &&
+        ACTIVE_SUBSCRIPTION_STATUSES.has(context.subscriptionStatus),
+    );
+  }
+
+  private requireCreditAllocation(
+    context: SubscriptionCreditReconciliationInput & {
+      organizationId: string;
+    },
+  ): SubscriptionCreditReconciliationContext | null {
+    const creditsToAdd = this.resolvePlanCredits(context.subscription);
+    if (creditsToAdd > 0) {
+      return this.requireCreditReference({ ...context, creditsToAdd });
+    }
+
+    this.loggerService.warn(
+      `${context.url} subscription credit reconciliation skipped`,
+      {
+        billingReason: context.billingReason,
+        organizationId: context.organizationId,
+        outcome: 'no_credit_allocation',
+        stripeSubscriptionId: context.stripeSubscriptionId,
+        subscriptionType: context.subscription.type,
+        trigger: context.trigger,
+      },
+    );
+    return null;
+  }
+
+  private requireCreditReference(
+    context: SubscriptionCreditReconciliationInput & {
+      creditsToAdd: number;
+      organizationId: string;
+    },
+  ): SubscriptionCreditReconciliationContext | null {
+    const creditReference = this.resolveCreditReference(context);
+    if (creditReference) {
+      return { ...context, creditReference };
+    }
+
+    this.loggerService.warn(
+      `${context.url} subscription credit reconciliation skipped`,
+      {
+        billingReason: context.billingReason,
+        organizationId: context.organizationId,
+        outcome: 'missing_invoice_id',
+        stripeSubscriptionId: context.stripeSubscriptionId,
+        trigger: context.trigger,
+      },
+    );
+    return null;
+  }
+
+  private resolveCreditReference(
+    context: SubscriptionCreditReconciliationInput,
+  ): CreditReference | null {
+    if (context.billingReason === 'subscription_create') {
+      return {
+        referenceId: `stripe-subscription:${context.stripeSubscriptionId}`,
+        referenceType: SUBSCRIPTION_INITIAL_CREDIT_REFERENCE_TYPE,
+      };
+    }
+
+    return context.invoiceId
+      ? {
+          referenceId: `stripe-invoice:${context.invoiceId}`,
+          referenceType: SUBSCRIPTION_INVOICE_CREDIT_REFERENCE_TYPE,
+        }
+      : null;
+  }
+
+  private async reconcileContext(
+    context: SubscriptionCreditReconciliationContext,
+  ): Promise<boolean> {
+    if (await this.hasExistingGrant(context)) {
+      this.logDuplicateFromContext(context, 'existing_grant');
+      return false;
+    }
 
     try {
-      if (subscription.type === SubscriptionPlan.MONTHLY) {
-        await this.creditsUtilsService.addOrganizationCreditsWithExpiration(
-          organizationId,
-          creditsToAdd,
-          subscription.type,
-          `${subscription.type} subscription billing period`,
-          new Date(Date.now() + 90 * 24 * 60 * 60 * 1000),
-          transactionOptions,
-        );
-      } else if (subscription.type === SubscriptionPlan.YEARLY) {
-        await this.creditsUtilsService.resetOrganizationCredits(
-          organizationId,
-          creditsToAdd,
-          subscription.type,
-          `${subscription.type} subscription billing period reset`,
-          transactionOptions,
-        );
-      }
+      await this.applyCreditTransaction(context);
     } catch (error: unknown) {
-      if (this.supportService.isUniqueConstraintError(error)) {
-        this.logDuplicate({
-          billingReason,
-          invoiceId,
-          organizationId,
-          outcome: 'unique_constraint_race',
-          referenceId: creditReference.referenceId,
-          referenceType: creditReference.referenceType,
-          stripeSubscriptionId,
-          trigger,
-          url,
-        });
-        return false;
+      if (!this.supportService.isUniqueConstraintError(error)) {
+        throw error;
       }
-      throw error;
+
+      this.logDuplicateFromContext(context, 'unique_constraint_race');
+      return false;
     }
 
-    const activityKey =
-      subscription.type === SubscriptionPlan.MONTHLY
-        ? ActivityKey.CREDITS_ADD
-        : ActivityKey.CREDITS_RESET;
+    await this.recordSuccessfulReconciliation(context);
+    return true;
+  }
 
-    await this.supportService.recordCreditsActivity({
-      brandId: organizationId,
-      key: activityKey,
-      organizationId,
-      source: ActivitySource.SUBSCRIPTION,
-      ...(subscription.user ? { userId: String(subscription.user) } : {}),
-      value: String(creditsToAdd),
-    });
+  private async hasExistingGrant(
+    context: SubscriptionCreditReconciliationContext,
+  ): Promise<boolean> {
+    return await this.supportService.hasSubscriptionCreditGrant(
+      context.organizationId,
+      this.buildGrantLookup(context),
+    );
+  }
 
+  private buildGrantLookup(
+    context: SubscriptionCreditReconciliationContext,
+  ): SubscriptionCreditGrantLookup {
+    const lookup: SubscriptionCreditGrantLookup = {
+      reference: context.creditReference,
+    };
+    this.addLegacyInvoiceReference(lookup, context);
+    this.addLegacyPeriod(lookup, context);
+    return lookup;
+  }
+
+  private addLegacyInvoiceReference(
+    lookup: SubscriptionCreditGrantLookup,
+    context: SubscriptionCreditReconciliationContext,
+  ): void {
+    if (context.billingReason === 'subscription_create' && context.invoiceId) {
+      lookup.legacyInvoiceReference = {
+        referenceId: `stripe-invoice:${context.invoiceId}`,
+        referenceType: SUBSCRIPTION_INVOICE_CREDIT_REFERENCE_TYPE,
+      };
+    }
+  }
+
+  private addLegacyPeriod(
+    lookup: SubscriptionCreditGrantLookup,
+    context: SubscriptionCreditReconciliationContext,
+  ): void {
+    if (
+      context.billingReason === 'subscription_create' &&
+      context.periodStart &&
+      context.periodEnd &&
+      context.subscription.type
+    ) {
+      lookup.legacyPeriod = {
+        end: context.periodEnd,
+        source: context.subscription.type,
+        start: context.periodStart,
+      };
+    }
+  }
+
+  private async applyCreditTransaction(
+    context: SubscriptionCreditReconciliationContext,
+  ): Promise<void> {
+    const transactionOptions = this.buildTransactionOptions(context);
+    if (context.subscription.type === SubscriptionPlan.MONTHLY) {
+      await this.addMonthlyCredits(context, transactionOptions);
+      return;
+    }
+
+    await this.resetYearlyCredits(context, transactionOptions);
+  }
+
+  private buildTransactionOptions(
+    context: SubscriptionCreditReconciliationContext,
+  ): CreditTransactionOptions {
+    const metadata: Record<string, unknown> = {
+      billingReason: context.billingReason,
+      stripeSubscriptionId: context.stripeSubscriptionId,
+      trigger: context.trigger,
+    };
+    this.addInvoiceMetadata(metadata, context);
+    this.addPeriodMetadata(metadata, context);
+    return { metadata, ...context.creditReference };
+  }
+
+  private addInvoiceMetadata(
+    metadata: Record<string, unknown>,
+    context: SubscriptionCreditReconciliationContext,
+  ): void {
+    if (context.invoiceId) {
+      metadata.stripeInvoiceId = context.invoiceId;
+    }
+  }
+
+  private addPeriodMetadata(
+    metadata: Record<string, unknown>,
+    context: SubscriptionCreditReconciliationContext,
+  ): void {
+    if (context.periodStart) {
+      metadata.periodStart = context.periodStart.toISOString();
+    }
+    if (context.periodEnd) {
+      metadata.periodEnd = context.periodEnd.toISOString();
+    }
+  }
+
+  private async addMonthlyCredits(
+    context: SubscriptionCreditReconciliationContext,
+    transactionOptions: CreditTransactionOptions,
+  ): Promise<void> {
+    await this.creditsUtilsService.addOrganizationCreditsWithExpiration(
+      context.organizationId,
+      context.creditsToAdd,
+      SubscriptionPlan.MONTHLY,
+      `${SubscriptionPlan.MONTHLY} subscription billing period`,
+      new Date(Date.now() + 90 * 24 * 60 * 60 * 1000),
+      transactionOptions,
+    );
+  }
+
+  private async resetYearlyCredits(
+    context: SubscriptionCreditReconciliationContext,
+    transactionOptions: CreditTransactionOptions,
+  ): Promise<void> {
+    await this.creditsUtilsService.resetOrganizationCredits(
+      context.organizationId,
+      context.creditsToAdd,
+      SubscriptionPlan.YEARLY,
+      `${SubscriptionPlan.YEARLY} subscription billing period reset`,
+      transactionOptions,
+    );
+  }
+
+  private async recordSuccessfulReconciliation(
+    context: SubscriptionCreditReconciliationContext,
+  ): Promise<void> {
+    await this.recordCreditsActivity(context);
     const currentBalance =
       await this.creditsUtilsService.getOrganizationCreditsBalance(
-        organizationId,
+        context.organizationId,
       );
+    this.logSuccessfulReconciliation(context, currentBalance);
+    await this.supportService.setHasEverHadCredits(
+      context.organizationId,
+      context.url,
+    );
+  }
 
-    this.loggerService.log(`${url} subscription credits reconciled`, {
-      billingReason,
-      creditsAdded: creditsToAdd,
+  private async recordCreditsActivity(
+    context: SubscriptionCreditReconciliationContext,
+  ): Promise<void> {
+    await this.supportService.recordCreditsActivity({
+      brandId: context.organizationId,
+      key:
+        context.subscription.type === SubscriptionPlan.MONTHLY
+          ? ActivityKey.CREDITS_ADD
+          : ActivityKey.CREDITS_RESET,
+      organizationId: context.organizationId,
+      source: ActivitySource.SUBSCRIPTION,
+      ...(context.subscription.user
+        ? { userId: String(context.subscription.user) }
+        : {}),
+      value: String(context.creditsToAdd),
+    });
+  }
+
+  private logSuccessfulReconciliation(
+    context: SubscriptionCreditReconciliationContext,
+    currentBalance: number,
+  ): void {
+    this.loggerService.log(`${context.url} subscription credits reconciled`, {
+      billingReason: context.billingReason,
+      creditsAdded: context.creditsToAdd,
       currentBalance,
-      invoiceId,
-      organizationId,
+      invoiceId: context.invoiceId,
+      organizationId: context.organizationId,
       outcome: 'allocated',
       policy:
-        subscription.type === SubscriptionPlan.MONTHLY
+        context.subscription.type === SubscriptionPlan.MONTHLY
           ? '3-month rollover'
           : 'reset only',
-      referenceId: creditReference.referenceId,
-      referenceType: creditReference.referenceType,
-      stripeSubscriptionId,
-      subscriptionType: subscription.type,
-      trigger,
+      referenceId: context.creditReference.referenceId,
+      referenceType: context.creditReference.referenceType,
+      stripeSubscriptionId: context.stripeSubscriptionId,
+      subscriptionType: context.subscription.type,
+      trigger: context.trigger,
     });
-
-    await this.supportService.setHasEverHadCredits(organizationId, url);
-    return true;
   }
 
   private resolvePlanCredits(
     subscription: Pick<ISubscriptionOssReadModel, 'stripePriceId' | 'type'>,
   ): number {
-    const tier = subscription.stripePriceId
-      ? this.supportService.resolveTierFromPriceId(subscription.stripePriceId)
-      : null;
-    const tierMonthlyCredits = tier
-      ? TIER_INCLUDED_MONTHLY_CREDITS[tier]
-      : undefined;
-
+    const tierMonthlyCredits = this.resolveTierMonthlyCredits(
+      subscription.stripePriceId,
+    );
     if (subscription.type === SubscriptionPlan.MONTHLY) {
-      return (
-        tierMonthlyCredits ??
-        (Number(this.configService.get('STRIPE_MONTHLY_CREDITS')) || 35_000)
-      );
+      return this.resolveMonthlyCredits(tierMonthlyCredits);
     }
-
     if (subscription.type === SubscriptionPlan.YEARLY) {
-      return tierMonthlyCredits != null
-        ? tierMonthlyCredits * 12
-        : Number(this.configService.get('STRIPE_YEARLY_CREDITS')) || 500_000;
+      return this.resolveYearlyCredits(tierMonthlyCredits);
     }
-
     return 0;
   }
 
-  private logDuplicate(details: {
-    billingReason: string;
-    invoiceId?: string;
-    organizationId: string;
-    outcome: 'existing_grant' | 'unique_constraint_race';
-    referenceId: string;
-    referenceType: string;
-    stripeSubscriptionId: string;
-    trigger: SubscriptionCreditTrigger;
-    url: string;
-  }): void {
+  private resolveTierMonthlyCredits(
+    stripePriceId?: string | null,
+  ): number | undefined {
+    if (!stripePriceId) {
+      return undefined;
+    }
+
+    const tier = this.supportService.resolveTierFromPriceId(stripePriceId);
+    return tier ? TIER_INCLUDED_MONTHLY_CREDITS[tier] : undefined;
+  }
+
+  private resolveMonthlyCredits(tierMonthlyCredits?: number): number {
+    return tierMonthlyCredits ?? this.resolveConfiguredMonthlyCredits();
+  }
+
+  private resolveYearlyCredits(tierMonthlyCredits?: number): number {
+    return tierMonthlyCredits === undefined
+      ? this.resolveConfiguredYearlyCredits()
+      : tierMonthlyCredits * 12;
+  }
+
+  private resolveConfiguredMonthlyCredits(): number {
+    return Number(this.configService.get('STRIPE_MONTHLY_CREDITS')) || 35_000;
+  }
+
+  private resolveConfiguredYearlyCredits(): number {
+    return Number(this.configService.get('STRIPE_YEARLY_CREDITS')) || 500_000;
+  }
+
+  private logDuplicateFromContext(
+    context: SubscriptionCreditReconciliationContext,
+    outcome: DuplicateLogDetails['outcome'],
+  ): void {
+    this.logDuplicate({
+      billingReason: context.billingReason,
+      invoiceId: context.invoiceId,
+      organizationId: context.organizationId,
+      outcome,
+      referenceId: context.creditReference.referenceId,
+      referenceType: context.creditReference.referenceType,
+      stripeSubscriptionId: context.stripeSubscriptionId,
+      trigger: context.trigger,
+      url: context.url,
+    });
+  }
+
+  private logDuplicate(details: DuplicateLogDetails): void {
     const { url, ...metadata } = details;
     this.loggerService.log(
       `${url} subscription credit reconciliation skipped`,

--- a/apps/server/api/src/endpoints/webhooks/stripe/handlers/stripe-subscription-credit-reconciler.service.ts
+++ b/apps/server/api/src/endpoints/webhooks/stripe/handlers/stripe-subscription-credit-reconciler.service.ts
@@ -1,0 +1,316 @@
+import { CreditsUtilsService } from '@api/collections/credits/services/credits.utils.service';
+import { StripeWebhookSupportService } from '@api/endpoints/webhooks/stripe/handlers/stripe-webhook-support.service';
+import {
+  ActivityKey,
+  ActivitySource,
+  SubscriptionPlan,
+  SubscriptionStatus,
+} from '@genfeedai/enums';
+import type { ISubscriptionOssReadModel } from '@genfeedai/interfaces/billing';
+import { TIER_INCLUDED_MONTHLY_CREDITS } from '@genfeedai/pricing';
+import { ConfigService } from '@libs/config/config.service';
+import { LoggerService } from '@libs/logger/logger.service';
+import { Injectable } from '@nestjs/common';
+
+const SUBSCRIPTION_INITIAL_CREDIT_REFERENCE_TYPE =
+  'stripe-subscription:initial-grant';
+const SUBSCRIPTION_INVOICE_CREDIT_REFERENCE_TYPE =
+  'stripe-invoice:subscription-grant';
+const ACTIVE_SUBSCRIPTION_STATUSES = new Set<string>([
+  SubscriptionStatus.ACTIVE,
+  SubscriptionStatus.TRIALING,
+]);
+
+type SubscriptionCreditTrigger =
+  | 'customer.subscription.created'
+  | 'invoice.paid';
+
+type SubscriptionCreditReconciliationInput = {
+  billingReason: 'subscription_create' | 'subscription_cycle';
+  invoiceId?: string;
+  periodEnd?: Date;
+  periodStart?: Date;
+  stripeSubscriptionId: string;
+  subscription: ISubscriptionOssReadModel;
+  subscriptionStatus?: string | null;
+  trigger: SubscriptionCreditTrigger;
+  url: string;
+};
+
+/**
+ * Converges subscription.created and invoice.paid onto one durable initial
+ * credit grant while preserving invoice-keyed grants for later billing cycles.
+ */
+@Injectable()
+export class StripeSubscriptionCreditReconcilerService {
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly loggerService: LoggerService,
+    private readonly creditsUtilsService: CreditsUtilsService,
+    private readonly supportService: StripeWebhookSupportService,
+  ) {}
+
+  async reconcile({
+    billingReason,
+    invoiceId,
+    periodEnd,
+    periodStart,
+    stripeSubscriptionId,
+    subscription,
+    subscriptionStatus,
+    trigger,
+    url,
+  }: SubscriptionCreditReconciliationInput): Promise<boolean> {
+    const organizationId = subscription.organization
+      ? String(subscription.organization)
+      : '';
+
+    if (!organizationId) {
+      this.loggerService.warn(
+        `${url} subscription credit reconciliation skipped`,
+        {
+          billingReason,
+          outcome: 'missing_organization',
+          stripeSubscriptionId,
+          trigger,
+        },
+      );
+      return false;
+    }
+
+    if (
+      trigger === 'customer.subscription.created' &&
+      (!subscriptionStatus ||
+        !ACTIVE_SUBSCRIPTION_STATUSES.has(subscriptionStatus))
+    ) {
+      this.loggerService.log(
+        `${url} subscription credit reconciliation skipped`,
+        {
+          billingReason,
+          organizationId,
+          outcome: 'ineligible_status',
+          status: subscriptionStatus,
+          stripeSubscriptionId,
+          trigger,
+        },
+      );
+      return false;
+    }
+
+    const creditsToAdd = this.resolvePlanCredits(subscription);
+    if (creditsToAdd <= 0) {
+      this.loggerService.warn(
+        `${url} subscription credit reconciliation skipped`,
+        {
+          billingReason,
+          organizationId,
+          outcome: 'no_credit_allocation',
+          stripeSubscriptionId,
+          subscriptionType: subscription.type,
+          trigger,
+        },
+      );
+      return false;
+    }
+
+    const creditReference =
+      billingReason === 'subscription_create'
+        ? {
+            referenceId: `stripe-subscription:${stripeSubscriptionId}`,
+            referenceType: SUBSCRIPTION_INITIAL_CREDIT_REFERENCE_TYPE,
+          }
+        : invoiceId
+          ? {
+              referenceId: `stripe-invoice:${invoiceId}`,
+              referenceType: SUBSCRIPTION_INVOICE_CREDIT_REFERENCE_TYPE,
+            }
+          : null;
+
+    if (!creditReference) {
+      this.loggerService.warn(
+        `${url} subscription credit reconciliation skipped`,
+        {
+          billingReason,
+          organizationId,
+          outcome: 'missing_invoice_id',
+          stripeSubscriptionId,
+          trigger,
+        },
+      );
+      return false;
+    }
+
+    const legacyInvoiceReference =
+      billingReason === 'subscription_create' && invoiceId
+        ? {
+            referenceId: `stripe-invoice:${invoiceId}`,
+            referenceType: SUBSCRIPTION_INVOICE_CREDIT_REFERENCE_TYPE,
+          }
+        : undefined;
+
+    if (
+      await this.supportService.hasSubscriptionCreditGrant(organizationId, {
+        ...(legacyInvoiceReference ? { legacyInvoiceReference } : {}),
+        ...(billingReason === 'subscription_create' &&
+        periodStart &&
+        periodEnd &&
+        subscription.type
+          ? {
+              legacyPeriod: {
+                end: periodEnd,
+                source: subscription.type,
+                start: periodStart,
+              },
+            }
+          : {}),
+        reference: creditReference,
+      })
+    ) {
+      this.logDuplicate({
+        billingReason,
+        invoiceId,
+        organizationId,
+        outcome: 'existing_grant',
+        referenceId: creditReference.referenceId,
+        referenceType: creditReference.referenceType,
+        stripeSubscriptionId,
+        trigger,
+        url,
+      });
+      return false;
+    }
+
+    const transactionOptions = {
+      metadata: {
+        billingReason,
+        ...(invoiceId ? { stripeInvoiceId: invoiceId } : {}),
+        ...(periodEnd ? { periodEnd: periodEnd.toISOString() } : {}),
+        ...(periodStart ? { periodStart: periodStart.toISOString() } : {}),
+        stripeSubscriptionId,
+        trigger,
+      },
+      ...creditReference,
+    };
+
+    try {
+      if (subscription.type === SubscriptionPlan.MONTHLY) {
+        await this.creditsUtilsService.addOrganizationCreditsWithExpiration(
+          organizationId,
+          creditsToAdd,
+          subscription.type,
+          `${subscription.type} subscription billing period`,
+          new Date(Date.now() + 90 * 24 * 60 * 60 * 1000),
+          transactionOptions,
+        );
+      } else if (subscription.type === SubscriptionPlan.YEARLY) {
+        await this.creditsUtilsService.resetOrganizationCredits(
+          organizationId,
+          creditsToAdd,
+          subscription.type,
+          `${subscription.type} subscription billing period reset`,
+          transactionOptions,
+        );
+      }
+    } catch (error: unknown) {
+      if (this.supportService.isUniqueConstraintError(error)) {
+        this.logDuplicate({
+          billingReason,
+          invoiceId,
+          organizationId,
+          outcome: 'unique_constraint_race',
+          referenceId: creditReference.referenceId,
+          referenceType: creditReference.referenceType,
+          stripeSubscriptionId,
+          trigger,
+          url,
+        });
+        return false;
+      }
+      throw error;
+    }
+
+    const activityKey =
+      subscription.type === SubscriptionPlan.MONTHLY
+        ? ActivityKey.CREDITS_ADD
+        : ActivityKey.CREDITS_RESET;
+
+    await this.supportService.recordCreditsActivity({
+      brandId: organizationId,
+      key: activityKey,
+      organizationId,
+      source: ActivitySource.SUBSCRIPTION,
+      ...(subscription.user ? { userId: String(subscription.user) } : {}),
+      value: String(creditsToAdd),
+    });
+
+    const currentBalance =
+      await this.creditsUtilsService.getOrganizationCreditsBalance(
+        organizationId,
+      );
+
+    this.loggerService.log(`${url} subscription credits reconciled`, {
+      billingReason,
+      creditsAdded: creditsToAdd,
+      currentBalance,
+      invoiceId,
+      organizationId,
+      outcome: 'allocated',
+      policy:
+        subscription.type === SubscriptionPlan.MONTHLY
+          ? '3-month rollover'
+          : 'reset only',
+      referenceId: creditReference.referenceId,
+      referenceType: creditReference.referenceType,
+      stripeSubscriptionId,
+      subscriptionType: subscription.type,
+      trigger,
+    });
+
+    await this.supportService.setHasEverHadCredits(organizationId, url);
+    return true;
+  }
+
+  private resolvePlanCredits(
+    subscription: Pick<ISubscriptionOssReadModel, 'stripePriceId' | 'type'>,
+  ): number {
+    const tier = subscription.stripePriceId
+      ? this.supportService.resolveTierFromPriceId(subscription.stripePriceId)
+      : null;
+    const tierMonthlyCredits = tier
+      ? TIER_INCLUDED_MONTHLY_CREDITS[tier]
+      : undefined;
+
+    if (subscription.type === SubscriptionPlan.MONTHLY) {
+      return (
+        tierMonthlyCredits ??
+        (Number(this.configService.get('STRIPE_MONTHLY_CREDITS')) || 35_000)
+      );
+    }
+
+    if (subscription.type === SubscriptionPlan.YEARLY) {
+      return tierMonthlyCredits != null
+        ? tierMonthlyCredits * 12
+        : Number(this.configService.get('STRIPE_YEARLY_CREDITS')) || 500_000;
+    }
+
+    return 0;
+  }
+
+  private logDuplicate(details: {
+    billingReason: string;
+    invoiceId?: string;
+    organizationId: string;
+    outcome: 'existing_grant' | 'unique_constraint_race';
+    referenceId: string;
+    referenceType: string;
+    stripeSubscriptionId: string;
+    trigger: SubscriptionCreditTrigger;
+    url: string;
+  }): void {
+    const { url, ...metadata } = details;
+    this.loggerService.log(
+      `${url} subscription credit reconciliation skipped`,
+      metadata,
+    );
+  }
+}

--- a/apps/server/api/src/endpoints/webhooks/stripe/handlers/stripe-subscription-credit-reconciler.service.ts
+++ b/apps/server/api/src/endpoints/webhooks/stripe/handlers/stripe-subscription-credit-reconciler.service.ts
@@ -279,18 +279,34 @@ export class StripeSubscriptionCreditReconcilerService {
     lookup: SubscriptionCreditGrantLookup,
     context: SubscriptionCreditReconciliationContext,
   ): void {
-    if (
-      context.billingReason === 'subscription_create' &&
-      context.periodStart &&
-      context.periodEnd &&
-      context.subscription.type
-    ) {
-      lookup.legacyPeriod = {
-        end: context.periodEnd,
-        source: context.subscription.type,
-        start: context.periodStart,
-      };
+    if (context.billingReason !== 'subscription_create') {
+      return;
     }
+
+    const legacyPeriod = this.resolveLegacyPeriod(context);
+    if (legacyPeriod) {
+      lookup.legacyPeriod = legacyPeriod;
+    }
+  }
+
+  private resolveLegacyPeriod(
+    context: SubscriptionCreditReconciliationContext,
+  ): SubscriptionCreditGrantLookup['legacyPeriod'] {
+    if (!context.periodStart) {
+      return undefined;
+    }
+    if (!context.periodEnd) {
+      return undefined;
+    }
+    if (!context.subscription.type) {
+      return undefined;
+    }
+
+    return {
+      end: context.periodEnd,
+      source: context.subscription.type,
+      start: context.periodStart,
+    };
   }
 
   private async applyCreditTransaction(

--- a/apps/server/api/src/endpoints/webhooks/stripe/handlers/stripe-subscription-webhook.handler.spec.ts
+++ b/apps/server/api/src/endpoints/webhooks/stripe/handlers/stripe-subscription-webhook.handler.spec.ts
@@ -1,5 +1,6 @@
 import { CreditsUtilsService } from '@api/collections/credits/services/credits.utils.service';
 import { UsersService } from '@api/collections/users/services/users.service';
+import { StripeSubscriptionCreditReconcilerService } from '@api/endpoints/webhooks/stripe/handlers/stripe-subscription-credit-reconciler.service';
 import { StripeSubscriptionWebhookHandler } from '@api/endpoints/webhooks/stripe/handlers/stripe-subscription-webhook.handler';
 import { StripeWebhookSupportService } from '@api/endpoints/webhooks/stripe/handlers/stripe-webhook-support.service';
 import type { StripeSubscription } from '@api/services/integrations/stripe/services/stripe.service';
@@ -31,6 +32,7 @@ describe('StripeSubscriptionWebhookHandler', () => {
   const lifecycleEmailService = {
     recordSubscriptionLapsed: vi.fn(),
   };
+  const creditReconciler = { reconcile: vi.fn() };
 
   function stripeSubscription(
     overrides: Record<string, unknown> = {},
@@ -42,6 +44,7 @@ describe('StripeSubscriptionWebhookHandler', () => {
       items: {
         data: [
           {
+            current_period_start: 1_747_321_600,
             current_period_end: 1_750_000_000,
             price: { id: 'price_1', recurring: { interval: 'month' } },
           },
@@ -74,6 +77,10 @@ describe('StripeSubscriptionWebhookHandler', () => {
         { provide: UsersService, useValue: usersService },
         { provide: StripeWebhookSupportService, useValue: supportService },
         { provide: LifecycleEmailService, useValue: lifecycleEmailService },
+        {
+          provide: StripeSubscriptionCreditReconcilerService,
+          useValue: creditReconciler,
+        },
       ],
     }).compile();
 
@@ -104,6 +111,20 @@ describe('StripeSubscriptionWebhookHandler', () => {
         'price_1',
         'active',
       );
+      expect(creditReconciler.reconcile).toHaveBeenCalledWith({
+        billingReason: 'subscription_create',
+        periodEnd: new Date(1_750_000_000 * 1000),
+        periodStart: new Date(1_747_321_600 * 1000),
+        stripeSubscriptionId: 'sub_stripe_1',
+        subscription: expect.objectContaining({
+          organization: 'org_1',
+          stripePriceId: 'price_1',
+          type: SubscriptionPlan.MONTHLY,
+        }),
+        subscriptionStatus: 'active',
+        trigger: 'customer.subscription.created',
+        url: 'test',
+      });
     });
 
     it('updates the org tier when the price maps to one', async () => {
@@ -132,6 +153,25 @@ describe('StripeSubscriptionWebhookHandler', () => {
         expect.objectContaining({ customerId: 'cus_123' }),
       );
       expect(subscriptionsService.patch).not.toHaveBeenCalled();
+      expect(creditReconciler.reconcile).not.toHaveBeenCalled();
+    });
+
+    it('propagates reconciliation failures so Stripe can retry the event', async () => {
+      const reconciliationError = new Error('credit ledger unavailable');
+      subscriptionsService.findByStripeCustomerId.mockResolvedValue(
+        dbSubscription,
+      );
+      subscriptionsService.patch.mockResolvedValue(dbSubscription);
+      creditReconciler.reconcile.mockRejectedValueOnce(reconciliationError);
+
+      await expect(
+        handler.handleSubscriptionCreated(stripeSubscription(), 'test'),
+      ).rejects.toBe(reconciliationError);
+
+      expect(loggerService.error).toHaveBeenCalledWith(
+        expect.stringContaining('failed to handle subscription created'),
+        reconciliationError,
+      );
     });
   });
 

--- a/apps/server/api/src/endpoints/webhooks/stripe/handlers/stripe-subscription-webhook.handler.ts
+++ b/apps/server/api/src/endpoints/webhooks/stripe/handlers/stripe-subscription-webhook.handler.ts
@@ -1,5 +1,6 @@
 import { CreditsUtilsService } from '@api/collections/credits/services/credits.utils.service';
 import { UsersService } from '@api/collections/users/services/users.service';
+import { StripeSubscriptionCreditReconcilerService } from '@api/endpoints/webhooks/stripe/handlers/stripe-subscription-credit-reconciler.service';
 import { StripeWebhookSupportService } from '@api/endpoints/webhooks/stripe/handlers/stripe-webhook-support.service';
 import type { StripeSubscription } from '@api/services/integrations/stripe/services/stripe.service';
 import { LifecycleEmailService } from '@api/services/lifecycle-emails/lifecycle-email.service';
@@ -24,6 +25,7 @@ export class StripeSubscriptionWebhookHandler {
     private readonly usersService: UsersService,
     private readonly supportService: StripeWebhookSupportService,
     private readonly lifecycleEmailService: LifecycleEmailService,
+    private readonly creditReconciler: StripeSubscriptionCreditReconcilerService,
   ) {}
 
   async handleSubscriptionCreated(
@@ -80,6 +82,33 @@ export class StripeSubscriptionWebhookHandler {
         );
       }
 
+      const subscriptionItem = subscription.items.data[0];
+      await this.creditReconciler.reconcile({
+        billingReason: 'subscription_create',
+        ...(subscriptionItem.current_period_end
+          ? {
+              periodEnd: new Date(subscriptionItem.current_period_end * 1000),
+            }
+          : {}),
+        ...(subscriptionItem.current_period_start
+          ? {
+              periodStart: new Date(
+                subscriptionItem.current_period_start * 1000,
+              ),
+            }
+          : {}),
+        stripeSubscriptionId: subscription.id,
+        subscription: {
+          ...existingSubscription,
+          ...(updatedSubscription ?? {}),
+          stripePriceId,
+          type: subscriptionData.type,
+        },
+        subscriptionStatus: subscription.status,
+        trigger: 'customer.subscription.created',
+        url,
+      });
+
       this.loggerService.log(`${url} subscription created successfully`, {
         organizationId: existingSubscription.organization,
         status: subscription.status,
@@ -90,6 +119,7 @@ export class StripeSubscriptionWebhookHandler {
         `${url} failed to handle subscription created`,
         error,
       );
+      throw error;
     }
   }
 
@@ -104,10 +134,13 @@ export class StripeSubscriptionWebhookHandler {
     // Stripe API: cancel_at_period_end is on Subscription,
     // current_period_end is on subscription items (moved in newer API versions)
     const currentPeriodEnd = subscription.items.data[0]?.current_period_end;
+    const currentPeriodStart = subscription.items.data[0]?.current_period_start;
 
     return {
       cancelAtPeriodEnd: subscription.cancel_at_period_end,
       currentPeriodEnd: currentPeriodEnd && new Date(currentPeriodEnd * 1000),
+      currentPeriodStart:
+        currentPeriodStart && new Date(currentPeriodStart * 1000),
       status: subscription.status as SubscriptionStatus,
       stripePriceId: subscription.items.data[0].price.id,
       stripeSubscriptionId: subscription.id,

--- a/apps/server/api/src/endpoints/webhooks/stripe/handlers/stripe-webhook-support.service.spec.ts
+++ b/apps/server/api/src/endpoints/webhooks/stripe/handlers/stripe-webhook-support.service.spec.ts
@@ -276,14 +276,16 @@ describe('StripeWebhookSupportService', () => {
     });
   });
 
-  describe('hasSubscriptionInvoiceCreditGrant', () => {
+  describe('hasSubscriptionCreditGrant', () => {
     it('returns false when no matching credit transaction exists', async () => {
       prisma.creditTransaction.findFirst.mockResolvedValue(null);
 
       await expect(
-        service.hasSubscriptionInvoiceCreditGrant('org_1', {
-          referenceId: 'stripe-invoice:in_123',
-          referenceType: 'stripe-invoice:subscription-grant',
+        service.hasSubscriptionCreditGrant('org_1', {
+          reference: {
+            referenceId: 'stripe-invoice:in_123',
+            referenceType: 'stripe-invoice:subscription-grant',
+          },
         }),
       ).resolves.toBe(false);
 
@@ -292,8 +294,12 @@ describe('StripeWebhookSupportService', () => {
         where: {
           isDeleted: false,
           organizationId: 'org_1',
-          referenceId: 'stripe-invoice:in_123',
-          referenceType: 'stripe-invoice:subscription-grant',
+          OR: [
+            {
+              referenceId: 'stripe-invoice:in_123',
+              referenceType: 'stripe-invoice:subscription-grant',
+            },
+          ],
         },
       });
     });
@@ -302,14 +308,55 @@ describe('StripeWebhookSupportService', () => {
       prisma.creditTransaction.findFirst.mockResolvedValue({ id: 'txn_1' });
 
       await expect(
-        service.hasSubscriptionInvoiceCreditGrant('org_1', {
-          referenceId: 'stripe-invoice:in_123',
-          referenceType: 'stripe-invoice:subscription-grant',
+        service.hasSubscriptionCreditGrant('org_1', {
+          reference: {
+            referenceId: 'stripe-invoice:in_123',
+            referenceType: 'stripe-invoice:subscription-grant',
+          },
         }),
       ).resolves.toBe(true);
 
       const where = prisma.creditTransaction.findFirst.mock.calls[0][0].where;
       expect(where).not.toHaveProperty('category');
+    });
+
+    it('recognizes legacy invoice grants from the same subscription period', async () => {
+      prisma.creditTransaction.findFirst.mockResolvedValue({ id: 'txn_1' });
+      const periodStart = new Date('2026-07-01T00:00:00.000Z');
+      const periodEnd = new Date('2026-08-01T00:00:00.000Z');
+
+      await expect(
+        service.hasSubscriptionCreditGrant('org_1', {
+          legacyPeriod: {
+            end: periodEnd,
+            source: 'monthly',
+            start: periodStart,
+          },
+          reference: {
+            referenceId: 'stripe-subscription:sub_123',
+            referenceType: 'stripe-subscription:initial-grant',
+          },
+        }),
+      ).resolves.toBe(true);
+
+      expect(prisma.creditTransaction.findFirst).toHaveBeenCalledWith({
+        select: { id: true },
+        where: {
+          isDeleted: false,
+          organizationId: 'org_1',
+          OR: [
+            {
+              referenceId: 'stripe-subscription:sub_123',
+              referenceType: 'stripe-subscription:initial-grant',
+            },
+            {
+              createdAt: { gte: periodStart, lt: periodEnd },
+              referenceType: 'stripe-invoice:subscription-grant',
+              source: 'monthly',
+            },
+          ],
+        },
+      });
     });
   });
 

--- a/apps/server/api/src/endpoints/webhooks/stripe/handlers/stripe-webhook-support.service.ts
+++ b/apps/server/api/src/endpoints/webhooks/stripe/handlers/stripe-webhook-support.service.ts
@@ -53,6 +53,16 @@ type PurchasedCreditsReference = {
   referenceType: string;
 };
 
+type SubscriptionCreditGrantLookup = {
+  legacyInvoiceReference?: PurchasedCreditsReference;
+  legacyPeriod?: {
+    end: Date;
+    source: string;
+    start: Date;
+  };
+  reference: PurchasedCreditsReference;
+};
+
 /**
  * Shared side-effect helpers used by the per-concern Stripe webhook handlers.
  * Each helper is the single definition of a block that was previously
@@ -207,25 +217,49 @@ export class StripeWebhookSupportService {
   }
 
   /**
-   * Durable Postgres-level dedup for subscription-invoice credit grants
-   * (#1398). The Redis `stripe:webhook:{event.id}` marker only covers the
-   * originating event for 24h; a Stripe replay past that window (auto-retry
-   * runs up to 3 days, or a manual Dashboard resend) must still be a no-op.
-   * Unlike {@link hasPurchasedCreditGrant} this is NOT filtered by
-   * `category` — a MONTHLY grant writes an ADD row, a YEARLY grant writes a
-   * RESET row, and either must block a re-grant for the same invoice.
+   * Durable Postgres-level dedup for subscription credit grants. The exact
+   * reference is the concurrency guard; optional legacy lookups prevent a
+   * historical invoice grant from being repeated after the initial-grant key
+   * introduced by #1608. Category is intentionally unrestricted because
+   * monthly grants write ADD rows while yearly grants write RESET rows.
    */
-  async hasSubscriptionInvoiceCreditGrant(
+  async hasSubscriptionCreditGrant(
     organizationId: string,
-    reference: PurchasedCreditsReference,
+    lookup: SubscriptionCreditGrantLookup,
   ): Promise<boolean> {
+    const references = [
+      {
+        referenceId: lookup.reference.referenceId,
+        referenceType: lookup.reference.referenceType,
+      },
+      ...(lookup.legacyInvoiceReference
+        ? [
+            {
+              referenceId: lookup.legacyInvoiceReference.referenceId,
+              referenceType: lookup.legacyInvoiceReference.referenceType,
+            },
+          ]
+        : []),
+      ...(lookup.legacyPeriod
+        ? [
+            {
+              createdAt: {
+                gte: lookup.legacyPeriod.start,
+                lt: lookup.legacyPeriod.end,
+              },
+              referenceType: 'stripe-invoice:subscription-grant',
+              source: lookup.legacyPeriod.source,
+            },
+          ]
+        : []),
+    ];
+
     const existing = await this.prisma.creditTransaction.findFirst({
       select: { id: true },
       where: {
         isDeleted: false,
         organizationId,
-        referenceId: reference.referenceId,
-        referenceType: reference.referenceType,
+        OR: references,
       },
     });
 

--- a/apps/server/api/src/endpoints/webhooks/stripe/stripe-webhooks.module.spec.ts
+++ b/apps/server/api/src/endpoints/webhooks/stripe/stripe-webhooks.module.spec.ts
@@ -2,6 +2,7 @@ import { StripeAttributionTrackerService } from '@api/endpoints/webhooks/stripe/
 import { StripeCheckoutWebhookHandler } from '@api/endpoints/webhooks/stripe/handlers/stripe-checkout-webhook.handler';
 import { StripeCustomerWebhookHandler } from '@api/endpoints/webhooks/stripe/handlers/stripe-customer-webhook.handler';
 import { StripeInvoiceWebhookHandler } from '@api/endpoints/webhooks/stripe/handlers/stripe-invoice-webhook.handler';
+import { StripeSubscriptionCreditReconcilerService } from '@api/endpoints/webhooks/stripe/handlers/stripe-subscription-credit-reconciler.service';
 import { StripeSubscriptionWebhookHandler } from '@api/endpoints/webhooks/stripe/handlers/stripe-subscription-webhook.handler';
 import { StripeWebhookSupportService } from '@api/endpoints/webhooks/stripe/handlers/stripe-webhook-support.service';
 import { StripeWebhooksModule } from '@api/endpoints/webhooks/stripe/stripe-webhooks.module';
@@ -35,6 +36,7 @@ describe('StripeWebhooksModule', () => {
       StripeCheckoutWebhookHandler,
       StripeCustomerWebhookHandler,
       StripeInvoiceWebhookHandler,
+      StripeSubscriptionCreditReconcilerService,
       StripeSubscriptionWebhookHandler,
       StripeWebhookSupportService,
     ]) {

--- a/apps/server/api/src/endpoints/webhooks/stripe/stripe-webhooks.module.ts
+++ b/apps/server/api/src/endpoints/webhooks/stripe/stripe-webhooks.module.ts
@@ -14,6 +14,7 @@ import { StripeAttributionTrackerService } from '@api/endpoints/webhooks/stripe/
 import { StripeCheckoutWebhookHandler } from '@api/endpoints/webhooks/stripe/handlers/stripe-checkout-webhook.handler';
 import { StripeCustomerWebhookHandler } from '@api/endpoints/webhooks/stripe/handlers/stripe-customer-webhook.handler';
 import { StripeInvoiceWebhookHandler } from '@api/endpoints/webhooks/stripe/handlers/stripe-invoice-webhook.handler';
+import { StripeSubscriptionCreditReconcilerService } from '@api/endpoints/webhooks/stripe/handlers/stripe-subscription-credit-reconciler.service';
 import { StripeSubscriptionWebhookHandler } from '@api/endpoints/webhooks/stripe/handlers/stripe-subscription-webhook.handler';
 import { StripeWebhookSupportService } from '@api/endpoints/webhooks/stripe/handlers/stripe-webhook-support.service';
 import { StripeWebhookController } from '@api/endpoints/webhooks/stripe/webhooks.stripe.controller';
@@ -52,6 +53,7 @@ const BaseModule = createServiceModule(StripeWebhookService, {
     StripeCheckoutWebhookHandler,
     StripeCustomerWebhookHandler,
     StripeInvoiceWebhookHandler,
+    StripeSubscriptionCreditReconcilerService,
     StripeSubscriptionWebhookHandler,
     StripeWebhookSupportService,
   ],

--- a/apps/server/api/test/integration/stripe-webhook-credit-grant.integration.spec.ts
+++ b/apps/server/api/test/integration/stripe-webhook-credit-grant.integration.spec.ts
@@ -18,7 +18,7 @@
  *  2. Postgres-level: Stripe redelivering the SAME invoice under a NEW event
  *     id (e.g. a dashboard "Resend" or a retry after the 24h Redis TTL
  *     expires) must not double-grant credits. This is enforced by
- *     `StripeWebhookSupportService#hasSubscriptionInvoiceCreditGrant`,
+ *     `StripeWebhookSupportService#hasSubscriptionCreditGrant`,
  *     keyed on a `referenceId`/`referenceType` persisted on the credit
  *     transaction row.
  *
@@ -58,6 +58,7 @@ import { RequestContextCacheService } from '@api/common/services/request-context
 import { StripeCheckoutWebhookHandler } from '@api/endpoints/webhooks/stripe/handlers/stripe-checkout-webhook.handler';
 import { StripeCustomerWebhookHandler } from '@api/endpoints/webhooks/stripe/handlers/stripe-customer-webhook.handler';
 import { StripeInvoiceWebhookHandler } from '@api/endpoints/webhooks/stripe/handlers/stripe-invoice-webhook.handler';
+import { StripeSubscriptionCreditReconcilerService } from '@api/endpoints/webhooks/stripe/handlers/stripe-subscription-credit-reconciler.service';
 import { StripeSubscriptionWebhookHandler } from '@api/endpoints/webhooks/stripe/handlers/stripe-subscription-webhook.handler';
 import { StripeWebhookSupportService } from '@api/endpoints/webhooks/stripe/handlers/stripe-webhook-support.service';
 import { StripeWebhookController } from '@api/endpoints/webhooks/stripe/webhooks.stripe.controller';
@@ -205,6 +206,7 @@ describe('Stripe webhook subscription credit grant (#1398 real-backend E2E)', ()
         StripeService,
         StripeWebhookService,
         StripeInvoiceWebhookHandler,
+        StripeSubscriptionCreditReconcilerService,
         StripeWebhookSupportService,
         CreditsUtilsService,
         CreditBalanceService,
@@ -435,7 +437,7 @@ describe('Stripe webhook subscription credit grant (#1398 real-backend E2E)', ()
       },
     });
     // Before the #1398 fix, resetOrganizationCredits had no way to persist a
-    // referenceId/referenceType, so hasSubscriptionInvoiceCreditGrant could
+    // referenceId/referenceType, so hasSubscriptionCreditGrant could
     // never find this row and the redelivery would reset credits a second
     // time (the balance would still read 500_000 either way, since RESET is
     // absolute — but a second RESET row, and re-running side effects like

--- a/packages/prisma/prisma/migrations/20260715120000_add_stripe_subscription_initial_credit_reference_unique/migration.sql
+++ b/packages/prisma/prisma/migrations/20260715120000_add_stripe_subscription_initial_credit_reference_unique/migration.sql
@@ -1,0 +1,11 @@
+-- Converge customer.subscription.created and the initial invoice.paid event on
+-- one durable credit grant per Stripe subscription (#1608). Later billing
+-- cycles remain protected by the invoice-reference index added for #1398.
+--
+-- Partial predicates cannot be represented in schema.prisma. CONCURRENTLY
+-- keeps the hot credit ledger writable while the index builds.
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "credit_transactions_stripe_subscription_initial_reference_key"
+  ON "credit_transactions" ("organizationId", "referenceType", "referenceId")
+  WHERE "isDeleted" = false
+    AND "referenceId" IS NOT NULL
+    AND "referenceType" = 'stripe-subscription:initial-grant';


### PR DESCRIPTION
## Summary

- reconcile initial subscription credits from both `customer.subscription.created` and `invoice.paid`
- converge both event orders on a durable Stripe-subscription grant key with a Postgres unique-index race backstop
- preserve recurring invoice-keyed grants and recognize legacy invoice grants within the same billing period
- emit structured allocation/skip outcomes and propagate ledger failures so Stripe retries instead of leaving a paid workspace creditless
- add focused unit coverage for duplicate, out-of-order, ineligible-status, race, and retry paths

## Design

Event-time reconciliation avoids a new scheduler and does not infer a missed grant from a zero balance, which could be legitimate after usage. Active/trialing subscription creation grants the initial allotment immediately; the later initial invoice becomes a durable no-op. Recurring invoices retain the existing per-invoice allocation semantics.

## Verification

- Biome format/check on changed webhook and focused test files
- `git diff --check`
- staged secret path/content scan
- repo pre-commit gates: secretlint, staged Biome, UI control guard
- local tests, typechecks, builds, compilation, E2E, and dependency installs intentionally not run per workstation policy; PR CI is the broad verification gate
- local `check:di-value-imports` could not start because this dependency-free worktree resolves TypeScript without `ScriptTarget`; deferred to CI

Closes #1608