### PR TITLE
fix(realtime): recover unexpected socket disconnects

### DIFF
--- a/packages/services/core/socket-manager.service.test.ts
+++ b/packages/services/core/socket-manager.service.test.ts
@@ -6,12 +6,25 @@ const mockSocketOff = vi.fn();
 const mockSocketConnect = vi.fn();
 const mockSocketDisconnect = vi.fn();
 const mockSocketRemoveAllListeners = vi.fn();
+const mockManagerOn = vi.fn();
+const mockManagerOff = vi.fn();
+const socketState = vi.hoisted(() => ({ active: true, connected: false }));
 
 vi.mock('socket.io-client', () => ({
   io: vi.fn(() => ({
+    get active() {
+      return socketState.active;
+    },
     connect: mockSocketConnect,
+    get connected() {
+      return socketState.connected;
+    },
     disconnect: mockSocketDisconnect,
     id: 'mock-socket-id',
+    io: {
+      off: mockManagerOff,
+      on: mockManagerOn,
+    },
     off: mockSocketOff,
     on: mockSocketOn,
     removeAllListeners: mockSocketRemoveAllListeners,
@@ -40,6 +53,8 @@ import { SocketManager } from '@services/core/socket-manager.service';
 describe('SocketManager', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    socketState.active = true;
+    socketState.connected = false;
     SocketManager.clearInstance();
     SocketService.clearInstance();
   });
@@ -118,6 +133,111 @@ describe('SocketManager', () => {
       manager.subscribe('ev1', vi.fn());
       manager.subscribe('ev2', vi.fn());
       expect(manager.getListenersCount()).toBe(2);
+    });
+  });
+
+  describe('connection recovery', () => {
+    const getSocketHandler = (event: string) => {
+      const call = mockSocketOn.mock.calls.findLast(
+        ([registeredEvent]) => registeredEvent === event,
+      );
+      return call?.[1] as ((...args: unknown[]) => void) | undefined;
+    };
+
+    it('observes reconnect attempts on the underlying Socket.IO manager', () => {
+      const manager = SocketManager.getInstance({ autoConnect: false });
+      const states: string[] = [];
+      manager.subscribeConnectionState((state) => states.push(state));
+
+      expect(mockManagerOn).toHaveBeenCalledWith(
+        'reconnect_attempt',
+        expect.any(Function),
+      );
+      expect(mockSocketOn).not.toHaveBeenCalledWith(
+        'reconnect_attempt',
+        expect.any(Function),
+      );
+
+      const reconnectAttemptHandler = mockManagerOn.mock.calls.find(
+        ([event]) => event === 'reconnect_attempt',
+      )?.[1] as (() => void) | undefined;
+      reconnectAttemptHandler?.();
+
+      expect(states.at(-1)).toBe('reconnecting');
+    });
+
+    it('keeps subscriptions active while transport loss reconnects automatically', () => {
+      const manager = SocketManager.getInstance({ autoConnect: false });
+      const eventHandler = vi.fn();
+      const states: string[] = [];
+      manager.subscribe('generation-progress', eventHandler);
+      manager.subscribeConnectionState((state) => states.push(state));
+
+      socketState.active = true;
+      getSocketHandler('disconnect')?.('transport close');
+
+      expect(states.at(-1)).toBe('reconnecting');
+      expect(mockSocketConnect).not.toHaveBeenCalled();
+
+      socketState.connected = true;
+      getSocketHandler('connect')?.();
+      const subscribedHandler = mockSocketOn.mock.calls.find(
+        ([event]) => event === 'generation-progress',
+      )?.[1] as ((data: unknown) => void) | undefined;
+      subscribedHandler?.({ progress: 25 });
+
+      expect(states.at(-1)).toBe('connected');
+      expect(eventHandler).toHaveBeenCalledWith({ progress: 25 });
+      expect(mockSocketOff).not.toHaveBeenCalledWith(
+        'generation-progress',
+        expect.any(Function),
+      );
+    });
+
+    it('manually reconnects a server-disconnected namespace', () => {
+      const manager = SocketManager.getInstance({ autoConnect: false });
+      const states: string[] = [];
+      manager.subscribeConnectionState((state) => states.push(state));
+
+      socketState.active = false;
+      getSocketHandler('disconnect')?.('io server disconnect');
+
+      expect(states.at(-1)).toBe('reconnecting');
+      expect(mockSocketConnect).toHaveBeenCalledOnce();
+    });
+
+    it('leaves deliberate client disconnects offline without reconnecting', () => {
+      const manager = SocketManager.getInstance({ autoConnect: false });
+      const states: string[] = [];
+      manager.subscribeConnectionState((state) => states.push(state));
+
+      socketState.active = false;
+      getSocketHandler('disconnect')?.('io client disconnect');
+
+      expect(states.at(-1)).toBe('offline');
+      expect(mockSocketConnect).not.toHaveBeenCalled();
+    });
+
+    it('exposes denied connection attempts as offline', () => {
+      const manager = SocketManager.getInstance({ autoConnect: false });
+      const states: string[] = [];
+      manager.subscribeConnectionState((state) => states.push(state));
+
+      socketState.active = false;
+      getSocketHandler('connect_error')?.(new Error('denied'));
+
+      expect(states.at(-1)).toBe('offline');
+    });
+
+    it('removes manager reconnect listeners during cleanup', () => {
+      SocketManager.getInstance({ autoConnect: false });
+
+      SocketManager.clearInstance();
+
+      expect(mockManagerOff).toHaveBeenCalledWith(
+        'reconnect_attempt',
+        expect.any(Function),
+      );
     });
   });
 

--- a/packages/services/core/socket-manager.service.ts
+++ b/packages/services/core/socket-manager.service.ts
@@ -9,7 +9,10 @@ import type {
 import type { SocketListener } from '@genfeedai/interfaces/services/socket-listener.interface';
 import { logger } from '@services/core/logger.service';
 import { NotificationsService } from '@services/core/notifications.service';
-import { SocketService } from '@services/core/socket.service';
+import {
+  classifySocketDisconnect,
+  SocketService,
+} from '@services/core/socket.service';
 
 export type SocketConnectionState =
   | 'connecting'
@@ -30,7 +33,7 @@ export class SocketManager {
   >();
   private onConnectHandler?: () => void;
   private onConnectErrorHandler?: () => void;
-  private onDisconnectHandler?: () => void;
+  private onDisconnectHandler?: (reason: string) => void;
   private onReconnectAttemptHandler?: () => void;
 
   constructor(config: ISocketManagerConfig = {}) {
@@ -96,10 +99,26 @@ export class SocketManager {
       this.setConnectionState('connected');
     };
     this.onConnectErrorHandler = () => {
-      this.setConnectionState('reconnecting');
+      this.setConnectionState(
+        this.socketService.socket.active ? 'reconnecting' : 'offline',
+      );
     };
-    this.onDisconnectHandler = () => {
-      this.setConnectionState('offline');
+    this.onDisconnectHandler = (reason: string) => {
+      const disposition = classifySocketDisconnect(
+        reason,
+        this.socketService.socket.active,
+      );
+
+      if (disposition.expected) {
+        this.setConnectionState('offline');
+        return;
+      }
+
+      this.setConnectionState('reconnecting');
+
+      if (disposition.recovery === 'manual') {
+        this.socketService.connect();
+      }
     };
     this.onReconnectAttemptHandler = () => {
       this.setConnectionState('reconnecting');
@@ -108,7 +127,7 @@ export class SocketManager {
     this.socketService.socket.on('connect', this.onConnectHandler);
     this.socketService.socket.on('connect_error', this.onConnectErrorHandler);
     this.socketService.socket.on('disconnect', this.onDisconnectHandler);
-    this.socketService.socket.on(
+    this.socketService.socket.io.on(
       'reconnect_attempt',
       this.onReconnectAttemptHandler,
     );
@@ -229,7 +248,7 @@ export class SocketManager {
     }
 
     if (this.onReconnectAttemptHandler) {
-      this.socketService.off(
+      this.socketService.socket.io.off(
         'reconnect_attempt',
         this.onReconnectAttemptHandler,
       );

--- a/packages/services/core/socket-manager.service.ts
+++ b/packages/services/core/socket-manager.service.ts
@@ -243,7 +243,10 @@ export class SocketManager {
     }
 
     if (this.onDisconnectHandler) {
-      this.socketService.off('disconnect', this.onDisconnectHandler);
+      this.socketService.off(
+        'disconnect',
+        this.onDisconnectHandler as (...args: unknown[]) => void,
+      );
       this.onDisconnectHandler = undefined;
     }
 

--- a/packages/services/core/socket.service.test.ts
+++ b/packages/services/core/socket.service.test.ts
@@ -135,25 +135,26 @@ describe('SocketService', () => {
       expect(mockLogger.warn).not.toHaveBeenCalled();
     });
 
-    it.each(['ping timeout', 'transport close', 'transport error'])(
-      'records %s as an automatically recovering interruption',
-      (reason) => {
-        SocketService.getInstance();
+    it.each([
+      'ping timeout',
+      'transport close',
+      'transport error',
+    ])('records %s as an automatically recovering interruption', (reason) => {
+      SocketService.getInstance();
 
-        socketState.active = true;
-        socketEventHandlers.get('disconnect')?.(reason);
+      socketState.active = true;
+      socketEventHandlers.get('disconnect')?.(reason);
 
-        expect(mockLogger.info).toHaveBeenCalledWith(
-          'Socket connection interrupted',
-          {
-            expected: false,
-            reason,
-            recovery: 'automatic',
-          },
-        );
-        expect(mockLogger.warn).not.toHaveBeenCalled();
-      },
-    );
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'Socket connection interrupted',
+        {
+          expected: false,
+          reason,
+          recovery: 'automatic',
+        },
+      );
+      expect(mockLogger.warn).not.toHaveBeenCalled();
+    });
 
     it('keeps server-forced disconnects observable with bounded context', () => {
       SocketService.getInstance();

--- a/packages/services/core/socket.service.test.ts
+++ b/packages/services/core/socket.service.test.ts
@@ -7,6 +7,7 @@ const mockSocketDisconnect = vi.fn();
 const mockSocketOff = vi.fn();
 const mockSocketRemoveAllListeners = vi.fn();
 const socketEventHandlers = new Map<string, (...args: unknown[]) => void>();
+const socketState = vi.hoisted(() => ({ active: true }));
 const { mockLogger } = vi.hoisted(() => ({
   mockLogger: {
     debug: vi.fn(),
@@ -19,6 +20,9 @@ const { mockLogger } = vi.hoisted(() => ({
 vi.mock('socket.io-client', () => ({
   io: vi.fn(() => {
     const socket = {
+      get active() {
+        return socketState.active;
+      },
       connect: mockSocketConnect,
       disconnect: mockSocketDisconnect,
       off: mockSocketOff,
@@ -49,6 +53,7 @@ describe('SocketService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     socketEventHandlers.clear();
+    socketState.active = true;
     SocketService.clearInstance();
   });
 
@@ -113,21 +118,103 @@ describe('SocketService', () => {
   });
 
   describe('socket lifecycle logging', () => {
-    it('logs disconnects as warnings instead of errors', () => {
+    it('keeps deliberate client disconnects out of warning telemetry', () => {
       SocketService.getInstance();
 
       const disconnectHandler = socketEventHandlers.get('disconnect');
       expect(disconnectHandler).toBeDefined();
 
-      disconnectHandler?.('transport close');
+      socketState.active = false;
+      disconnectHandler?.('io client disconnect');
 
-      expect(mockLogger.warn).toHaveBeenCalledWith('Socket disconnected', {
+      expect(mockLogger.info).toHaveBeenCalledWith('Socket disconnected', {
         expected: true,
-        reason: 'transport close',
+        reason: 'io client disconnect',
+        recovery: 'none',
       });
-      expect(mockLogger.error).not.toHaveBeenCalledWith(
-        'Socket disconnected',
+      expect(mockLogger.warn).not.toHaveBeenCalled();
+    });
+
+    it.each(['ping timeout', 'transport close', 'transport error'])(
+      'records %s as an automatically recovering interruption',
+      (reason) => {
+        SocketService.getInstance();
+
+        socketState.active = true;
+        socketEventHandlers.get('disconnect')?.(reason);
+
+        expect(mockLogger.info).toHaveBeenCalledWith(
+          'Socket connection interrupted',
+          {
+            expected: false,
+            reason,
+            recovery: 'automatic',
+          },
+        );
+        expect(mockLogger.warn).not.toHaveBeenCalled();
+      },
+    );
+
+    it('keeps server-forced disconnects observable with bounded context', () => {
+      SocketService.getInstance();
+
+      socketState.active = false;
+      socketEventHandlers.get('disconnect')?.('io server disconnect');
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'Socket disconnected unexpectedly',
+        {
+          expected: false,
+          reason: 'io server disconnect',
+          recovery: 'manual',
+          tags: {
+            component: 'realtime',
+            recovery: 'manual',
+          },
+        },
+      );
+    });
+
+    it('does not report temporary connection errors while Socket.IO retries', () => {
+      SocketService.getInstance();
+
+      socketState.active = true;
+      socketEventHandlers.get('connect_error')?.(
+        new Error('token and endpoint content must stay out of telemetry'),
+      );
+
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'Socket connection retry scheduled',
+        {
+          errorName: 'Error',
+          recovery: 'automatic',
+        },
+      );
+      expect(mockLogger.warn).not.toHaveBeenCalled();
+    });
+
+    it('reports rejected connections without error-message content', () => {
+      SocketService.getInstance();
+
+      socketState.active = false;
+      socketEventHandlers.get('connect_error')?.(
+        new TypeError('sensitive endpoint response'),
+      );
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'Socket connection rejected',
+        {
+          errorName: 'TypeError',
+          recovery: 'manual',
+          tags: {
+            component: 'realtime',
+            recovery: 'manual',
+          },
+        },
+      );
+      expect(mockLogger.warn).not.toHaveBeenCalledWith(
         expect.anything(),
+        expect.objectContaining({ message: expect.anything() }),
       );
     });
   });

--- a/packages/services/core/socket.service.ts
+++ b/packages/services/core/socket.service.ts
@@ -2,9 +2,30 @@ import { EnvironmentService } from '@services/core/environment.service';
 import { logger } from '@services/core/logger.service';
 import { io, type Socket } from 'socket.io-client';
 
+export type SocketDisconnectRecovery = 'automatic' | 'manual' | 'none';
+
+export interface SocketDisconnectDisposition {
+  expected: boolean;
+  recovery: SocketDisconnectRecovery;
+}
+
+export function classifySocketDisconnect(
+  reason: string,
+  isAutomaticallyReconnecting: boolean,
+): SocketDisconnectDisposition {
+  if (reason === 'io client disconnect') {
+    return { expected: true, recovery: 'none' };
+  }
+
+  return {
+    expected: false,
+    recovery: isAutomaticallyReconnecting ? 'automatic' : 'manual',
+  };
+}
+
 export class SocketService {
   private static classInstance?: SocketService;
-  public socket: Socket | Record<string, never> = {};
+  public socket!: Socket;
   private currentToken?: string;
 
   private constructor(token?: string) {
@@ -42,28 +63,45 @@ export class SocketService {
     });
 
     this.socket.on('connect_error', (error: Error) => {
-      logger.warn('Socket connection error', {
-        message: error.message,
-        name: error.name,
+      const recovery = this.socket.active ? 'automatic' : 'manual';
+      const context = { errorName: error.name, recovery };
+
+      if (recovery === 'automatic') {
+        logger.info('Socket connection retry scheduled', context);
+        return;
+      }
+
+      logger.warn('Socket connection rejected', {
+        ...context,
+        tags: { component: 'realtime', recovery },
       });
     });
 
     this.socket.on('disconnect', (reason: string) => {
-      logger.warn('Socket disconnected', {
-        expected: this.isExpectedDisconnectReason(reason),
+      const disposition = classifySocketDisconnect(reason, this.socket.active);
+      const context = {
+        ...disposition,
         reason,
+      };
+
+      if (disposition.expected) {
+        logger.info('Socket disconnected', context);
+        return;
+      }
+
+      if (disposition.recovery === 'automatic') {
+        logger.info('Socket connection interrupted', context);
+        return;
+      }
+
+      logger.warn('Socket disconnected unexpectedly', {
+        ...context,
+        tags: {
+          component: 'realtime',
+          recovery: disposition.recovery,
+        },
       });
     });
-  }
-
-  private isExpectedDisconnectReason(reason: string): boolean {
-    return (
-      reason === 'io client disconnect' ||
-      reason === 'io server disconnect' ||
-      reason === 'transport close' ||
-      reason === 'transport error' ||
-      reason === 'ping timeout'
-    );
   }
 
   public static getInstance(token?: string): SocketService {


### PR DESCRIPTION
Advances #1714. Keep the issue open through the first production release and post-release APP-GENFEED-AI-4 monitoring window.

## Root cause

Two independent production facts separate this from the already-shipped CORS fix in #1260:

- #1260 is an ancestor of the July 8 successful production head, while APP-GENFEED-AI-4 recurred on July 13. This PR does not duplicate the server CORS work.
- `logger.warn()` captures messages in Sentry. `SocketService` warned with the identical `Socket disconnected` message for every Socket.IO reason, including deliberate client cleanup and automatically recovering transport loss.
- `SocketManager` registered `reconnect_attempt` on the `Socket`, but Socket.IO v3+ emits reconnect events on `socket.io` (the underlying Manager). It also marked every disconnect offline and never manually reconnected `io server disconnect`, for which Socket.IO disables automatic recovery.

Official lifecycle contract: https://socket.io/docs/v4/client-socket-instance/#events

## Approaches considered

1. Suppress the `Socket disconnected` warning only. This removes Sentry noise but leaves server-forced namespace disconnects permanently offline and hides connection state transitions.
2. Classify lifecycle outcomes at the client boundary, use Socket.IO's `active` recovery signal, observe reconnect attempts on the Manager, and manually reconnect only when automatic recovery is disabled.

This PR implements option 2 so the user path recovers while telemetry remains useful.

## What changes

- Deliberate `io client disconnect` lifecycle exits log at info and never reach Sentry.
- Ping/transport interruptions that Socket.IO is already recovering log at info and keep the UI in `reconnecting`.
- Server-forced/unknown non-active disconnects remain Sentry-visible with only bounded reason/recovery/component context, then immediately reconnect the namespace.
- Temporary `connect_error` retries omit error-message content; non-retrying connection rejection remains warning telemetry with name/recovery only.
- Reconnect attempts are observed and cleaned up on the underlying Socket.IO Manager.
- Existing application event listeners remain attached across reconnect and the connection state returns to `connected` on rehydration.

## Verification

- Focused regression coverage added for expected/manual disconnect classification, all three automatic transport reasons, bounded rejection telemetry, Manager reconnect event registration/cleanup, automatic reconnect listener continuity, server-disconnect manual recovery, and connection-state transitions.
- Focused Biome check: pass.
- `git diff --check`: pass.
- Staged gitleaks: pass, no leaks.
- Commit hooks: Biome, secretlint, and UI control guard passed.
- Per workstation policy, no local tests/typechecks/builds/E2E were run; PR CI is authoritative.

## Sentry/release disposition

The Sentry MCP/token is not available in this session and the logged-in Brave session was locked, so raw event payloads were not exposed or copied. Existing durable evidence is issue #1714 (20 events, July 13 recurrence) plus the deployment ancestry above. After merge/deploy, verify that APP-GENFEED-AI-4 receives no new `Socket disconnected` events; expected lifecycle events now use info logging, while genuinely non-recovering paths use distinct bounded warning messages.
