### PR TITLE
fix(app-shell): derive breadcrumbs from canonical routes

### DIFF
--- a/apps/app/packages/components/app-protected-layout.test.tsx
+++ b/apps/app/packages/components/app-protected-layout.test.tsx
@@ -889,6 +889,45 @@ describe('AppProtectedLayout', () => {
     );
   });
 
+  it.each([
+    ['/org-123/~/settings/api-keys', 'Settings', 'API Keys'],
+    ['/org-123/brand-123/research/following', 'Research', 'Following'],
+    ['/org-123/brand-123/library/ingredients', 'Library', 'Ingredients'],
+    ['/org-123/brand-123/library/moodboard', 'Library', 'Moodboard'],
+    ['/org-123/brand-123/studio/clips', 'Studio', 'Clips'],
+    ['/org-123/brand-123/analytics/trends', 'Analytics', 'Trends'],
+    [
+      '/org-123/brand-123/analytics/trends/detail/trend-1',
+      'Analytics',
+      'Trend Detail',
+    ],
+    ['/org-123/brand-123/workflows/templates', 'Workflows', 'Templates'],
+    ['/org-123/brand-123/workflows/new', 'Workflows', 'New Workflow'],
+    [
+      '/org-123/brand-123/orchestration/content-runs/run-1',
+      'Workflows',
+      'Content Run',
+    ],
+    [
+      '/org-123/brand-123/orchestration/campaigns/campaign-1',
+      'Workflows',
+      'Campaign',
+    ],
+  ] as const)('feeds canonical root and leaf breadcrumb metadata on %s', (pathname, rootLabel, leafLabel) => {
+    mockPathname.value = pathname;
+
+    render(
+      <AppProtectedLayout>
+        <div>Protected content</div>
+      </AppProtectedLayout>,
+    );
+
+    const layoutProps = appLayoutSpy.mock.lastCall?.[0] as {
+      breadcrumb?: { leafLabel: string; rootLabel: string };
+    };
+    expect(layoutProps.breadcrumb).toEqual({ leafLabel, rootLabel });
+  });
+
   it('hides sidebar and topbar chrome for focused onboarding agent routes', () => {
     mockPathname.value = '/agent/onboarding';
 

--- a/apps/app/packages/components/app-protected-layout.test.tsx
+++ b/apps/app/packages/components/app-protected-layout.test.tsx
@@ -914,6 +914,7 @@ describe('AppProtectedLayout', () => {
       'Campaign',
     ],
   ] as const)('feeds canonical root and leaf breadcrumb metadata on %s', (pathname, rootLabel, leafLabel) => {
+    featureFlagState.conversationShell = true;
     mockPathname.value = pathname;
 
     render(

--- a/apps/app/packages/components/app-protected-layout.tsx
+++ b/apps/app/packages/components/app-protected-layout.tsx
@@ -431,6 +431,7 @@ function AppLayoutWithDynamicMenu({
   const mainLayout = (
     <AppLayout
       bannerComponent={shellBanner}
+      breadcrumb={workspaceShellRoute?.breadcrumb}
       brandSlug={brandSlug}
       currentApp={currentApp}
       menuComponent={menuComponent}
@@ -468,6 +469,7 @@ function AppLayoutWithDynamicMenu({
       <AppLayout
         agentPanel={legacyAgentPanel}
         bannerComponent={shellBanner}
+        breadcrumb={workspaceShellRoute?.breadcrumb}
         brandSlug={brandSlug}
         currentApp={currentApp}
         hasSecondaryTopbar={hasSecondaryTopbar}

--- a/apps/app/src/components/shell/AppProtectedTopbar.tsx
+++ b/apps/app/src/components/shell/AppProtectedTopbar.tsx
@@ -310,11 +310,7 @@ function AppProtectedTopbarContent({
             fallbackRootLabel={
               TOPBAR_BREADCRUMB_ROOT_LABELS[effectiveCurrentApp]
             }
-            rootLabel={
-              isSettingsRoute
-                ? 'Settings'
-                : TOPBAR_BREADCRUMB_ROOT_LABELS[effectiveCurrentApp]
-            }
+            rootLabel={isSettingsRoute ? 'Settings' : undefined}
           />
         </div>
 

--- a/apps/app/src/lib/workspace-shell/workspace-shell-registry.spec.ts
+++ b/apps/app/src/lib/workspace-shell/workspace-shell-registry.spec.ts
@@ -46,6 +46,8 @@ describe('workspace shell trusted registry', () => {
         route.mode === 'dedicated' ? 'always' : 'conversation-shell',
       );
       expect(route.canonicalUrl).toMatch(/^\//);
+      expect(route.breadcrumb.rootLabel).not.toHaveLength(0);
+      expect(route.breadcrumb.leafLabel).not.toHaveLength(0);
       expect(route.deployments).toEqual([
         'cloud-web',
         'self-hosted-web',
@@ -75,7 +77,50 @@ describe('workspace shell trusted registry', () => {
       );
 
       expect(route?.key).toBe(registration.key);
+      expect(route?.breadcrumb.rootLabel).not.toMatch(/:/);
+      expect(route?.breadcrumb.leafLabel).not.toMatch(/:/);
     }
+  });
+
+  it.each([
+    ['/acme/~/settings/api-keys', 'Settings', 'API Keys'],
+    ['/acme/moonrise/research/following', 'Research', 'Following'],
+    ['/acme/moonrise/research/instagram', 'Research', 'Instagram'],
+    ['/acme/moonrise/library/ingredients', 'Library', 'Ingredients'],
+    ['/acme/moonrise/library/moodboard', 'Library', 'Moodboard'],
+    ['/acme/moonrise/studio/clips', 'Studio', 'Clips'],
+    ['/acme/moonrise/studio/video/asset-1', 'Studio', 'Video'],
+    ['/acme/moonrise/analytics/trends', 'Analytics', 'Trends'],
+    [
+      '/acme/moonrise/analytics/trends/detail/trend-1',
+      'Analytics',
+      'Trend Detail',
+    ],
+    [
+      '/acme/moonrise/analytics/trends/platforms/instagram',
+      'Analytics',
+      'Instagram Trends',
+    ],
+    ['/acme/moonrise/workflows/templates', 'Workflows', 'Templates'],
+    ['/acme/moonrise/workflows/new', 'Workflows', 'New Workflow'],
+    ['/acme/moonrise/workflows/workflow-1', 'Workflows', 'Workflow'],
+    ['/acme/moonrise/orchestration/overview', 'Workflows', 'Overview'],
+    [
+      '/acme/moonrise/orchestration/content-runs/run-1',
+      'Workflows',
+      'Content Run',
+    ],
+    [
+      '/acme/moonrise/orchestration/campaigns/campaign-1',
+      'Workflows',
+      'Campaign',
+    ],
+    ['/acme/moonrise/orchestration/library/images', 'Workflows', 'Images'],
+  ] as const)('resolves canonical breadcrumb metadata for %s', (pathname, rootLabel, leafLabel) => {
+    expect(resolveWorkspaceShellRoute(pathname)?.breadcrumb).toEqual({
+      leafLabel,
+      rootLabel,
+    });
   });
 
   it.each([
@@ -265,6 +310,9 @@ describe('workspace shell trusted registry', () => {
     expect(Object.isFrozen(PROTECTED_ROUTE_INVENTORY)).toBe(true);
     expect(Object.isFrozen(PROTECTED_ROUTE_INVENTORY[0])).toBe(true);
     expect(Object.isFrozen(PROTECTED_ROUTE_INVENTORY[0]?.adapter)).toBe(true);
+    expect(Object.isFrozen(PROTECTED_ROUTE_INVENTORY[0]?.breadcrumb)).toBe(
+      true,
+    );
     expect(
       Reflect.set(PROTECTED_ROUTE_INVENTORY, 0, {
         key: 'model-produced-surface',

--- a/apps/app/src/lib/workspace-shell/workspace-shell-registry.ts
+++ b/apps/app/src/lib/workspace-shell/workspace-shell-registry.ts
@@ -3,6 +3,7 @@ import type {
   WorkspaceShellAccessPolicy,
   WorkspaceShellAdapterSeam,
   WorkspaceShellAuxiliaryRegistration,
+  WorkspaceShellBreadcrumbMetadata,
   WorkspaceShellDeployment,
   WorkspaceShellOverlayRegistration,
   WorkspaceShellRestorationPolicy,
@@ -18,6 +19,7 @@ export type {
   WorkspaceShellAuxiliaryRegistration,
   WorkspaceShellAvailability,
   WorkspaceShellBaseState,
+  WorkspaceShellBreadcrumbMetadata,
   WorkspaceShellChromeRegistration,
   WorkspaceShellDeployment,
   WorkspaceShellLaunchTarget,
@@ -99,6 +101,174 @@ const LAUNCH_TARGET_BY_MODE = Object.freeze({
   WorkspaceShellRouteRegistration['launchTarget']
 >);
 
+const BREADCRUMB_ROOT_LABELS = Object.freeze({
+  admin: 'Admin',
+  agent: 'Agent',
+  analytics: 'Analytics',
+  compose: 'Compose',
+  editor: 'Editor',
+  lab: 'Lab',
+  library: 'Library',
+  messages: 'Messages',
+  orchestration: 'Workflows',
+  overview: 'Workspace',
+  posts: 'Publish',
+  research: 'Research',
+  settings: 'Settings',
+  studio: 'Studio',
+  tasks: 'Workspace',
+  workflows: 'Workflows',
+  workspace: 'Workspace',
+  write: 'Compose',
+} as const satisfies Readonly<Record<string, string>>);
+
+const BREADCRUMB_WORD_LABELS = Object.freeze({
+  api: 'API',
+  gifs: 'GIFs',
+  id: 'ID',
+} as const satisfies Readonly<Record<string, string>>);
+
+const BREADCRUMB_LEAF_OVERRIDES = Object.freeze({
+  '/': 'Workspace',
+  '/:orgSlug': 'Overview',
+  '/:orgSlug/:brandSlug/agent': 'New Conversation',
+  '/:orgSlug/:brandSlug/agent/:id': 'Conversation',
+  '/:orgSlug/:brandSlug/agent/new': 'New Conversation',
+  '/:orgSlug/:brandSlug/agent/onboarding/:threadId': 'Onboarding',
+  '/:orgSlug/:brandSlug/analytics/brands/:id': 'Brand Details',
+  '/:orgSlug/:brandSlug/analytics/brands/:id/platforms/:platform': ':platform',
+  '/:orgSlug/:brandSlug/analytics/trends/detail/:id': 'Trend Detail',
+  '/:orgSlug/:brandSlug/analytics/trends/platforms/:platform':
+    ':platform Trends',
+  '/:orgSlug/:brandSlug/editor': 'Projects',
+  '/:orgSlug/:brandSlug/editor/:id': 'Project',
+  '/:orgSlug/:brandSlug/orchestration': 'Overview',
+  '/:orgSlug/:brandSlug/orchestration/:agentId': 'Agent',
+  '/:orgSlug/:brandSlug/orchestration/campaigns/:id': 'Campaign',
+  '/:orgSlug/:brandSlug/orchestration/content-runs/:runId': 'Content Run',
+  '/:orgSlug/:brandSlug/orchestration/library/:type': ':type',
+  '/:orgSlug/:brandSlug/orchestration/outreach-campaigns/:id':
+    'Outreach Campaign',
+  '/:orgSlug/:brandSlug/posts/:id': 'Post',
+  '/:orgSlug/:brandSlug/research/:platform': ':platform',
+  '/:orgSlug/:brandSlug/settings': 'General',
+  '/:orgSlug/:brandSlug/studio/:type': ':type',
+  '/:orgSlug/:brandSlug/studio/:type/:id': ':type',
+  '/:orgSlug/:brandSlug/tasks/:id': 'Task',
+  '/:orgSlug/:brandSlug/workflows/:id': 'Workflow',
+  '/:orgSlug/:brandSlug/workflows/executions/:id': 'Run',
+  '/:orgSlug/:brandSlug/workflows/new': 'New Workflow',
+  '/:orgSlug/~/agent': 'New Conversation',
+  '/:orgSlug/~/agent/:id': 'Conversation',
+  '/:orgSlug/~/agent/new': 'New Conversation',
+  '/:orgSlug/~/agent/onboarding/:threadId': 'Onboarding',
+  '/:orgSlug/~/compose/:segment': ':segment',
+  '/:orgSlug/~/editor': 'Projects',
+  '/:orgSlug/~/editor/:id': 'Project',
+  '/:orgSlug/~/library/:type': ':type',
+  '/:orgSlug/~/settings': 'General',
+  '/:orgSlug/~/settings/models/:type': ':type',
+  '/:orgSlug/~/studio/:type': ':type',
+  '/:orgSlug/~/workflows/:id': 'Workflow',
+  '/:orgSlug/~/workflows/executions/:id': 'Run',
+  '/:orgSlug/~/workflows/new': 'New Workflow',
+  '/:orgSlug/~/write/:segment': ':segment',
+  '/admin': 'Dashboard',
+  '/admin/agent': 'New Conversation',
+  '/admin/agent/:threadId': 'Conversation',
+  '/admin/agent/new': 'New Conversation',
+  '/admin/automation/models/:type': ':type Models',
+  '/admin/automation/trainings/:id/images': 'Training Images',
+  '/admin/automation/trainings/:id/sources': 'Training Sources',
+  '/admin/configuration/tags/:filter': ':filter Tags',
+  '/admin/content/ingredients/:type': ':type Ingredients',
+  '/admin/content/posts/:id': 'Post',
+  '/admin/content/templates/:id': 'Template',
+  '/admin/fleet/characters/:slug': 'Character',
+  '/admin/images/:id': 'Image',
+  '/admin/overview/analytics/brands/:id': 'Brand Details',
+  '/admin/overview/analytics/brands/:id/platforms/:platform': ':platform',
+  '/admin/overview/analytics/organizations/:id': 'Organization Details',
+  '/admin/videos/:id': 'Video',
+  '/settings': 'General',
+} as const satisfies Readonly<Record<string, string>>);
+
+function humanizeBreadcrumbLabel(value: string): string {
+  return value
+    .split('-')
+    .filter(Boolean)
+    .map((word) => {
+      const normalizedWord = word.toLowerCase();
+      return (
+        BREADCRUMB_WORD_LABELS[
+          normalizedWord as keyof typeof BREADCRUMB_WORD_LABELS
+        ] ??
+        `${normalizedWord.charAt(0).toUpperCase()}${normalizedWord.slice(1)}`
+      );
+    })
+    .join(' ');
+}
+
+function getCanonicalAppSegment(canonicalUrl: string): string {
+  if (canonicalUrl === '/') {
+    return 'workspace';
+  }
+
+  const segments = canonicalUrl.split('/').filter(Boolean);
+  if (segments[0] === 'admin' || segments[0] === 'settings') {
+    return segments[0];
+  }
+
+  if (segments[0] === ':orgSlug') {
+    if (segments.length === 1) {
+      return 'workspace';
+    }
+
+    return segments[1] === '~'
+      ? (segments[2] ?? 'overview')
+      : (segments[2] ?? 'workspace');
+  }
+
+  return segments[0] ?? 'workspace';
+}
+
+function getDefaultBreadcrumbLeafLabel(canonicalUrl: string): string {
+  const segments = canonicalUrl.split('/').filter(Boolean);
+  const lastStaticSegment = [...segments]
+    .reverse()
+    .find((segment) => !segment.startsWith(':') && segment !== '~');
+
+  return humanizeBreadcrumbLabel(lastStaticSegment ?? 'overview');
+}
+
+function getRouteBreadcrumbMetadata(
+  canonicalUrl: string,
+): WorkspaceShellBreadcrumbMetadata {
+  const appSegment = getCanonicalAppSegment(canonicalUrl);
+  const rootLabel =
+    BREADCRUMB_ROOT_LABELS[appSegment as keyof typeof BREADCRUMB_ROOT_LABELS] ??
+    humanizeBreadcrumbLabel(appSegment);
+  const leafLabel =
+    BREADCRUMB_LEAF_OVERRIDES[
+      canonicalUrl as keyof typeof BREADCRUMB_LEAF_OVERRIDES
+    ] ?? getDefaultBreadcrumbLeafLabel(canonicalUrl);
+
+  return Object.freeze({ leafLabel, rootLabel });
+}
+
+function resolveBreadcrumbMetadata(
+  breadcrumb: WorkspaceShellBreadcrumbMetadata,
+  params: Readonly<Record<string, string>>,
+): WorkspaceShellBreadcrumbMetadata {
+  const leafLabel = breadcrumb.leafLabel.replace(
+    /:([A-Za-z][A-Za-z0-9]*)/g,
+    (_, parameterName: string) =>
+      humanizeBreadcrumbLabel(params[parameterName] ?? parameterName),
+  );
+
+  return Object.freeze({ ...breadcrumb, leafLabel });
+}
+
 function freezeRouteRegistration(
   canonicalUrl: string,
   config: RouteGroupConfig,
@@ -113,6 +283,7 @@ function freezeRouteRegistration(
     ),
     allowedShellModes: Object.freeze([config.mode] as const),
     availability: AVAILABILITY_BY_MODE[config.mode],
+    breadcrumb: getRouteBreadcrumbMetadata(canonicalUrl),
     canonicalUrl,
     deployments: ALL_DEPLOYMENTS,
     key: `route:${canonicalUrl}`,
@@ -965,7 +1136,14 @@ export function resolveWorkspaceShellRoute(
     ),
   );
 
-  return Object.freeze({ ...bestMatch.registration, params });
+  return Object.freeze({
+    ...bestMatch.registration,
+    breadcrumb: resolveBreadcrumbMetadata(
+      bestMatch.registration.breadcrumb,
+      params,
+    ),
+    params,
+  });
 }
 
 export function getWorkspaceShellOverlayRegistration(

--- a/packages/contexts/ui/sidebar-navigation-context.test.tsx
+++ b/packages/contexts/ui/sidebar-navigation-context.test.tsx
@@ -13,8 +13,24 @@ vi.mock('next/navigation', () => ({
 }));
 
 function NavigationState() {
-  const { activePageLabel } = useSidebarNavigation();
-  return <span>{activePageLabel || 'none'}</span>;
+  const {
+    activeGroupId,
+    activePageLabel,
+    breadcrumbPageLabel,
+    breadcrumbRootLabel,
+    groups,
+  } = useSidebarNavigation();
+  return (
+    <span>
+      {[
+        activeGroupId || 'none',
+        activePageLabel || 'none',
+        breadcrumbRootLabel || 'none',
+        breadcrumbPageLabel || 'none',
+        groups.length,
+      ].join('|')}
+    </span>
+  );
 }
 
 function renderNavigation(items: MenuItemConfig[]) {
@@ -37,7 +53,9 @@ describe('SidebarNavigationProvider', () => {
       },
     ]);
 
-    expect(screen.getByText('Dashboard')).toBeInTheDocument();
+    expect(
+      screen.getByText('none|Dashboard|none|Dashboard|1'),
+    ).toBeInTheDocument();
   });
 
   it.each([
@@ -66,7 +84,9 @@ describe('SidebarNavigationProvider', () => {
       },
     ]);
 
-    expect(screen.getByText(childLabel)).toBeInTheDocument();
+    expect(
+      screen.getByText(`none|${childLabel}|none|${childLabel}|1`),
+    ).toBeInTheDocument();
   });
 
   it('ignores task-context query parameters when matching menu hrefs', () => {
@@ -79,7 +99,7 @@ describe('SidebarNavigationProvider', () => {
       },
     ]);
 
-    expect(screen.getByText('Images')).toBeInTheDocument();
+    expect(screen.getByText('none|Images|none|Images|1')).toBeInTheDocument();
   });
 
   it('preserves exact matching for root items with sibling pages', () => {
@@ -90,6 +110,26 @@ describe('SidebarNavigationProvider', () => {
       { href: '/settings/members', label: 'Members' },
     ]);
 
-    expect(screen.getByText('Members')).toBeInTheDocument();
+    expect(screen.getByText('none|Members|none|Members|1')).toBeInTheDocument();
+  });
+
+  it('uses canonical route breadcrumbs without discarding sidebar groups', () => {
+    pathnameState.value = '/acme/brand/library/moodboard';
+
+    render(
+      <SidebarNavigationProvider
+        breadcrumb={{ leafLabel: 'Moodboard', rootLabel: 'Library' }}
+        items={[
+          { group: 'Assets', href: '/library/images', label: 'Images' },
+          { group: 'Assets', href: '/library/videos', label: 'Videos' },
+        ]}
+      >
+        <NavigationState />
+      </SidebarNavigationProvider>,
+    );
+
+    expect(
+      screen.getByText('Assets|none|Library|Moodboard|1'),
+    ).toBeInTheDocument();
   });
 });

--- a/packages/contexts/ui/sidebar-navigation-context.tsx
+++ b/packages/contexts/ui/sidebar-navigation-context.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { MenuItemConfig } from '@genfeedai/interfaces/ui/menu-config.interface';
+import type { WorkspaceShellBreadcrumbMetadata } from '@genfeedai/interfaces/ui/workspace-shell.interface';
 import { usePathname } from 'next/navigation';
 import type { ReactNode } from 'react';
 import { createContext, use, useCallback, useMemo, useState } from 'react';
@@ -17,6 +18,10 @@ interface SidebarNavigationContextType {
   nestedGroupId: string | null;
   /** Label of the currently active page */
   activePageLabel: string;
+  /** Canonical breadcrumb root, independent of sidebar discovery coverage. */
+  breadcrumbRootLabel: string;
+  /** Canonical breadcrumb leaf, independent of sidebar discovery coverage. */
+  breadcrumbPageLabel: string;
   /** All grouped menu items for breadcrumb/navigation reference */
   groups: GroupedMenu[];
   /** Enter nested sidebar mode for a group */
@@ -105,6 +110,7 @@ function isPathActive(href: string, pathname: string | null): boolean {
 }
 
 interface SidebarNavigationProviderProps {
+  breadcrumb?: WorkspaceShellBreadcrumbMetadata;
   children: ReactNode;
   items: MenuItemConfig[];
 }
@@ -115,6 +121,7 @@ interface NestedGroupOverride {
 }
 
 export function SidebarNavigationProvider({
+  breadcrumb,
   children,
   items,
 }: SidebarNavigationProviderProps) {
@@ -221,6 +228,8 @@ export function SidebarNavigationProvider({
     () => ({
       activeGroupId: derivedGroupId,
       activePageLabel: derivedPageLabel,
+      breadcrumbPageLabel: breadcrumb?.leafLabel ?? derivedPageLabel,
+      breadcrumbRootLabel: breadcrumb?.rootLabel ?? derivedGroupId,
       enterNestedGroup,
       exitNestedGroup,
       groups,
@@ -230,6 +239,7 @@ export function SidebarNavigationProvider({
       derivedGroupId,
       nestedGroupId,
       derivedPageLabel,
+      breadcrumb,
       groups,
       enterNestedGroup,
       exitNestedGroup,
@@ -246,6 +256,8 @@ export function SidebarNavigationProvider({
 const DEFAULT_CONTEXT: SidebarNavigationContextType = {
   activeGroupId: '',
   activePageLabel: '',
+  breadcrumbPageLabel: '',
+  breadcrumbRootLabel: '',
   enterNestedGroup: () => {},
   exitNestedGroup: () => {},
   groups: [],

--- a/packages/interfaces/src/ui/workspace-shell.interface.ts
+++ b/packages/interfaces/src/ui/workspace-shell.interface.ts
@@ -105,11 +105,17 @@ export interface WorkspaceShellAdapterSeam {
   readonly status: 'dedicated-route' | 'embedded' | 'placeholder' | 'ready';
 }
 
+export interface WorkspaceShellBreadcrumbMetadata {
+  readonly leafLabel: string;
+  readonly rootLabel: string;
+}
+
 export interface WorkspaceShellRouteRegistration {
   readonly accessPolicy: WorkspaceShellAccessPolicy;
   readonly adapter: WorkspaceShellAdapterSeam;
   readonly allowedShellModes: readonly [WorkspaceShellRouteMode];
   readonly availability: Exclude<WorkspaceShellAvailability, 'legacy-shell'>;
+  readonly breadcrumb: WorkspaceShellBreadcrumbMetadata;
   readonly canonicalUrl: string;
   readonly deployments: readonly WorkspaceShellDeployment[];
   readonly key: string;

--- a/packages/props/layout/app-layout.props.ts
+++ b/packages/props/layout/app-layout.props.ts
@@ -1,5 +1,6 @@
 import type { AppContext } from '@genfeedai/interfaces';
 import type { MenuItemConfig } from '@genfeedai/interfaces/ui/menu-config.interface';
+import type { WorkspaceShellBreadcrumbMetadata } from '@genfeedai/interfaces/ui/workspace-shell.interface';
 import type { TopbarProps } from '@props/navigation/topbar.props';
 import type { ComponentType, ReactNode } from 'react';
 
@@ -17,6 +18,8 @@ export interface AppLayoutProps {
   hasSecondaryTopbar?: boolean;
   /** Menu items for SidebarNavigationProvider (breadcrumbs, nested nav) */
   menuItems?: MenuItemConfig[];
+  /** Canonical route breadcrumb, independent of sidebar discovery coverage. */
+  breadcrumb?: WorkspaceShellBreadcrumbMetadata;
   /** Agent panel rendered as a persistent bottom terminal dock */
   agentPanel?: ReactNode | null;
   /** Whether the agent panel is collapsed */

--- a/packages/ui/src/components/layouts/app/AppLayout.tsx
+++ b/packages/ui/src/components/layouts/app/AppLayout.tsx
@@ -23,6 +23,7 @@ export default function AppLayout({
   topbarChromeVariant = 'inherit',
   hasSecondaryTopbar: _hasSecondaryTopbar = false,
   menuItems = EMPTY_ARRAY,
+  breadcrumb,
   agentPanel,
   isAgentCollapsed = false,
   onAgentToggle,
@@ -67,7 +68,7 @@ export default function AppLayout({
     ) : null;
 
   const layoutContent = (
-    <SidebarNavigationProvider items={menuItems}>
+    <SidebarNavigationProvider breadcrumb={breadcrumb} items={menuItems}>
       <div
         className="ship-ui min-h-screen overflow-x-hidden bg-background"
         data-workspace-shell={isWorkspaceShell ? 'true' : undefined}

--- a/packages/ui/src/components/topbars/breadcrumbs/TopbarBreadcrumbs.test.tsx
+++ b/packages/ui/src/components/topbars/breadcrumbs/TopbarBreadcrumbs.test.tsx
@@ -4,7 +4,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockExitNestedGroup = vi.fn();
 
-let mockNavigationState = {
+let mockNavigationState: {
+  activeGroupId: string;
+  activePageLabel: string;
+  breadcrumbPageLabel?: string;
+  breadcrumbRootLabel?: string;
+  exitNestedGroup: typeof mockExitNestedGroup;
+  nestedGroupId?: string | null;
+} = {
   activeGroupId: '',
   activePageLabel: '',
   exitNestedGroup: mockExitNestedGroup,
@@ -14,10 +21,16 @@ vi.mock('@genfeedai/contexts/ui/sidebar-navigation-context', () => ({
   useSidebarNavigation: () => ({
     activeGroupId: mockNavigationState.activeGroupId,
     activePageLabel: mockNavigationState.activePageLabel,
+    breadcrumbPageLabel:
+      mockNavigationState.breadcrumbPageLabel ??
+      mockNavigationState.activePageLabel,
+    breadcrumbRootLabel:
+      mockNavigationState.breadcrumbRootLabel ??
+      mockNavigationState.activeGroupId,
     enterNestedGroup: vi.fn(),
     exitNestedGroup: mockNavigationState.exitNestedGroup,
     groups: [],
-    nestedGroupId: null,
+    nestedGroupId: mockNavigationState.nestedGroupId ?? null,
   }),
 }));
 
@@ -42,6 +55,7 @@ describe('TopbarBreadcrumbs', () => {
       activeGroupId: 'Library',
       activePageLabel: 'Images',
       exitNestedGroup: mockExitNestedGroup,
+      nestedGroupId: 'Library',
     };
 
     render(<TopbarBreadcrumbs />);
@@ -62,6 +76,22 @@ describe('TopbarBreadcrumbs', () => {
 
     expect(screen.getByText('Admin')).toBeInTheDocument();
     expect(screen.queryByText('Library')).not.toBeInTheDocument();
+  });
+
+  it('uses canonical route labels without changing nested navigation state', () => {
+    mockNavigationState = {
+      activeGroupId: 'Assets',
+      activePageLabel: '',
+      breadcrumbPageLabel: 'Moodboard',
+      breadcrumbRootLabel: 'Library',
+      exitNestedGroup: mockExitNestedGroup,
+    };
+
+    render(<TopbarBreadcrumbs />);
+
+    expect(screen.getByText('Library')).toBeInTheDocument();
+    expect(screen.getByText('Moodboard')).toBeInTheDocument();
+    expect(screen.queryByText('Assets')).not.toBeInTheDocument();
   });
 
   it('uses a fallback root label when the active page has no group', () => {
@@ -99,6 +129,7 @@ describe('TopbarBreadcrumbs', () => {
       activeGroupId: 'Library',
       activePageLabel: 'Images',
       exitNestedGroup: mockExitNestedGroup,
+      nestedGroupId: 'Library',
     };
 
     render(<TopbarBreadcrumbs />);

--- a/packages/ui/src/components/topbars/breadcrumbs/TopbarBreadcrumbs.tsx
+++ b/packages/ui/src/components/topbars/breadcrumbs/TopbarBreadcrumbs.tsx
@@ -21,13 +21,20 @@ export default function TopbarBreadcrumbs({
   fallbackRootLabel,
   rootLabel,
 }: TopbarBreadcrumbsProps) {
-  const { activeGroupId, activePageLabel, exitNestedGroup } =
-    useSidebarNavigation();
+  const {
+    activeGroupId,
+    breadcrumbPageLabel,
+    breadcrumbRootLabel,
+    exitNestedGroup,
+    nestedGroupId,
+  } = useSidebarNavigation();
 
-  const groupLabel = rootLabel || activeGroupId || fallbackRootLabel;
-  const canExitNestedGroup = Boolean(activeGroupId && activePageLabel);
+  const groupLabel = rootLabel || breadcrumbRootLabel || fallbackRootLabel;
+  const canExitNestedGroup = Boolean(
+    activeGroupId && breadcrumbPageLabel && nestedGroupId,
+  );
 
-  if (!groupLabel && !activePageLabel) {
+  if (!groupLabel && !breadcrumbPageLabel) {
     return null;
   }
 
@@ -36,7 +43,7 @@ export default function TopbarBreadcrumbs({
       className="flex items-center gap-1.5 text-[13px]"
       aria-label="Breadcrumb"
     >
-      {groupLabel && activePageLabel && canExitNestedGroup ? (
+      {groupLabel && breadcrumbPageLabel && canExitNestedGroup ? (
         <Button
           variant={ButtonVariant.UNSTYLED}
           withWrapper={false}
@@ -54,15 +61,15 @@ export default function TopbarBreadcrumbs({
         </span>
       ) : null}
 
-      {groupLabel && activePageLabel && (
+      {groupLabel && breadcrumbPageLabel && (
         <span aria-hidden="true" className="text-foreground/30 select-none">
           /
         </span>
       )}
 
-      {activePageLabel && (
+      {breadcrumbPageLabel && (
         <span className="truncate max-w-truncate-lg text-foreground font-semibold">
-          {activePageLabel}
+          {breadcrumbPageLabel}
         </span>
       )}
     </nav>

--- a/playwright/e2e/tests/shell/page-context-contract.spec.ts
+++ b/playwright/e2e/tests/shell/page-context-contract.spec.ts
@@ -30,12 +30,12 @@ const CONTRACTS: PageContextContract[] = [
   {
     route: `${BRAND_BASE}/library/images`,
     currentApp: 'library',
-    sectionLabel: 'Workspace',
+    sectionLabel: 'Library',
   },
   {
     route: `${BRAND_BASE}/studio/image`,
     currentApp: 'studio',
-    sectionLabel: 'Workspace',
+    sectionLabel: 'Studio',
   },
   {
     route: `${BRAND_BASE}/posts/scheduled`,


### PR DESCRIPTION
## Summary
- attach deterministic root and leaf breadcrumb metadata to every canonical protected-route registration
- feed route-owned breadcrumbs through the layout context without changing sidebar navigation or canonical URLs
- cover Settings, Research, Library, Studio, Analytics, Workflows, and orchestration gaps with exact-label regressions

## Verification
- scoped Biome check passed for all 12 changed files
- `git diff --check` passed
- staged Secretlint scan passed
- local tests/typechecks/builds/E2E intentionally not run; PR CI is the verification authority

Closes #1598