### PR TITLE
fix(dx): resolve worktree and package publishing follow-ups

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -118,8 +118,11 @@ jobs:
         run: |
           # shellcheck disable=SC2016
           node -e '
-            const [major, minor] = process.argv[1].split(".").map(Number);
-            if (major < 11 || (major === 11 && minor < 5)) {
+            const [major, minor, patch] = process.argv[1].split(".").map(Number);
+            if (
+              major < 11 ||
+              (major === 11 && (minor < 5 || (minor === 5 && patch < 1)))
+            ) {
               throw new Error(`npm >=11.5.1 is required for OIDC trusted publishing; found ${process.argv[1]}`);
             }
           ' "$(npm --version)"

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "deps:update": "bunx npm-check-updates -u --deep --cooldown 3h --reject typescript && bun install",
     "dev": "bunx turbo run dev",
     "wt:sync": "bash scripts/sync-worktree-includes.sh",
-    "wt:setup": "git config alias.wt '!f(){ git worktree add \"$@\" && \"$(git rev-parse --show-toplevel)/scripts/sync-worktree-includes.sh\" \"$(git worktree list --porcelain | awk \"/^worktree /{w=\\$2} END{print w}\")\"; }; f' && echo 'Installed: use `git wt <path> [branch]` to add a worktree with env files copied.'",
+    "wt:setup": "git config alias.wt '!f(){ \"$(git rev-parse --show-toplevel)/scripts/git-wt.sh\" \"$@\"; }; f' && echo 'Installed: use `git wt <path> [branch]` to add a worktree with env files copied.'",
     "dev:admin:be": "bunx turbo run dev --filter=@genfeedai/api --filter=@genfeedai/notifications",
     "dev:all": "bunx turbo run dev",
     "dev:app": "bunx turbo run dev --filter=@genfeedai/app",

--- a/scripts/git-wt.sh
+++ b/scripts/git-wt.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+#
+# Add a worktree and sync the gitignored files declared in `.worktreeinclude`.
+#
+# Usage:
+#   scripts/git-wt.sh [git-worktree-add-options] <path> [commit-ish]
+
+set -euo pipefail
+
+if [ "$#" -lt 1 ]; then
+  echo "Usage: $0 [git-worktree-add-options] <path> [commit-ish]" >&2
+  exit 1
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+before_worktrees=()
+while IFS= read -r worktree_path; do
+  before_worktrees+=("$worktree_path")
+done < <(
+  git worktree list --porcelain |
+    awk '/^worktree /{print substr($0, 10)}'
+)
+
+git worktree add "$@"
+
+new_worktree=""
+new_worktree_count=0
+while IFS= read -r worktree_path; do
+  is_existing=0
+  for existing_worktree in "${before_worktrees[@]}"; do
+    if [ "$worktree_path" = "$existing_worktree" ]; then
+      is_existing=1
+      break
+    fi
+  done
+
+  if [ "$is_existing" -eq 0 ]; then
+    new_worktree="$worktree_path"
+    new_worktree_count=$((new_worktree_count + 1))
+  fi
+done < <(
+  git worktree list --porcelain |
+    awk '/^worktree /{print substr($0, 10)}'
+)
+
+if [ "$new_worktree_count" -ne 1 ]; then
+  echo "git wt — expected one new worktree, found $new_worktree_count" >&2
+  exit 1
+fi
+
+"$repo_root/scripts/sync-worktree-includes.sh" "$new_worktree"

--- a/scripts/package-release/review-followups.test.ts
+++ b/scripts/package-release/review-followups.test.ts
@@ -1,0 +1,164 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = fileURLToPath(new URL('../..', import.meta.url));
+
+interface PackageManifest {
+  scripts?: Record<string, string>;
+}
+
+describe('package and worktree review follow-ups', () => {
+  it('syncs includes to the newly created worktree when its path has spaces', () => {
+    const fixtureRoot = mkdtempSync(path.join(tmpdir(), 'git-wt-review-'));
+    const repository = path.join(fixtureRoot, 'repository');
+    const existingWorktree = path.join(fixtureRoot, 'zzz-existing');
+    const createdWorktree = path.join(fixtureRoot, 'aaa created with spaces');
+
+    try {
+      initializeFixtureRepository(repository);
+      runGit(repository, [
+        'worktree',
+        'add',
+        '--detach',
+        existingWorktree,
+        'HEAD',
+      ]);
+
+      execFileSync(
+        'bash',
+        [
+          path.join(repository, 'scripts/git-wt.sh'),
+          '-b',
+          'fixture-branch',
+          createdWorktree,
+          'HEAD',
+        ],
+        { cwd: repository, stdio: 'pipe' },
+      );
+
+      expect(
+        readFileSync(path.join(createdWorktree, '.fixture-env'), 'utf8'),
+      ).toBe('fixture-value\n');
+      expect(existsSync(path.join(existingWorktree, '.fixture-env'))).toBe(
+        false,
+      );
+      expect(readJson('package.json').scripts?.['wt:setup']).toContain(
+        'scripts/git-wt.sh',
+      );
+    } finally {
+      rmSync(fixtureRoot, { force: true, recursive: true });
+    }
+  });
+
+  it('reports worktree include copy failures', () => {
+    const fixtureRoot = mkdtempSync(
+      path.join(tmpdir(), 'worktree-copy-failure-'),
+    );
+    const repository = path.join(fixtureRoot, 'repository');
+    const worktree = path.join(fixtureRoot, 'worktree');
+    const fakeBin = path.join(fixtureRoot, 'bin');
+
+    try {
+      initializeFixtureRepository(repository);
+      runGit(repository, ['worktree', 'add', '--detach', worktree, 'HEAD']);
+      mkdirSync(fakeBin);
+      const fakeCopy = path.join(fakeBin, 'cp');
+      writeFileSync(
+        fakeCopy,
+        '#!/usr/bin/env sh\nprintf "partial\\n" > "$2"\nexit 1\n',
+      );
+      chmodSync(fakeCopy, 0o755);
+
+      const result = spawnSync(
+        'bash',
+        [path.join(repository, 'scripts/sync-worktree-includes.sh'), worktree],
+        {
+          cwd: repository,
+          encoding: 'utf8',
+          env: {
+            ...process.env,
+            PATH: `${fakeBin}:${process.env.PATH ?? ''}`,
+          },
+        },
+      );
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('failed to copy .fixture-env');
+      expect(result.stdout).toContain('1 failed');
+      expect(existsSync(path.join(worktree, '.fixture-env'))).toBe(false);
+    } finally {
+      rmSync(fixtureRoot, { force: true, recursive: true });
+    }
+  });
+
+  it('requires npm 11.5.1 in both release jobs', () => {
+    const workflow = readText('.github/workflows/publish-packages.yml');
+    const guards = Array.from(
+      workflow.matchAll(/node -e '\n([\s\S]*?)\n\s+' "\$\(npm --version\)"/g),
+      (match) => match[1],
+    );
+
+    expect(guards).toHaveLength(2);
+    for (const guard of guards) {
+      expect(runNodeGuard(guard, '11.5.0').status).not.toBe(0);
+      expect(runNodeGuard(guard, '11.5.1').status).toBe(0);
+      expect(runNodeGuard(guard, '12.0.0').status).toBe(0);
+    }
+  });
+});
+
+function readJson(relativePath: string): PackageManifest {
+  return JSON.parse(readText(relativePath)) as PackageManifest;
+}
+
+function readText(relativePath: string): string {
+  return readFileSync(path.join(ROOT, relativePath), 'utf8');
+}
+
+function initializeFixtureRepository(repository: string): void {
+  mkdirSync(repository);
+  mkdirSync(path.join(repository, 'scripts'));
+  runGit(repository, ['init', '--quiet']);
+  runGit(repository, ['config', 'user.name', 'Worktree Test']);
+  runGit(repository, ['config', 'user.email', 'worktree-test@example.com']);
+  writeFileSync(path.join(repository, '.gitignore'), '.fixture-env\n');
+  writeFileSync(path.join(repository, '.worktreeinclude'), '.fixture-env\n');
+  writeFileSync(path.join(repository, '.fixture-env'), 'fixture-value\n');
+  writeFileSync(path.join(repository, 'tracked.txt'), 'tracked\n');
+  for (const scriptName of ['git-wt.sh', 'sync-worktree-includes.sh']) {
+    const fixtureScript = path.join(repository, 'scripts', scriptName);
+    writeFileSync(fixtureScript, readText(`scripts/${scriptName}`));
+    chmodSync(fixtureScript, 0o755);
+  }
+  runGit(repository, [
+    'add',
+    '.gitignore',
+    '.worktreeinclude',
+    'scripts/git-wt.sh',
+    'scripts/sync-worktree-includes.sh',
+    'tracked.txt',
+  ]);
+  runGit(repository, ['commit', '--quiet', '-m', 'fixture']);
+}
+
+function runGit(cwd: string, args: string[]): void {
+  execFileSync('git', args, { cwd, stdio: 'pipe' });
+}
+
+function runNodeGuard(source: string, version: string) {
+  return spawnSync('node', ['-e', source, version], {
+    encoding: 'utf8',
+  });
+}

--- a/scripts/sync-worktree-includes.sh
+++ b/scripts/sync-worktree-includes.sh
@@ -53,6 +53,7 @@ echo "  primary: $primary"
 echo "  current: $current"
 
 copied=0
+failed=0
 skipped=0
 
 # Expand each glob relative to the primary worktree.
@@ -77,8 +78,16 @@ while IFS= read -r pattern || [ -n "$pattern" ]; do
     if cp "$primary/$rel" "$dest"; then
       echo "  + $rel"
       copied=$((copied + 1))
+    else
+      rm -f "$dest"
+      echo "  ! failed to copy $rel" >&2
+      failed=$((failed + 1))
     fi
   done
 done < "$include_file"
 
-echo "wt:sync — done ($copied copied, $skipped already present)"
+echo "wt:sync — done ($copied copied, $skipped already present, $failed failed)"
+
+if [ "$failed" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- replace the fragile inline `git wt` worktree lookup with a wrapper that identifies the newly added worktree, including option-first invocations and paths containing spaces
- make `.worktreeinclude` copy failures visible, retryable, and non-zero by removing partial destinations
- enforce npm `>=11.5.1` in both trusted-publishing workflow jobs
- add focused regression coverage for worktree selection, partial-copy cleanup, and npm version boundaries

## Review follow-up disposition

- `packages/helpers`: the reported `tsc-alias` runtime dependency is already absent and the build no longer invokes it
- `packages/ui`: moving the listed runtime imports into `dependencies` is no longer a valid isolated fix because those workspace packages are private; `check-public-package-manifests` rejects the proposed change
- `isSrcPath`: bare `src` / `./src` handling and its regression test are already present on `master`
- release subprocess timeouts: the shared runner, `npm view`, and `npm pack` already use the 15-minute timeout with actionable timeout errors

## Verification

- `bash -n scripts/git-wt.sh scripts/sync-worktree-includes.sh`
- `shellcheck scripts/git-wt.sh scripts/sync-worktree-includes.sh`
- `actionlint .github/workflows/publish-packages.yml`
- `bunx biome check package.json scripts/package-release/review-followups.test.ts`
- scratch-repository behavior check: option-first `git worktree add` with a spaced path syncs only the new worktree
- forced partial-copy failure check: logs the file, removes the partial destination, and exits `1`
- npm guard execution: `11.5.0` rejected; `11.5.1` and `12.0.0` accepted in both jobs
- `node scripts/check-public-package-manifests.mjs packages/ui`
- `git diff --check`
- Claude Opus 4.8 high-effort final review: no actionable findings

## Skipped locally

- `bunx vitest run --config scripts/package-release/vitest.config.ts review-followups.test.ts` could not resolve local `vitest/config` because this isolated worktree has no installed workspace dependencies; PR CI runs the package-release test config.

Closes #1634
Refs #1578
Refs #1588
