### PR TITLE
fix(agent): bind scheduled posts to approvals

### DIFF
--- a/apps/server/api/src/collections/post-groups/services/post-groups.service.spec.ts
+++ b/apps/server/api/src/collections/post-groups/services/post-groups.service.spec.ts
@@ -35,6 +35,12 @@ type MockPostGroup = {
 };
 
 type MockPostTarget = {
+  agentContextSource: string | null;
+  agentContextVersion: number | null;
+  agentRunId: string | null;
+  agentStrategyId: string | null;
+  agentThreadId: string | null;
+  brandId: string | null;
   createdAt: Date;
   credentialId: string;
   externalId: string | null;
@@ -412,6 +418,401 @@ describe('PostGroupsService', () => {
     );
   });
 
+  it('schedules a canonical target with a version-bound approval in the same transaction', async () => {
+    const scheduledAt = '2026-07-09T12:00:00.000Z';
+    prisma.postGroup.findFirst.mockResolvedValue(
+      makeGroup({ id: 'group-1', status: ReleaseStatus.DRAFT }),
+    );
+    prisma.post.findFirst.mockResolvedValue(
+      makeTarget({
+        agentContextSource: null,
+        agentContextVersion: null,
+        agentThreadId: null,
+        groupId: 'group-1',
+        id: 'target-1',
+        publishApproval: null,
+        publishApprovalId: null,
+        scheduledDate: null,
+        targetExecutionState: TargetExecutionState.DRAFT,
+      }),
+    );
+    prisma.post.findMany.mockResolvedValue([
+      makeTarget({
+        agentContextSource: 'explicit',
+        agentContextVersion: 3,
+        agentThreadId: 'thread-1',
+        groupId: 'group-1',
+        id: 'target-1',
+        scheduledDate: new Date(scheduledAt),
+        targetExecutionState: TargetExecutionState.SCHEDULED,
+      }),
+    ]);
+    prisma.postGroup.update.mockImplementation(({ data }) =>
+      Promise.resolve(
+        makeGroup({
+          id: 'group-1',
+          status: data.status,
+          statusTransitions: data.statusTransitions,
+        }),
+      ),
+    );
+
+    const result = await service.scheduleTarget(
+      'org-1',
+      'user-1',
+      'group-1',
+      'target-1',
+      scheduledAt,
+      {
+        agentContextSource: 'explicit',
+        agentContextVersion: 3,
+        agentThreadId: 'thread-1',
+      },
+    );
+
+    expect(prisma.post.updateMany).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        agentContextSource: 'explicit',
+        agentContextVersion: 3,
+        agentThreadId: 'thread-1',
+        scheduledDate: new Date(scheduledAt),
+        status: TargetExecutionState.SCHEDULED,
+        targetExecutionState: TargetExecutionState.SCHEDULED,
+        targetValidationState: TargetValidationState.VALID,
+      }),
+      where: {
+        groupId: 'group-1',
+        id: 'target-1',
+        isDeleted: false,
+        organizationId: 'org-1',
+        targetExecutionState: TargetExecutionState.DRAFT,
+        updatedAt: now,
+      },
+    });
+    expect(publishApprovalsService.createForCurrentPost).toHaveBeenCalledWith({
+      actorUserId: 'user-1',
+      contextVersion: 3,
+      mode: 'scheduled',
+      organizationId: 'org-1',
+      postId: 'target-1',
+      provenance: {
+        releaseId: 'group-1',
+        surface: 'agent-schedule-post',
+      },
+      transaction: prisma,
+    });
+    expect(postPublishQueueService.enqueue).not.toHaveBeenCalled();
+    expect(result.status).toBe(ReleaseStatus.SCHEDULED);
+    expect(result.targets?.[0]).toEqual(
+      expect.objectContaining({
+        id: 'target-1',
+        scheduledAt,
+      }),
+    );
+  });
+
+  it('replays an exact canonical schedule without mutating the target or creating a second queue job', async () => {
+    const scheduledAt = '2026-07-09T12:00:00.000Z';
+    const target = makeTarget({
+      agentContextSource: 'explicit',
+      agentContextVersion: 3,
+      agentThreadId: 'thread-1',
+      groupId: 'group-1',
+      id: 'target-1',
+      scheduledDate: new Date(scheduledAt),
+      targetExecutionState: TargetExecutionState.SCHEDULED,
+    });
+    prisma.postGroup.findFirst.mockResolvedValue(
+      makeGroup({ id: 'group-1', status: ReleaseStatus.SCHEDULED }),
+    );
+    prisma.post.findFirst.mockResolvedValue(target);
+    prisma.post.findMany.mockResolvedValue([target]);
+    prisma.postGroup.update.mockImplementation(({ data }) =>
+      Promise.resolve(
+        makeGroup({
+          id: 'group-1',
+          status: data.status,
+          statusTransitions: data.statusTransitions,
+        }),
+      ),
+    );
+
+    await service.scheduleTarget(
+      'org-1',
+      'user-1',
+      'group-1',
+      'target-1',
+      scheduledAt,
+      {
+        agentContextSource: 'explicit',
+        agentContextVersion: 3,
+        agentThreadId: 'thread-1',
+      },
+    );
+
+    expect(prisma.post.updateMany).not.toHaveBeenCalled();
+    expect(publishApprovalsService.createForCurrentPost).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(postPublishQueueService.enqueue).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid schedule destination scope before durable mutation', async () => {
+    prisma.postGroup.findFirst.mockResolvedValue(
+      makeGroup({ id: 'group-1', status: ReleaseStatus.DRAFT }),
+    );
+    prisma.post.findFirst.mockResolvedValue(
+      makeTarget({
+        groupId: 'group-1',
+        id: 'target-1',
+        targetExecutionState: TargetExecutionState.DRAFT,
+      }),
+    );
+    prisma.credential.findMany.mockResolvedValue([]);
+
+    await expect(
+      service.scheduleTarget(
+        'org-1',
+        'user-1',
+        'group-1',
+        'target-1',
+        '2026-07-09T12:00:00.000Z',
+      ),
+    ).rejects.toThrow(BadRequestException);
+
+    expect(prisma.post.updateMany).not.toHaveBeenCalled();
+    expect(prisma.postGroup.update).not.toHaveBeenCalled();
+    expect(publishApprovalsService.createForCurrentPost).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unsupported canonical target platform before durable mutation', async () => {
+    prisma.postGroup.findFirst.mockResolvedValue(
+      makeGroup({ id: 'group-1', status: ReleaseStatus.DRAFT }),
+    );
+    prisma.post.findFirst.mockResolvedValue(
+      makeTarget({
+        groupId: 'group-1',
+        id: 'target-1',
+        platform: 'unsupported-platform',
+        targetExecutionState: TargetExecutionState.DRAFT,
+      }),
+    );
+
+    await expect(
+      service.scheduleTarget(
+        'org-1',
+        'user-1',
+        'group-1',
+        'target-1',
+        '2026-07-09T12:00:00.000Z',
+      ),
+    ).rejects.toThrow('not supported');
+
+    expect(prisma.credential.findMany).not.toHaveBeenCalled();
+    expect(prisma.post.updateMany).not.toHaveBeenCalled();
+    expect(publishApprovalsService.createForCurrentPost).not.toHaveBeenCalled();
+  });
+
+  it('rejects a disconnected canonical target credential before durable mutation', async () => {
+    prisma.postGroup.findFirst.mockResolvedValue(
+      makeGroup({ id: 'group-1', status: ReleaseStatus.DRAFT }),
+    );
+    prisma.post.findFirst.mockResolvedValue(
+      makeTarget({
+        groupId: 'group-1',
+        id: 'target-1',
+        targetExecutionState: TargetExecutionState.DRAFT,
+      }),
+    );
+    prisma.credential.findMany.mockResolvedValue([
+      {
+        brandId: 'brand-1',
+        id: 'cred-x',
+        isConnected: false,
+        organizationId: 'org-1',
+        platform: CredentialPlatform.TWITTER,
+      },
+    ]);
+
+    await expect(
+      service.scheduleTarget(
+        'org-1',
+        'user-1',
+        'group-1',
+        'target-1',
+        '2026-07-09T12:00:00.000Z',
+      ),
+    ).rejects.toThrow('not connected');
+
+    expect(prisma.post.updateMany).not.toHaveBeenCalled();
+    expect(publishApprovalsService.createForCurrentPost).not.toHaveBeenCalled();
+  });
+
+  it('rejects a canonical target without a valid release brand before durable mutation', async () => {
+    prisma.postGroup.findFirst.mockResolvedValue(
+      makeGroup({
+        brandId: null,
+        id: 'group-1',
+        status: ReleaseStatus.DRAFT,
+      }),
+    );
+    prisma.post.findFirst.mockResolvedValue(
+      makeTarget({
+        groupId: 'group-1',
+        id: 'target-1',
+        targetExecutionState: TargetExecutionState.DRAFT,
+      }),
+    );
+
+    await expect(
+      service.scheduleTarget(
+        'org-1',
+        'user-1',
+        'group-1',
+        'target-1',
+        '2026-07-09T12:00:00.000Z',
+      ),
+    ).rejects.toThrow('missing a brand assignment');
+
+    expect(prisma.credential.findMany).not.toHaveBeenCalled();
+    expect(prisma.post.updateMany).not.toHaveBeenCalled();
+    expect(publishApprovalsService.createForCurrentPost).not.toHaveBeenCalled();
+  });
+
+  it('rejects a target whose brand differs from its canonical release', async () => {
+    prisma.postGroup.findFirst.mockResolvedValue(
+      makeGroup({ brandId: 'brand-1', id: 'group-1' }),
+    );
+    prisma.post.findFirst.mockResolvedValue(
+      makeTarget({
+        brandId: 'brand-2',
+        groupId: 'group-1',
+        id: 'target-1',
+        targetExecutionState: TargetExecutionState.DRAFT,
+      }),
+    );
+
+    await expect(
+      service.scheduleTarget(
+        'org-1',
+        'user-1',
+        'group-1',
+        'target-1',
+        '2026-07-09T12:00:00.000Z',
+      ),
+    ).rejects.toThrow('does not match its canonical release');
+
+    expect(prisma.credential.findMany).not.toHaveBeenCalled();
+    expect(prisma.post.updateMany).not.toHaveBeenCalled();
+    expect(publishApprovalsService.createForCurrentPost).not.toHaveBeenCalled();
+  });
+
+  it('rejects a stale target write before binding an approval', async () => {
+    prisma.postGroup.findFirst.mockResolvedValue(
+      makeGroup({ id: 'group-1', status: ReleaseStatus.DRAFT }),
+    );
+    prisma.post.findFirst.mockResolvedValue(
+      makeTarget({
+        groupId: 'group-1',
+        id: 'target-1',
+        targetExecutionState: TargetExecutionState.DRAFT,
+      }),
+    );
+    prisma.post.updateMany.mockResolvedValue({ count: 0 });
+
+    await expect(
+      service.scheduleTarget(
+        'org-1',
+        'user-1',
+        'group-1',
+        'target-1',
+        '2026-07-09T12:00:00.000Z',
+      ),
+    ).rejects.toThrow('changed while scheduling');
+
+    expect(prisma.post.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          groupId: 'group-1',
+          id: 'target-1',
+          isDeleted: false,
+          organizationId: 'org-1',
+          targetExecutionState: TargetExecutionState.DRAFT,
+          updatedAt: now,
+        }),
+      }),
+    );
+    expect(publishApprovalsService.createForCurrentPost).not.toHaveBeenCalled();
+  });
+
+  it('keeps target mutation and approval binding in one rollback boundary', async () => {
+    prisma.postGroup.findFirst.mockResolvedValue(
+      makeGroup({ id: 'group-1', status: ReleaseStatus.DRAFT }),
+    );
+    prisma.post.findFirst.mockResolvedValue(
+      makeTarget({
+        groupId: 'group-1',
+        id: 'target-1',
+        scheduledDate: null,
+        targetExecutionState: TargetExecutionState.DRAFT,
+      }),
+    );
+    publishApprovalsService.createForCurrentPost.mockRejectedValue(
+      new Error('Version pin creation failed'),
+    );
+
+    await expect(
+      service.scheduleTarget(
+        'org-1',
+        'user-1',
+        'group-1',
+        'target-1',
+        '2026-07-09T12:00:00.000Z',
+      ),
+    ).rejects.toThrow('Version pin creation failed');
+
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+    expect(prisma.post.updateMany).toHaveBeenCalledTimes(1);
+    expect(publishApprovalsService.createForCurrentPost).toHaveBeenCalledWith(
+      expect.objectContaining({ transaction: prisma }),
+    );
+    expect(prisma.postGroup.update).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid and past schedule timestamps before querying or mutation', async () => {
+    await expect(
+      service.scheduleTarget(
+        'org-1',
+        'user-1',
+        'group-1',
+        'target-1',
+        'not-a-date',
+      ),
+    ).rejects.toThrow('valid ISO 8601');
+    await expect(
+      service.scheduleTarget(
+        'org-1',
+        'user-1',
+        'group-1',
+        'target-1',
+        '2026-07-08T22:25:13.000Z',
+      ),
+    ).rejects.toThrow('must be in the future');
+    await expect(
+      service.scheduleTarget(
+        'org-1',
+        'user-1',
+        'group-1',
+        'target-1',
+        '2026-07-09T12:00:00',
+      ),
+    ).rejects.toThrow('explicit UTC offset');
+
+    expect(prisma.postGroup.findFirst).not.toHaveBeenCalled();
+    expect(prisma.post.updateMany).not.toHaveBeenCalled();
+    expect(publishApprovalsService.createForCurrentPost).not.toHaveBeenCalled();
+  });
+
   it('pauses eligible targets and rolls the group up to paused', async () => {
     prisma.postGroup.findFirst.mockResolvedValue(
       makeGroup({ id: 'group-1', status: ReleaseStatus.SCHEDULED }),
@@ -609,6 +1010,12 @@ function makeGroup(overrides: Partial<MockPostGroup> = {}): MockPostGroup {
 
 function makeTarget(overrides: Partial<MockPostTarget> = {}): MockPostTarget {
   return {
+    agentContextSource: null,
+    agentContextVersion: null,
+    agentRunId: null,
+    agentStrategyId: null,
+    agentThreadId: null,
+    brandId: 'brand-1',
     createdAt: new Date('2026-07-08T22:25:13.000Z'),
     credentialId: 'cred-x',
     externalId: null,

--- a/apps/server/api/src/collections/post-groups/services/post-groups.service.ts
+++ b/apps/server/api/src/collections/post-groups/services/post-groups.service.ts
@@ -44,7 +44,7 @@ import {
   ConflictException,
   Injectable,
 } from '@nestjs/common';
-import type { ZodError } from 'zod';
+import { type ZodError, z } from 'zod';
 
 type SchedulerTx = Prisma.TransactionClient;
 
@@ -78,6 +78,12 @@ type SchedulerPostGroup = {
 };
 
 type SchedulerPostTarget = {
+  agentContextSource: string | null;
+  agentContextVersion: number | null;
+  agentRunId: string | null;
+  agentStrategyId: string | null;
+  agentThreadId: string | null;
+  brandId: string | null;
   createdAt: Date;
   credentialId: string;
   externalId: string | null;
@@ -115,11 +121,19 @@ const CREATE_ALLOWED_STATUSES = new Set<string>([
   ReleaseStatus.SCHEDULED,
 ]);
 
+const STRICT_SCHEDULE_DATE_SCHEMA = z.string().datetime({ offset: true });
+
 const GROUP_ACTION_STATES = new Set<string>([
   TargetExecutionState.DRAFT,
   TargetExecutionState.SCHEDULED,
   TargetExecutionState.PAUSED,
   TargetExecutionState.FAILED,
+]);
+
+const SCHEDULABLE_TARGET_STATES = new Set<string>([
+  TargetExecutionState.DRAFT,
+  TargetExecutionState.PAUSED,
+  TargetExecutionState.SCHEDULED,
 ]);
 
 @Injectable()
@@ -304,6 +318,132 @@ export class PostGroupsService {
       group.id,
     );
     return this.toReleaseGroup(group, targets);
+  }
+
+  async scheduleTarget(
+    organizationId: string,
+    userId: string,
+    groupId: string,
+    targetId: string,
+    scheduledAt: string,
+    provenance?: PostGroupCreateProvenance,
+  ): Promise<IReleaseGroup> {
+    const scheduledDate = this.parseFutureScheduleDate(scheduledAt);
+
+    return this.prisma.$transaction(async (tx) => {
+      const group = await this.getGroupOrThrow(tx, organizationId, groupId);
+      const target = await this.getTargetOrThrow(
+        tx,
+        organizationId,
+        group.id,
+        targetId,
+      );
+
+      if (!SCHEDULABLE_TARGET_STATES.has(target.targetExecutionState)) {
+        throw new ConflictException(
+          `Channel target cannot be scheduled from ${target.targetExecutionState}.`,
+        );
+      }
+      if (!group.brandId) {
+        throw new BadRequestException(
+          'Canonical release target is missing a brand assignment.',
+        );
+      }
+      if (target.brandId !== group.brandId) {
+        throw new BadRequestException(
+          'Channel target brand does not match its canonical release.',
+        );
+      }
+
+      const platform = this.parseCredentialPlatform(target.platform);
+      const targetInput: ChannelTargetInput = {
+        credentialId: target.credentialId,
+        platform,
+        scheduledDate: scheduledDate.toISOString(),
+        settings: this.asRecord(target.targetSettings),
+        timezone: target.timezone,
+      };
+      const credentials = await this.resolveCredentials(tx, organizationId, [
+        targetInput,
+      ]);
+      await this.resolveBrandId(tx, organizationId, group.brandId, credentials);
+
+      const validation = validateChannelTargetSettings({
+        caption: group.baseContent,
+        credentialId: targetInput.credentialId,
+        media: this.toValidationMedia(this.asMedia(group.media)),
+        platform: targetInput.platform,
+        publishMode: 'scheduled',
+        settings: targetInput.settings ?? {},
+      });
+      if (!validation.valid) {
+        throw this.invalidTargetException(targetInput, validation);
+      }
+
+      const isExactReplay =
+        target.targetExecutionState === TargetExecutionState.SCHEDULED &&
+        target.scheduledDate?.getTime() === scheduledDate.getTime() &&
+        this.matchesScheduleProvenance(target, provenance);
+      if (!isExactReplay) {
+        const updated = await tx.post.updateMany({
+          data: {
+            ...(provenance?.agentContextSource && {
+              agentContextSource: provenance.agentContextSource,
+            }),
+            ...(provenance?.agentContextVersion !== undefined && {
+              agentContextVersion: provenance.agentContextVersion,
+            }),
+            ...(provenance?.agentRunId && {
+              agentRunId: provenance.agentRunId,
+            }),
+            ...(provenance?.agentStrategyId && {
+              agentStrategyId: provenance.agentStrategyId,
+            }),
+            ...(provenance?.agentThreadId && {
+              agentThreadId: provenance.agentThreadId,
+            }),
+            scheduledDate,
+            status: PostStatus.SCHEDULED,
+            targetExecutionState: TargetExecutionState.SCHEDULED,
+            targetReadiness: validation.readiness
+              ? this.toJson(validation.readiness)
+              : Prisma.JsonNull,
+            targetValidationIssues: this.validationIssues(validation),
+            targetValidationState: validation.validationState,
+          },
+          where: {
+            groupId: group.id,
+            id: target.id,
+            isDeleted: false,
+            organizationId,
+            targetExecutionState: target.targetExecutionState,
+            updatedAt: target.updatedAt,
+          },
+        });
+        if (updated.count !== 1) {
+          throw new ConflictException(
+            'Channel target changed while scheduling. Refresh and retry.',
+          );
+        }
+      }
+
+      await this.publishApprovalsService.createForCurrentPost({
+        actorUserId: userId,
+        ...(provenance?.agentContextVersion !== undefined && {
+          contextVersion: provenance.agentContextVersion,
+        }),
+        mode: 'scheduled',
+        organizationId,
+        postId: target.id,
+        provenance: {
+          releaseId: group.id,
+          surface: 'agent-schedule-post',
+        },
+        transaction: tx,
+      });
+
+      return this.recalculateAndHydrate(tx, organizationId, group.id, userId);
+    });
   }
 
   async update(
@@ -1323,6 +1463,49 @@ export class PostGroupsService {
       return PostStatus.PUBLIC;
     }
     return status;
+  }
+
+  private parseCredentialPlatform(value: string): CredentialPlatform {
+    const platform = Object.values(CredentialPlatform).find(
+      (candidate) => candidate === value.toLowerCase(),
+    );
+    if (!platform) {
+      throw new BadRequestException(
+        `Channel target platform ${value} is not supported.`,
+      );
+    }
+    return platform;
+  }
+
+  private matchesScheduleProvenance(
+    target: SchedulerPostTarget,
+    provenance: PostGroupCreateProvenance | undefined,
+  ): boolean {
+    return (
+      (provenance?.agentContextSource === undefined ||
+        target.agentContextSource === provenance.agentContextSource) &&
+      (provenance?.agentContextVersion === undefined ||
+        target.agentContextVersion === provenance.agentContextVersion) &&
+      (provenance?.agentRunId === undefined ||
+        target.agentRunId === provenance.agentRunId) &&
+      (provenance?.agentStrategyId === undefined ||
+        target.agentStrategyId === provenance.agentStrategyId) &&
+      (provenance?.agentThreadId === undefined ||
+        target.agentThreadId === provenance.agentThreadId)
+    );
+  }
+
+  private parseFutureScheduleDate(value: string): Date {
+    if (!STRICT_SCHEDULE_DATE_SCHEMA.safeParse(value).success) {
+      throw new BadRequestException(
+        'scheduledAt must be a valid ISO 8601 date and time with an explicit UTC offset.',
+      );
+    }
+    const date = new Date(value);
+    if (date.getTime() <= Date.now()) {
+      throw new BadRequestException('scheduledAt must be in the future.');
+    }
+    return date;
   }
 
   private toDate(value: string | undefined | null): Date | null {

--- a/apps/server/api/src/collections/posts/entities/post.entity.ts
+++ b/apps/server/api/src/collections/posts/entities/post.entity.ts
@@ -24,9 +24,11 @@ export interface PostAnalyticsSummary {
 export class PostEntity extends BaseEntity {
   declare readonly ingredients: string[];
   declare readonly credential: string;
+  declare readonly brandId: string;
   declare readonly user: string;
   declare readonly brand: string;
   declare readonly organization: string;
+  declare readonly groupId?: string | null;
   declare readonly children?: string[];
   declare readonly agentContextSource?: string;
   declare readonly agentContextVersion?: number;

--- a/apps/server/api/src/collections/publish-approvals/services/publish-approvals.service.spec.ts
+++ b/apps/server/api/src/collections/publish-approvals/services/publish-approvals.service.spec.ts
@@ -210,6 +210,68 @@ describe('PublishApprovalsService', () => {
     });
   });
 
+  it('reuses the exact scheduled approval scope without creating duplicate approval or operation identities', async () => {
+    const post = makePost({ publishApprovalId: 'approval-1' });
+    const existing = makeApproval({
+      scopeDigest: scopeDigest(),
+      status: PublishApprovalStatus.APPROVED,
+    });
+    const publishApproval = {
+      create: vi.fn(),
+      findFirst: vi.fn().mockResolvedValue(existing),
+      findMany: vi.fn(),
+      update: vi.fn(),
+      updateMany: vi.fn(),
+    };
+    const prisma = {
+      post: {
+        findFirst: vi.fn().mockResolvedValue(post),
+        update: vi.fn().mockResolvedValue(post),
+      },
+      publishApproval,
+    };
+    const artifactReferenceService = {
+      createOrReuseVersionPin: vi.fn().mockResolvedValue({ id: 'pin-1' }),
+    };
+    const service = new PublishApprovalsService(
+      prisma as never,
+      artifactReferenceService as unknown as AgentArtifactReferenceService,
+    );
+    const transaction = { post: prisma.post, publishApproval };
+
+    const first = await service.createForCurrentPost({
+      actorUserId: 'user-1',
+      contextVersion: 4,
+      mode: 'scheduled',
+      organizationId: 'org-1',
+      postId: 'post-1',
+      transaction: transaction as never,
+    });
+    const replay = await service.createForCurrentPost({
+      actorUserId: 'user-1',
+      contextVersion: 4,
+      mode: 'scheduled',
+      organizationId: 'org-1',
+      postId: 'post-1',
+      transaction: transaction as never,
+    });
+
+    expect(first.id).toBe('approval-1');
+    expect(replay.id).toBe(first.id);
+    expect(replay.operationId).toBe(first.operationId);
+    expect(publishApproval.create).not.toHaveBeenCalled();
+    expect(publishApproval.update).not.toHaveBeenCalled();
+    expect(prisma.post.update).toHaveBeenCalledTimes(2);
+    expect(prisma.post.update).toHaveBeenNthCalledWith(2, {
+      data: {
+        publishApprovalId: 'approval-1',
+        reviewDecision: 'APPROVED',
+        reviewVersionPinId: 'pin-1',
+      },
+      where: { id: 'post-1' },
+    });
+  });
+
   it('fails closed and invalidates when the canonical brand drifts', async () => {
     const approval = makeApproval();
     const publishApproval = {

--- a/apps/server/api/src/services/agent-orchestrator/tools/agent-publish-tool-handler.service.ts
+++ b/apps/server/api/src/services/agent-orchestrator/tools/agent-publish-tool-handler.service.ts
@@ -4,13 +4,15 @@ import {
   CredentialPlatform,
   IngredientCategory,
   ReleaseStatus,
+  TargetExecutionState,
 } from '@genfeedai/enums';
 import type {
   AgentPublishIdempotencyInput,
   AgentToolResult,
   PublishConfirmedContentInput,
+  ScheduleCanonicalPostInput,
 } from '@genfeedai/interfaces';
-import { Injectable } from '@nestjs/common';
+import { ConflictException, Injectable } from '@nestjs/common';
 
 /**
  * Routes confirmed agent publishing through the canonical release scheduler.
@@ -20,6 +22,55 @@ import { Injectable } from '@nestjs/common';
 @Injectable()
 export class AgentPublishToolHandler {
   constructor(private readonly postGroupsService: PostGroupsService) {}
+
+  async scheduleCanonicalPost(
+    input: ScheduleCanonicalPostInput,
+  ): Promise<AgentToolResult> {
+    const release = await this.postGroupsService.scheduleTarget(
+      input.ctx.organizationId,
+      input.ctx.userId,
+      input.groupId,
+      input.postId,
+      input.scheduledAt,
+      {
+        agentContextSource: input.ctx.validatedScope?.source,
+        agentContextVersion: input.ctx.validatedScope?.contextVersion,
+        agentRunId: input.ctx.runId,
+        agentStrategyId: input.ctx.strategyId,
+        agentThreadId: input.ctx.validatedScope?.threadId,
+      },
+    );
+    const target = release.targets?.find(
+      (candidate) => candidate.id === input.postId,
+    );
+    if (!target || target.executionState !== TargetExecutionState.SCHEDULED) {
+      throw new ConflictException(
+        'Canonical scheduler did not return the scheduled release target.',
+      );
+    }
+
+    return {
+      creditsUsed: 1,
+      data: {
+        id: input.postId,
+        releaseId: release.id,
+        scheduledAt: target.scheduledAt ?? input.scheduledAt,
+        status: target.executionState,
+      },
+      nextActions: [
+        {
+          ctas: [{ href: '/content/posts', label: 'Open posts' }],
+          description:
+            'The canonical release target is approval-backed and will enter the normal publish queue when due.',
+          id: `scheduled-post-${input.postId}`,
+          scheduledAt: target.scheduledAt ?? input.scheduledAt,
+          title: 'Post scheduled',
+          type: 'schedule_post_card',
+        },
+      ],
+      success: true,
+    };
+  }
 
   async publishConfirmedContent(
     input: PublishConfirmedContentInput,

--- a/apps/server/api/src/services/agent-orchestrator/tools/agent-schedule-error.util.ts
+++ b/apps/server/api/src/services/agent-orchestrator/tools/agent-schedule-error.util.ts
@@ -1,0 +1,45 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+const SAFE_AGENT_SCHEDULE_VALIDATION_STATUSES = new Set<number>([
+  HttpStatus.BAD_REQUEST,
+  HttpStatus.NOT_FOUND,
+  HttpStatus.CONFLICT,
+  HttpStatus.UNPROCESSABLE_ENTITY,
+]);
+
+export const SAFE_AGENT_SCHEDULE_ERROR =
+  'The canonical release target could not be scheduled safely.';
+
+export function readAgentScheduleValidationError(
+  error: unknown,
+): string | undefined {
+  if (!(error instanceof HttpException)) {
+    return undefined;
+  }
+  if (!SAFE_AGENT_SCHEDULE_VALIDATION_STATUSES.has(error.getStatus())) {
+    return undefined;
+  }
+
+  const response = error.getResponse();
+  if (typeof response === 'string') {
+    return response;
+  }
+  if (!response || typeof response !== 'object' || Array.isArray(response)) {
+    return undefined;
+  }
+
+  const record = response as Record<string, unknown>;
+  if (typeof record.detail === 'string' && record.detail.trim()) {
+    return record.detail;
+  }
+  if (typeof record.message === 'string' && record.message.trim()) {
+    return record.message;
+  }
+  if (Array.isArray(record.message)) {
+    const messages = record.message.filter(
+      (message): message is string => typeof message === 'string',
+    );
+    return messages.length > 0 ? messages.join('; ') : undefined;
+  }
+  return undefined;
+}

--- a/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.spec.ts
+++ b/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.spec.ts
@@ -19,6 +19,10 @@ import type { CreateReleaseGroupInput } from '@api-types/contracts/scheduler.con
 import { PostStatus, ReleaseStatus } from '@genfeedai/enums';
 import { AgentToolName } from '@genfeedai/interfaces';
 import { LoggerService } from '@libs/logger/logger.service';
+import {
+  BadRequestException,
+  InternalServerErrorException,
+} from '@nestjs/common';
 import { Effect } from 'effect';
 import { of } from 'rxjs';
 
@@ -62,6 +66,7 @@ describe('AgentToolExecutorService', () => {
       findAll: vi.fn(),
       findOne: vi.fn(),
       handleYoutubePost: vi.fn(),
+      patch: vi.fn(),
     };
     const postGroupsService = {
       create: vi
@@ -102,6 +107,19 @@ describe('AgentToolExecutorService', () => {
             executionState: 'scheduled',
             id: 'target-2',
             platform: 'youtube',
+          },
+        ],
+      }),
+      scheduleTarget: vi.fn().mockResolvedValue({
+        id: 'release-1',
+        organizationId: '67a123456789012345678901',
+        status: ReleaseStatus.SCHEDULED,
+        targets: [
+          {
+            executionState: 'scheduled',
+            id: 'target-1',
+            platform: 'linkedin',
+            scheduledAt: '2099-07-18T09:00:00.000Z',
           },
         ],
       }),
@@ -953,6 +971,317 @@ describe('AgentToolExecutorService', () => {
         type: 'publish_post_card',
       }),
     ]);
+  });
+
+  it('schedules a canonical release target through the approval-backed scheduler', async () => {
+    const { postGroupsService, postsService, service } = createService();
+    postsService.findOne.mockResolvedValue({
+      brandId: '67a123456789012345678931',
+      groupId: 'release-1',
+      id: 'target-1',
+    });
+
+    const result = await service.executeTool(
+      AgentToolName.SCHEDULE_POST,
+      {
+        postId: 'target-1',
+        scheduledAt: '2099-07-18T09:00:00.000Z',
+      },
+      scopedContext('67a123456789012345678931'),
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        creditsUsed: 1,
+        data: expect.objectContaining({
+          id: 'target-1',
+          releaseId: 'release-1',
+          scheduledAt: '2099-07-18T09:00:00.000Z',
+        }),
+        success: true,
+      }),
+    );
+    expect(postGroupsService.scheduleTarget).toHaveBeenCalledWith(
+      '67a123456789012345678901',
+      '67a123456789012345678902',
+      'release-1',
+      'target-1',
+      '2099-07-18T09:00:00.000Z',
+      expect.objectContaining({
+        agentContextSource: 'explicit',
+        agentContextVersion: 3,
+        agentThreadId: '67a123456789012345678999',
+      }),
+    );
+    expect(postsService.patch).not.toHaveBeenCalled();
+  });
+
+  it('fails closed with a remediation action for a legacy standalone draft', async () => {
+    const { postGroupsService, postsService, service } = createService();
+    postsService.findOne.mockResolvedValue({
+      brandId: '67a123456789012345678931',
+      id: 'legacy-post-1',
+    });
+
+    const result = await service.executeTool(
+      AgentToolName.SCHEDULE_POST,
+      {
+        postId: 'legacy-post-1',
+        scheduledAt: '2099-07-18T09:00:00.000Z',
+      },
+      scopedContext('67a123456789012345678931'),
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          requiredAction: 'create_canonical_release',
+        }),
+        error: expect.stringContaining('legacy standalone draft'),
+        nextActions: [
+          expect.objectContaining({
+            ctas: [{ href: '/content/posts', label: 'Open posts' }],
+            type: 'schedule_post_card',
+          }),
+        ],
+        success: false,
+      }),
+    );
+    expect(postGroupsService.scheduleTarget).not.toHaveBeenCalled();
+    expect(postsService.patch).not.toHaveBeenCalled();
+  });
+
+  it('returns an actionable fail-closed result when canonical scheduling validation rejects', async () => {
+    const { postGroupsService, postsService, service } = createService();
+    postsService.findOne.mockResolvedValue({
+      brandId: '67a123456789012345678931',
+      groupId: 'release-1',
+      id: 'target-1',
+    });
+    postGroupsService.scheduleTarget.mockRejectedValue(
+      new BadRequestException('Credential cred-1 is not connected.'),
+    );
+
+    const result = await service.executeTool(
+      AgentToolName.SCHEDULE_POST,
+      {
+        postId: 'target-1',
+        scheduledAt: '2099-07-18T09:00:00.000Z',
+      },
+      scopedContext('67a123456789012345678931'),
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        creditsUsed: 0,
+        error: 'Credential cred-1 is not connected.',
+        nextActions: [
+          expect.objectContaining({
+            ctas: [{ href: '/content/posts', label: 'Review post setup' }],
+            type: 'schedule_post_card',
+          }),
+        ],
+        success: false,
+      }),
+    );
+    expect(postsService.patch).not.toHaveBeenCalled();
+  });
+
+  it('logs unexpected canonical scheduling failures without exposing internal details', async () => {
+    const { loggerService, postGroupsService, postsService, service } =
+      createService();
+    postsService.findOne.mockResolvedValue({
+      brandId: '67a123456789012345678931',
+      groupId: 'release-1',
+      id: 'target-1',
+    });
+    postGroupsService.scheduleTarget.mockRejectedValue(
+      new Error('Prisma connection detail with internal host'),
+    );
+
+    const result = await service.executeTool(
+      AgentToolName.SCHEDULE_POST,
+      {
+        postId: 'target-1',
+        scheduledAt: '2099-07-18T09:00:00.000Z',
+      },
+      scopedContext('67a123456789012345678931'),
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        error: 'The canonical release target could not be scheduled safely.',
+        success: false,
+      }),
+    );
+    expect(result.error).not.toContain('Prisma');
+    expect(loggerService.error).toHaveBeenCalledWith(
+      expect.stringContaining('Prisma connection detail'),
+      'AgentToolExecutorService',
+    );
+  });
+
+  it('does not expose 5xx HTTP exception details from canonical scheduling', async () => {
+    const { loggerService, postGroupsService, postsService, service } =
+      createService();
+    postsService.findOne.mockResolvedValue({
+      brandId: '67a123456789012345678931',
+      groupId: 'release-1',
+      id: 'target-1',
+    });
+    postGroupsService.scheduleTarget.mockRejectedValue(
+      new InternalServerErrorException('Database host is db.internal'),
+    );
+
+    const result = await service.executeTool(
+      AgentToolName.SCHEDULE_POST,
+      {
+        postId: 'target-1',
+        scheduledAt: '2099-07-18T09:00:00.000Z',
+      },
+      scopedContext('67a123456789012345678931'),
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        error: 'The canonical release target could not be scheduled safely.',
+        success: false,
+      }),
+    );
+    expect(result.error).not.toContain('db.internal');
+    expect(loggerService.error).toHaveBeenCalled();
+  });
+
+  it('fails closed when the canonical scheduler omits the scheduled target', async () => {
+    const { postGroupsService, postsService, service } = createService();
+    postsService.findOne.mockResolvedValue({
+      brandId: '67a123456789012345678931',
+      groupId: 'release-1',
+      id: 'target-1',
+    });
+    postGroupsService.scheduleTarget.mockResolvedValue({
+      id: 'release-1',
+      organizationId: '67a123456789012345678901',
+      status: ReleaseStatus.SCHEDULED,
+      targets: [],
+    });
+
+    const result = await service.executeTool(
+      AgentToolName.SCHEDULE_POST,
+      {
+        postId: 'target-1',
+        scheduledAt: '2099-07-18T09:00:00.000Z',
+      },
+      scopedContext('67a123456789012345678931'),
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        error:
+          'Canonical scheduler did not return the scheduled release target.',
+        success: false,
+      }),
+    );
+  });
+
+  it('fails closed when the canonical scheduler returns an unscheduled target', async () => {
+    const { postGroupsService, postsService, service } = createService();
+    postsService.findOne.mockResolvedValue({
+      brandId: '67a123456789012345678931',
+      groupId: 'release-1',
+      id: 'target-1',
+    });
+    postGroupsService.scheduleTarget.mockResolvedValue({
+      id: 'release-1',
+      organizationId: '67a123456789012345678901',
+      status: ReleaseStatus.DRAFT,
+      targets: [
+        {
+          executionState: 'draft',
+          id: 'target-1',
+          platform: 'linkedin',
+        },
+      ],
+    });
+
+    const result = await service.executeTool(
+      AgentToolName.SCHEDULE_POST,
+      {
+        postId: 'target-1',
+        scheduledAt: '2099-07-18T09:00:00.000Z',
+      },
+      scopedContext('67a123456789012345678931'),
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        error:
+          'Canonical scheduler did not return the scheduled release target.',
+        success: false,
+      }),
+    );
+  });
+
+  it('sanitizes unexpected post lookup failures before canonical scheduling', async () => {
+    const { loggerService, postsService, service } = createService();
+    postsService.findOne.mockRejectedValue(
+      new Error('Post query failed against db.internal'),
+    );
+
+    const result = await service.executeTool(
+      AgentToolName.SCHEDULE_POST,
+      {
+        postId: 'target-1',
+        scheduledAt: '2099-07-18T09:00:00.000Z',
+      },
+      scopedContext('67a123456789012345678931'),
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        error: 'The canonical release target could not be scheduled safely.',
+        success: false,
+      }),
+    );
+    expect(result.error).not.toContain('db.internal');
+    expect(loggerService.error).toHaveBeenCalled();
+  });
+
+  it('rejects invalid schedule timestamps before loading a post', async () => {
+    const { postsService, service } = createService();
+
+    const result = await service.executeTool(
+      AgentToolName.SCHEDULE_POST,
+      { postId: 'target-1', scheduledAt: 'not-a-date' },
+      scopedContext('67a123456789012345678931'),
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        error:
+          'scheduledAt must be a valid ISO 8601 date and time with an explicit UTC offset.',
+        success: false,
+      }),
+    );
+    expect(postsService.findOne).not.toHaveBeenCalled();
+  });
+
+  it('rejects schedule timestamps without an explicit UTC offset', async () => {
+    const { postsService, service } = createService();
+
+    const result = await service.executeTool(
+      AgentToolName.SCHEDULE_POST,
+      { postId: 'target-1', scheduledAt: '2099-07-18T09:00:00' },
+      scopedContext('67a123456789012345678931'),
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        error: expect.stringContaining('explicit UTC offset'),
+        success: false,
+      }),
+    );
+    expect(postsService.findOne).not.toHaveBeenCalled();
   });
 
   it('returns a generic integrations card when connection status has no platform', async () => {

--- a/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts
+++ b/apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts
@@ -38,6 +38,10 @@ import { AgentDashboardToolHandler } from '@api/services/agent-orchestrator/tool
 import { AgentMemoryGoalsToolHandler } from '@api/services/agent-orchestrator/tools/agent-memory-goals-tool-handler.service';
 import { AgentPublishToolHandler } from '@api/services/agent-orchestrator/tools/agent-publish-tool-handler.service';
 import { AgentRouteRewriteService } from '@api/services/agent-orchestrator/tools/agent-route-rewrite.service';
+import {
+  readAgentScheduleValidationError,
+  SAFE_AGENT_SCHEDULE_ERROR,
+} from '@api/services/agent-orchestrator/tools/agent-schedule-error.util';
 import { AgentSpawnService } from '@api/services/agent-spawn/agent-spawn.service';
 import { BatchGenerationService } from '@api/services/batch-generation/batch-generation.service';
 import { ContentQualityScorerService } from '@api/services/content-quality/content-quality-scorer.service';
@@ -109,6 +113,9 @@ import { HttpService } from '@nestjs/axios';
 import { Inject, Injectable, Optional } from '@nestjs/common';
 import { Effect } from 'effect';
 import { firstValueFrom } from 'rxjs';
+import { z } from 'zod';
+
+const STRICT_SCHEDULE_DATE_SCHEMA = z.string().datetime({ offset: true });
 
 export interface ToolExecutionContext {
   /** URLs of user-attached images from the chat message */
@@ -4418,46 +4425,110 @@ export class AgentToolExecutorService {
     params: Record<string, unknown>,
     ctx: ToolExecutionContext,
   ): Promise<AgentToolResult> {
-    const postId = params.postId as string;
-    const scheduledAt = params.scheduledAt as string;
-
-    const post = await this.postsService.findOne({
-      _id: postId,
-      isDeleted: false,
-      organization: ctx.organizationId,
-    });
-
-    if (!post) {
+    const postId = this.readOptionalString(params.postId);
+    const scheduledAt = this.readOptionalString(params.scheduledAt);
+    if (!postId || !scheduledAt) {
       return {
         creditsUsed: 0,
-        error: `Post ${postId} not found`,
+        error: 'postId and scheduledAt are required to schedule a post.',
+        success: false,
+      };
+    }
+    if (!STRICT_SCHEDULE_DATE_SCHEMA.safeParse(scheduledAt).success) {
+      return {
+        creditsUsed: 0,
+        error:
+          'scheduledAt must be a valid ISO 8601 date and time with an explicit UTC offset.',
+        success: false,
+      };
+    }
+    const scheduledDate = new Date(scheduledAt);
+    if (scheduledDate.getTime() <= Date.now()) {
+      return {
+        creditsUsed: 0,
+        error: 'scheduledAt must be in the future.',
         success: false,
       };
     }
 
-    await this.assertPublishingScope(
-      ctx,
-      this.readOptionalString((post as { brand?: unknown }).brand),
-      'scheduled post',
-    );
+    let groupId: string | undefined;
+    try {
+      const post = await this.postsService.findOne({
+        _id: postId,
+        isDeleted: false,
+        organization: ctx.organizationId,
+      });
 
-    await this.postsService.patch(postId, {
-      agentContextSource: ctx.validatedScope?.source,
-      agentContextVersion: ctx.validatedScope?.contextVersion,
-      agentThreadId: ctx.validatedScope?.threadId,
-      scheduledDate: new Date(scheduledAt),
-      status: PostStatus.SCHEDULED,
-    } as never);
+      if (!post) {
+        return {
+          creditsUsed: 0,
+          error: `Post ${postId} not found`,
+          success: false,
+        };
+      }
 
-    return {
-      creditsUsed: 1,
-      data: {
-        id: postId,
-        scheduledAt,
-        status: PostStatus.SCHEDULED,
-      },
-      success: true,
-    };
+      await this.assertPublishingScope(
+        ctx,
+        this.readOptionalString(post.brandId) ??
+          this.readOptionalString(post.brand),
+        'scheduled post',
+      );
+
+      groupId = this.readOptionalString(post.groupId);
+      if (!groupId) {
+        return {
+          creditsUsed: 0,
+          data: {
+            id: postId,
+            requiredAction: 'create_canonical_release',
+          },
+          error:
+            'This legacy standalone draft cannot be scheduled safely. Open Posts and create a canonical release with an explicit platform and connected account.',
+          nextActions: [
+            {
+              ctas: [{ href: '/content/posts', label: 'Open posts' }],
+              description:
+                'Choose the destination and connected account in the canonical release composer before scheduling.',
+              id: `schedule-legacy-post-${postId}`,
+              title: 'Canonical release required',
+              type: 'schedule_post_card',
+            },
+          ],
+          success: false,
+        };
+      }
+
+      return await this.publishHandler.scheduleCanonicalPost({
+        ctx,
+        groupId,
+        postId,
+        scheduledAt: scheduledDate.toISOString(),
+      });
+    } catch (error: unknown) {
+      const validationError = readAgentScheduleValidationError(error);
+      if (!validationError) {
+        this.loggerService.error(
+          `Canonical schedule failed: ${error instanceof Error ? error.message : 'Unknown error'}`,
+          this.constructorName,
+        );
+      }
+      return {
+        creditsUsed: 0,
+        data: { id: postId, ...(groupId ? { releaseId: groupId } : {}) },
+        error: validationError ?? SAFE_AGENT_SCHEDULE_ERROR,
+        nextActions: [
+          {
+            ctas: [{ href: '/content/posts', label: 'Review post setup' }],
+            description:
+              'Verify the release brand, platform, connected account, and future schedule before retrying.',
+            id: `schedule-post-failed-${postId}`,
+            title: 'Scheduling needs attention',
+            type: 'schedule_post_card',
+          },
+        ],
+        success: false,
+      };
+    }
   }
 
   private async createWorkflowFromRecurringScaffold(

--- a/apps/server/workers/src/crons/posts/cron.posts.service.spec.ts
+++ b/apps/server/workers/src/crons/posts/cron.posts.service.spec.ts
@@ -296,6 +296,39 @@ describe('CronPostsService', () => {
     });
   });
 
+  it('carries the canonical schedule approval identity into the worker queue contract', async () => {
+    postsService.findAll.mockResolvedValueOnce({
+      docs: [
+        {
+          brandId: 'brand-1',
+          id: 'post-1',
+          organizationId: 'org-1',
+          publishApproval: {
+            artifactVersionPinId: 'pin-1',
+            id: 'approval-1',
+            operationId: 'operation-1',
+          },
+        },
+      ],
+      total: 1,
+    } as never);
+
+    await service.publishScheduledPosts();
+
+    expect(publishApprovalsService.markQueued).toHaveBeenCalledWith(
+      'approval-1',
+      'org-1',
+    );
+    expect(postPublishQueueService.enqueue).toHaveBeenCalledWith({
+      approvalId: 'approval-1',
+      operationId: 'operation-1',
+      organizationId: 'org-1',
+      postId: 'post-1',
+      source: 'scheduled_sweep',
+      versionPinId: 'pin-1',
+    });
+  });
+
   it('validates a queued pin against the same canonical Post before publishing', async () => {
     const post = {
       brandId: 'brand-1',

--- a/packages/interfaces/src/ai/agent-publish.interface.ts
+++ b/packages/interfaces/src/ai/agent-publish.interface.ts
@@ -25,6 +25,13 @@ export interface PublishConfirmedContentInput {
   sourceActionId: string;
 }
 
+export interface ScheduleCanonicalPostInput {
+  ctx: AgentPublishContext;
+  groupId: string;
+  postId: string;
+  scheduledAt: string;
+}
+
 export interface AgentPublishIdempotencyInput {
   baseContent: string;
   contentId: string;


### PR DESCRIPTION
## Summary

- route `schedule_post` through the canonical release-target scheduler instead of patching legacy Post state
- validate future timestamp, target platform, connected credential, tenant/brand scope, and channel capability before mutation
- bind the versioned `PublishApproval` in the same Prisma transaction as the schedule transition, with exact-replay idempotency
- fail closed with an actionable agent card for legacy standalone drafts and canonical validation failures
- prove the scheduled sweep carries `approvalId`, `operationId`, and `versionPinId` into the worker queue contract

## Verification

- `biome check --write` on all changed files (pre-commit)
- staged secretlint and UI control guard passed
- agent decomposition size ratchet passed (9,288 / 9,307 lines)
- `git diff --check`
- no local tests, typechecks, builds, compilation, or E2E were run; PR CI is the test/build authority

Closes #1810
