### PR TITLE
docs: restore residual agent guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,8 @@ Detailed docs: `.agents/README.md`
 6. Do not manually edit generated `dist/` artifacts.
 7. Respect package boundaries: shared logic in `packages/*`, app-specific code in `apps/*`.
 8. Enterprise code (`ee/`): enforce multi-tenancy query guards (`{ organizationId: orgId, isDeleted: false }`).
+9. Self-hosted code outside `ee/` is single-tenant by default; organization filtering is optional there.
+10. Soft deletes use `isDeleted: boolean`, never `deletedAt`.
 
 ## Decorator Boundary Rules
 


### PR DESCRIPTION
## Summary
- restore the self-hosted single-tenant boundary omitted when #1633 was superseded
- make the canonical `isDeleted` soft-delete convention explicit

## Context
PR #1632 correctly superseded the CODEX.md removals from #1633 and intentionally kept repository verification guidance machine-neutral. Two `AGENTS.md` domain guardrails were not present on `master`; this fresh PR contains only those residual rules.

## Verification
- `git diff --check`
- secretlint passed via the repository dependency tree and pre-commit hook
- Claude Fable 5 adversarial audit confirmed the two retained rules and identified the superseded machine-local verification wording, which was removed
- documentation-only change; no local tests, typechecks, or builds were run

Related: #1632, #1633