### PR TITLE
refactor(agent): extract artifact metadata persistence

### DIFF
--- a/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.ts
+++ b/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.ts
@@ -57,8 +57,10 @@ import { AgentToolExecutorService } from '@api/services/agent-orchestrator/tools
 import { getToolDefinitions } from '@api/services/agent-orchestrator/tools/agent-tool-registry';
 import {
   type AgentArtifactCompletionMetadata,
-  buildAgentArtifactCompletionMetadata,
+  buildAgentArtifactCompletionMetadata as buildArtifactMetadata,
+  captureRunArtifacts,
   mergeAgentArtifactCompletionMetadata,
+  persistRunArtifacts,
 } from '@api/services/agent-orchestrator/utils/agent-artifact-reference-metadata.util';
 import { buildPageContextPrompt } from '@api/services/agent-orchestrator/utils/agent-page-context.util';
 import {
@@ -764,7 +766,11 @@ export class AgentOrchestratorService {
             ...(latestUiBlocks ? { uiBlocks: latestUiBlocks } : {}),
           };
 
-          await this.persistRunArtifactMetadata(context, artifactMetadata);
+          await persistRunArtifacts(
+            this.agentRunsService,
+            context,
+            artifactMetadata,
+          );
           await this.agentMessagesService.addMessage({
             brandId: context.scope?.brandId,
             content,
@@ -1022,12 +1028,7 @@ export class AgentOrchestratorService {
             },
           );
           const durationMs = Date.now() - startTime;
-          allArtifactMetadata.push(
-            buildAgentArtifactCompletionMetadata(result.data, {
-              brandId: context.scope?.brandId,
-              organizationId: context.organizationId,
-            }),
-          );
+          allArtifactMetadata.push(buildArtifactMetadata(result.data, context));
 
           if (result.nextActions?.length) {
             allUiActions.push(...result.nextActions);
@@ -1641,7 +1642,11 @@ export class AgentOrchestratorService {
             mergeAgentArtifactCompletionMetadata(allArtifactMetadata);
 
           // Save assistant message to DB
-          await this.persistRunArtifactMetadata(context, artifactMetadata);
+          await persistRunArtifacts(
+            this.agentRunsService,
+            context,
+            artifactMetadata,
+          );
           await this.agentMessagesService.addMessage({
             brandId: context.scope?.brandId,
             content,
@@ -1966,12 +1971,7 @@ export class AgentOrchestratorService {
           }
 
           const durationMs = Date.now() - startTime;
-          allArtifactMetadata.push(
-            buildAgentArtifactCompletionMetadata(result.data, {
-              brandId: context.scope?.brandId,
-              organizationId: context.organizationId,
-            }),
-          );
+          allArtifactMetadata.push(buildArtifactMetadata(result.data, context));
 
           if (result.nextActions?.length) {
             allUiActions.push(...result.nextActions);
@@ -2917,10 +2917,11 @@ export class AgentOrchestratorService {
         toolCalls: [{ status: summary.status, toolName }],
         uiActions: result.nextActions ?? [],
       });
-    const artifactMetadata = buildAgentArtifactCompletionMetadata(result.data, {
-      brandId: params.context.scope?.brandId,
-      organizationId: params.context.organizationId,
-    });
+    const artifactMetadata = await captureRunArtifacts(
+      this.agentRunsService,
+      params.context,
+      result.data,
+    );
     const assistantMetadata = {
       ...artifactMetadata,
       ...buildAgentScopeMetadata(params.context),
@@ -2935,7 +2936,6 @@ export class AgentOrchestratorService {
       uiActions: enhancedUiActions.uiActions,
     };
 
-    await this.persistRunArtifactMetadata(params.context, artifactMetadata);
     await this.agentMessagesService.addMessage({
       brandId: params.context.scope?.brandId,
       content: fullContent,
@@ -5030,12 +5030,10 @@ export class AgentOrchestratorService {
       params.toolCalls,
       enhancedUiActions.uiActions,
     );
-    const artifactMetadata = buildAgentArtifactCompletionMetadata(
+    const artifactMetadata = await captureRunArtifacts(
+      this.agentRunsService,
+      params.context,
       params.result.data,
-      {
-        brandId: params.context.scope?.brandId,
-        organizationId: params.context.organizationId,
-      },
     );
     const creditsRemaining =
       await this.creditsUtilsService.getOrganizationCreditsBalance(
@@ -5056,7 +5054,6 @@ export class AgentOrchestratorService {
       ...(latestUiBlocks ? { uiBlocks: latestUiBlocks } : {}),
     };
 
-    await this.persistRunArtifactMetadata(params.context, artifactMetadata);
     await this.agentMessagesService.addMessage({
       brandId: params.context.scope?.brandId,
       content: normalizedContent.content,
@@ -5295,25 +5292,6 @@ export class AgentOrchestratorService {
     }
 
     return trimmedResponseModel;
-  }
-
-  private async persistRunArtifactMetadata(
-    context: AgentChatContext,
-    metadata: AgentArtifactCompletionMetadata,
-  ): Promise<void> {
-    if (
-      !context.runId ||
-      (!metadata.artifactReferences?.length &&
-        !metadata.artifactVersionPinIds?.length)
-    ) {
-      return;
-    }
-
-    await this.agentRunsService.mergeMetadata(
-      context.runId,
-      context.organizationId,
-      metadata,
-    );
   }
 
   private async recordAgentResponseModel(params: {

--- a/apps/server/api/src/services/agent-orchestrator/utils/agent-artifact-reference-metadata.util.ts
+++ b/apps/server/api/src/services/agent-orchestrator/utils/agent-artifact-reference-metadata.util.ts
@@ -24,6 +24,21 @@ export interface AgentArtifactCompletionMetadata
   artifactVersionPinIds?: string[];
 }
 
+interface AgentArtifactCompletionContext {
+  brandId?: string;
+  organizationId: string;
+  runId?: string;
+  scope?: { brandId?: string };
+}
+
+interface AgentArtifactRunMetadataWriter {
+  mergeMetadata(
+    id: string,
+    organizationId: string,
+    metadata: Record<string, unknown>,
+  ): Promise<void>;
+}
+
 export function mergeAgentArtifactCompletionMetadata(
   metadata: AgentArtifactCompletionMetadata[],
 ): AgentArtifactCompletionMetadata {
@@ -86,7 +101,7 @@ function buildReference(
  */
 export function buildAgentArtifactCompletionMetadata(
   data: Record<string, unknown> | undefined,
-  context: { brandId?: string; organizationId: string },
+  context: AgentArtifactCompletionContext,
 ): AgentArtifactCompletionMetadata {
   if (!data) {
     return {};
@@ -102,7 +117,12 @@ export function buildAgentArtifactCompletionMetadata(
     ].filter((id): id is string => id !== undefined);
     for (const recordId of ids) {
       references.push(
-        buildReference(kind, recordId, context.organizationId, context.brandId),
+        buildReference(
+          kind,
+          recordId,
+          context.organizationId,
+          context.brandId ?? context.scope?.brandId,
+        ),
       );
     }
   }
@@ -135,4 +155,30 @@ export function buildAgentArtifactCompletionMetadata(
         }
       : {}),
   };
+}
+
+export async function persistRunArtifacts(
+  writer: AgentArtifactRunMetadataWriter,
+  context: AgentArtifactCompletionContext,
+  metadata: AgentArtifactCompletionMetadata,
+): Promise<void> {
+  if (
+    !context.runId ||
+    (!metadata.artifactReferences?.length &&
+      !metadata.artifactVersionPinIds?.length)
+  ) {
+    return;
+  }
+
+  await writer.mergeMetadata(context.runId, context.organizationId, metadata);
+}
+
+export async function captureRunArtifacts(
+  writer: AgentArtifactRunMetadataWriter,
+  context: AgentArtifactCompletionContext,
+  data: Record<string, unknown> | undefined,
+): Promise<AgentArtifactCompletionMetadata> {
+  const metadata = buildAgentArtifactCompletionMetadata(data, context);
+  await persistRunArtifacts(writer, context, metadata);
+  return metadata;
 }


### PR DESCRIPTION
## Summary
- preserve the unique final commit from closed PR #1697 on a fresh branch from current `master`
- move run artifact metadata persistence and capture into focused utility helpers
- keep `agent-orchestrator.service.ts` below the decomposition size ratchet without changing behavior

## Context
PR #1694 merged the versioned artifact persistence feature, but the final refactor commit from #1697 was never merged. This PR contains only that residual two-file refactor.

## Verification
- `git diff --check`
- focused Biome check completed with no errors; one pre-existing warning and one informational finding remain in the large orchestrator file
- secretlint passed via the repository dependency tree and pre-commit hook
- local tests, typechecks, and builds were not run per machine policy; PR CI is authoritative

Related: #1673, #1694, #1697