### PR TITLE
ci(docs): gate Nextra prerender regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -702,7 +702,7 @@ jobs:
       - name: Run build
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            TURBO_SCM_BASE="${{ github.event.pull_request.base.sha }}" bunx turbo run build --filter='./packages/*' --affected
+            TURBO_SCM_BASE="${{ github.event.pull_request.base.sha }}" bunx turbo run build --filter='./packages/*' --filter=@genfeedai/docs --affected
           else
             bun run build
           fi

--- a/apps/docs/tests/nextra-layout-patch.test.ts
+++ b/apps/docs/tests/nextra-layout-patch.test.ts
@@ -15,7 +15,9 @@ describe('Nextra docs layout prerender patch', () => {
   it('validates the complete layout props object', () => {
     const layout = readThemeFile('layout.js');
 
+    expect(layout).toContain('if ($[3] !== t0)');
     expect(layout).toContain('LayoutPropsSchema.safeParse(t0)');
+    expect(layout).toContain('$[3] = t0');
     expect(layout).not.toContain('LayoutPropsSchema.safeParse(themeConfig)');
   });
 


### PR DESCRIPTION
## Summary
- include `@genfeedai/docs` in the affected PR build gate so docs changes must complete a real Next.js prerender build
- strengthen the Nextra layout regression test to assert React compiler cache state tracks the complete props object

## Context
Follow-up to #1800 / #1419. PR #1800 was merged while final verification was in progress; its CI build job only covered `packages/*`, so it did not exercise the docs prerender path. This follow-up closes that verification gap without invoking the production Vercel deploy workflow.

## Verification
- GitHub CI: https://github.com/genfeedai/genfeed.ai/actions/runs/29455375674 — success on `627ed10781ac3c171262f88a939ace50d08131d8`
- Docs build: https://github.com/genfeedai/genfeed.ai/actions/runs/29455375674/job/87488243219 — cache miss; Next.js 16.2.10 compiled successfully and generated 53/53 static pages
- Docs regression tests: https://github.com/genfeedai/genfeed.ai/actions/runs/29455375674/job/87487296112 — 1 file / 2 tests passed
- Local lightweight checks: `biome check apps/docs/tests/nextra-layout-patch.test.ts`, `actionlint .github/workflows/ci.yml`, `git diff --check`, staged Gitleaks
- Local tests, typechecks, builds, E2E, and installs intentionally not run per repository instructions
- No deploy workflow dispatched