### PR TITLE
test(agent): cover setup OAuth recovery

### DIFF
--- a/packages/agent/src/components/AgentSetupPanel.spec.tsx
+++ b/packages/agent/src/components/AgentSetupPanel.spec.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -87,6 +87,62 @@ describe('AgentSetupPanel', () => {
     fireEvent.click(screen.getByText('Twitter'));
 
     expect(onOAuthConnect).toHaveBeenCalledWith('twitter');
+  });
+
+  it('re-enables connect actions when a successful handoff does not navigate', async () => {
+    const onOAuthConnect = vi.fn(() => undefined);
+    render(
+      <AgentSetupPanel
+        brand={brand}
+        connectedConnections={[]}
+        connectedPlatformsCount={0}
+        onOAuthConnect={onOAuthConnect}
+      />,
+    );
+
+    const twitterButton = screen.getByRole('button', { name: 'Twitter' });
+    fireEvent.click(twitterButton);
+
+    expect(onOAuthConnect).toHaveBeenCalledWith('twitter');
+    await waitFor(() => expect(twitterButton).toBeEnabled());
+  });
+
+  it('re-enables connect actions when an async handoff rejects', async () => {
+    const onOAuthConnect = vi.fn().mockRejectedValue(new Error('api down'));
+    render(
+      <AgentSetupPanel
+        brand={brand}
+        connectedConnections={[]}
+        connectedPlatformsCount={0}
+        onOAuthConnect={onOAuthConnect}
+      />,
+    );
+
+    const twitterButton = screen.getByRole('button', { name: 'Twitter' });
+    fireEvent.click(twitterButton);
+
+    expect(onOAuthConnect).toHaveBeenCalledWith('twitter');
+    await waitFor(() => expect(twitterButton).toBeEnabled());
+  });
+
+  it('re-enables connect actions when the handoff throws synchronously', async () => {
+    const onOAuthConnect = vi.fn(() => {
+      throw new Error('popup blocked');
+    });
+    render(
+      <AgentSetupPanel
+        brand={brand}
+        connectedConnections={[]}
+        connectedPlatformsCount={0}
+        onOAuthConnect={onOAuthConnect}
+      />,
+    );
+
+    const twitterButton = screen.getByRole('button', { name: 'Twitter' });
+    fireEvent.click(twitterButton);
+
+    expect(onOAuthConnect).toHaveBeenCalledWith('twitter');
+    await waitFor(() => expect(twitterButton).toBeEnabled());
   });
 
   it('lists connected accounts and hides them from the connect list', () => {

--- a/packages/agent/src/components/AgentSetupPanel.tsx
+++ b/packages/agent/src/components/AgentSetupPanel.tsx
@@ -19,7 +19,7 @@ interface AgentSetupPanelProps {
   className?: string;
   connectedConnections: AgentSetupConnection[];
   connectedPlatformsCount: number;
-  onOAuthConnect?: (platform: string) => void;
+  onOAuthConnect?: (platform: string) => void | Promise<void>;
 }
 
 function getConnectionLabel(connection: AgentSetupConnection): string {


### PR DESCRIPTION
## Summary
- align `AgentSetupPanel`'s OAuth callback contract with the sync-or-async handoff it already awaits
- prove connect actions recover when a successful handoff stays on-page
- prove rejected promises and synchronous throws leave the setup action retryable

## Verification
- `biome check packages/agent/src/components/AgentSetupPanel.tsx packages/agent/src/components/AgentSetupPanel.spec.tsx`
- `git diff --check`
- staged `gitleaks git --staged --no-banner --redact`
- pre-commit Biome, secretlint, UI control guard, and bespoke-card guard
- focused tests intentionally not run locally; PR CI is the test/build authority on this MacBook

Closes #1667
