### PR TITLE
fix(website): stabilize pricing hydration

### DIFF
--- a/apps/website/app/(public)/pricing/pricing-content.test.tsx
+++ b/apps/website/app/(public)/pricing/pricing-content.test.tsx
@@ -106,11 +106,7 @@ describe('PricingContent launch pricing', () => {
         locales?: Intl.LocalesArgument,
         options?: Intl.NumberFormatOptions,
       ) {
-        return originalToLocaleString.call(
-          this,
-          locales ?? 'de-DE',
-          options,
-        );
+        return originalToLocaleString.call(this, locales ?? 'de-DE', options);
       });
 
     try {

--- a/apps/website/app/(public)/pricing/pricing-content.test.tsx
+++ b/apps/website/app/(public)/pricing/pricing-content.test.tsx
@@ -1,3 +1,4 @@
+import { withSimulatedNumberLocale } from '@shared/localeTestUtils';
 import { render, screen } from '@testing-library/react';
 import type { ComponentProps, ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
@@ -98,25 +99,12 @@ describe('PricingContent launch pricing', () => {
   });
 
   it('formats public pricing numbers deterministically across runtime locales', () => {
-    const originalToLocaleString = Number.prototype.toLocaleString;
-    const toLocaleStringSpy = vi
-      .spyOn(Number.prototype, 'toLocaleString')
-      .mockImplementation(function (
-        this: number,
-        locales?: Intl.LocalesArgument,
-        options?: Intl.NumberFormatOptions,
-      ) {
-        return originalToLocaleString.call(this, locales ?? 'de-DE', options);
-      });
-
-    try {
+    withSimulatedNumberLocale('de-DE', () => {
       render(<PricingContent />);
 
       expect(screen.getByText('$1,000')).toBeInTheDocument();
       expect(screen.getByText('100,000 credits')).toBeInTheDocument();
       expect(screen.getByText('8,000 credits included')).toBeInTheDocument();
-    } finally {
-      toLocaleStringSpy.mockRestore();
-    }
+    });
   });
 });

--- a/apps/website/app/(public)/pricing/pricing-content.test.tsx
+++ b/apps/website/app/(public)/pricing/pricing-content.test.tsx
@@ -1,8 +1,12 @@
+import {
+  getProPlan,
+  getScalePlan,
+} from '@helpers/business/pricing/pricing.helper';
 import { withSimulatedNumberLocale } from '@shared/localeTestUtils';
 import { render, screen } from '@testing-library/react';
 import type { ComponentProps, ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
-import PricingContent from './pricing-content';
+import PricingContent, { getPriceQualifier } from './pricing-content';
 
 vi.mock('next/link', () => ({
   default: ({ children, href, ...props }: ComponentProps<'a'>) => (
@@ -98,13 +102,26 @@ describe('PricingContent launch pricing', () => {
     expect(screen.getByText('$499')).not.toHaveClass('line-through');
   });
 
-  it('formats public pricing numbers deterministically across runtime locales', () => {
-    withSimulatedNumberLocale('de-DE', () => {
+  it('formats public pricing numbers deterministically across runtime locales', async () => {
+    await withSimulatedNumberLocale('de-DE', async () => {
+      await Promise.resolve();
       render(<PricingContent />);
 
       expect(screen.getByText('$1,000')).toBeInTheDocument();
       expect(screen.getByText('100,000 credits')).toBeInTheDocument();
       expect(screen.getByText('8,000 credits included')).toBeInTheDocument();
     });
+  });
+
+  it('uses explicit subscription qualifiers when included credits are absent', () => {
+    const proPlan = getProPlan();
+    const scalePlan = getScalePlan();
+
+    expect(getPriceQualifier({ ...proPlan, includedCredits: null })).toBe(
+      'Monthly subscription',
+    );
+    expect(
+      getPriceQualifier({ ...scalePlan, includedCredits: undefined }),
+    ).toBe('Unlimited seats');
   });
 });

--- a/apps/website/app/(public)/pricing/pricing-content.test.tsx
+++ b/apps/website/app/(public)/pricing/pricing-content.test.tsx
@@ -96,4 +96,31 @@ describe('PricingContent launch pricing', () => {
     // Cloud Teams has no launchPrice — its price renders un-struck.
     expect(screen.getByText('$499')).not.toHaveClass('line-through');
   });
+
+  it('formats public pricing numbers deterministically across runtime locales', () => {
+    const originalToLocaleString = Number.prototype.toLocaleString;
+    const toLocaleStringSpy = vi
+      .spyOn(Number.prototype, 'toLocaleString')
+      .mockImplementation(function (
+        this: number,
+        locales?: Intl.LocalesArgument,
+        options?: Intl.NumberFormatOptions,
+      ) {
+        return originalToLocaleString.call(
+          this,
+          locales ?? 'de-DE',
+          options,
+        );
+      });
+
+    try {
+      render(<PricingContent />);
+
+      expect(screen.getByText('$1,000')).toBeInTheDocument();
+      expect(screen.getByText('100,000 credits')).toBeInTheDocument();
+      expect(screen.getByText('8,000 credits included')).toBeInTheDocument();
+    } finally {
+      toLocaleStringSpy.mockRestore();
+    }
+  });
 });

--- a/apps/website/app/(public)/pricing/pricing-content.tsx
+++ b/apps/website/app/(public)/pricing/pricing-content.tsx
@@ -13,6 +13,7 @@ import {
   websitePlans,
 } from '@helpers/business/pricing/pricing.helper';
 import { cn } from '@helpers/formatting/cn/cn.util';
+import { formatNumberWithCommas } from '@helpers/formatting/format/format.helper';
 import { useMarketingEntrance } from '@hooks/ui/use-marketing-entrance';
 import { EnvironmentService } from '@services/core/environment.service';
 import SectionHeader from '@ui/marketing/SectionHeader';
@@ -104,7 +105,7 @@ const OUTPUT_COSTS: OutputCostRow[] = [
 ];
 
 function formatCredits(credits: number): string {
-  return `${credits.toLocaleString()} credits`;
+  return `${formatNumberWithCommas(credits)} credits`;
 }
 
 function formatCreditsDollars(credits: number): string {
@@ -136,7 +137,7 @@ function getPriceQualifier(plan: (typeof websitePlans)[number]): string {
   }
 
   if (plan.type === 'subscription') {
-    const credits = plan.includedCredits?.toLocaleString();
+    const credits = formatNumberWithCommas(plan.includedCredits);
 
     return plan.label === 'Scale'
       ? `Unlimited seats + ${credits} credits`
@@ -370,10 +371,10 @@ export default function PricingContent() {
                 className="flex items-baseline justify-between gap-4 bg-background px-5 py-4"
               >
                 <span className="text-sm font-semibold text-surface">
-                  ${creditPackPrice(pack).toLocaleString()}
+                  ${formatNumberWithCommas(creditPackPrice(pack))}
                 </span>
                 <span className="text-sm text-surface/60">
-                  {creditPackTotalCredits(pack).toLocaleString()} credits
+                  {formatNumberWithCommas(creditPackTotalCredits(pack))} credits
                 </span>
               </div>
             ))}

--- a/apps/website/app/(public)/pricing/pricing-content.tsx
+++ b/apps/website/app/(public)/pricing/pricing-content.tsx
@@ -137,6 +137,12 @@ function getPriceQualifier(plan: (typeof websitePlans)[number]): string {
   }
 
   if (plan.type === 'subscription') {
+    if (plan.includedCredits == null) {
+      return plan.label === 'Scale'
+        ? 'Unlimited seats'
+        : 'Monthly subscription';
+    }
+
     const credits = formatNumberWithCommas(plan.includedCredits);
 
     return plan.label === 'Scale'

--- a/apps/website/app/(public)/pricing/pricing-content.tsx
+++ b/apps/website/app/(public)/pricing/pricing-content.tsx
@@ -131,7 +131,7 @@ function getDisplayName(label: string): string {
   return label;
 }
 
-function getPriceQualifier(plan: (typeof websitePlans)[number]): string {
+export function getPriceQualifier(plan: (typeof websitePlans)[number]): string {
   if (plan.type === 'payg') {
     return 'No monthly fee, buy credit packs as you go';
   }

--- a/apps/website/packages/components/home/_credits.spec.tsx
+++ b/apps/website/packages/components/home/_credits.spec.tsx
@@ -1,3 +1,4 @@
+import { withSimulatedNumberLocale } from '@shared/localeTestUtils';
 import { render, screen } from '@testing-library/react';
 import HomeCredits from '@web-components/home/_credits';
 import { describe, expect, it, vi } from 'vitest';
@@ -51,25 +52,12 @@ describe('HomeCredits', () => {
   });
 
   it('formats credit amounts deterministically across runtime locales', () => {
-    const originalToLocaleString = Number.prototype.toLocaleString;
-    const toLocaleStringSpy = vi
-      .spyOn(Number.prototype, 'toLocaleString')
-      .mockImplementation(function (
-        this: number,
-        locales?: Intl.LocalesArgument,
-        options?: Intl.NumberFormatOptions,
-      ) {
-        return originalToLocaleString.call(this, locales ?? 'de-DE', options);
-      });
-
-    try {
+    withSimulatedNumberLocale('de-DE', () => {
       render(<HomeCredits />);
 
       expect(screen.getByText('$1,000')).toBeInTheDocument();
       expect(screen.getByText('100,000 credits')).toBeInTheDocument();
-    } finally {
-      toLocaleStringSpy.mockRestore();
-    }
+    });
   });
 
   it('surfaces the launch pricing note', () => {

--- a/apps/website/packages/components/home/_credits.spec.tsx
+++ b/apps/website/packages/components/home/_credits.spec.tsx
@@ -50,6 +50,32 @@ describe('HomeCredits', () => {
     expect(screen.getAllByText(/credits/i).length).toBeGreaterThan(0);
   });
 
+  it('formats credit amounts deterministically across runtime locales', () => {
+    const originalToLocaleString = Number.prototype.toLocaleString;
+    const toLocaleStringSpy = vi
+      .spyOn(Number.prototype, 'toLocaleString')
+      .mockImplementation(function (
+        this: number,
+        locales?: Intl.LocalesArgument,
+        options?: Intl.NumberFormatOptions,
+      ) {
+        return originalToLocaleString.call(
+          this,
+          locales ?? 'de-DE',
+          options,
+        );
+      });
+
+    try {
+      render(<HomeCredits />);
+
+      expect(screen.getByText('$1,000')).toBeInTheDocument();
+      expect(screen.getByText('100,000 credits')).toBeInTheDocument();
+    } finally {
+      toLocaleStringSpy.mockRestore();
+    }
+  });
+
   it('surfaces the launch pricing note', () => {
     render(<HomeCredits />);
 

--- a/apps/website/packages/components/home/_credits.spec.tsx
+++ b/apps/website/packages/components/home/_credits.spec.tsx
@@ -59,11 +59,7 @@ describe('HomeCredits', () => {
         locales?: Intl.LocalesArgument,
         options?: Intl.NumberFormatOptions,
       ) {
-        return originalToLocaleString.call(
-          this,
-          locales ?? 'de-DE',
-          options,
-        );
+        return originalToLocaleString.call(this, locales ?? 'de-DE', options);
       });
 
     try {

--- a/apps/website/packages/components/home/_credits.tsx
+++ b/apps/website/packages/components/home/_credits.tsx
@@ -7,6 +7,7 @@ import {
   getProPlan,
   WEBSITE_CREDIT_PACKS,
 } from '@helpers/business/pricing/pricing.helper';
+import { formatNumberWithCommas } from '@helpers/formatting/format/format.helper';
 import { EnvironmentService } from '@services/core/environment.service';
 import ButtonTracked from '@ui/buttons/tracked/ButtonTracked';
 import { HStack, VStack } from '@ui/layout/stack';
@@ -66,10 +67,10 @@ export default function HomeCredits(): React.ReactElement {
               className="flex items-baseline justify-between gap-4 bg-background px-6 py-4"
             >
               <Text className="text-sm font-semibold text-surface">
-                ${creditPackPrice(pack).toLocaleString()}
+                ${formatNumberWithCommas(creditPackPrice(pack))}
               </Text>
               <Text className="text-sm text-surface/60">
-                {creditPackTotalCredits(pack).toLocaleString()} credits
+                {formatNumberWithCommas(creditPackTotalCredits(pack))} credits
               </Text>
             </div>
           ))}

--- a/apps/website/packages/components/home/_formats.tsx
+++ b/apps/website/packages/components/home/_formats.tsx
@@ -7,6 +7,7 @@ import {
   INTERNAL_CREDIT_COSTS,
   VIDEO_CREDIT_COSTS,
 } from '@helpers/business/pricing/pricing.helper';
+import { formatNumberWithCommas } from '@helpers/formatting/format/format.helper';
 import type { OutputFormat } from '@props/website/home.props';
 import { EnvironmentService } from '@services/core/environment.service';
 import ButtonTracked from '@ui/buttons/tracked/ButtonTracked';
@@ -124,7 +125,7 @@ export default function HomeFormats(): React.ReactElement {
                     {format.title}
                   </Heading>
                   <Text className="shrink-0 text-xs font-semibold uppercase tracking-[0.12em] text-surface/45">
-                    from {format.credits.toLocaleString()} credits
+                    from {formatNumberWithCommas(format.credits)} credits
                   </Text>
                 </div>
                 <Text className="text-sm leading-6 text-surface/55">

--- a/packages/pricing/src/plans-pricing.ts
+++ b/packages/pricing/src/plans-pricing.ts
@@ -103,7 +103,10 @@ export const BASE_MARGIN_PERCENT = 70;
 export const MAX_MARGIN_MULTIPLIER = 10;
 export const BYOK_FEE_PER_CREDIT =
   BYOK_CREDIT_VALUE_DOLLARS * (BYOK_FEE_PERCENTAGE / 100);
-const PRICING_NUMBER_FORMATTER = new Intl.NumberFormat('en-US');
+
+function formatPricingNumber(value: number): string {
+  return value.toLocaleString('en-US');
+}
 
 /**
  * Process-scoped margin multiplier applied on top of the base provider-cost
@@ -396,7 +399,7 @@ export function formatPrice(price: number | null): string {
   if (price === 0) {
     return 'Free';
   }
-  return `$${PRICING_NUMBER_FORMATTER.format(price)}`;
+  return `$${formatPricingNumber(price)}`;
 }
 
 /**
@@ -414,7 +417,7 @@ export function formatOutputs(
     parts.push(`${outputs.videoMinutes} min video`);
   }
   if (outputs.images) {
-    parts.push(`${PRICING_NUMBER_FORMATTER.format(outputs.images)} images`);
+    parts.push(`${formatPricingNumber(outputs.images)} images`);
   }
   if (outputs.voiceMinutes) {
     parts.push(`${outputs.voiceMinutes} min voice`);

--- a/packages/pricing/src/plans-pricing.ts
+++ b/packages/pricing/src/plans-pricing.ts
@@ -103,6 +103,7 @@ export const BASE_MARGIN_PERCENT = 70;
 export const MAX_MARGIN_MULTIPLIER = 10;
 export const BYOK_FEE_PER_CREDIT =
   BYOK_CREDIT_VALUE_DOLLARS * (BYOK_FEE_PERCENTAGE / 100);
+const PRICING_NUMBER_FORMATTER = new Intl.NumberFormat('en-US');
 
 /**
  * Process-scoped margin multiplier applied on top of the base provider-cost
@@ -395,7 +396,7 @@ export function formatPrice(price: number | null): string {
   if (price === 0) {
     return 'Free';
   }
-  return `$${price.toLocaleString()}`;
+  return `$${PRICING_NUMBER_FORMATTER.format(price)}`;
 }
 
 /**
@@ -413,7 +414,7 @@ export function formatOutputs(
     parts.push(`${outputs.videoMinutes} min video`);
   }
   if (outputs.images) {
-    parts.push(`${outputs.images.toLocaleString()} images`);
+    parts.push(`${PRICING_NUMBER_FORMATTER.format(outputs.images)} images`);
   }
   if (outputs.voiceMinutes) {
     parts.push(`${outputs.voiceMinutes} min voice`);

--- a/packages/ui/src/components/tests/setup.ts
+++ b/packages/ui/src/components/tests/setup.ts
@@ -198,6 +198,20 @@ Object.defineProperty(window, 'scrollTo', {
 // Mock fetch
 global.fetch = vi.fn();
 
+// Prevent indirect imports of @genfeedai/auth-client from mounting Better
+// Auth's browser session store. Its broadcast refresh timer can outlive jsdom
+// and throw from cleanupBroadcastSetup after an otherwise successful UI suite.
+vi.mock('better-auth/react', () => ({
+  createAuthClient: () => ({
+    $fetch: vi.fn().mockResolvedValue({ data: null }),
+    getSession: vi.fn().mockResolvedValue({ data: null }),
+    signIn: { email: vi.fn(), magicLink: vi.fn(), social: vi.fn() },
+    signOut: vi.fn(),
+    signUp: { email: vi.fn() },
+    useSession: vi.fn(() => ({ data: null, error: null, isPending: false })),
+  }),
+}));
+
 // Mock next/navigation
 vi.mock('next/navigation', () => ({
   usePathname: () => '/',

--- a/tests/localeTestUtils.ts
+++ b/tests/localeTestUtils.ts
@@ -2,8 +2,16 @@ import { vi } from 'vitest';
 
 export function withSimulatedNumberLocale(
   locale: Intl.LocalesArgument,
+  assertion: () => Promise<void>,
+): Promise<void>;
+export function withSimulatedNumberLocale(
+  locale: Intl.LocalesArgument,
   assertion: () => void,
-): void {
+): void;
+export function withSimulatedNumberLocale(
+  locale: Intl.LocalesArgument,
+  assertion: () => void | Promise<void>,
+): void | Promise<void> {
   const originalToLocaleString = Number.prototype.toLocaleString;
   const toLocaleStringSpy = vi
     .spyOn(Number.prototype, 'toLocaleString')
@@ -16,8 +24,17 @@ export function withSimulatedNumberLocale(
     });
 
   try {
-    assertion();
-  } finally {
+    const result = assertion();
+
+    if (result instanceof Promise) {
+      return result.finally(() => {
+        toLocaleStringSpy.mockRestore();
+      });
+    }
+
     toLocaleStringSpy.mockRestore();
+  } catch (error) {
+    toLocaleStringSpy.mockRestore();
+    throw error;
   }
 }

--- a/tests/localeTestUtils.ts
+++ b/tests/localeTestUtils.ts
@@ -1,0 +1,23 @@
+import { vi } from 'vitest';
+
+export function withSimulatedNumberLocale(
+  locale: Intl.LocalesArgument,
+  assertion: () => void,
+): void {
+  const originalToLocaleString = Number.prototype.toLocaleString;
+  const toLocaleStringSpy = vi
+    .spyOn(Number.prototype, 'toLocaleString')
+    .mockImplementation(function (
+      this: number,
+      locales?: Intl.LocalesArgument,
+      options?: Intl.NumberFormatOptions,
+    ) {
+      return originalToLocaleString.call(this, locales ?? locale, options);
+    });
+
+  try {
+    assertion();
+  } finally {
+    toLocaleStringSpy.mockRestore();
+  }
+}


### PR DESCRIPTION
## Summary

- pin homepage and pricing credit formatting to the existing deterministic `en-US` formatter
- add regression coverage that simulates a non-US browser locale during client rendering
- prevent server/client thousands-separator differences from triggering hydration recovery

## Root cause

Sentry issue GENFEED-AI-3R is concentrated on the public homepage across non-US locales. Public pricing components rendered credit values with locale-implicit `toLocaleString()`, allowing the server and browser to produce different separators.

## Verification

- GitHub Actions CI run `29514919240` — passed
- build, lint, format, typecheck, guards, React health, Secretlint, Gitleaks, package tests, server-service tests, extension tests, and web/desktop/mobile tests — passed
- link checks, CodeRabbit, GitGuardian, and Socket security checks — passed
- `bunx @biomejs/biome@2.5.3 check` on the corrected tests — passed
- `bun run design:lint` — passed with 0 errors and 9 pre-existing unused-token warnings
- `bun run check:design-system` — passed
- `git diff --check` — passed
- two Claude Opus 4.8 high-effort reviews — no blocking findings
- local test, typecheck, and build execution skipped per workstation policy; completed successfully in PR CI

## Residual risk

A repository-wide implicit-locale guard is still desirable. Other out-of-scope locale-implicit formatting remains in a currently sub-1000 pricing helper and a build-time documentation generator.

Closes #1637