### PR TITLE
docs(extension): clarify local authentication guidance

### DIFF
--- a/apps/extensions/browser/app/docs/README.md
+++ b/apps/extensions/browser/app/docs/README.md
@@ -33,10 +33,10 @@ Load `build/chrome-mv3-dev` in Brave (Developer Mode → Load unpacked) during d
 
 ### Environment Configuration
 
-- **Development**: Extension connects to `genfeed.localhost` for authentication
+- **Development**: The extension uses `genfeed.localhost` for authentication
 - **Production**: Extension connects to `genfeed.ai` for authentication
 - **Dark Mode**: Enabled by default for better user experience
-- **Authentication**: Extension opens GenFeed sign in or free signup in the browser
+- **Authentication**: The extension opens GenFeed in your browser so you can sign in or sign up for free
 
 ### Scripts
 


### PR DESCRIPTION
## Summary
- clarify that extension authentication uses `genfeed.localhost` in development
- rewrite the deferred sign-in/sign-up guidance for grammatical clarity
- preserve the production-host documentation unchanged

## Verification
- `bunx biome format apps/extensions/browser/app/docs/README.md`
- exact wording assertions for development, production, and authentication bullets
- `git diff --check HEAD^ HEAD`
- staged/tree-delta secret-pattern scan
- Claude Opus 4.8 high-effort review: no actionable findings

## Skipped locally
- tests, typecheck, and build: documentation-only change; broad validation is delegated to PR CI under workstation policy
- link check: no links changed; PR Link Check will provide repository-level evidence

Closes #1731
