### PR TITLE
ci: add stable aggregate Tests Gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -750,4 +750,4 @@ jobs:
           TEST_API_CHANGED_RESULT: ${{ needs.test-api-changed.result }}
           OPENAPI_DRIFT_RESULT: ${{ needs.openapi-drift.result }}
           BUILD_RESULT: ${{ needs.build.result }}
-        run: node scripts/ci/tests-gate.mjs
+        run: node scripts/ci/tests-gate.mjs | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -750,4 +750,5 @@ jobs:
           TEST_API_CHANGED_RESULT: ${{ needs.test-api-changed.result }}
           OPENAPI_DRIFT_RESULT: ${{ needs.openapi-drift.result }}
           BUILD_RESULT: ${{ needs.build.result }}
+        shell: bash
         run: node scripts/ci/tests-gate.mjs | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,6 +277,8 @@ jobs:
         run: bun run check:public-packages
       - name: Package Release Scripts
         run: bunx vitest run --config scripts/package-release/vitest.config.ts
+      - name: CI Workflow Contract
+        run: node --test scripts/ci/tests-gate.test.mjs
       # Fail the build if the committed Prisma model metadata (enum-field-map)
       # has drifted from schema.prisma — soft-delete filtering + enum
       # normalization under the Prisma 7 driver adapter depend on it, and it
@@ -706,3 +708,46 @@ jobs:
           else
             bun run build
           fi
+
+  # Stable aggregate for the test/build portion of pull-request CI. Every
+  # upstream job is declared explicitly so an expression error that leaves an
+  # applicable job skipped cannot produce a false-green gate. Full-suite and
+  # changed-test jobs are mutually exclusive; scope-filtered skips are accepted
+  # only when the scope detector marked them non-applicable.
+  tests-gate:
+    name: Tests Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs:
+      - test-scope
+      - test-packages
+      - test-server-services
+      - test-web-desktop-mobile
+      - test-extensions
+      - test-app
+      - test-app-changed
+      - test-api
+      - test-api-changed
+      - openapi-drift
+      - build
+    if: ${{ always() && github.event_name == 'pull_request' }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Aggregate test and build results
+        env:
+          TEST_SCOPE_APP: ${{ needs.test-scope.outputs.app }}
+          TEST_SCOPE_API: ${{ needs.test-scope.outputs.api }}
+          FULL_SUITE: ${{ contains(github.event.pull_request.labels.*.name, 'full-suite') }}
+          TEST_SCOPE_RESULT: ${{ needs.test-scope.result }}
+          TEST_PACKAGES_RESULT: ${{ needs.test-packages.result }}
+          TEST_SERVER_SERVICES_RESULT: ${{ needs.test-server-services.result }}
+          TEST_WEB_DESKTOP_MOBILE_RESULT: ${{ needs.test-web-desktop-mobile.result }}
+          TEST_EXTENSIONS_RESULT: ${{ needs.test-extensions.result }}
+          TEST_APP_RESULT: ${{ needs.test-app.result }}
+          TEST_APP_CHANGED_RESULT: ${{ needs.test-app-changed.result }}
+          TEST_API_RESULT: ${{ needs.test-api.result }}
+          TEST_API_CHANGED_RESULT: ${{ needs.test-api-changed.result }}
+          OPENAPI_DRIFT_RESULT: ${{ needs.openapi-drift.result }}
+          BUILD_RESULT: ${{ needs.build.result }}
+        run: node scripts/ci/tests-gate.mjs

--- a/scripts/ci/tests-gate.mjs
+++ b/scripts/ci/tests-gate.mjs
@@ -12,9 +12,9 @@ const ALWAYS_APPLICABLE_JOBS = [
   ['Build', 'BUILD_RESULT'],
 ];
 
-function parseBoolean(value, name) {
+function parseBoolean(value, name, allowEmpty = false) {
   if (value === 'true') return true;
-  if (value === 'false' || value === '') return false;
+  if (value === 'false' || (allowEmpty && value === '')) return false;
   throw new Error(`${name} must be "true" or "false"; received "${value}"`);
 }
 
@@ -29,14 +29,16 @@ function readResult(env, key) {
 }
 
 export function createTestsGateJobs(env) {
-  const appScope = parseBoolean(env.TEST_SCOPE_APP, 'TEST_SCOPE_APP');
-  const apiScope = parseBoolean(env.TEST_SCOPE_API, 'TEST_SCOPE_API');
+  const testScopeResult = readResult(env, 'TEST_SCOPE_RESULT');
+  const allowEmptyScope = testScopeResult !== 'success';
+  const appScope = parseBoolean(env.TEST_SCOPE_APP, 'TEST_SCOPE_APP', allowEmptyScope);
+  const apiScope = parseBoolean(env.TEST_SCOPE_API, 'TEST_SCOPE_API', allowEmptyScope);
   const fullSuite = parseBoolean(env.FULL_SUITE, 'FULL_SUITE');
 
   return [
     {
       name: 'Test scope',
-      result: readResult(env, 'TEST_SCOPE_RESULT'),
+      result: testScopeResult,
       applicable: true,
     },
     ...ALWAYS_APPLICABLE_JOBS.map(([name, key]) => ({

--- a/scripts/ci/tests-gate.mjs
+++ b/scripts/ci/tests-gate.mjs
@@ -14,7 +14,7 @@ const ALWAYS_APPLICABLE_JOBS = [
 
 function parseBoolean(value, name) {
   if (value === 'true') return true;
-  if (value === 'false') return false;
+  if (value === 'false' || value === '') return false;
   throw new Error(`${name} must be "true" or "false"; received "${value}"`);
 }
 

--- a/scripts/ci/tests-gate.mjs
+++ b/scripts/ci/tests-gate.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from 'node:url';
+
+const VALID_RESULTS = new Set(['success', 'failure', 'cancelled', 'skipped']);
+
+const ALWAYS_APPLICABLE_JOBS = [
+  ['Package tests', 'TEST_PACKAGES_RESULT'],
+  ['Server-service tests', 'TEST_SERVER_SERVICES_RESULT'],
+  ['Web, desktop, and mobile tests', 'TEST_WEB_DESKTOP_MOBILE_RESULT'],
+  ['Extension tests', 'TEST_EXTENSIONS_RESULT'],
+  ['Build', 'BUILD_RESULT'],
+];
+
+function parseBoolean(value, name) {
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  throw new Error(`${name} must be "true" or "false"; received "${value}"`);
+}
+
+function readResult(env, key) {
+  const result = env[key];
+  if (!VALID_RESULTS.has(result)) {
+    throw new Error(
+      `${key} must be a GitHub job result; received "${result ?? ''}"`,
+    );
+  }
+  return result;
+}
+
+export function createTestsGateJobs(env) {
+  const appScope = parseBoolean(env.TEST_SCOPE_APP, 'TEST_SCOPE_APP');
+  const apiScope = parseBoolean(env.TEST_SCOPE_API, 'TEST_SCOPE_API');
+  const fullSuite = parseBoolean(env.FULL_SUITE, 'FULL_SUITE');
+
+  return [
+    {
+      name: 'Test scope',
+      result: readResult(env, 'TEST_SCOPE_RESULT'),
+      applicable: true,
+    },
+    ...ALWAYS_APPLICABLE_JOBS.map(([name, key]) => ({
+      name,
+      result: readResult(env, key),
+      applicable: true,
+    })),
+    {
+      name: 'App tests (full matrix)',
+      result: readResult(env, 'TEST_APP_RESULT'),
+      applicable: appScope && fullSuite,
+    },
+    {
+      name: 'App tests (changed)',
+      result: readResult(env, 'TEST_APP_CHANGED_RESULT'),
+      applicable: appScope && !fullSuite,
+    },
+    {
+      name: 'API tests (full matrix)',
+      result: readResult(env, 'TEST_API_RESULT'),
+      applicable: apiScope && fullSuite,
+    },
+    {
+      name: 'API tests (changed)',
+      result: readResult(env, 'TEST_API_CHANGED_RESULT'),
+      applicable: apiScope && !fullSuite,
+    },
+    {
+      name: 'OpenAPI spec drift',
+      result: readResult(env, 'OPENAPI_DRIFT_RESULT'),
+      applicable: apiScope,
+    },
+  ];
+}
+
+export function evaluateTestsGate(jobs) {
+  const failures = [];
+  const rows = [];
+
+  for (const job of jobs) {
+    const { name, result, applicable } = job;
+
+    if (!VALID_RESULTS.has(result)) {
+      failures.push(`${name} reported an unknown result: ${result}`);
+      rows.push({ ...job, classification: 'invalid' });
+      continue;
+    }
+
+    if (result === 'failure' || result === 'cancelled') {
+      failures.push(`${name} ${result}`);
+      rows.push({ ...job, classification: result });
+      continue;
+    }
+
+    if (applicable && result !== 'success') {
+      failures.push(`${name} was applicable but ${result}`);
+      rows.push({ ...job, classification: 'missing' });
+      continue;
+    }
+
+    rows.push({
+      ...job,
+      classification: result === 'skipped' ? 'not applicable' : 'passed',
+    });
+  }
+
+  return {
+    passed: failures.length === 0,
+    failures,
+    rows,
+  };
+}
+
+export function formatTestsGateSummary(evaluation) {
+  const lines = [
+    '# Tests Gate',
+    '',
+    '| Job | Expected | Result | Classification |',
+    '| --- | --- | --- | --- |',
+  ];
+
+  for (const row of evaluation.rows) {
+    lines.push(
+      `| ${row.name} | ${row.applicable ? 'applicable' : 'not applicable'} | ${row.result} | ${row.classification} |`,
+    );
+  }
+
+  lines.push(
+    '',
+    evaluation.passed
+      ? 'All applicable test and build jobs passed.'
+      : `Gate failures: ${evaluation.failures.join('; ')}.`,
+  );
+
+  return `${lines.join('\n')}\n`;
+}
+
+function runCli() {
+  let evaluation;
+
+  try {
+    evaluation = evaluateTestsGate(createTestsGateJobs(process.env));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+    return;
+  }
+
+  const summary = formatTestsGateSummary(evaluation);
+  process.stdout.write(summary);
+
+  if (!evaluation.passed) {
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) runCli();

--- a/scripts/ci/tests-gate.mjs
+++ b/scripts/ci/tests-gate.mjs
@@ -31,8 +31,16 @@ function readResult(env, key) {
 export function createTestsGateJobs(env) {
   const testScopeResult = readResult(env, 'TEST_SCOPE_RESULT');
   const allowEmptyScope = testScopeResult !== 'success';
-  const appScope = parseBoolean(env.TEST_SCOPE_APP, 'TEST_SCOPE_APP', allowEmptyScope);
-  const apiScope = parseBoolean(env.TEST_SCOPE_API, 'TEST_SCOPE_API', allowEmptyScope);
+  const appScope = parseBoolean(
+    env.TEST_SCOPE_APP,
+    'TEST_SCOPE_APP',
+    allowEmptyScope,
+  );
+  const apiScope = parseBoolean(
+    env.TEST_SCOPE_API,
+    'TEST_SCOPE_API',
+    allowEmptyScope,
+  );
   const fullSuite = parseBoolean(env.FULL_SUITE, 'FULL_SUITE');
 
   return [

--- a/scripts/ci/tests-gate.test.mjs
+++ b/scripts/ci/tests-gate.test.mjs
@@ -28,9 +28,7 @@ function evaluate(env = {}) {
 }
 
 function runGateCli(env = {}) {
-  const gatePath = fileURLToPath(
-    new URL('./tests-gate.mjs', import.meta.url),
-  );
+  const gatePath = fileURLToPath(new URL('./tests-gate.mjs', import.meta.url));
 
   return spawnSync(process.execPath, [gatePath], {
     env: { ...process.env, ...ALL_SUCCESS_ENV, ...env },

--- a/scripts/ci/tests-gate.test.mjs
+++ b/scripts/ci/tests-gate.test.mjs
@@ -61,6 +61,17 @@ test('fails when an applicable job is unexpectedly skipped', () => {
   ]);
 });
 
+test('reports a scope failure when its outputs are empty', () => {
+  const result = evaluate({
+    TEST_SCOPE_APP: '',
+    TEST_SCOPE_API: '',
+    TEST_SCOPE_RESULT: 'failure',
+  });
+
+  assert.equal(result.passed, false);
+  assert.deepEqual(result.failures, ['Test scope failure']);
+});
+
 test('switches full-suite applicability without accepting missing matrix jobs', () => {
   const result = evaluate({
     FULL_SUITE: 'true',

--- a/scripts/ci/tests-gate.test.mjs
+++ b/scripts/ci/tests-gate.test.mjs
@@ -91,6 +91,17 @@ test('reports a scope failure when its outputs are empty', () => {
   assert.deepEqual(result.failures, ['Test scope failure']);
 });
 
+test('fails closed when a successful scope job omits its outputs', () => {
+  const result = runGateCli({
+    TEST_SCOPE_APP: '',
+    TEST_SCOPE_API: '',
+    TEST_SCOPE_RESULT: 'success',
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /TEST_SCOPE_APP must be "true" or "false"/);
+});
+
 test('switches full-suite applicability without accepting missing matrix jobs', () => {
   const result = evaluate({
     FULL_SUITE: 'true',

--- a/scripts/ci/tests-gate.test.mjs
+++ b/scripts/ci/tests-gate.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 import { fileURLToPath } from 'node:url';
@@ -26,6 +27,17 @@ function evaluate(env = {}) {
   return evaluateTestsGate(createTestsGateJobs({ ...ALL_SUCCESS_ENV, ...env }));
 }
 
+function runGateCli(env = {}) {
+  const gatePath = fileURLToPath(
+    new URL('./tests-gate.mjs', import.meta.url),
+  );
+
+  return spawnSync(process.execPath, [gatePath], {
+    env: { ...process.env, ...ALL_SUCCESS_ENV, ...env },
+    encoding: 'utf8',
+  });
+}
+
 test('passes when applicable jobs succeed and intentional skips are explicit', () => {
   const result = evaluate();
 
@@ -43,6 +55,13 @@ test('fails when an applicable upstream job fails', () => {
 
   assert.equal(result.passed, false);
   assert.deepEqual(result.failures, ['Package tests failure']);
+});
+
+test('exits non-zero when an applicable upstream job fails', () => {
+  const result = runGateCli({ TEST_PACKAGES_RESULT: 'failure' });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stdout, /Gate failures: Package tests failure\./);
 });
 
 test('fails when an upstream job is cancelled', () => {
@@ -115,4 +134,9 @@ test('keeps the workflow contract stable', () => {
   ]) {
     assert.match(workflow, new RegExp(`^      - ${job}$`, 'm'));
   }
+
+  assert.match(
+    workflow,
+    /^ {8}shell: bash\n {8}run: node scripts\/ci\/tests-gate\.mjs \| tee -a "\$GITHUB_STEP_SUMMARY"$/m,
+  );
 });

--- a/scripts/ci/tests-gate.test.mjs
+++ b/scripts/ci/tests-gate.test.mjs
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { createTestsGateJobs, evaluateTestsGate } from './tests-gate.mjs';
+
+const ALL_SUCCESS_ENV = {
+  TEST_SCOPE_APP: 'true',
+  TEST_SCOPE_API: 'true',
+  FULL_SUITE: 'false',
+  TEST_SCOPE_RESULT: 'success',
+  TEST_PACKAGES_RESULT: 'success',
+  TEST_SERVER_SERVICES_RESULT: 'success',
+  TEST_WEB_DESKTOP_MOBILE_RESULT: 'success',
+  TEST_EXTENSIONS_RESULT: 'success',
+  BUILD_RESULT: 'success',
+  TEST_APP_RESULT: 'skipped',
+  TEST_APP_CHANGED_RESULT: 'success',
+  TEST_API_RESULT: 'skipped',
+  TEST_API_CHANGED_RESULT: 'success',
+  OPENAPI_DRIFT_RESULT: 'success',
+};
+
+function evaluate(env = {}) {
+  return evaluateTestsGate(createTestsGateJobs({ ...ALL_SUCCESS_ENV, ...env }));
+}
+
+test('passes when applicable jobs succeed and intentional skips are explicit', () => {
+  const result = evaluate();
+
+  assert.equal(result.passed, true);
+  assert.deepEqual(result.failures, []);
+  assert.equal(
+    result.rows.find((row) => row.name === 'App tests (full matrix)')
+      ?.classification,
+    'not applicable',
+  );
+});
+
+test('fails when an applicable upstream job fails', () => {
+  const result = evaluate({ TEST_PACKAGES_RESULT: 'failure' });
+
+  assert.equal(result.passed, false);
+  assert.deepEqual(result.failures, ['Package tests failure']);
+});
+
+test('fails when an upstream job is cancelled', () => {
+  const result = evaluate({ BUILD_RESULT: 'cancelled' });
+
+  assert.equal(result.passed, false);
+  assert.deepEqual(result.failures, ['Build cancelled']);
+});
+
+test('fails when an applicable job is unexpectedly skipped', () => {
+  const result = evaluate({ TEST_APP_CHANGED_RESULT: 'skipped' });
+
+  assert.equal(result.passed, false);
+  assert.deepEqual(result.failures, [
+    'App tests (changed) was applicable but skipped',
+  ]);
+});
+
+test('switches full-suite applicability without accepting missing matrix jobs', () => {
+  const result = evaluate({
+    FULL_SUITE: 'true',
+    TEST_APP_RESULT: 'skipped',
+    TEST_APP_CHANGED_RESULT: 'skipped',
+    TEST_API_RESULT: 'success',
+    TEST_API_CHANGED_RESULT: 'skipped',
+  });
+
+  assert.equal(result.passed, false);
+  assert.deepEqual(result.failures, [
+    'App tests (full matrix) was applicable but skipped',
+  ]);
+});
+
+test('keeps the workflow contract stable', () => {
+  const workflowPath = fileURLToPath(
+    new URL('../../.github/workflows/ci.yml', import.meta.url),
+  );
+  const workflow = readFileSync(workflowPath, 'utf8');
+
+  assert.match(workflow, /^ {2}tests-gate:\n/m);
+  assert.match(workflow, /^ {4}name: Tests Gate\n/m);
+  assert.match(
+    workflow,
+    /^ {4}if: \$\{\{ always\(\) && github\.event_name == 'pull_request' \}\}\n/m,
+  );
+
+  for (const job of [
+    'test-scope',
+    'test-packages',
+    'test-server-services',
+    'test-web-desktop-mobile',
+    'test-extensions',
+    'test-app',
+    'test-app-changed',
+    'test-api',
+    'test-api-changed',
+    'openapi-drift',
+    'build',
+  ]) {
+    assert.match(workflow, new RegExp(`^      - ${job}$`, 'm'));
+  }
+});


### PR DESCRIPTION
## Summary

- add a stable pull-request check named `Tests Gate`
- aggregate package, server-service, web/desktop/mobile, extension, app, API, OpenAPI, and build results
- fail on failed, cancelled, or unexpectedly skipped applicable jobs while accepting intentional path/full-suite skips
- add a deterministic Node contract suite for success, failure, cancellation, applicability, and workflow wiring

## Why

PR CI already runs affected tests and builds, but those jobs are not required by the master ruleset. A stable aggregate context makes the existing coverage observable as one future required check without renaming or weakening the six checks already enforced.

The exact stable check name is `Tests Gate`. Follow-up ruleset activation remains operational work in #1826 after representative PR observation.

## Verification

- `actionlint .github/workflows/ci.yml` — passed
- `bunx @biomejs/biome@2.5.3 check scripts/ci/tests-gate.mjs scripts/ci/tests-gate.test.mjs` — passed
- `node --check scripts/ci/tests-gate.mjs` and test module syntax check — passed
- `git diff --check` — passed
- staged sensitive filename and added-secret-pattern scans — passed
- local unit tests, typecheck, and build skipped under workstation policy; PR CI is the authoritative broad validation

## Review note

The required Claude Opus 4.8 high-effort review was invoked. The CLI emitted the repository permission warning `Write(**/.env*) is not matched by file permission checks` and then produced no review output for two minutes; the hung non-interactive process was terminated. Static review and CI evidence are recorded here instead of claiming an unavailable Claude verdict.

## Risk

The aggregate intentionally does not include Playwright or full API E2E. The main risk is GitHub Actions result/applicability semantics, covered by the contract suite and this PR run; #1826 requires observation on three representative PRs before making the context required.

Closes #1825
Refs #71
Refs #1826