### PR TITLE
fix(reply-bot): reject unsupported action platforms

### DIFF
--- a/apps/server/api/src/services/reply-bot/bot-action-executor.service.spec.ts
+++ b/apps/server/api/src/services/reply-bot/bot-action-executor.service.spec.ts
@@ -67,48 +67,48 @@ describe('BotActionExecutorService', () => {
       { isSupported: false, platform: ReplyBotPlatform.YOUTUBE },
       { isSupported: false, platform: ReplyBotPlatform.REDDIT },
       { isSupported: false, platform: 'unknown' },
-    ])(
-      'routes reply actions fail-closed for $platform',
-      async ({ isSupported, platform }) => {
-        const postTwitterReply = vi
-          .spyOn(
-            service as unknown as BotActionExecutorRouting,
-            'postTwitterReply',
-          )
-          .mockResolvedValue({ contentId: 'reply-1', success: true });
-        mockInstagramService.postComment.mockResolvedValue({
-          commentId: 'reply-1',
-        });
-        const credential = {
-          accessToken: 'token',
-          brandId: 'brand-1',
-          organizationId: 'org-1',
-          platform,
-        } as IReplyBotCredentialData;
+    ])('routes reply actions fail-closed for $platform', async ({
+      isSupported,
+      platform,
+    }) => {
+      const postTwitterReply = vi
+        .spyOn(
+          service as unknown as BotActionExecutorRouting,
+          'postTwitterReply',
+        )
+        .mockResolvedValue({ contentId: 'reply-1', success: true });
+      mockInstagramService.postComment.mockResolvedValue({
+        commentId: 'reply-1',
+      });
+      const credential = {
+        accessToken: 'token',
+        brandId: 'brand-1',
+        organizationId: 'org-1',
+        platform,
+      } as IReplyBotCredentialData;
 
-        const result = await service.postReply(
-          credential,
-          targetContent,
-          'Nice post!',
-        );
+      const result = await service.postReply(
+        credential,
+        targetContent,
+        'Nice post!',
+      );
 
-        expect(result.success).toBe(isSupported);
-        if (isSupported) {
-          expect(result.error).toBeUndefined();
-          if (platform === ReplyBotPlatform.TWITTER) {
-            expect(postTwitterReply).toHaveBeenCalledOnce();
-          } else {
-            expect(mockInstagramService.postComment).toHaveBeenCalledOnce();
-          }
+      expect(result.success).toBe(isSupported);
+      if (isSupported) {
+        expect(result.error).toBeUndefined();
+        if (platform === ReplyBotPlatform.TWITTER) {
+          expect(postTwitterReply).toHaveBeenCalledOnce();
         } else {
-          expect(result.error).toBe(
-            `Unsupported reply bot platform: ${platform}`,
-          );
-          expect(postTwitterReply).not.toHaveBeenCalled();
-          expect(mockInstagramService.postComment).not.toHaveBeenCalled();
+          expect(mockInstagramService.postComment).toHaveBeenCalledOnce();
         }
-      },
-    );
+      } else {
+        expect(result.error).toBe(
+          `Unsupported reply bot platform: ${platform}`,
+        );
+        expect(postTwitterReply).not.toHaveBeenCalled();
+        expect(mockInstagramService.postComment).not.toHaveBeenCalled();
+      }
+    });
 
     it('should route to Instagram when platform is instagram', async () => {
       const credential = {
@@ -169,50 +169,41 @@ describe('BotActionExecutorService', () => {
       { isSupported: false, platform: ReplyBotPlatform.YOUTUBE },
       { isSupported: false, platform: ReplyBotPlatform.REDDIT },
       { isSupported: false, platform: 'unknown' },
-    ])(
-      'routes DM actions fail-closed for $platform',
-      async ({ isSupported, platform }) => {
-        const sendTwitterDm = vi
-          .spyOn(
-            service as unknown as BotActionExecutorRouting,
-            'sendTwitterDm',
-          )
-          .mockResolvedValue({ success: true });
-        mockInstagramService.sendCommentReplyDm.mockResolvedValue(undefined);
-        const credential = {
-          accessToken: 'token',
-          brandId: 'brand-1',
-          organizationId: 'org-1',
-          platform,
-        } as IReplyBotCredentialData;
+    ])('routes DM actions fail-closed for $platform', async ({
+      isSupported,
+      platform,
+    }) => {
+      const sendTwitterDm = vi
+        .spyOn(service as unknown as BotActionExecutorRouting, 'sendTwitterDm')
+        .mockResolvedValue({ success: true });
+      mockInstagramService.sendCommentReplyDm.mockResolvedValue(undefined);
+      const credential = {
+        accessToken: 'token',
+        brandId: 'brand-1',
+        organizationId: 'org-1',
+        platform,
+      } as IReplyBotCredentialData;
 
-        const result = await service.sendDm(
-          credential,
-          'recipient-1',
-          'Hello!',
-        );
+      const result = await service.sendDm(credential, 'recipient-1', 'Hello!');
 
-        expect(result.success).toBe(isSupported);
-        if (isSupported) {
-          expect(result.error).toBeUndefined();
-          if (platform === ReplyBotPlatform.TWITTER) {
-            expect(sendTwitterDm).toHaveBeenCalledOnce();
-          } else {
-            expect(
-              mockInstagramService.sendCommentReplyDm,
-            ).toHaveBeenCalledOnce();
-          }
+      expect(result.success).toBe(isSupported);
+      if (isSupported) {
+        expect(result.error).toBeUndefined();
+        if (platform === ReplyBotPlatform.TWITTER) {
+          expect(sendTwitterDm).toHaveBeenCalledOnce();
         } else {
-          expect(result.error).toBe(
-            `Unsupported reply bot platform: ${platform}`,
-          );
-          expect(sendTwitterDm).not.toHaveBeenCalled();
           expect(
             mockInstagramService.sendCommentReplyDm,
-          ).not.toHaveBeenCalled();
+          ).toHaveBeenCalledOnce();
         }
-      },
-    );
+      } else {
+        expect(result.error).toBe(
+          `Unsupported reply bot platform: ${platform}`,
+        );
+        expect(sendTwitterDm).not.toHaveBeenCalled();
+        expect(mockInstagramService.sendCommentReplyDm).not.toHaveBeenCalled();
+      }
+    });
 
     it('should route to Instagram DM when platform is instagram', async () => {
       const credential = {

--- a/apps/server/api/src/services/reply-bot/bot-action-executor.service.spec.ts
+++ b/apps/server/api/src/services/reply-bot/bot-action-executor.service.spec.ts
@@ -1,5 +1,19 @@
+const mockTwitterTweet = vi.fn();
+const mockTwitterDm = vi.fn();
+
+vi.mock('twitter-api-v2', () => ({
+  TwitterApi: vi.fn().mockImplementation(() => ({
+    v2: {
+      sendDmToParticipant: mockTwitterDm,
+      tweet: mockTwitterTweet,
+    },
+  })),
+}));
+
 import { InstagramService } from '@api/services/integrations/instagram/services/instagram.service';
 import { BotActionExecutorService } from '@api/services/reply-bot/bot-action-executor.service';
+import { ReplyBotPlatform } from '@genfeedai/enums';
+import type { IReplyBotCredentialData } from '@genfeedai/interfaces';
 import { ConfigService } from '@libs/config/config.service';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Test, TestingModule } from '@nestjs/testing';
@@ -45,6 +59,54 @@ describe('BotActionExecutorService', () => {
   });
 
   describe('postReply', () => {
+    const targetContent = {
+      authorId: 'author-1',
+      authorUsername: 'user1',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      id: 'content-123',
+      text: 'Original content',
+    };
+
+    it.each([
+      { isSupported: true, platform: ReplyBotPlatform.TWITTER },
+      { isSupported: true, platform: ReplyBotPlatform.INSTAGRAM },
+      { isSupported: false, platform: ReplyBotPlatform.TIKTOK },
+      { isSupported: false, platform: ReplyBotPlatform.YOUTUBE },
+      { isSupported: false, platform: ReplyBotPlatform.REDDIT },
+      { isSupported: false, platform: 'unknown' },
+    ])(
+      'routes reply actions fail-closed for $platform',
+      async ({ isSupported, platform }) => {
+        mockTwitterTweet.mockResolvedValue({ data: { id: 'reply-1' } });
+        mockInstagramService.postComment.mockResolvedValue({
+          commentId: 'reply-1',
+        });
+        const credential = {
+          accessToken: 'token',
+          brandId: 'brand-1',
+          organizationId: 'org-1',
+          platform,
+        } as IReplyBotCredentialData;
+
+        const result = await service.postReply(
+          credential,
+          targetContent,
+          'Nice post!',
+        );
+
+        expect(result.success).toBe(isSupported);
+        if (isSupported) {
+          expect(result.error).toBeUndefined();
+        } else {
+          expect(result.error).toBe(
+            `Unsupported reply bot platform: ${platform}`,
+          );
+          expect(mockTwitterTweet).not.toHaveBeenCalled();
+          expect(mockInstagramService.postComment).not.toHaveBeenCalled();
+        }
+      },
+    );
+
     it('should route to Instagram when platform is instagram', async () => {
       const credential = {
         accessToken: 'encrypted-token',
@@ -97,6 +159,46 @@ describe('BotActionExecutorService', () => {
   });
 
   describe('sendDm', () => {
+    it.each([
+      { isSupported: true, platform: ReplyBotPlatform.TWITTER },
+      { isSupported: true, platform: ReplyBotPlatform.INSTAGRAM },
+      { isSupported: false, platform: ReplyBotPlatform.TIKTOK },
+      { isSupported: false, platform: ReplyBotPlatform.YOUTUBE },
+      { isSupported: false, platform: ReplyBotPlatform.REDDIT },
+      { isSupported: false, platform: 'unknown' },
+    ])(
+      'routes DM actions fail-closed for $platform',
+      async ({ isSupported, platform }) => {
+        mockTwitterDm.mockResolvedValue(undefined);
+        mockInstagramService.sendCommentReplyDm.mockResolvedValue(undefined);
+        const credential = {
+          accessToken: 'token',
+          brandId: 'brand-1',
+          organizationId: 'org-1',
+          platform,
+        } as IReplyBotCredentialData;
+
+        const result = await service.sendDm(
+          credential,
+          'recipient-1',
+          'Hello!',
+        );
+
+        expect(result.success).toBe(isSupported);
+        if (isSupported) {
+          expect(result.error).toBeUndefined();
+        } else {
+          expect(result.error).toBe(
+            `Unsupported reply bot platform: ${platform}`,
+          );
+          expect(mockTwitterDm).not.toHaveBeenCalled();
+          expect(
+            mockInstagramService.sendCommentReplyDm,
+          ).not.toHaveBeenCalled();
+        }
+      },
+    );
+
     it('should route to Instagram DM when platform is instagram', async () => {
       const credential = {
         accessToken: 'token',
@@ -197,7 +299,7 @@ describe('BotActionExecutorService', () => {
 
       expect(result.reply.success).toBe(true);
       expect(result.dm).toBeDefined();
-      expect(result.dm!.success).toBe(true);
+      expect(result.dm?.success).toBe(true);
     });
   });
 

--- a/apps/server/api/src/services/reply-bot/bot-action-executor.service.spec.ts
+++ b/apps/server/api/src/services/reply-bot/bot-action-executor.service.spec.ts
@@ -1,15 +1,3 @@
-const mockTwitterTweet = vi.fn();
-const mockTwitterDm = vi.fn();
-
-vi.mock('twitter-api-v2', () => ({
-  TwitterApi: vi.fn().mockImplementation(() => ({
-    v2: {
-      sendDmToParticipant: mockTwitterDm,
-      tweet: mockTwitterTweet,
-    },
-  })),
-}));
-
 import { InstagramService } from '@api/services/integrations/instagram/services/instagram.service';
 import { BotActionExecutorService } from '@api/services/reply-bot/bot-action-executor.service';
 import { ReplyBotPlatform } from '@genfeedai/enums';
@@ -17,6 +5,11 @@ import type { IReplyBotCredentialData } from '@genfeedai/interfaces';
 import { ConfigService } from '@libs/config/config.service';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Test, TestingModule } from '@nestjs/testing';
+
+type BotActionExecutorRouting = {
+  postTwitterReply: BotActionExecutorService['postReply'];
+  sendTwitterDm: BotActionExecutorService['sendDm'];
+};
 
 describe('BotActionExecutorService', () => {
   let service: BotActionExecutorService;
@@ -77,7 +70,12 @@ describe('BotActionExecutorService', () => {
     ])(
       'routes reply actions fail-closed for $platform',
       async ({ isSupported, platform }) => {
-        mockTwitterTweet.mockResolvedValue({ data: { id: 'reply-1' } });
+        const postTwitterReply = vi
+          .spyOn(
+            service as unknown as BotActionExecutorRouting,
+            'postTwitterReply',
+          )
+          .mockResolvedValue({ contentId: 'reply-1', success: true });
         mockInstagramService.postComment.mockResolvedValue({
           commentId: 'reply-1',
         });
@@ -97,11 +95,16 @@ describe('BotActionExecutorService', () => {
         expect(result.success).toBe(isSupported);
         if (isSupported) {
           expect(result.error).toBeUndefined();
+          if (platform === ReplyBotPlatform.TWITTER) {
+            expect(postTwitterReply).toHaveBeenCalledOnce();
+          } else {
+            expect(mockInstagramService.postComment).toHaveBeenCalledOnce();
+          }
         } else {
           expect(result.error).toBe(
             `Unsupported reply bot platform: ${platform}`,
           );
-          expect(mockTwitterTweet).not.toHaveBeenCalled();
+          expect(postTwitterReply).not.toHaveBeenCalled();
           expect(mockInstagramService.postComment).not.toHaveBeenCalled();
         }
       },
@@ -169,7 +172,12 @@ describe('BotActionExecutorService', () => {
     ])(
       'routes DM actions fail-closed for $platform',
       async ({ isSupported, platform }) => {
-        mockTwitterDm.mockResolvedValue(undefined);
+        const sendTwitterDm = vi
+          .spyOn(
+            service as unknown as BotActionExecutorRouting,
+            'sendTwitterDm',
+          )
+          .mockResolvedValue({ success: true });
         mockInstagramService.sendCommentReplyDm.mockResolvedValue(undefined);
         const credential = {
           accessToken: 'token',
@@ -187,11 +195,18 @@ describe('BotActionExecutorService', () => {
         expect(result.success).toBe(isSupported);
         if (isSupported) {
           expect(result.error).toBeUndefined();
+          if (platform === ReplyBotPlatform.TWITTER) {
+            expect(sendTwitterDm).toHaveBeenCalledOnce();
+          } else {
+            expect(
+              mockInstagramService.sendCommentReplyDm,
+            ).toHaveBeenCalledOnce();
+          }
         } else {
           expect(result.error).toBe(
             `Unsupported reply bot platform: ${platform}`,
           );
-          expect(mockTwitterDm).not.toHaveBeenCalled();
+          expect(sendTwitterDm).not.toHaveBeenCalled();
           expect(
             mockInstagramService.sendCommentReplyDm,
           ).not.toHaveBeenCalled();

--- a/apps/server/api/src/services/reply-bot/bot-action-executor.service.ts
+++ b/apps/server/api/src/services/reply-bot/bot-action-executor.service.ts
@@ -1,4 +1,8 @@
 import { InstagramService } from '@api/services/integrations/instagram/services/instagram.service';
+import {
+  normalizeReplyBotPlatform,
+  unsupportedReplyBotPlatformMessage,
+} from '@api/services/reply-bot/reply-bot-platform.util';
 import { ReplyBotPlatform } from '@genfeedai/enums';
 import type {
   IReplyBotContentData,
@@ -112,13 +116,19 @@ export class BotActionExecutorService {
     targetContent: IReplyBotContentData,
     replyText: string,
   ): Promise<IReplyBotReplyResult> {
-    const platform = credential.platform || ReplyBotPlatform.TWITTER;
+    const platformInput = credential.platform ?? ReplyBotPlatform.TWITTER;
+    const platform = normalizeReplyBotPlatform(platformInput);
 
     switch (platform) {
+      case ReplyBotPlatform.TWITTER:
+        return this.postTwitterReply(credential, targetContent, replyText);
       case ReplyBotPlatform.INSTAGRAM:
         return this.postInstagramComment(credential, targetContent, replyText);
       default:
-        return this.postTwitterReply(credential, targetContent, replyText);
+        return Promise.resolve({
+          error: unsupportedReplyBotPlatformMessage(platformInput),
+          success: false,
+        });
     }
   }
 
@@ -130,13 +140,19 @@ export class BotActionExecutorService {
     recipientUserId: string,
     message: string,
   ): Promise<IReplyBotDmResult> {
-    const platform = credential.platform || ReplyBotPlatform.TWITTER;
+    const platformInput = credential.platform ?? ReplyBotPlatform.TWITTER;
+    const platform = normalizeReplyBotPlatform(platformInput);
 
     switch (platform) {
+      case ReplyBotPlatform.TWITTER:
+        return this.sendTwitterDm(credential, recipientUserId, message);
       case ReplyBotPlatform.INSTAGRAM:
         return this.sendInstagramDm(credential, recipientUserId, message);
       default:
-        return this.sendTwitterDm(credential, recipientUserId, message);
+        return Promise.resolve({
+          error: unsupportedReplyBotPlatformMessage(platformInput),
+          success: false,
+        });
     }
   }
 

--- a/apps/server/api/src/services/reply-bot/reply-bot-orchestrator.service.spec.ts
+++ b/apps/server/api/src/services/reply-bot/reply-bot-orchestrator.service.spec.ts
@@ -9,6 +9,7 @@ import { ReplyBotOrchestratorService } from '@api/services/reply-bot/reply-bot-o
 import { ReplyCandidatePrefilterService } from '@api/services/reply-bot/reply-candidate-prefilter.service';
 import { ReplyGenerationService } from '@api/services/reply-bot/reply-generation.service';
 import { SocialMonitorService } from '@api/services/reply-bot/social-monitor.service';
+import { ReplyBotPlatform } from '@genfeedai/enums';
 import { ConfigService } from '@libs/config/config.service';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Test, TestingModule } from '@nestjs/testing';
@@ -228,6 +229,44 @@ describe('ReplyBotOrchestratorService', () => {
       expect(result.repliesSent).toBe(0);
       expect(result.skipped).toBe(0);
       expect(result.errors).toBe(0);
+      expect(mockSocialMonitorService.getUserMentions).not.toHaveBeenCalled();
+    });
+
+    it('normalizes the credential platform before processing', async () => {
+      const botConfig = makeBotConfig();
+      mockRateLimitService.isWithinSchedule.mockReturnValue(false);
+
+      const result = await service.processSingleBot(botConfig as never, orgId, {
+        ...credential,
+        platform: 'TWITTER' as ReplyBotPlatform,
+      });
+
+      expect(result.platform).toBe(ReplyBotPlatform.TWITTER);
+    });
+
+    it('normalizes the config platform when the credential omits it', async () => {
+      const botConfig = makeBotConfig({ platform: 'INSTAGRAM' });
+      mockRateLimitService.isWithinSchedule.mockReturnValue(false);
+
+      const result = await service.processSingleBot(botConfig as never, orgId, {
+        accessToken: 'token-123',
+        username: 'testuser',
+      });
+
+      expect(result.platform).toBe(ReplyBotPlatform.INSTAGRAM);
+    });
+
+    it('rejects an unknown platform before processing', async () => {
+      const botConfig = makeBotConfig();
+
+      await expect(
+        service.processSingleBot(botConfig as never, orgId, {
+          ...credential,
+          platform: 'unknown' as ReplyBotPlatform,
+        }),
+      ).rejects.toThrow('Unsupported reply bot platform: unknown');
+
+      expect(mockRateLimitService.isWithinSchedule).not.toHaveBeenCalled();
       expect(mockSocialMonitorService.getUserMentions).not.toHaveBeenCalled();
     });
 

--- a/apps/server/api/src/services/reply-bot/reply-bot-orchestrator.service.ts
+++ b/apps/server/api/src/services/reply-bot/reply-bot-orchestrator.service.ts
@@ -21,6 +21,10 @@ import {
 import { BotActionExecutorService } from '@api/services/reply-bot/bot-action-executor.service';
 import { RateLimitService } from '@api/services/reply-bot/rate-limit.service';
 import {
+  normalizeReplyBotPlatform,
+  unsupportedReplyBotPlatformMessage,
+} from '@api/services/reply-bot/reply-bot-platform.util';
+import {
   type ReplyCandidate,
   ReplyCandidatePrefilterService,
 } from '@api/services/reply-bot/reply-candidate-prefilter.service';
@@ -131,7 +135,18 @@ export class ReplyBotOrchestratorService {
   ): Promise<ProcessingResult> {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
     const botConfigId = botConfig.id.toString();
-    const platform = credential.platform || ReplyBotPlatform.TWITTER;
+    const platformInput =
+      credential.platform ?? botConfig.platform ?? ReplyBotPlatform.TWITTER;
+    const platform = normalizeReplyBotPlatform(platformInput);
+
+    if (!platform) {
+      throw new Error(unsupportedReplyBotPlatformMessage(platformInput));
+    }
+
+    const normalizedCredential: IReplyBotCredentialData = {
+      ...credential,
+      platform,
+    };
 
     const result: ProcessingResult = {
       botConfigId,
@@ -156,21 +171,21 @@ export class ReplyBotOrchestratorService {
       if (botConfig.type === ReplyBotType.REPLY_GUY) {
         content = await this.fetchMentions(
           botConfig,
-          credential,
+          normalizedCredential,
           organizationId,
           platform,
         );
       } else if (botConfig.type === ReplyBotType.ACCOUNT_MONITOR) {
         content = await this.fetchMonitoredAccountContent(
           botConfig,
-          credential,
+          normalizedCredential,
           organizationId,
           platform,
         );
       } else if (botConfig.type === ReplyBotType.COMMENT_RESPONDER) {
         content = await this.fetchComments(
           botConfig,
-          credential,
+          normalizedCredential,
           organizationId,
           platform,
         );
@@ -188,7 +203,7 @@ export class ReplyBotOrchestratorService {
         {
           botConfig,
           botType: (botConfig.type ?? ReplyBotType.REPLY_GUY) as ReplyBotType,
-          credential,
+          credential: normalizedCredential,
           organizationId,
           platform,
         },
@@ -211,7 +226,7 @@ export class ReplyBotOrchestratorService {
           botConfig,
           item,
           organizationId,
-          credential,
+          normalizedCredential,
         );
 
         result.contentProcessed++;
@@ -532,15 +547,6 @@ export class ReplyBotOrchestratorService {
       let replyContentId: string | undefined;
       let replyContentUrl: string | undefined;
 
-      // Ensure credential has platform info for routing
-      const platformCredential = {
-        ...credential,
-        platform:
-          credential.platform ||
-          (botConfig as unknown as { platform?: string }).platform ||
-          ReplyBotPlatform.TWITTER,
-      };
-
       const actionExecution =
         await this.systemWorkflowProvenanceService.runAction(
           {
@@ -553,7 +559,7 @@ export class ReplyBotOrchestratorService {
               actionType: botConfig.actionType,
               botConfigId,
               contentId: content.id,
-              platform: platformCredential.platform,
+              platform: credential.platform,
             },
             label: 'Reply and DM Automation',
             metadata: {
@@ -578,8 +584,7 @@ export class ReplyBotOrchestratorService {
               };
 
               const replyResult = await this.botActionExecutorService.postReply(
-                // @ts-expect-error TS2345
-                platformCredential,
+                credential,
                 contentData,
                 replyText,
               );
@@ -607,8 +612,7 @@ export class ReplyBotOrchestratorService {
               await this.delay(dmDelay);
 
               const dmResult = await this.botActionExecutorService.sendDm(
-                // @ts-expect-error TS2345
-                platformCredential,
+                credential,
                 content.authorId,
                 dmText,
               );

--- a/apps/server/api/src/services/reply-bot/reply-bot-platform.util.ts
+++ b/apps/server/api/src/services/reply-bot/reply-bot-platform.util.ts
@@ -1,0 +1,23 @@
+import { ReplyBotPlatform } from '@genfeedai/enums';
+
+export function normalizeReplyBotPlatform(
+  value: unknown,
+): ReplyBotPlatform | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  return Object.values(ReplyBotPlatform).find(
+    (platform) => platform === normalized,
+  );
+}
+
+export function unsupportedReplyBotPlatformMessage(value: unknown): string {
+  const platform =
+    typeof value === 'string' && value.trim().length > 0
+      ? value.trim()
+      : 'unknown';
+
+  return `Unsupported reply bot platform: ${platform}`;
+}


### PR DESCRIPTION
## Summary
- normalize credential/config platforms to `ReplyBotPlatform` before reply-bot processing
- route only Twitter and Instagram reply/DM actions; fail closed for TikTok, YouTube, Reddit, and unknown values
- remove platform type suppressions and cover every enum member plus unknown with table-driven tests

## Verification
- `bunx biome check` on the five changed files
- `git diff --check`
- staged gitleaks scan: no leaks
- pre-commit focused Biome, Secretlint, and UI control guard passed
- local tests/typechecks/builds intentionally not run per workstation policy; PR CI is the verification gate

Closes #1548