### PR TITLE
refactor(notifications): simplify Resend retry classifier

### DIFF
--- a/apps/server/notifications/src/services/resend/resend.service.ts
+++ b/apps/server/notifications/src/services/resend/resend.service.ts
@@ -53,29 +53,30 @@ export class ResendEmailDeliveryError extends Error {
   }
 }
 
+const RESEND_RETRYABILITY_OVERRIDES: Partial<
+  Record<ErrorResponse['name'], boolean>
+> = {
+  concurrent_idempotent_requests: true,
+  daily_quota_exceeded: false,
+  monthly_quota_exceeded: false,
+  rate_limit_exceeded: true,
+};
+
+const RETRYABLE_RESEND_STATUS_CODES = new Set([408, 425, 429]);
+
 function isRetryableResendFailure(error: ErrorResponse): boolean {
-  if (
-    error.name === 'daily_quota_exceeded' ||
-    error.name === 'monthly_quota_exceeded'
-  ) {
-    return false;
+  const override = RESEND_RETRYABILITY_OVERRIDES[error.name];
+  if (override !== undefined) {
+    return override;
   }
 
-  if (
-    error.name === 'concurrent_idempotent_requests' ||
-    error.name === 'rate_limit_exceeded'
-  ) {
+  if (error.statusCode === null) {
     return true;
   }
 
-  const statusCode = error.statusCode;
-
   return (
-    statusCode === null ||
-    statusCode === 408 ||
-    statusCode === 425 ||
-    statusCode === 429 ||
-    statusCode >= 500
+    error.statusCode >= 500 ||
+    RETRYABLE_RESEND_STATUS_CODES.has(error.statusCode)
   );
 }
 


### PR DESCRIPTION
## Summary

- Replace the branch-heavy Resend retry classifier added in #1799 with explicit provider-code overrides and a retryable-status set.
- Preserve the exact permanent/transient behavior while reducing cyclomatic complexity below Fallow's CRAP threshold.

## Context

PR #1799 was merged while its final advisory audit was being inspected. Fallow reported a branch-owned `high-crap-score` finding for `isRetryableResendFailure`; this is the focused follow-up. The separate `unlisted-dependency` advisory predates #1799 on `master` and is intentionally not bundled here.

## Validation

- `biome check apps/server/notifications/src/services/resend/resend.service.ts`
- `git diff --check`
- staged `gitleaks protect --staged --redact --no-banner`
- commit hooks: staged Biome, secretlint, and UI control guard
- no local tests, typechecks, builds, compilation, or E2E per workstation policy; PR CI is authoritative