### PR TITLE
fix(agent): enqueue confirmed publishes through scheduler

### DIFF
--- a/apps/server/api/src/collections/post-groups/services/post-groups.service.spec.ts
+++ b/apps/server/api/src/collections/post-groups/services/post-groups.service.spec.ts
@@ -220,6 +220,15 @@ describe('PostGroupsService', () => {
         title: 'Launch note',
       },
       'same-request',
+      {
+        agentContextSource: 'explicit',
+        agentContextVersion: 3,
+        agentRunId: 'run-1',
+        agentStrategyId: 'strategy-1',
+        agentThreadId: 'thread-1',
+        source: 'agent',
+        sourceActionId: 'publish-card-1',
+      },
     );
 
     expect(prisma.postGroup.create).toHaveBeenCalledWith(
@@ -233,8 +242,15 @@ describe('PostGroupsService', () => {
     expect(prisma.post.create).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({
+          agentContextSource: 'explicit',
+          agentContextVersion: 3,
+          agentRunId: 'run-1',
+          agentStrategyId: 'strategy-1',
+          agentThreadId: 'thread-1',
           groupId: 'group-1',
+          source: 'agent',
           status: TargetExecutionState.SCHEDULED,
+          sourceActionId: 'publish-card-1',
           targetExecutionState: TargetExecutionState.SCHEDULED,
           targetValidationState: TargetValidationState.VALID,
         }),

--- a/apps/server/api/src/collections/post-groups/services/post-groups.service.ts
+++ b/apps/server/api/src/collections/post-groups/services/post-groups.service.ts
@@ -34,6 +34,7 @@ import type {
   IReleaseMediaReference,
   IReleaseTargetSummary,
   IScheduleStatusTransition,
+  PostGroupCreateProvenance,
 } from '@genfeedai/interfaces';
 import { Prisma } from '@genfeedai/prisma';
 import { PostPublishQueueService } from '@genfeedai/server';
@@ -46,16 +47,6 @@ import {
 import type { ZodError } from 'zod';
 
 type SchedulerTx = Prisma.TransactionClient;
-
-export interface PostGroupCreateProvenance {
-  agentContextSource?: string;
-  agentContextVersion?: number;
-  agentRunId?: string;
-  agentStrategyId?: string;
-  agentThreadId?: string;
-  source?: string;
-  sourceActionId?: string;
-}
 
 type SchedulerCredential = {
   brandId: string | null;

--- a/apps/server/api/src/collections/post-groups/services/post-groups.service.ts
+++ b/apps/server/api/src/collections/post-groups/services/post-groups.service.ts
@@ -47,6 +47,16 @@ import type { ZodError } from 'zod';
 
 type SchedulerTx = Prisma.TransactionClient;
 
+export interface PostGroupCreateProvenance {
+  agentContextSource?: string;
+  agentContextVersion?: number;
+  agentRunId?: string;
+  agentStrategyId?: string;
+  agentThreadId?: string;
+  source?: string;
+  sourceActionId?: string;
+}
+
 type SchedulerCredential = {
   brandId: string | null;
   id: string;
@@ -135,6 +145,7 @@ export class PostGroupsService {
     userId: string,
     body: unknown,
     headerIdempotencyKey?: string,
+    provenance?: PostGroupCreateProvenance,
   ): Promise<IReleaseGroup> {
     const input = this.parseCreateInput(body, headerIdempotencyKey);
 
@@ -216,6 +227,21 @@ export class PostGroupsService {
 
         const created = (await tx.post.create({
           data: {
+            ...(provenance?.agentContextSource && {
+              agentContextSource: provenance.agentContextSource,
+            }),
+            ...(provenance?.agentContextVersion !== undefined && {
+              agentContextVersion: provenance.agentContextVersion,
+            }),
+            ...(provenance?.agentRunId && {
+              agentRunId: provenance.agentRunId,
+            }),
+            ...(provenance?.agentStrategyId && {
+              agentStrategyId: provenance.agentStrategyId,
+            }),
+            ...(provenance?.agentThreadId && {
+              agentThreadId: provenance.agentThreadId,
+            }),
             brandId,
             credentialId: target.credentialId,
             description: input.baseContent,
@@ -225,6 +251,10 @@ export class PostGroupsService {
             order: target.order ?? index,
             organizationId,
             platform: target.platform,
+            ...(provenance?.source && { source: provenance.source }),
+            ...(provenance?.sourceActionId && {
+              sourceActionId: provenance.sourceActionId,
+            }),
             scheduledDate:
               this.toDate(target.scheduledDate) ?? group.scheduledAt,
             status: this.toPostStatus(status),

--- a/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.module.ts
+++ b/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.module.ts
@@ -19,6 +19,7 @@ import { ImagesModule } from '@api/collections/images/images.module';
 import { OrganizationSettingsModule } from '@api/collections/organization-settings/organization-settings.module';
 import { OrganizationsModule } from '@api/collections/organizations/organizations.module';
 import { OutreachCampaignsModule } from '@api/collections/outreach-campaigns/outreach-campaigns.module';
+import { PostGroupsModule } from '@api/collections/post-groups/post-groups.module';
 import { PostsModule } from '@api/collections/posts/posts.module';
 import { SettingsModule } from '@api/collections/settings/settings.module';
 import { SocialInboxModule } from '@api/collections/social-inbox/social-inbox.module';
@@ -90,6 +91,7 @@ import { forwardRef, Module } from '@nestjs/common';
     forwardRef(() => MarketplaceIntegrationModule),
     forwardRef(() => OrganizationSettingsModule),
     forwardRef(() => OrganizationsModule),
+    forwardRef(() => PostGroupsModule),
     forwardRef(() => PostsModule),
     forwardRef(() => SettingsModule),
     forwardRef(() => SocialInboxModule),

--- a/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.module.ts
+++ b/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.module.ts
@@ -42,6 +42,7 @@ import { AgentThreadEventRecorderService } from '@api/services/agent-orchestrato
 import { AgentToolsController } from '@api/services/agent-orchestrator/agent-tools.controller';
 import { AgentDashboardToolHandler } from '@api/services/agent-orchestrator/tools/agent-dashboard-tool-handler.service';
 import { AgentMemoryGoalsToolHandler } from '@api/services/agent-orchestrator/tools/agent-memory-goals-tool-handler.service';
+import { AgentPublishToolHandler } from '@api/services/agent-orchestrator/tools/agent-publish-tool-handler.service';
 import { AgentRouteRewriteService } from '@api/services/agent-orchestrator/tools/agent-route-rewrite.service';
 import { AgentToolExecutorService } from '@api/services/agent-orchestrator/tools/agent-tool-executor.service';
 import { AgentSpawnModule } from '@api/services/agent-spawn/agent-spawn.module';
@@ -108,6 +109,7 @@ import { forwardRef, Module } from '@nestjs/common';
     AgentCompletionCardBuilderService,
     AgentDashboardToolHandler,
     AgentMemoryGoalsToolHandler,
+    AgentPublishToolHandler,
     AgentOrchestratorService,
     AgentRouteRewriteService,
     AgentStreamEffectsService,

--- a/apps/server/api/src/services/agent-orchestrator/tools/agent-publish-tool-handler.service.ts
+++ b/apps/server/api/src/services/agent-orchestrator/tools/agent-publish-tool-handler.service.ts
@@ -1,0 +1,245 @@
+import { createHash } from 'node:crypto';
+import { PostGroupsService } from '@api/collections/post-groups/services/post-groups.service';
+import type { ToolExecutionContext } from '@api/services/agent-orchestrator/tools/agent-tool-executor.service';
+import {
+  CredentialPlatform,
+  IngredientCategory,
+  ReleaseStatus,
+} from '@genfeedai/enums';
+import type { AgentToolResult } from '@genfeedai/interfaces';
+import { Injectable } from '@nestjs/common';
+
+interface AgentPublishCredential {
+  id?: unknown;
+  platform?: unknown;
+}
+
+interface PublishConfirmedContentInput {
+  caption?: string;
+  contentId: string;
+  credentials: AgentPublishCredential[];
+  ctx: ToolExecutionContext;
+  ingredient: Record<string, unknown>;
+  platforms: string[];
+  scheduledAt?: string;
+  sourceActionId?: string;
+}
+
+/**
+ * Routes confirmed agent publishing through the canonical release scheduler.
+ * Extracted from AgentToolExecutorService per #519/#520 so the executor remains
+ * an orchestration boundary rather than growing another publishing subsystem.
+ */
+@Injectable()
+export class AgentPublishToolHandler {
+  constructor(private readonly postGroupsService: PostGroupsService) {}
+
+  async publishConfirmedContent(
+    input: PublishConfirmedContentInput,
+  ): Promise<AgentToolResult> {
+    const {
+      caption,
+      contentId,
+      credentials,
+      ctx,
+      ingredient,
+      platforms,
+      scheduledAt,
+      sourceActionId,
+    } = input;
+
+    if (credentials.length === 0) {
+      return {
+        creditsUsed: 0,
+        error:
+          'No connected social accounts are available for the selected platforms.',
+        success: false,
+      };
+    }
+
+    const createdPlatforms = Array.from(
+      new Set(
+        credentials
+          .map((credential) => String(credential.platform || '').toLowerCase())
+          .filter((platform) => platform.length > 0),
+      ),
+    );
+    const missingPlatforms = platforms.filter(
+      (platform) => !createdPlatforms.includes(platform),
+    );
+    if (missingPlatforms.length > 0) {
+      return {
+        creditsUsed: 0,
+        data: {
+          availablePlatforms: createdPlatforms,
+          contentId,
+          missingPlatforms,
+        },
+        error: `Missing connected accounts for: ${missingPlatforms.join(', ')}.`,
+        success: false,
+      };
+    }
+
+    const baseContent = this.resolvePublishBaseContent(caption, ingredient);
+    const idempotencyKey = this.buildIdempotencyKey({
+      baseContent,
+      contentId,
+      organizationId: ctx.organizationId,
+      platforms,
+      scheduledAt,
+      sourceActionId,
+      threadId: ctx.threadId,
+      userId: ctx.userId,
+    });
+    const mediaKind = this.resolveReleaseMediaKind(ingredient.category);
+    const release = await this.postGroupsService.create(
+      ctx.organizationId,
+      ctx.userId,
+      {
+        baseContent,
+        brandId: String(ingredient.brand),
+        idempotencyKey,
+        media: [
+          {
+            assetId: contentId,
+            ...(mediaKind ? { kind: mediaKind } : {}),
+          },
+        ],
+        ...(scheduledAt
+          ? {
+              scheduledDate: scheduledAt,
+              status: ReleaseStatus.SCHEDULED,
+            }
+          : { status: ReleaseStatus.DRAFT }),
+        targets: credentials.map((credential, order) => ({
+          credentialId: String(credential.id),
+          order,
+          platform: credential.platform as CredentialPlatform,
+          ...(scheduledAt ? { scheduledDate: scheduledAt } : {}),
+        })),
+        timezone: 'UTC',
+        title: baseContent.slice(0, 100),
+      },
+      idempotencyKey,
+      {
+        agentContextSource: ctx.validatedScope?.source,
+        agentContextVersion: ctx.validatedScope?.contextVersion,
+        agentRunId: ctx.runId,
+        agentStrategyId: ctx.strategyId,
+        agentThreadId: ctx.validatedScope?.threadId,
+        source: 'agent',
+        sourceActionId,
+      },
+    );
+    const canonicalRelease = scheduledAt
+      ? release
+      : await this.postGroupsService.publishNow(
+          ctx.organizationId,
+          ctx.userId,
+          release.id,
+        );
+    const groupId = canonicalRelease.id;
+    const postIds = (canonicalRelease.targets ?? []).map((target) =>
+      String(target.id),
+    );
+    const description = scheduledAt
+      ? `Scheduled ${postIds.length} post${postIds.length === 1 ? '' : 's'} for ${createdPlatforms.join(', ')}.`
+      : `Queued ${postIds.length} post${postIds.length === 1 ? '' : 's'} for publishing on ${createdPlatforms.join(', ')}.`;
+
+    return {
+      creditsUsed: 0,
+      data: {
+        contentId,
+        createdPlatforms,
+        missingPlatforms,
+        postIds,
+        scheduledAt,
+        totalCreated: postIds.length,
+      },
+      nextActions: [
+        {
+          ctas: [
+            { href: '/content/posts', label: 'Open posts' },
+            ...(postIds[0]
+              ? [
+                  {
+                    href: `/analytics/posts?postId=${postIds[0]}`,
+                    label: 'Open analytics',
+                  },
+                ]
+              : []),
+          ],
+          description,
+          id: `published-posts-${groupId}`,
+          title: scheduledAt ? 'Posts scheduled' : 'Posts queued',
+          type: 'content_preview_card' as const,
+        },
+      ],
+      success: true,
+    };
+  }
+
+  private buildIdempotencyKey(input: {
+    baseContent: string;
+    contentId: string;
+    organizationId: string;
+    platforms: string[];
+    scheduledAt?: string;
+    sourceActionId?: string;
+    threadId?: string;
+    userId: string;
+  }): string {
+    const digest = createHash('sha256')
+      .update(
+        JSON.stringify({
+          ...input,
+          platforms: [...input.platforms].sort(),
+        }),
+      )
+      .digest('hex');
+    return `agent-publish:${digest}`;
+  }
+
+  private resolvePublishBaseContent(
+    caption: string | undefined,
+    ingredient: Record<string, unknown>,
+  ): string {
+    const candidates = [
+      caption,
+      this.readOptionalString(ingredient.label),
+      this.readOptionalString(ingredient.description),
+      this.readOptionalString(ingredient.assetLabel),
+      this.readOptionalString(ingredient.generationPrompt),
+    ];
+    const resolved = candidates.find((candidate) => Boolean(candidate?.trim()));
+    if (resolved) {
+      return resolved.trim();
+    }
+
+    const category = this.readOptionalString(ingredient.category) ?? 'content';
+    return `Selected ${category} asset`;
+  }
+
+  private resolveReleaseMediaKind(category: unknown): string | undefined {
+    if (
+      category === IngredientCategory.IMAGE ||
+      category === IngredientCategory.IMAGE_EDIT ||
+      category === IngredientCategory.GIF
+    ) {
+      return 'image';
+    }
+    if (
+      category === IngredientCategory.VIDEO ||
+      category === IngredientCategory.VIDEO_EDIT
+    ) {
+      return 'video';
+    }
+    return undefined;
+  }
+
+  private readOptionalString(value: unknown): string | undefined {
+    return typeof value === 'string' && value.trim().length > 0
+      ? value.trim()
+      : undefined;
+  }
+}

--- a/apps/server/api/src/services/agent-orchestrator/tools/agent-publish-tool-handler.service.ts
+++ b/apps/server/api/src/services/agent-orchestrator/tools/agent-publish-tool-handler.service.ts
@@ -1,29 +1,17 @@
 import { createHash } from 'node:crypto';
 import { PostGroupsService } from '@api/collections/post-groups/services/post-groups.service';
-import type { ToolExecutionContext } from '@api/services/agent-orchestrator/tools/agent-tool-executor.service';
+import { UsersService } from '@api/collections/users/services/users.service';
 import {
   CredentialPlatform,
   IngredientCategory,
   ReleaseStatus,
 } from '@genfeedai/enums';
-import type { AgentToolResult } from '@genfeedai/interfaces';
+import type {
+  AgentPublishIdempotencyInput,
+  AgentToolResult,
+  PublishConfirmedContentInput,
+} from '@genfeedai/interfaces';
 import { Injectable } from '@nestjs/common';
-
-interface AgentPublishCredential {
-  id?: unknown;
-  platform?: unknown;
-}
-
-interface PublishConfirmedContentInput {
-  caption?: string;
-  contentId: string;
-  credentials: AgentPublishCredential[];
-  ctx: ToolExecutionContext;
-  ingredient: Record<string, unknown>;
-  platforms: string[];
-  scheduledAt?: string;
-  sourceActionId?: string;
-}
 
 /**
  * Routes confirmed agent publishing through the canonical release scheduler.
@@ -32,7 +20,10 @@ interface PublishConfirmedContentInput {
  */
 @Injectable()
 export class AgentPublishToolHandler {
-  constructor(private readonly postGroupsService: PostGroupsService) {}
+  constructor(
+    private readonly postGroupsService: PostGroupsService,
+    private readonly usersService: UsersService,
+  ) {}
 
   async publishConfirmedContent(
     input: PublishConfirmedContentInput,
@@ -80,6 +71,17 @@ export class AgentPublishToolHandler {
       };
     }
 
+    const canonicalUserId = await this.usersService.findMongoIdByAuthProviderId(
+      ctx.userId,
+    );
+    if (!canonicalUserId) {
+      return {
+        creditsUsed: 0,
+        error: 'The publishing user could not be resolved.',
+        success: false,
+      };
+    }
+
     const baseContent = this.resolvePublishBaseContent(caption, ingredient);
     const idempotencyKey = this.buildIdempotencyKey({
       baseContent,
@@ -89,12 +91,12 @@ export class AgentPublishToolHandler {
       scheduledAt,
       sourceActionId,
       threadId: ctx.threadId,
-      userId: ctx.userId,
+      userId: canonicalUserId,
     });
     const mediaKind = this.resolveReleaseMediaKind(ingredient.category);
     const release = await this.postGroupsService.create(
       ctx.organizationId,
-      ctx.userId,
+      canonicalUserId,
       {
         baseContent,
         brandId: String(ingredient.brand),
@@ -135,7 +137,7 @@ export class AgentPublishToolHandler {
       ? release
       : await this.postGroupsService.publishNow(
           ctx.organizationId,
-          ctx.userId,
+          canonicalUserId,
           release.id,
         );
     const groupId = canonicalRelease.id;
@@ -179,16 +181,7 @@ export class AgentPublishToolHandler {
     };
   }
 
-  private buildIdempotencyKey(input: {
-    baseContent: string;
-    contentId: string;
-    organizationId: string;
-    platforms: string[];
-    scheduledAt?: string;
-    sourceActionId?: string;
-    threadId?: string;
-    userId: string;
-  }): string {
+  private buildIdempotencyKey(input: AgentPublishIdempotencyInput): string {
     const digest = createHash('sha256')
       .update(
         JSON.stringify({

--- a/apps/server/api/src/services/agent-orchestrator/tools/agent-publish-tool-handler.service.ts
+++ b/apps/server/api/src/services/agent-orchestrator/tools/agent-publish-tool-handler.service.ts
@@ -1,6 +1,5 @@
 import { createHash } from 'node:crypto';
 import { PostGroupsService } from '@api/collections/post-groups/services/post-groups.service';
-import { UsersService } from '@api/collections/users/services/users.service';
 import {
   CredentialPlatform,
   IngredientCategory,
@@ -20,10 +19,7 @@ import { Injectable } from '@nestjs/common';
  */
 @Injectable()
 export class AgentPublishToolHandler {
-  constructor(
-    private readonly postGroupsService: PostGroupsService,
-    private readonly usersService: UsersService,
-  ) {}
+  constructor(private readonly postGroupsService: PostGroupsService) {}
 
   async publishConfirmedContent(
     input: PublishConfirmedContentInput,
@@ -71,17 +67,6 @@ export class AgentPublishToolHandler {
       };
     }
 
-    const canonicalUserId = await this.usersService.findMongoIdByAuthProviderId(
-      ctx.userId,
-    );
-    if (!canonicalUserId) {
-      return {
-        creditsUsed: 0,
-        error: 'The publishing user could not be resolved.',
-        success: false,
-      };
-    }
-
     const baseContent = this.resolvePublishBaseContent(caption, ingredient);
     const idempotencyKey = this.buildIdempotencyKey({
       baseContent,
@@ -91,12 +76,12 @@ export class AgentPublishToolHandler {
       scheduledAt,
       sourceActionId,
       threadId: ctx.threadId,
-      userId: canonicalUserId,
+      userId: ctx.userId,
     });
     const mediaKind = this.resolveReleaseMediaKind(ingredient.category);
     const release = await this.postGroupsService.create(
       ctx.organizationId,
-      canonicalUserId,
+      ctx.userId,
       {
         baseContent,
         brandId: String(ingredient.brand),
@@ -137,7 +122,7 @@ export class AgentPublishToolHandler {
       ? release
       : await this.postGroupsService.publishNow(
           ctx.organizationId,
-          canonicalUserId,
+          ctx.userId,
           release.id,
         );
     const groupId = canonicalRelease.id;

--- a/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.spec.ts
+++ b/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.spec.ts
@@ -15,6 +15,7 @@ import {
   AgentToolExecutorService,
   type ToolExecutionContext,
 } from '@api/services/agent-orchestrator/tools/agent-tool-executor.service';
+import type { CreateReleaseGroupInput } from '@api-types/contracts/scheduler.contract';
 import { PostStatus, ReleaseStatus } from '@genfeedai/enums';
 import { AgentToolName } from '@genfeedai/interfaces';
 import { LoggerService } from '@libs/logger/logger.service';
@@ -63,31 +64,30 @@ describe('AgentToolExecutorService', () => {
       handleYoutubePost: vi.fn(),
     };
     const postGroupsService = {
-      create: vi.fn().mockImplementation(
-        (
-          organizationId: string,
-          _userId: string,
-          input: {
-            status: ReleaseStatus;
-            targets: Array<{ platform: string }>;
-          },
-          _headerIdempotencyKey?: string,
-          _provenance?: Record<string, unknown>,
-        ) =>
-          Promise.resolve({
-            id: 'release-1',
-            organizationId,
-            status: input.status,
-            targets: input.targets.map((target, index) => ({
-              executionState:
-                input.status === ReleaseStatus.SCHEDULED
-                  ? 'scheduled'
-                  : 'draft',
-              id: `target-${index + 1}`,
-              platform: target.platform,
-            })),
-          }),
-      ),
+      create: vi
+        .fn()
+        .mockImplementation(
+          (
+            organizationId: string,
+            _userId: string,
+            input: CreateReleaseGroupInput,
+            _headerIdempotencyKey?: string,
+            _provenance?: Record<string, unknown>,
+          ) =>
+            Promise.resolve({
+              id: 'release-1',
+              organizationId,
+              status: input.status,
+              targets: input.targets.map((target, index) => ({
+                executionState:
+                  input.status === ReleaseStatus.SCHEDULED
+                    ? 'scheduled'
+                    : 'draft',
+                id: `target-${index + 1}`,
+                platform: target.platform,
+              })),
+            }),
+        ),
       publishNow: vi.fn().mockResolvedValue({
         id: 'release-1',
         organizationId: '67a123456789012345678901',
@@ -443,6 +443,7 @@ describe('AgentToolExecutorService', () => {
       }),
     };
     const usersService = {
+      findMongoIdByAuthProviderId: vi.fn().mockResolvedValue('user-db-1'),
       findOne: vi.fn().mockResolvedValue({ id: 'user-db-1' }),
       patch: vi.fn().mockResolvedValue({}),
     };
@@ -706,6 +707,7 @@ describe('AgentToolExecutorService', () => {
     const dashboardHandler = new AgentDashboardToolHandler(undefined as never);
     const publishHandler = new AgentPublishToolHandler(
       postGroupsService as never,
+      usersService as never,
     );
     const agentScopeContextService = {
       assertConsequentialBoundary: vi.fn().mockResolvedValue(undefined),
@@ -1209,7 +1211,7 @@ describe('AgentToolExecutorService', () => {
     expect(result.creditsUsed).toBe(0);
     expect(postGroupsService.create).toHaveBeenCalledWith(
       '67a123456789012345678901',
-      '67a123456789012345678902',
+      'user-db-1',
       expect.objectContaining({
         baseContent: 'Published from chat',
         brandId: '67a123456789012345678941',
@@ -1242,7 +1244,7 @@ describe('AgentToolExecutorService', () => {
     );
     expect(postGroupsService.publishNow).toHaveBeenCalledWith(
       '67a123456789012345678901',
-      '67a123456789012345678902',
+      'user-db-1',
       'release-1',
     );
     expect(postsService.create).not.toHaveBeenCalled();
@@ -1366,14 +1368,21 @@ describe('AgentToolExecutorService', () => {
 
     await service.executeTool(AgentToolName.CREATE_POST, parameters, context);
     await service.executeTool(AgentToolName.CREATE_POST, parameters, context);
+    await service.executeTool(
+      AgentToolName.CREATE_POST,
+      { ...parameters, sourceActionId: 'publish-card-distinct' },
+      context,
+    );
 
     const firstKey = postGroupsService.create.mock.calls[0]?.[3];
     const secondKey = postGroupsService.create.mock.calls[1]?.[3];
+    const distinctKey = postGroupsService.create.mock.calls[2]?.[3];
     expect(firstKey).toMatch(/^agent-publish:[a-f0-9]{64}$/);
     expect(secondKey).toBe(firstKey);
+    expect(distinctKey).not.toBe(firstKey);
   });
 
-  it('builds a deterministic retry key when a non-UI caller omits sourceActionId', async () => {
+  it('fails closed when a confirmed caller omits sourceActionId', async () => {
     const {
       credentialsService,
       ingredientsService,
@@ -1391,18 +1400,6 @@ describe('AgentToolExecutorService', () => {
         platform: 'linkedin',
       },
     ]);
-    postGroupsService.publishNow.mockResolvedValue({
-      id: 'release-1',
-      organizationId: '67a123456789012345678901',
-      status: ReleaseStatus.SCHEDULED,
-      targets: [
-        {
-          executionState: 'scheduled',
-          id: 'target-1',
-          platform: 'linkedin',
-        },
-      ],
-    });
     const parameters = {
       caption: 'Deterministic fallback',
       confirmed: true,
@@ -1411,13 +1408,21 @@ describe('AgentToolExecutorService', () => {
     };
     const context = scopedContext('67a123456789012345678941');
 
-    await service.executeTool(AgentToolName.CREATE_POST, parameters, context);
-    await service.executeTool(AgentToolName.CREATE_POST, parameters, context);
+    const result = await service.executeTool(
+      AgentToolName.CREATE_POST,
+      parameters,
+      context,
+    );
 
-    const firstKey = postGroupsService.create.mock.calls[0]?.[3];
-    const secondKey = postGroupsService.create.mock.calls[1]?.[3];
-    expect(firstKey).toMatch(/^agent-publish:[a-f0-9]{64}$/);
-    expect(secondKey).toBe(firstKey);
+    expect(result).toEqual(
+      expect.objectContaining({
+        error:
+          'sourceActionId is required to publish confirmed content safely.',
+        success: false,
+      }),
+    );
+    expect(postGroupsService.create).not.toHaveBeenCalled();
+    expect(postGroupsService.publishNow).not.toHaveBeenCalled();
   });
 
   it('fails before creating a release when any requested platform is disconnected', async () => {
@@ -1456,6 +1461,48 @@ describe('AgentToolExecutorService', () => {
           missingPlatforms: ['instagram'],
         }),
         error: 'Missing connected accounts for: instagram.',
+        success: false,
+      }),
+    );
+    expect(postGroupsService.create).not.toHaveBeenCalled();
+    expect(postGroupsService.publishNow).not.toHaveBeenCalled();
+  });
+
+  it('fails before creating a release when the canonical user cannot be resolved', async () => {
+    const {
+      credentialsService,
+      ingredientsService,
+      postGroupsService,
+      service,
+      usersService,
+    } = createService();
+    ingredientsService.findOne.mockResolvedValue({
+      brand: '67a123456789012345678941',
+      category: 'image',
+      id: '67a123456789012345678940',
+    });
+    credentialsService.find.mockResolvedValue([
+      {
+        id: '67a123456789012345678942',
+        platform: 'linkedin',
+      },
+    ]);
+    usersService.findMongoIdByAuthProviderId.mockResolvedValueOnce(null);
+
+    const result = await service.executeTool(
+      AgentToolName.CREATE_POST,
+      {
+        confirmed: true,
+        contentId: '67a123456789012345678940',
+        platforms: ['linkedin'],
+        sourceActionId: 'publish-card-missing-user',
+      },
+      scopedContext('67a123456789012345678941'),
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        error: 'The publishing user could not be resolved.',
         success: false,
       }),
     );
@@ -3640,7 +3687,7 @@ describe('AgentToolExecutorService', () => {
       ),
       new AgentMemoryGoalsToolHandler(undefined as never, undefined as never),
       new AgentDashboardToolHandler(undefined as never),
-      new AgentPublishToolHandler({} as never),
+      new AgentPublishToolHandler({} as never, {} as never),
       {} as never,
       {} as never,
       {} as never,

--- a/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.spec.ts
+++ b/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.spec.ts
@@ -9,6 +9,7 @@ import 'reflect-metadata';
 import { AiActionType } from '@api/endpoints/ai-actions/dto/ai-action.dto';
 import { AgentDashboardToolHandler } from '@api/services/agent-orchestrator/tools/agent-dashboard-tool-handler.service';
 import { AgentMemoryGoalsToolHandler } from '@api/services/agent-orchestrator/tools/agent-memory-goals-tool-handler.service';
+import { AgentPublishToolHandler } from '@api/services/agent-orchestrator/tools/agent-publish-tool-handler.service';
 import { AgentRouteRewriteService } from '@api/services/agent-orchestrator/tools/agent-route-rewrite.service';
 import {
   AgentToolExecutorService,
@@ -703,6 +704,9 @@ describe('AgentToolExecutorService', () => {
       agentGoalsService as never,
     );
     const dashboardHandler = new AgentDashboardToolHandler(undefined as never);
+    const publishHandler = new AgentPublishToolHandler(
+      postGroupsService as never,
+    );
     const agentScopeContextService = {
       assertConsequentialBoundary: vi.fn().mockResolvedValue(undefined),
       assertResourceBrand: vi.fn(),
@@ -717,6 +721,7 @@ describe('AgentToolExecutorService', () => {
       routeRewriteService,
       memoryGoalsHandler,
       dashboardHandler,
+      publishHandler,
       botsService as never,
       botsLivestreamService as never,
       campaignsService as never,
@@ -746,7 +751,6 @@ describe('AgentToolExecutorService', () => {
       {} as never, // votesService
       adsResearchService as never,
       brandInterviewService as never,
-      postGroupsService as never,
       agentScopeContextService as never,
     );
 
@@ -3636,6 +3640,7 @@ describe('AgentToolExecutorService', () => {
       ),
       new AgentMemoryGoalsToolHandler(undefined as never, undefined as never),
       new AgentDashboardToolHandler(undefined as never),
+      new AgentPublishToolHandler({} as never),
       {} as never,
       {} as never,
       {} as never,
@@ -3665,7 +3670,6 @@ describe('AgentToolExecutorService', () => {
       undefined as never, // votesService
       undefined as never, // adsResearchService
       undefined as never, // brandInterviewService
-      {} as never, // postGroupsService
       undefined as never, // agentScopeContextService
     );
 

--- a/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.spec.ts
+++ b/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.spec.ts
@@ -443,7 +443,6 @@ describe('AgentToolExecutorService', () => {
       }),
     };
     const usersService = {
-      findMongoIdByAuthProviderId: vi.fn().mockResolvedValue('user-db-1'),
       findOne: vi.fn().mockResolvedValue({ id: 'user-db-1' }),
       patch: vi.fn().mockResolvedValue({}),
     };
@@ -707,7 +706,6 @@ describe('AgentToolExecutorService', () => {
     const dashboardHandler = new AgentDashboardToolHandler(undefined as never);
     const publishHandler = new AgentPublishToolHandler(
       postGroupsService as never,
-      usersService as never,
     );
     const agentScopeContextService = {
       assertConsequentialBoundary: vi.fn().mockResolvedValue(undefined),
@@ -1211,7 +1209,7 @@ describe('AgentToolExecutorService', () => {
     expect(result.creditsUsed).toBe(0);
     expect(postGroupsService.create).toHaveBeenCalledWith(
       '67a123456789012345678901',
-      'user-db-1',
+      '67a123456789012345678902',
       expect.objectContaining({
         baseContent: 'Published from chat',
         brandId: '67a123456789012345678941',
@@ -1244,7 +1242,7 @@ describe('AgentToolExecutorService', () => {
     );
     expect(postGroupsService.publishNow).toHaveBeenCalledWith(
       '67a123456789012345678901',
-      'user-db-1',
+      '67a123456789012345678902',
       'release-1',
     );
     expect(postsService.create).not.toHaveBeenCalled();
@@ -1461,48 +1459,6 @@ describe('AgentToolExecutorService', () => {
           missingPlatforms: ['instagram'],
         }),
         error: 'Missing connected accounts for: instagram.',
-        success: false,
-      }),
-    );
-    expect(postGroupsService.create).not.toHaveBeenCalled();
-    expect(postGroupsService.publishNow).not.toHaveBeenCalled();
-  });
-
-  it('fails before creating a release when the canonical user cannot be resolved', async () => {
-    const {
-      credentialsService,
-      ingredientsService,
-      postGroupsService,
-      service,
-      usersService,
-    } = createService();
-    ingredientsService.findOne.mockResolvedValue({
-      brand: '67a123456789012345678941',
-      category: 'image',
-      id: '67a123456789012345678940',
-    });
-    credentialsService.find.mockResolvedValue([
-      {
-        id: '67a123456789012345678942',
-        platform: 'linkedin',
-      },
-    ]);
-    usersService.findMongoIdByAuthProviderId.mockResolvedValueOnce(null);
-
-    const result = await service.executeTool(
-      AgentToolName.CREATE_POST,
-      {
-        confirmed: true,
-        contentId: '67a123456789012345678940',
-        platforms: ['linkedin'],
-        sourceActionId: 'publish-card-missing-user',
-      },
-      scopedContext('67a123456789012345678941'),
-    );
-
-    expect(result).toEqual(
-      expect.objectContaining({
-        error: 'The publishing user could not be resolved.',
         success: false,
       }),
     );
@@ -3687,7 +3643,7 @@ describe('AgentToolExecutorService', () => {
       ),
       new AgentMemoryGoalsToolHandler(undefined as never, undefined as never),
       new AgentDashboardToolHandler(undefined as never),
-      new AgentPublishToolHandler({} as never, {} as never),
+      new AgentPublishToolHandler({} as never),
       {} as never,
       {} as never,
       {} as never,

--- a/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.spec.ts
+++ b/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.spec.ts
@@ -910,7 +910,7 @@ describe('AgentToolExecutorService', () => {
     );
   });
 
-  it('returns a publish confirmation card for direct content publish requests', async () => {
+  it('preserves a naive wall time in the publish confirmation preview', async () => {
     const { credentialsService, ingredientsService, service } = createService();
 
     ingredientsService.findOne.mockResolvedValue({
@@ -934,6 +934,7 @@ describe('AgentToolExecutorService', () => {
       {
         caption: 'Ship this now',
         contentId: '67a123456789012345678930',
+        scheduledAt: '2026-07-18T09:00',
       },
       {
         organizationId: '67a123456789012345678901',
@@ -947,6 +948,7 @@ describe('AgentToolExecutorService', () => {
       expect.objectContaining({
         contentId: '67a123456789012345678930',
         platforms: ['linkedin', 'twitter'],
+        scheduledAt: '2026-07-18T09:00',
         textContent: 'Ship this now',
         type: 'publish_post_card',
       }),

--- a/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.spec.ts
+++ b/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.spec.ts
@@ -14,7 +14,7 @@ import {
   AgentToolExecutorService,
   type ToolExecutionContext,
 } from '@api/services/agent-orchestrator/tools/agent-tool-executor.service';
-import { PostStatus } from '@genfeedai/enums';
+import { PostStatus, ReleaseStatus } from '@genfeedai/enums';
 import { AgentToolName } from '@genfeedai/interfaces';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Effect } from 'effect';
@@ -60,6 +60,50 @@ describe('AgentToolExecutorService', () => {
       findAll: vi.fn(),
       findOne: vi.fn(),
       handleYoutubePost: vi.fn(),
+    };
+    const postGroupsService = {
+      create: vi.fn().mockImplementation(
+        (
+          organizationId: string,
+          _userId: string,
+          input: {
+            status: ReleaseStatus;
+            targets: Array<{ platform: string }>;
+          },
+          _headerIdempotencyKey?: string,
+          _provenance?: Record<string, unknown>,
+        ) =>
+          Promise.resolve({
+            id: 'release-1',
+            organizationId,
+            status: input.status,
+            targets: input.targets.map((target, index) => ({
+              executionState:
+                input.status === ReleaseStatus.SCHEDULED
+                  ? 'scheduled'
+                  : 'draft',
+              id: `target-${index + 1}`,
+              platform: target.platform,
+            })),
+          }),
+      ),
+      publishNow: vi.fn().mockResolvedValue({
+        id: 'release-1',
+        organizationId: '67a123456789012345678901',
+        status: ReleaseStatus.SCHEDULED,
+        targets: [
+          {
+            executionState: 'scheduled',
+            id: 'target-1',
+            platform: 'linkedin',
+          },
+          {
+            executionState: 'scheduled',
+            id: 'target-2',
+            platform: 'youtube',
+          },
+        ],
+      }),
     };
     const brandsService = {
       create: vi.fn().mockResolvedValue({ id: 'brand-1' }),
@@ -702,6 +746,7 @@ describe('AgentToolExecutorService', () => {
       {} as never, // votesService
       adsResearchService as never,
       brandInterviewService as never,
+      postGroupsService as never,
       agentScopeContextService as never,
     );
 
@@ -731,6 +776,7 @@ describe('AgentToolExecutorService', () => {
       organizationSettingsService,
       organizationsService,
       postAnalyticsService,
+      postGroupsService,
       postsService,
       recurringWorkflowId,
       service,
@@ -1115,9 +1161,14 @@ describe('AgentToolExecutorService', () => {
     ]);
   });
 
-  it('publishes accessible content across connected platforms after confirmation', async () => {
-    const { credentialsService, ingredientsService, postsService, service } =
-      createService();
+  it('publishes accessible content through the canonical release queue after confirmation', async () => {
+    const {
+      credentialsService,
+      ingredientsService,
+      postGroupsService,
+      postsService,
+      service,
+    } = createService();
 
     ingredientsService.findOne.mockResolvedValue({
       id: '67a123456789012345678940',
@@ -1134,14 +1185,6 @@ describe('AgentToolExecutorService', () => {
         platform: 'youtube',
       },
     ]);
-    postsService.create
-      .mockResolvedValueOnce({
-        id: '67a123456789012345678944',
-      })
-      .mockResolvedValueOnce({
-        id: '67a123456789012345678945',
-      });
-
     const result = await service.executeTool(
       AgentToolName.CREATE_POST,
       {
@@ -1149,6 +1192,7 @@ describe('AgentToolExecutorService', () => {
         confirmed: true,
         contentId: '67a123456789012345678940',
         platforms: ['linkedin', 'youtube'],
+        sourceActionId: 'publish-card-1',
       },
       {
         ...scopedContext('67a123456789012345678941'),
@@ -1159,13 +1203,260 @@ describe('AgentToolExecutorService', () => {
 
     expect(result.success).toBe(true);
     expect(result.creditsUsed).toBe(0);
-    expect(postsService.create).toHaveBeenCalledTimes(2);
-    expect(postsService.handleYoutubePost).toHaveBeenCalledTimes(1);
+    expect(postGroupsService.create).toHaveBeenCalledWith(
+      '67a123456789012345678901',
+      '67a123456789012345678902',
+      expect.objectContaining({
+        baseContent: 'Published from chat',
+        brandId: '67a123456789012345678941',
+        media: [
+          {
+            assetId: '67a123456789012345678940',
+            kind: 'video',
+          },
+        ],
+        status: ReleaseStatus.DRAFT,
+        targets: [
+          expect.objectContaining({
+            credentialId: '67a123456789012345678942',
+            platform: 'linkedin',
+          }),
+          expect.objectContaining({
+            credentialId: '67a123456789012345678943',
+            platform: 'youtube',
+          }),
+        ],
+      }),
+      expect.stringMatching(/^agent-publish:[a-f0-9]{64}$/),
+      expect.objectContaining({
+        agentRunId: '67a123456789012345678946',
+        agentStrategyId: '67a123456789012345678947',
+        agentThreadId: '67a123456789012345678999',
+        source: 'agent',
+        sourceActionId: 'publish-card-1',
+      }),
+    );
+    expect(postGroupsService.publishNow).toHaveBeenCalledWith(
+      '67a123456789012345678901',
+      '67a123456789012345678902',
+      'release-1',
+    );
+    expect(postsService.create).not.toHaveBeenCalled();
+    expect(postsService.handleYoutubePost).not.toHaveBeenCalled();
     expect(result.data).toMatchObject({
       contentId: '67a123456789012345678940',
       createdPlatforms: ['linkedin', 'youtube'],
+      postIds: ['target-1', 'target-2'],
       totalCreated: 2,
     });
+  });
+
+  it('creates a scheduled canonical release without publishing it early', async () => {
+    const {
+      credentialsService,
+      ingredientsService,
+      postGroupsService,
+      service,
+    } = createService();
+    ingredientsService.findOne.mockResolvedValue({
+      assetLabel: 'promo',
+      brand: '67a123456789012345678941',
+      category: 'image',
+      id: '67a123456789012345678940',
+    });
+    credentialsService.find.mockResolvedValue([
+      {
+        id: '67a123456789012345678942',
+        platform: 'instagram',
+      },
+    ]);
+    postGroupsService.create.mockResolvedValueOnce({
+      id: 'release-scheduled',
+      organizationId: '67a123456789012345678901',
+      status: ReleaseStatus.SCHEDULED,
+      targets: [
+        {
+          executionState: 'scheduled',
+          id: 'target-scheduled',
+          platform: 'instagram',
+        },
+      ],
+    });
+    const expectedScheduledAt = new Date('2026-07-18T09:00').toISOString();
+
+    const result = await service.executeTool(
+      AgentToolName.CREATE_POST,
+      {
+        confirmed: true,
+        contentId: '67a123456789012345678940',
+        platforms: ['instagram'],
+        scheduledAt: '2026-07-18T09:00',
+        sourceActionId: 'publish-card-scheduled',
+      },
+      scopedContext('67a123456789012345678941'),
+    );
+
+    expect(result.success).toBe(true);
+    expect(postGroupsService.create).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      expect.objectContaining({
+        baseContent: 'promo',
+        scheduledDate: expectedScheduledAt,
+        status: ReleaseStatus.SCHEDULED,
+        targets: [
+          expect.objectContaining({
+            scheduledDate: expectedScheduledAt,
+          }),
+        ],
+      }),
+      expect.stringMatching(/^agent-publish:[a-f0-9]{64}$/),
+      expect.any(Object),
+    );
+    expect(postGroupsService.publishNow).not.toHaveBeenCalled();
+    expect(result.data).toMatchObject({
+      postIds: ['target-scheduled'],
+      scheduledAt: expectedScheduledAt,
+      totalCreated: 1,
+    });
+  });
+
+  it('reuses the same release idempotency key for an exact confirmed-action retry', async () => {
+    const {
+      credentialsService,
+      ingredientsService,
+      postGroupsService,
+      service,
+    } = createService();
+    ingredientsService.findOne.mockResolvedValue({
+      brand: '67a123456789012345678941',
+      category: 'image',
+      id: '67a123456789012345678940',
+    });
+    credentialsService.find.mockResolvedValue([
+      {
+        id: '67a123456789012345678942',
+        platform: 'linkedin',
+      },
+    ]);
+    postGroupsService.publishNow.mockResolvedValue({
+      id: 'release-1',
+      organizationId: '67a123456789012345678901',
+      status: ReleaseStatus.SCHEDULED,
+      targets: [
+        {
+          executionState: 'scheduled',
+          id: 'target-1',
+          platform: 'linkedin',
+        },
+      ],
+    });
+    const parameters = {
+      caption: 'Retry-safe caption',
+      confirmed: true,
+      contentId: '67a123456789012345678940',
+      platforms: ['linkedin'],
+      sourceActionId: 'publish-card-retry',
+    };
+    const context = scopedContext('67a123456789012345678941');
+
+    await service.executeTool(AgentToolName.CREATE_POST, parameters, context);
+    await service.executeTool(AgentToolName.CREATE_POST, parameters, context);
+
+    const firstKey = postGroupsService.create.mock.calls[0]?.[3];
+    const secondKey = postGroupsService.create.mock.calls[1]?.[3];
+    expect(firstKey).toMatch(/^agent-publish:[a-f0-9]{64}$/);
+    expect(secondKey).toBe(firstKey);
+  });
+
+  it('builds a deterministic retry key when a non-UI caller omits sourceActionId', async () => {
+    const {
+      credentialsService,
+      ingredientsService,
+      postGroupsService,
+      service,
+    } = createService();
+    ingredientsService.findOne.mockResolvedValue({
+      brand: '67a123456789012345678941',
+      category: 'image',
+      id: '67a123456789012345678940',
+    });
+    credentialsService.find.mockResolvedValue([
+      {
+        id: '67a123456789012345678942',
+        platform: 'linkedin',
+      },
+    ]);
+    postGroupsService.publishNow.mockResolvedValue({
+      id: 'release-1',
+      organizationId: '67a123456789012345678901',
+      status: ReleaseStatus.SCHEDULED,
+      targets: [
+        {
+          executionState: 'scheduled',
+          id: 'target-1',
+          platform: 'linkedin',
+        },
+      ],
+    });
+    const parameters = {
+      caption: 'Deterministic fallback',
+      confirmed: true,
+      contentId: '67a123456789012345678940',
+      platforms: ['linkedin'],
+    };
+    const context = scopedContext('67a123456789012345678941');
+
+    await service.executeTool(AgentToolName.CREATE_POST, parameters, context);
+    await service.executeTool(AgentToolName.CREATE_POST, parameters, context);
+
+    const firstKey = postGroupsService.create.mock.calls[0]?.[3];
+    const secondKey = postGroupsService.create.mock.calls[1]?.[3];
+    expect(firstKey).toMatch(/^agent-publish:[a-f0-9]{64}$/);
+    expect(secondKey).toBe(firstKey);
+  });
+
+  it('fails before creating a release when any requested platform is disconnected', async () => {
+    const {
+      credentialsService,
+      ingredientsService,
+      postGroupsService,
+      service,
+    } = createService();
+    ingredientsService.findOne.mockResolvedValue({
+      brand: '67a123456789012345678941',
+      category: 'image',
+      id: '67a123456789012345678940',
+    });
+    credentialsService.find.mockResolvedValue([
+      {
+        id: '67a123456789012345678942',
+        platform: 'linkedin',
+      },
+    ]);
+
+    const result = await service.executeTool(
+      AgentToolName.CREATE_POST,
+      {
+        confirmed: true,
+        contentId: '67a123456789012345678940',
+        platforms: ['linkedin', 'instagram'],
+        sourceActionId: 'publish-card-missing',
+      },
+      scopedContext('67a123456789012345678941'),
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          missingPlatforms: ['instagram'],
+        }),
+        error: 'Missing connected accounts for: instagram.',
+        success: false,
+      }),
+    );
+    expect(postGroupsService.create).not.toHaveBeenCalled();
+    expect(postGroupsService.publishNow).not.toHaveBeenCalled();
   });
 
   it('rejects stale publishing scope before creating post records', async () => {
@@ -3374,6 +3665,8 @@ describe('AgentToolExecutorService', () => {
       undefined as never, // votesService
       undefined as never, // adsResearchService
       undefined as never, // brandInterviewService
+      {} as never, // postGroupsService
+      undefined as never, // agentScopeContextService
     );
 
     const result = await serviceWithoutScorer.executeTool(

--- a/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts
+++ b/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'node:crypto';
+import { createHash } from 'node:crypto';
 import { BrandInterviewService } from '@api/collections/brands/brand-interview/services/brand-interview.service';
 import { resolveEffectiveBrandAgentConfig } from '@api/collections/brands/utils/brand-agent-config-resolution.util';
 import { ContentGeneratorService } from '@api/collections/content-intelligence/services/content-generator.service';
@@ -11,6 +11,7 @@ import { OrganizationSettingsService } from '@api/collections/organization-setti
 import { OrganizationsService } from '@api/collections/organizations/services/organizations.service';
 import { CreateOutreachCampaignDto } from '@api/collections/outreach-campaigns/dto/create-outreach-campaign.dto';
 import { OutreachCampaignsService } from '@api/collections/outreach-campaigns/services/outreach-campaigns.service';
+import { PostGroupsService } from '@api/collections/post-groups/services/post-groups.service';
 import { PostAnalyticsService } from '@api/collections/posts/services/post-analytics.service';
 import { PostsService } from '@api/collections/posts/services/posts.service';
 import { TrendsService } from '@api/collections/trends/services/trends.service';
@@ -53,8 +54,8 @@ import {
   CredentialPlatform,
   IngredientCategory,
   IngredientStatus,
-  PostCategory,
   PostStatus,
+  ReleaseStatus,
   Status,
   VoiceCloneStatus,
   VoiceProvider,
@@ -434,6 +435,7 @@ export class AgentToolExecutorService {
     private readonly adsResearchService: AdsResearchService | undefined,
     @Optional()
     private readonly brandInterviewService: BrandInterviewService | undefined,
+    private readonly postGroupsService: PostGroupsService,
     @Optional()
     private readonly agentScopeContextService?: AgentScopeContextService,
   ) {
@@ -3172,18 +3174,6 @@ export class AgentToolExecutorService {
     };
   }
 
-  private mapIngredientToPostCategory(category: unknown): PostCategory {
-    if (category === IngredientCategory.IMAGE) {
-      return PostCategory.IMAGE;
-    }
-
-    if (category === IngredientCategory.VIDEO) {
-      return PostCategory.VIDEO;
-    }
-
-    return PostCategory.POST;
-  }
-
   private normalizePlatforms(value: unknown): string[] {
     if (!Array.isArray(value)) {
       return [];
@@ -4315,10 +4305,21 @@ export class AgentToolExecutorService {
             ? [params.platform]
             : [],
       );
-      const scheduledAt =
+      const requestedScheduledAt =
         typeof params.scheduledAt === 'string' && params.scheduledAt.trim()
           ? params.scheduledAt.trim()
           : undefined;
+      const scheduledDate = requestedScheduledAt
+        ? new Date(requestedScheduledAt)
+        : undefined;
+      if (scheduledDate && Number.isNaN(scheduledDate.getTime())) {
+        return {
+          creditsUsed: 0,
+          error: 'scheduledAt must be a valid date and time.',
+          success: false,
+        };
+      }
+      const scheduledAt = scheduledDate?.toISOString();
 
       if (params.confirmed !== true) {
         return this.buildPublishCardResult(
@@ -4374,47 +4375,96 @@ export class AgentToolExecutorService {
         };
       }
 
-      const createdPlatforms = credentials
-        .map((credential) => String(credential.platform || '').toLowerCase())
-        .filter((platform) => platform.length > 0);
+      const createdPlatforms = Array.from(
+        new Set(
+          credentials
+            .map((credential) =>
+              String(credential.platform || '').toLowerCase(),
+            )
+            .filter((platform) => platform.length > 0),
+        ),
+      );
       const missingPlatforms = platforms.filter(
         (platform) => !createdPlatforms.includes(platform),
       );
-      const groupId = randomUUID();
-      const scheduledDate = scheduledAt ? new Date(scheduledAt) : undefined;
-      const postIds: string[] = [];
-
-      for (const credential of credentials) {
-        const platform = credential.platform as CredentialPlatform;
-        const post = await this.postsService.create({
-          ...(ctx.runId ? { agentRunId: ctx.runId } : {}),
-          ...(ctx.strategyId ? { agentStrategyId: ctx.strategyId } : {}),
-          agentContextSource: ctx.validatedScope?.source,
-          agentContextVersion: ctx.validatedScope?.contextVersion,
-          agentThreadId: ctx.validatedScope?.threadId,
-          brand: String(ingredient.brand),
-          category: this.mapIngredientToPostCategory(ingredient.category),
-          credential: String(credential.id),
-          description: caption ?? '',
-          groupId,
-          ingredients: [contentId],
-          label: (caption ?? '').trim().slice(0, 100) || 'Agent publish',
-          organization: ctx.organizationId,
-          platform,
-          scheduledDate,
-          source: 'agent',
-          status: scheduledDate ? PostStatus.SCHEDULED : PostStatus.PENDING,
-          user: ctx.userId,
-        } as never);
-
-        postIds.push(String((post as { id: string }).id));
-
-        if (platform === CredentialPlatform.YOUTUBE) {
-          await this.postsService.handleYoutubePost(post as never);
-        }
+      if (missingPlatforms.length > 0) {
+        return {
+          creditsUsed: 0,
+          data: {
+            availablePlatforms: createdPlatforms,
+            contentId,
+            missingPlatforms,
+          },
+          error: `Missing connected accounts for: ${missingPlatforms.join(', ')}.`,
+          success: false,
+        };
       }
 
-      const description = scheduledDate
+      const baseContent = this.resolvePublishBaseContent(caption, ingredient);
+      const sourceActionId = this.readOptionalString(params.sourceActionId);
+      const idempotencyKey = this.buildAgentPublishIdempotencyKey({
+        baseContent,
+        contentId,
+        organizationId: ctx.organizationId,
+        platforms,
+        scheduledAt,
+        sourceActionId,
+        threadId: ctx.threadId,
+        userId: ctx.userId,
+      });
+      const mediaKind = this.resolveReleaseMediaKind(ingredient.category);
+      const release = await this.postGroupsService.create(
+        ctx.organizationId,
+        ctx.userId,
+        {
+          baseContent,
+          brandId: String(ingredient.brand),
+          idempotencyKey,
+          media: [
+            {
+              assetId: contentId,
+              ...(mediaKind ? { kind: mediaKind } : {}),
+            },
+          ],
+          ...(scheduledAt
+            ? {
+                scheduledDate: scheduledAt,
+                status: ReleaseStatus.SCHEDULED,
+              }
+            : { status: ReleaseStatus.DRAFT }),
+          targets: credentials.map((credential, order) => ({
+            credentialId: String(credential.id),
+            order,
+            platform: credential.platform as CredentialPlatform,
+            ...(scheduledAt ? { scheduledDate: scheduledAt } : {}),
+          })),
+          timezone: 'UTC',
+          title: baseContent.slice(0, 100),
+        },
+        idempotencyKey,
+        {
+          agentContextSource: ctx.validatedScope?.source,
+          agentContextVersion: ctx.validatedScope?.contextVersion,
+          agentRunId: ctx.runId,
+          agentStrategyId: ctx.strategyId,
+          agentThreadId: ctx.validatedScope?.threadId,
+          source: 'agent',
+          sourceActionId,
+        },
+      );
+      const canonicalRelease = scheduledAt
+        ? release
+        : await this.postGroupsService.publishNow(
+            ctx.organizationId,
+            ctx.userId,
+            release.id,
+          );
+      const groupId = canonicalRelease.id;
+      const postIds = (canonicalRelease.targets ?? []).map((target) =>
+        String(target.id),
+      );
+
+      const description = scheduledAt
         ? `Scheduled ${postIds.length} post${postIds.length === 1 ? '' : 's'} for ${createdPlatforms.join(', ')}.`
         : `Queued ${postIds.length} post${postIds.length === 1 ? '' : 's'} for publishing on ${createdPlatforms.join(', ')}.`;
 
@@ -4441,12 +4491,9 @@ export class AgentToolExecutorService {
                   ]
                 : []),
             ],
-            description:
-              missingPlatforms.length > 0
-                ? `${description} Missing connected accounts for: ${missingPlatforms.join(', ')}.`
-                : description,
+            description,
             id: `published-posts-${groupId}`,
-            title: scheduledDate ? 'Posts scheduled' : 'Posts queued',
+            title: scheduledAt ? 'Posts scheduled' : 'Posts queued',
             type: 'content_preview_card' as const,
           },
         ],
@@ -4483,6 +4530,64 @@ export class AgentToolExecutorService {
       },
       success: true,
     };
+  }
+
+  private buildAgentPublishIdempotencyKey(input: {
+    baseContent: string;
+    contentId: string;
+    organizationId: string;
+    platforms: string[];
+    scheduledAt?: string;
+    sourceActionId?: string;
+    threadId?: string;
+    userId: string;
+  }): string {
+    const digest = createHash('sha256')
+      .update(
+        JSON.stringify({
+          ...input,
+          platforms: [...input.platforms].sort(),
+        }),
+      )
+      .digest('hex');
+    return `agent-publish:${digest}`;
+  }
+
+  private resolvePublishBaseContent(
+    caption: string | undefined,
+    ingredient: Record<string, unknown>,
+  ): string {
+    const candidates = [
+      caption,
+      this.readOptionalString(ingredient.label),
+      this.readOptionalString(ingredient.description),
+      this.readOptionalString(ingredient.assetLabel),
+      this.readOptionalString(ingredient.generationPrompt),
+    ];
+    const resolved = candidates.find((candidate) => Boolean(candidate?.trim()));
+    if (resolved) {
+      return resolved.trim();
+    }
+
+    const category = this.readOptionalString(ingredient.category) ?? 'content';
+    return `Selected ${category} asset`;
+  }
+
+  private resolveReleaseMediaKind(category: unknown): string | undefined {
+    if (
+      category === IngredientCategory.IMAGE ||
+      category === IngredientCategory.IMAGE_EDIT ||
+      category === IngredientCategory.GIF
+    ) {
+      return 'image';
+    }
+    if (
+      category === IngredientCategory.VIDEO ||
+      category === IngredientCategory.VIDEO_EDIT
+    ) {
+      return 'video';
+    }
+    return undefined;
   }
 
   private async schedulePost(

--- a/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts
+++ b/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts
@@ -4362,6 +4362,15 @@ export class AgentToolExecutorService {
         organizationId: ctx.organizationId,
         platforms,
       });
+      const sourceActionId = this.readOptionalString(params.sourceActionId);
+      if (!sourceActionId) {
+        return {
+          creditsUsed: 0,
+          error:
+            'sourceActionId is required to publish confirmed content safely.',
+          success: false,
+        };
+      }
 
       return this.publishHandler.publishConfirmedContent({
         caption,
@@ -4371,7 +4380,7 @@ export class AgentToolExecutorService {
         ingredient,
         platforms,
         scheduledAt,
-        sourceActionId: this.readOptionalString(params.sourceActionId),
+        sourceActionId,
       });
     }
 

--- a/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts
+++ b/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts
@@ -1,4 +1,3 @@
-import { createHash } from 'node:crypto';
 import { BrandInterviewService } from '@api/collections/brands/brand-interview/services/brand-interview.service';
 import { resolveEffectiveBrandAgentConfig } from '@api/collections/brands/utils/brand-agent-config-resolution.util';
 import { ContentGeneratorService } from '@api/collections/content-intelligence/services/content-generator.service';
@@ -11,7 +10,6 @@ import { OrganizationSettingsService } from '@api/collections/organization-setti
 import { OrganizationsService } from '@api/collections/organizations/services/organizations.service';
 import { CreateOutreachCampaignDto } from '@api/collections/outreach-campaigns/dto/create-outreach-campaign.dto';
 import { OutreachCampaignsService } from '@api/collections/outreach-campaigns/services/outreach-campaigns.service';
-import { PostGroupsService } from '@api/collections/post-groups/services/post-groups.service';
 import { PostAnalyticsService } from '@api/collections/posts/services/post-analytics.service';
 import { PostsService } from '@api/collections/posts/services/posts.service';
 import { TrendsService } from '@api/collections/trends/services/trends.service';
@@ -38,6 +36,7 @@ import { MarketplaceInstallService } from '@api/marketplace-integration/marketpl
 import { AgentStreamPublisherService } from '@api/services/agent-orchestrator/agent-stream-publisher.service';
 import { AgentDashboardToolHandler } from '@api/services/agent-orchestrator/tools/agent-dashboard-tool-handler.service';
 import { AgentMemoryGoalsToolHandler } from '@api/services/agent-orchestrator/tools/agent-memory-goals-tool-handler.service';
+import { AgentPublishToolHandler } from '@api/services/agent-orchestrator/tools/agent-publish-tool-handler.service';
 import { AgentRouteRewriteService } from '@api/services/agent-orchestrator/tools/agent-route-rewrite.service';
 import { AgentSpawnService } from '@api/services/agent-spawn/agent-spawn.service';
 import { BatchGenerationService } from '@api/services/batch-generation/batch-generation.service';
@@ -51,11 +50,9 @@ import {
   BotStatus,
   CampaignPlatform,
   CampaignType,
-  CredentialPlatform,
   IngredientCategory,
   IngredientStatus,
   PostStatus,
-  ReleaseStatus,
   Status,
   VoiceCloneStatus,
   VoiceProvider,
@@ -378,6 +375,7 @@ export class AgentToolExecutorService {
     private readonly routeRewriteService: AgentRouteRewriteService,
     private readonly memoryGoalsHandler: AgentMemoryGoalsToolHandler,
     private readonly dashboardHandler: AgentDashboardToolHandler,
+    private readonly publishHandler: AgentPublishToolHandler,
     @Optional()
     @Inject('AGENT_BOTS_SERVICE')
     private readonly botsService: AgentBotsServiceLike | undefined,
@@ -435,7 +433,6 @@ export class AgentToolExecutorService {
     private readonly adsResearchService: AdsResearchService | undefined,
     @Optional()
     private readonly brandInterviewService: BrandInterviewService | undefined,
-    private readonly postGroupsService: PostGroupsService,
     @Optional()
     private readonly agentScopeContextService?: AgentScopeContextService,
   ) {
@@ -4366,139 +4363,16 @@ export class AgentToolExecutorService {
         platforms,
       });
 
-      if (credentials.length === 0) {
-        return {
-          creditsUsed: 0,
-          error:
-            'No connected social accounts are available for the selected platforms.',
-          success: false,
-        };
-      }
-
-      const createdPlatforms = Array.from(
-        new Set(
-          credentials
-            .map((credential) =>
-              String(credential.platform || '').toLowerCase(),
-            )
-            .filter((platform) => platform.length > 0),
-        ),
-      );
-      const missingPlatforms = platforms.filter(
-        (platform) => !createdPlatforms.includes(platform),
-      );
-      if (missingPlatforms.length > 0) {
-        return {
-          creditsUsed: 0,
-          data: {
-            availablePlatforms: createdPlatforms,
-            contentId,
-            missingPlatforms,
-          },
-          error: `Missing connected accounts for: ${missingPlatforms.join(', ')}.`,
-          success: false,
-        };
-      }
-
-      const baseContent = this.resolvePublishBaseContent(caption, ingredient);
-      const sourceActionId = this.readOptionalString(params.sourceActionId);
-      const idempotencyKey = this.buildAgentPublishIdempotencyKey({
-        baseContent,
+      return this.publishHandler.publishConfirmedContent({
+        caption,
         contentId,
-        organizationId: ctx.organizationId,
+        credentials,
+        ctx,
+        ingredient,
         platforms,
         scheduledAt,
-        sourceActionId,
-        threadId: ctx.threadId,
-        userId: ctx.userId,
+        sourceActionId: this.readOptionalString(params.sourceActionId),
       });
-      const mediaKind = this.resolveReleaseMediaKind(ingredient.category);
-      const release = await this.postGroupsService.create(
-        ctx.organizationId,
-        ctx.userId,
-        {
-          baseContent,
-          brandId: String(ingredient.brand),
-          idempotencyKey,
-          media: [
-            {
-              assetId: contentId,
-              ...(mediaKind ? { kind: mediaKind } : {}),
-            },
-          ],
-          ...(scheduledAt
-            ? {
-                scheduledDate: scheduledAt,
-                status: ReleaseStatus.SCHEDULED,
-              }
-            : { status: ReleaseStatus.DRAFT }),
-          targets: credentials.map((credential, order) => ({
-            credentialId: String(credential.id),
-            order,
-            platform: credential.platform as CredentialPlatform,
-            ...(scheduledAt ? { scheduledDate: scheduledAt } : {}),
-          })),
-          timezone: 'UTC',
-          title: baseContent.slice(0, 100),
-        },
-        idempotencyKey,
-        {
-          agentContextSource: ctx.validatedScope?.source,
-          agentContextVersion: ctx.validatedScope?.contextVersion,
-          agentRunId: ctx.runId,
-          agentStrategyId: ctx.strategyId,
-          agentThreadId: ctx.validatedScope?.threadId,
-          source: 'agent',
-          sourceActionId,
-        },
-      );
-      const canonicalRelease = scheduledAt
-        ? release
-        : await this.postGroupsService.publishNow(
-            ctx.organizationId,
-            ctx.userId,
-            release.id,
-          );
-      const groupId = canonicalRelease.id;
-      const postIds = (canonicalRelease.targets ?? []).map((target) =>
-        String(target.id),
-      );
-
-      const description = scheduledAt
-        ? `Scheduled ${postIds.length} post${postIds.length === 1 ? '' : 's'} for ${createdPlatforms.join(', ')}.`
-        : `Queued ${postIds.length} post${postIds.length === 1 ? '' : 's'} for publishing on ${createdPlatforms.join(', ')}.`;
-
-      return {
-        creditsUsed: 0,
-        data: {
-          contentId,
-          createdPlatforms,
-          missingPlatforms,
-          postIds,
-          scheduledAt,
-          totalCreated: postIds.length,
-        },
-        nextActions: [
-          {
-            ctas: [
-              { href: '/content/posts', label: 'Open posts' },
-              ...(postIds[0]
-                ? [
-                    {
-                      href: `/analytics/posts?postId=${postIds[0]}`,
-                      label: 'Open analytics',
-                    },
-                  ]
-                : []),
-            ],
-            description,
-            id: `published-posts-${groupId}`,
-            title: scheduledAt ? 'Posts scheduled' : 'Posts queued',
-            type: 'content_preview_card' as const,
-          },
-        ],
-        success: true,
-      };
     }
 
     await this.assertPublishingScope(
@@ -4530,64 +4404,6 @@ export class AgentToolExecutorService {
       },
       success: true,
     };
-  }
-
-  private buildAgentPublishIdempotencyKey(input: {
-    baseContent: string;
-    contentId: string;
-    organizationId: string;
-    platforms: string[];
-    scheduledAt?: string;
-    sourceActionId?: string;
-    threadId?: string;
-    userId: string;
-  }): string {
-    const digest = createHash('sha256')
-      .update(
-        JSON.stringify({
-          ...input,
-          platforms: [...input.platforms].sort(),
-        }),
-      )
-      .digest('hex');
-    return `agent-publish:${digest}`;
-  }
-
-  private resolvePublishBaseContent(
-    caption: string | undefined,
-    ingredient: Record<string, unknown>,
-  ): string {
-    const candidates = [
-      caption,
-      this.readOptionalString(ingredient.label),
-      this.readOptionalString(ingredient.description),
-      this.readOptionalString(ingredient.assetLabel),
-      this.readOptionalString(ingredient.generationPrompt),
-    ];
-    const resolved = candidates.find((candidate) => Boolean(candidate?.trim()));
-    if (resolved) {
-      return resolved.trim();
-    }
-
-    const category = this.readOptionalString(ingredient.category) ?? 'content';
-    return `Selected ${category} asset`;
-  }
-
-  private resolveReleaseMediaKind(category: unknown): string | undefined {
-    if (
-      category === IngredientCategory.IMAGE ||
-      category === IngredientCategory.IMAGE_EDIT ||
-      category === IngredientCategory.GIF
-    ) {
-      return 'image';
-    }
-    if (
-      category === IngredientCategory.VIDEO ||
-      category === IngredientCategory.VIDEO_EDIT
-    ) {
-      return 'video';
-    }
-    return undefined;
   }
 
   private async schedulePost(

--- a/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts
+++ b/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts
@@ -4316,19 +4316,18 @@ export class AgentToolExecutorService {
           success: false,
         };
       }
-      const scheduledAt = scheduledDate?.toISOString();
-
       if (params.confirmed !== true) {
         return this.buildPublishCardResult(
           {
             caption,
             contentId,
             platforms,
-            scheduledAt,
+            scheduledAt: requestedScheduledAt,
           },
           ctx,
         );
       }
+      const scheduledAt = scheduledDate?.toISOString();
 
       const ingredient = await this.resolveIngredientForContent(
         contentId,

--- a/packages/agent/src/components/PublishPostCard.spec.tsx
+++ b/packages/agent/src/components/PublishPostCard.spec.tsx
@@ -90,4 +90,28 @@ describe('PublishPostCard', () => {
       sourceActionId: 'publish-card-3',
     });
   });
+
+  it('renders a prefilled ISO schedule as a datetime-local value', () => {
+    const scheduledAt = '2026-07-18T09:00:00.000Z';
+    const scheduledDate = new Date(scheduledAt);
+    const pad = (part: number): string => String(part).padStart(2, '0');
+    const expectedLocalValue = `${scheduledDate.getFullYear()}-${pad(scheduledDate.getMonth() + 1)}-${pad(scheduledDate.getDate())}T${pad(scheduledDate.getHours())}:${pad(scheduledDate.getMinutes())}`;
+    const action: AgentUiAction = {
+      contentId: 'ingredient-4',
+      data: {
+        availablePlatforms: ['linkedin'],
+      },
+      id: 'publish-card-4',
+      platforms: ['linkedin'],
+      scheduledAt,
+      title: 'Schedule selected content',
+      type: 'publish_post_card',
+    };
+
+    render(<PublishPostCard action={action} />);
+
+    expect(screen.getByLabelText('Schedule for later')).toHaveValue(
+      expectedLocalValue,
+    );
+  });
 });

--- a/packages/agent/src/components/PublishPostCard.spec.tsx
+++ b/packages/agent/src/components/PublishPostCard.spec.tsx
@@ -58,4 +58,36 @@ describe('PublishPostCard', () => {
       screen.getByRole('button', { name: 'Confirm publish' }),
     ).toBeDisabled();
   });
+
+  it('normalizes a browser-local schedule before submitting the confirmed action', async () => {
+    const onUiAction = vi.fn().mockResolvedValue(undefined);
+    const action: AgentUiAction = {
+      contentId: 'ingredient-3',
+      data: {
+        availablePlatforms: ['instagram'],
+      },
+      id: 'publish-card-3',
+      platforms: ['instagram'],
+      title: 'Schedule selected content',
+      type: 'publish_post_card',
+    };
+    const localSchedule = '2026-07-18T09:00';
+
+    render(<PublishPostCard action={action} onUiAction={onUiAction} />);
+
+    fireEvent.change(screen.getByLabelText('Schedule for later'), {
+      target: { value: localSchedule },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Confirm schedule' }));
+    });
+
+    expect(onUiAction).toHaveBeenCalledWith('confirm_publish_post', {
+      caption: undefined,
+      contentId: 'ingredient-3',
+      platforms: ['instagram'],
+      scheduledAt: new Date(localSchedule).toISOString(),
+      sourceActionId: 'publish-card-3',
+    });
+  });
 });

--- a/packages/agent/src/components/PublishPostCard.tsx
+++ b/packages/agent/src/components/PublishPostCard.tsx
@@ -80,11 +80,18 @@ export function PublishPostCard({
     setIsSubmitting(true);
 
     try {
+      const scheduleInput = scheduledAt.trim();
+      const scheduleDate = scheduleInput ? new Date(scheduleInput) : undefined;
+      const normalizedScheduledAt = scheduleDate
+        ? Number.isNaN(scheduleDate.getTime())
+          ? scheduleInput
+          : scheduleDate.toISOString()
+        : undefined;
       await onUiAction('confirm_publish_post', {
         caption: caption.trim() || undefined,
         contentId: action.contentId,
         platforms: selectedPlatforms,
-        scheduledAt: scheduledAt.trim() || undefined,
+        scheduledAt: normalizedScheduledAt,
         sourceActionId: action.id,
       });
       setIsSubmitted(true);

--- a/packages/agent/src/components/PublishPostCard.tsx
+++ b/packages/agent/src/components/PublishPostCard.tsx
@@ -23,6 +23,20 @@ interface PublishPostCardProps {
   ) => void | Promise<void>;
 }
 
+function toDatetimeLocalValue(value: string | undefined): string {
+  if (!value) {
+    return '';
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  const pad = (part: number): string => String(part).padStart(2, '0');
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
 export function PublishPostCard({
   action,
   onUiAction,
@@ -38,7 +52,9 @@ export function PublishPostCard({
       : availablePlatforms;
 
   const [caption, setCaption] = useState(action.textContent ?? '');
-  const [scheduledAt, setScheduledAt] = useState(action.scheduledAt ?? '');
+  const [scheduledAt, setScheduledAt] = useState(() =>
+    toDatetimeLocalValue(action.scheduledAt),
+  );
   const [selectedPlatforms, setSelectedPlatforms] =
     useState<string[]>(initialPlatforms);
   const [isSubmitting, setIsSubmitting] = useState(false);

--- a/packages/interfaces/src/ai/agent-publish.interface.ts
+++ b/packages/interfaces/src/ai/agent-publish.interface.ts
@@ -1,0 +1,37 @@
+import type { ValidatedAgentScope } from './agent-scope-context.interface';
+
+export interface AgentPublishCredential {
+  id?: unknown;
+  platform?: unknown;
+}
+
+export interface AgentPublishContext {
+  organizationId: string;
+  runId?: string;
+  strategyId?: string;
+  threadId?: string;
+  userId: string;
+  validatedScope?: ValidatedAgentScope;
+}
+
+export interface PublishConfirmedContentInput {
+  caption?: string;
+  contentId: string;
+  credentials: AgentPublishCredential[];
+  ctx: AgentPublishContext;
+  ingredient: Record<string, unknown>;
+  platforms: string[];
+  scheduledAt?: string;
+  sourceActionId: string;
+}
+
+export interface AgentPublishIdempotencyInput {
+  baseContent: string;
+  contentId: string;
+  organizationId: string;
+  platforms: string[];
+  scheduledAt?: string;
+  sourceActionId: string;
+  threadId?: string;
+  userId: string;
+}

--- a/packages/interfaces/src/ai/index.ts
+++ b/packages/interfaces/src/ai/index.ts
@@ -1,3 +1,4 @@
+export * from './agent-publish.interface';
 export * from './agent-ui-block.interface';
 export * from './harness-pack-registry.interface';
 export * from './resolved-runtime-skill.interface';

--- a/packages/interfaces/src/index.ts
+++ b/packages/interfaces/src/index.ts
@@ -4,6 +4,7 @@ export * from './admin/fleet.interface';
 export * from './admin/warmup-accounts.interface';
 export * from './ai/agent-artifact-reference.interface';
 export * from './ai/agent-campaign.interface';
+export * from './ai/agent-publish.interface';
 export * from './ai/agent-run.interface';
 export * from './ai/agent-scope-context.interface';
 export * from './ai/agent-strategy.interface';

--- a/packages/interfaces/src/scheduler/release-group.interface.ts
+++ b/packages/interfaces/src/scheduler/release-group.interface.ts
@@ -30,6 +30,17 @@ export type IReleaseTargetSummary = Partial<
   total: number;
 };
 
+/** Agent-side attribution persisted with every post target in a release. */
+export interface PostGroupCreateProvenance {
+  agentContextSource?: string;
+  agentContextVersion?: number;
+  agentRunId?: string;
+  agentStrategyId?: string;
+  agentThreadId?: string;
+  source?: string;
+  sourceActionId?: string;
+}
+
 /**
  * The canonical scheduler domain object: one composed piece of content and its
  * fan-out across channels. A single serialized `IReleaseGroup` is designed to


### PR DESCRIPTION
## Summary
- route confirmed agent media publishing through the canonical release-group scheduler
- create immediate releases as draft and invoke `publishNow`; create future releases as scheduled without early enqueue
- persist agent scope/provenance on canonical target posts and return canonical target IDs
- fail before creating a release when requested platforms are disconnected
- derive deterministic idempotency from the confirmed UI action plus normalized publish intent
- normalize browser-local schedule values before the backend scheduler contract

## Verification
- Biome error-level check passed for all seven touched files
- `git diff --check` passed
- staged gitleaks and commit secretlint passed
- focused runtime tests added for immediate, scheduled, disconnected-target, UI-action retry, fallback retry-key, persisted provenance, and browser-local schedule normalization
- local tests/typechecks/builds were not run per workstation policy; PR CI is the execution gate

## Bounded follow-up
The separate `schedule_post` tool still mutates a legacy standalone Post using only `postId` + date. It cannot safely adopt the canonical release domain without a credential/platform/release-group migration contract, and duplicating publish-approval logic here would violate the scheduler boundary. This PR leaves that path unchanged and documents it for a dedicated fail-closed migration.

Closes #1809