### PR TITLE
feat(editor): define Remotion export contract

### DIFF
--- a/apps/server/api/src/collections/editor-projects/editor-projects.service.ts
+++ b/apps/server/api/src/collections/editor-projects/editor-projects.service.ts
@@ -1,7 +1,6 @@
 import { CreateEditorProjectDto } from '@api/collections/editor-projects/dto/create-editor-project.dto';
 import { UpdateEditorProjectDto } from '@api/collections/editor-projects/dto/update-editor-project.dto';
 import type { EditorProjectDocument } from '@api/collections/editor-projects/schemas/editor-project.schema';
-import { NotFoundException } from '@api/helpers/exceptions/http/not-found.exception';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { BaseService } from '@api/shared/services/base/base.service';
 import {
@@ -33,15 +32,6 @@ export class EditorProjectsService extends BaseService<
     return this.isProjectObject(value) ? value : {};
   }
 
-  private readProjectStatus(project: {
-    config?: unknown;
-  }): EditorProjectStatus | undefined {
-    const status = this.readProjectConfig(project.config).status;
-    return typeof status === 'string'
-      ? (status as EditorProjectStatus)
-      : undefined;
-  }
-
   private mergeProjectStatus(
     project: { config?: unknown },
     status: EditorProjectStatus,
@@ -50,6 +40,19 @@ export class EditorProjectsService extends BaseService<
       ...this.readProjectConfig(project.config),
       status,
     };
+  }
+
+  async findForRender(
+    id: string,
+    organizationId: string,
+  ): Promise<EditorProjectDocument> {
+    const project = await findOrThrow(
+      this.prisma.editorProject,
+      { where: { id, isDeleted: false, organizationId } },
+      'Project',
+    );
+
+    return this.normalizeDocument(project);
   }
 
   /**

--- a/apps/server/api/src/collections/editor-projects/services/editor-render.service.spec.ts
+++ b/apps/server/api/src/collections/editor-projects/services/editor-render.service.spec.ts
@@ -11,7 +11,7 @@ import { NotFoundException } from '@api/helpers/exceptions/http/not-found.except
 import { FileQueueService } from '@api/services/files-microservice/queue/file-queue.service';
 import { NotificationsPublisherService } from '@api/services/notifications/publisher/notifications-publisher.service';
 import { SharedService } from '@api/shared/services/shared/shared.service';
-import { EditorTrackType } from '@genfeedai/enums';
+import { EditorTrackType, IngredientFormat } from '@genfeedai/enums';
 import { ConfigService } from '@libs/config/config.service';
 import { LoggerService } from '@libs/logger/logger.service';
 import { UnprocessableEntityException } from '@nestjs/common';
@@ -22,6 +22,7 @@ describe('EditorRenderService', () => {
   let service: EditorRenderService;
 
   let editorProjectsService: {
+    findForRender: ReturnType<typeof vi.fn>;
     markAsRendering: ReturnType<typeof vi.fn>;
     markAsFailed: ReturnType<typeof vi.fn>;
     markAsCompleted: ReturnType<typeof vi.fn>;
@@ -63,27 +64,45 @@ describe('EditorRenderService', () => {
   const makeTrack = (type: EditorTrackType, clipOverrides = {}) => ({
     clips: [
       {
+        durationFrames: 300,
+        effects: [],
+        id: `${type}-clip`,
         ingredientId: videoIngredientId,
+        ingredientUrl: `https://cdn.genfeed.ai/${type}`,
         sourceEndFrame: 300,
         sourceStartFrame: 0,
+        startFrame: 0,
         textOverlay: null,
         ...clipOverrides,
       },
     ],
+    id: `${type}-track`,
+    isLocked: false,
+    isMuted: false,
+    name: type,
     type,
+    volume: 100,
   });
 
   const makeProject = (
     tracks = [makeTrack(EditorTrackType.VIDEO)],
-    settings = { fps: 30 },
+    settings = {
+      backgroundColor: '#000000',
+      format: IngredientFormat.LANDSCAPE,
+      fps: 30,
+      height: 1080,
+      width: 1920,
+    },
   ) => ({
     id: projectId,
     settings,
+    totalDurationFrames: 300,
     tracks,
   });
 
   beforeEach(async () => {
     editorProjectsService = {
+      findForRender: vi.fn().mockResolvedValue(makeProject()),
       markAsCompleted: vi.fn().mockResolvedValue(undefined),
       markAsFailed: vi.fn().mockResolvedValue(undefined),
       markAsRendering: vi.fn().mockResolvedValue(makeProject()),
@@ -176,28 +195,67 @@ describe('EditorRenderService', () => {
     });
 
     it('should throw UnprocessableEntityException when no video track', async () => {
-      editorProjectsService.markAsRendering.mockResolvedValue(makeProject([]));
+      editorProjectsService.findForRender.mockResolvedValue(makeProject([]));
 
       await expect(service.render(projectId, orgId, mockUser)).rejects.toThrow(
         UnprocessableEntityException,
       );
+      expect(editorProjectsService.markAsRendering).not.toHaveBeenCalled();
+      expect(sharedService.saveDocuments).not.toHaveBeenCalled();
+      expect(fileQueueService.processVideo).not.toHaveBeenCalled();
+    });
+
+    it('should reject malformed export settings before render side effects', async () => {
+      editorProjectsService.findForRender.mockResolvedValue(
+        makeProject([makeTrack(EditorTrackType.VIDEO)], {
+          backgroundColor: '#000000',
+          format: IngredientFormat.LANDSCAPE,
+          fps: 30,
+          height: 1080,
+          width: 0,
+        }),
+      );
+
+      await expect(
+        service.render(projectId, orgId, mockUser),
+      ).rejects.toMatchObject({
+        response: expect.objectContaining({
+          code: 'editor_export_contract_invalid',
+          violations: expect.arrayContaining([
+            expect.objectContaining({ path: 'settings.width' }),
+          ]),
+        }),
+      });
+      expect(editorProjectsService.markAsRendering).not.toHaveBeenCalled();
+      expect(sharedService.saveDocuments).not.toHaveBeenCalled();
+      expect(fileQueueService.processVideo).not.toHaveBeenCalled();
     });
 
     it('should throw UnprocessableEntityException when more than one video track', async () => {
-      editorProjectsService.markAsRendering.mockResolvedValue(
+      editorProjectsService.findForRender.mockResolvedValue(
         makeProject([
           makeTrack(EditorTrackType.VIDEO),
-          makeTrack(EditorTrackType.VIDEO),
+          {
+            ...makeTrack(EditorTrackType.VIDEO),
+            id: 'second-video-track',
+            clips: [
+              {
+                ...makeTrack(EditorTrackType.VIDEO).clips[0],
+                id: 'second-video-clip',
+              },
+            ],
+          },
         ]),
       );
 
       await expect(service.render(projectId, orgId, mockUser)).rejects.toThrow(
         UnprocessableEntityException,
       );
+      expect(editorProjectsService.markAsRendering).not.toHaveBeenCalled();
     });
 
     it('should throw UnprocessableEntityException when video track has no clips', async () => {
-      editorProjectsService.markAsRendering.mockResolvedValue(
+      editorProjectsService.findForRender.mockResolvedValue(
         makeProject([{ ...makeTrack(EditorTrackType.VIDEO), clips: [] }]),
       );
 
@@ -210,21 +268,29 @@ describe('EditorRenderService', () => {
       const multiClipTrack = {
         clips: [
           {
-            ingredientId: videoIngredientId,
-            sourceEndFrame: 300,
-            sourceStartFrame: 0,
-            textOverlay: null,
+            ...makeTrack(EditorTrackType.VIDEO).clips[0],
+            durationFrames: 150,
+            id: 'video-clip-1',
+            sourceEndFrame: 150,
           },
           {
+            ...makeTrack(EditorTrackType.VIDEO).clips[0],
+            durationFrames: 150,
+            id: 'video-clip-2',
             ingredientId: videoIngredientId,
-            sourceEndFrame: 600,
-            sourceStartFrame: 300,
-            textOverlay: null,
+            sourceEndFrame: 300,
+            sourceStartFrame: 150,
+            startFrame: 150,
           },
         ],
+        id: 'multi-clip-track',
+        isLocked: false,
+        isMuted: false,
+        name: 'Video',
         type: EditorTrackType.VIDEO,
+        volume: 100,
       };
-      editorProjectsService.markAsRendering.mockResolvedValue(
+      editorProjectsService.findForRender.mockResolvedValue(
         makeProject([multiClipTrack]),
       );
 
@@ -234,7 +300,6 @@ describe('EditorRenderService', () => {
     });
 
     it('should throw NotFoundException when source video not found', async () => {
-      editorProjectsService.markAsRendering.mockResolvedValue(makeProject());
       ingredientsService.findOne.mockResolvedValue(null);
 
       await expect(service.render(projectId, orgId, mockUser)).rejects.toThrow(
@@ -243,7 +308,6 @@ describe('EditorRenderService', () => {
     });
 
     it('should call markAsFailed when post-transition step throws', async () => {
-      editorProjectsService.markAsRendering.mockResolvedValue(makeProject());
       ingredientsService.findOne.mockRejectedValue(new Error('DB error'));
 
       await expect(service.render(projectId, orgId, mockUser)).rejects.toThrow(
@@ -256,25 +320,36 @@ describe('EditorRenderService', () => {
 
     it('should pass text overlay job type when text track present', async () => {
       const textTrack = makeTrack(EditorTrackType.TEXT, {
-        textOverlay: { position: 'bottom', text: 'Hello World' },
+        ingredientId: '',
+        ingredientUrl: '',
+        textOverlay: {
+          color: '#ffffff',
+          fontSize: 32,
+          position: { x: 50, y: 80 },
+          text: 'Hello World',
+        },
       });
-      editorProjectsService.markAsRendering.mockResolvedValue(
+      editorProjectsService.findForRender.mockResolvedValue(
         makeProject([makeTrack(EditorTrackType.VIDEO), textTrack]),
       );
 
       await service.render(projectId, orgId, mockUser);
 
       expect(fileQueueService.processVideo).toHaveBeenCalledWith(
-        expect.objectContaining({ type: 'add-text-overlay' }),
+        expect.objectContaining({
+          params: expect.objectContaining({ position: 'bottom' }),
+          type: 'add-text-overlay',
+        }),
       );
     });
 
     it('should pass trim-video job type when no text overlay and video is trimmed', async () => {
       const trimmedTrack = makeTrack(EditorTrackType.VIDEO, {
+        durationFrames: 120,
         sourceEndFrame: 150,
         sourceStartFrame: 30,
       });
-      editorProjectsService.markAsRendering.mockResolvedValue(
+      editorProjectsService.findForRender.mockResolvedValue(
         makeProject([trimmedTrack]),
       );
 

--- a/apps/server/api/src/collections/editor-projects/services/editor-render.service.spec.ts
+++ b/apps/server/api/src/collections/editor-projects/services/editor-render.service.spec.ts
@@ -299,6 +299,31 @@ describe('EditorRenderService', () => {
       );
     });
 
+    it('should reject contract-valid audio tracks that the current renderer cannot consume', async () => {
+      editorProjectsService.findForRender.mockResolvedValue(
+        makeProject([
+          makeTrack(EditorTrackType.VIDEO),
+          {
+            ...makeTrack(EditorTrackType.AUDIO),
+            id: 'audio-track',
+            clips: [
+              {
+                ...makeTrack(EditorTrackType.AUDIO).clips[0],
+                id: 'audio-clip',
+              },
+            ],
+          },
+        ]),
+      );
+
+      await expect(service.render(projectId, orgId, mockUser)).rejects.toThrow(
+        'Audio tracks require the multi-track renderer',
+      );
+      expect(editorProjectsService.markAsRendering).not.toHaveBeenCalled();
+      expect(sharedService.saveDocuments).not.toHaveBeenCalled();
+      expect(fileQueueService.processVideo).not.toHaveBeenCalled();
+    });
+
     it('should throw NotFoundException when source video not found', async () => {
       ingredientsService.findOne.mockResolvedValue(null);
 

--- a/apps/server/api/src/collections/editor-projects/services/editor-render.service.ts
+++ b/apps/server/api/src/collections/editor-projects/services/editor-render.service.ts
@@ -1,7 +1,10 @@
 import fs from 'node:fs';
 import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticated-user.interface';
 import { EditorProjectsService } from '@api/collections/editor-projects/editor-projects.service';
-import { type EditorProjectDocument } from '@api/collections/editor-projects/schemas/editor-project.schema';
+import {
+  buildValidatedEditorExportContract,
+  EditorExportContractValidationError,
+} from '@api/collections/editor-projects/utils/editor-export-contract.util';
 import { IngredientsService } from '@api/collections/ingredients/services/ingredients.service';
 import { MetadataService } from '@api/collections/metadata/services/metadata.service';
 import { NotFoundException } from '@api/helpers/exceptions/http/not-found.exception';
@@ -18,7 +21,10 @@ import {
   WebSocketEventStatus,
   WebSocketEventType,
 } from '@genfeedai/enums';
-import type { IFileProcessingParams } from '@genfeedai/interfaces';
+import type {
+  IEditorExportCompositionSnapshot,
+  IFileProcessingParams,
+} from '@genfeedai/interfaces';
 import { ConfigService } from '@libs/config/config.service';
 import { LoggerService } from '@libs/logger/logger.service';
 import { getUserRoomName } from '@libs/websockets/room-name.util';
@@ -47,14 +53,33 @@ export class EditorRenderService {
 
   async render(id: string, orgId: string, user: User): Promise<RenderResult> {
     const publicMetadata = user.publicMetadata as Record<string, string>;
-
-    // Atomic CAS: only transitions DRAFT/COMPLETED/FAILED -> RENDERING
-    const project = await this.editorProjectsService.markAsRendering(id, orgId);
+    const projectForValidation = await this.editorProjectsService.findForRender(
+      id,
+      orgId,
+    );
+    let snapshot: IEditorExportCompositionSnapshot;
 
     try {
-      this.validateMvpConstraints(project);
+      snapshot =
+        buildValidatedEditorExportContract(projectForValidation).snapshot;
+    } catch (error: unknown) {
+      if (error instanceof EditorExportContractValidationError) {
+        throw new UnprocessableEntityException({
+          code: 'editor_export_contract_invalid',
+          message: error.message,
+          violations: error.violations,
+        });
+      }
+      throw error;
+    }
 
-      const renderParams = await this.extractRenderParams(project, orgId);
+    this.validateCurrentRendererCapability(snapshot);
+
+    // Atomic CAS: only transitions DRAFT/COMPLETED/FAILED -> RENDERING
+    await this.editorProjectsService.markAsRendering(id, orgId);
+
+    try {
+      const renderParams = await this.extractRenderParams(snapshot, orgId);
 
       const { metadataData, ingredientData } =
         await this.sharedService.saveDocuments(user, {
@@ -102,7 +127,9 @@ export class EditorRenderService {
     }
   }
 
-  private validateMvpConstraints(project: EditorProjectDocument): void {
+  private validateCurrentRendererCapability(
+    project: IEditorExportCompositionSnapshot,
+  ): void {
     const videoTracks = project.tracks.filter(
       (t) => t.type === EditorTrackType.VIDEO,
     );
@@ -149,19 +176,24 @@ export class EditorRenderService {
   }
 
   private async extractRenderParams(
-    project: EditorProjectDocument,
+    project: IEditorExportCompositionSnapshot,
     orgId: string,
   ) {
     const videoTrack = project.tracks.find(
       (t) => t.type === EditorTrackType.VIDEO,
-    )!;
+    );
+    if (!videoTrack) {
+      throw new UnprocessableEntityException(
+        'Project must have at least 1 video track to render',
+      );
+    }
     const textTrack = project.tracks.find(
       (t) => t.type === EditorTrackType.TEXT,
     );
 
     const clip = videoTrack.clips[0];
     const videoId = clip.ingredientId;
-    const fps = project.settings?.fps || 30;
+    const fps = project.settings.fps;
 
     // Validate source video ownership
     const video = await this.ingredientsService.findOne({
@@ -197,21 +229,22 @@ export class EditorRenderService {
     // Check for text overlay
     const textClip =
       textTrack && textTrack.clips.length > 0 ? textTrack.clips[0] : undefined;
-    const hasTextOverlay = !!textClip?.textOverlay?.text;
-    const textLabel = hasTextOverlay ? textClip!.textOverlay!.text : '';
+    const textOverlay = textClip?.textOverlay;
+    const hasTextOverlay = Boolean(textOverlay?.text);
+    const textLabel = textOverlay?.text ?? '';
 
     const videoUrl = `${this.configService.ingredientsEndpoint}/videos/${videoId}`;
 
     let jobType: string;
     let jobParams: IFileProcessingParams;
 
-    if (hasTextOverlay) {
+    if (textOverlay?.text) {
       jobType = 'add-text-overlay';
       jobParams = {
         height,
         inputPath: videoUrl,
-        position: textClip!.textOverlay!.position || 'top',
-        text: textClip!.textOverlay!.text,
+        position: this.toCurrentRendererTextPosition(textOverlay.position.y),
+        text: textOverlay.text,
         width,
         ...(isTrimmed ? { endTime, startTime } : {}),
       };
@@ -242,6 +275,18 @@ export class EditorRenderService {
       videoId,
       width,
     };
+  }
+
+  private toCurrentRendererTextPosition(
+    yPercentage: number,
+  ): 'bottom' | 'center' | 'top' {
+    if (yPercentage <= 33) {
+      return 'top';
+    }
+    if (yPercentage >= 67) {
+      return 'bottom';
+    }
+    return 'center';
   }
 
   private handleAsyncCompletion(

--- a/apps/server/api/src/collections/editor-projects/services/editor-render.service.ts
+++ b/apps/server/api/src/collections/editor-projects/services/editor-render.service.ts
@@ -133,6 +133,9 @@ export class EditorRenderService {
     const videoTracks = project.tracks.filter(
       (t) => t.type === EditorTrackType.VIDEO,
     );
+    const audioTracks = project.tracks.filter(
+      (t) => t.type === EditorTrackType.AUDIO,
+    );
     const textTracks = project.tracks.filter(
       (t) => t.type === EditorTrackType.TEXT,
     );
@@ -159,6 +162,12 @@ export class EditorRenderService {
     if (videoTrack.clips.length > 1) {
       throw new UnprocessableEntityException(
         'Multi-clip timelines are not yet supported. Please use a single video clip.',
+      );
+    }
+
+    if (audioTracks.length > 0) {
+      throw new UnprocessableEntityException(
+        'Audio tracks require the multi-track renderer and cannot be rendered by the current version.',
       );
     }
 

--- a/apps/server/api/src/collections/editor-projects/utils/editor-export-contract.util.spec.ts
+++ b/apps/server/api/src/collections/editor-projects/utils/editor-export-contract.util.spec.ts
@@ -1,0 +1,224 @@
+import {
+  EditorEffectType,
+  EditorTrackType,
+  IngredientFormat,
+} from '@genfeedai/enums';
+import {
+  EDITOR_EXPORT_CONTRACT_VERSION,
+  type IEditorTrack,
+} from '@genfeedai/interfaces';
+import {
+  buildValidatedEditorExportContract,
+  EditorExportContractValidationError,
+} from './editor-export-contract.util';
+
+const mediaClip = (
+  id: string,
+  ingredientId: string,
+  ingredientUrl: string,
+) => ({
+  durationFrames: 120,
+  effects: [{ intensity: 50, type: EditorEffectType.BRIGHTNESS }],
+  id,
+  ingredientId,
+  ingredientUrl,
+  sourceEndFrame: 150,
+  sourceStartFrame: 30,
+  startFrame: 0,
+  volume: 100,
+});
+
+const tracks: IEditorTrack[] = [
+  {
+    clips: [
+      mediaClip('video-1', 'video-ingredient', 'https://cdn.test/video.mp4'),
+      {
+        ...mediaClip(
+          'video-2',
+          'b-roll-ingredient',
+          'https://cdn.test/b-roll.mp4',
+        ),
+        durationFrames: 60,
+        sourceEndFrame: 60,
+        sourceStartFrame: 0,
+        startFrame: 120,
+      },
+    ],
+    id: 'video-track',
+    isLocked: false,
+    isMuted: false,
+    name: 'Video',
+    type: EditorTrackType.VIDEO,
+    volume: 100,
+  },
+  {
+    clips: [
+      {
+        durationFrames: 90,
+        effects: [],
+        id: 'text-1',
+        ingredientId: '',
+        ingredientUrl: '',
+        sourceEndFrame: 90,
+        sourceStartFrame: 0,
+        startFrame: 30,
+        textOverlay: {
+          color: '#ffffff',
+          fontSize: 42,
+          position: { x: 50, y: 80 },
+          text: 'Launch story',
+        },
+      },
+    ],
+    id: 'text-track',
+    isLocked: false,
+    isMuted: false,
+    name: 'Text',
+    type: EditorTrackType.TEXT,
+    volume: 100,
+  },
+  {
+    clips: [
+      mediaClip('audio-1', 'audio-ingredient', 'https://cdn.test/audio.mp3'),
+    ],
+    id: 'audio-track',
+    isLocked: false,
+    isMuted: false,
+    name: 'Audio',
+    type: EditorTrackType.AUDIO,
+    volume: 0,
+  },
+];
+
+const project = {
+  id: 'project-1',
+  settings: {
+    backgroundColor: '#000000',
+    format: IngredientFormat.PORTRAIT,
+    fps: 30,
+    height: 1920,
+    width: 1080,
+  },
+  totalDurationFrames: 180,
+  tracks,
+};
+
+describe('buildValidatedEditorExportContract', () => {
+  it('builds a deterministic versioned snapshot and ordered asset manifest', () => {
+    const first = buildValidatedEditorExportContract(project);
+    const second = buildValidatedEditorExportContract(project);
+
+    expect(first).toEqual(second);
+    expect(first.snapshot.version).toBe(EDITOR_EXPORT_CONTRACT_VERSION);
+    expect(first.snapshot.tracks).not.toBe(project.tracks);
+    expect(first.assetManifest).toEqual([
+      {
+        clipId: 'video-1',
+        ingredientId: 'video-ingredient',
+        ingredientUrl: 'https://cdn.test/video.mp4',
+        trackId: 'video-track',
+        type: EditorTrackType.VIDEO,
+      },
+      {
+        clipId: 'video-2',
+        ingredientId: 'b-roll-ingredient',
+        ingredientUrl: 'https://cdn.test/b-roll.mp4',
+        trackId: 'video-track',
+        type: EditorTrackType.VIDEO,
+      },
+      {
+        clipId: 'audio-1',
+        ingredientId: 'audio-ingredient',
+        ingredientUrl: 'https://cdn.test/audio.mp3',
+        trackId: 'audio-track',
+        type: EditorTrackType.AUDIO,
+      },
+    ]);
+  });
+
+  it('accepts percentage boundary values', () => {
+    const boundaryTracks = structuredClone(tracks);
+    boundaryTracks[0].clips[0].volume = 0;
+    boundaryTracks[0].volume = 100;
+    const boundaryTextOverlay = boundaryTracks[1].clips[0].textOverlay;
+    if (!boundaryTextOverlay) {
+      throw new Error('Expected text overlay fixture');
+    }
+    boundaryTextOverlay.position = { x: 0, y: 100 };
+
+    expect(
+      buildValidatedEditorExportContract({
+        ...project,
+        tracks: boundaryTracks,
+      }).snapshot.tracks,
+    ).toHaveLength(3);
+  });
+
+  it('reports actionable paths for malformed settings, timing, and assets', () => {
+    const invalidTracks = structuredClone(tracks);
+    invalidTracks[0].clips[0].ingredientId = '';
+    invalidTracks[0].clips[0].durationFrames = 181;
+
+    expect.assertions(2);
+    try {
+      buildValidatedEditorExportContract({
+        ...project,
+        settings: { ...project.settings, width: 0 },
+        tracks: invalidTracks,
+      });
+    } catch (error: unknown) {
+      expect(error).toBeInstanceOf(EditorExportContractValidationError);
+      expect((error as EditorExportContractValidationError).violations).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ path: 'settings.width' }),
+          expect.objectContaining({
+            path: 'tracks[0].clips[0].durationFrames',
+          }),
+          expect.objectContaining({
+            path: 'tracks[0].clips[0].ingredientId',
+          }),
+        ]),
+      );
+    }
+  });
+
+  it('rejects duplicate ids, unsupported effects, and invalid text overlays', () => {
+    const invalidTracks = structuredClone(tracks);
+    invalidTracks[1].id = invalidTracks[0].id;
+    invalidTracks[1].clips[0].id = invalidTracks[0].clips[0].id;
+    invalidTracks[0].clips[0].effects = [
+      { intensity: 50, type: 'unsupported' as EditorEffectType },
+    ];
+    const invalidTextOverlay = invalidTracks[1].clips[0].textOverlay;
+    if (!invalidTextOverlay) {
+      throw new Error('Expected text overlay fixture');
+    }
+    invalidTextOverlay.position.x = 101;
+
+    expect(() =>
+      buildValidatedEditorExportContract({
+        ...project,
+        tracks: invalidTracks,
+      }),
+    ).toThrow(EditorExportContractValidationError);
+
+    try {
+      buildValidatedEditorExportContract({
+        ...project,
+        tracks: invalidTracks,
+      });
+    } catch (error: unknown) {
+      const codes = (
+        error as EditorExportContractValidationError
+      ).violations.map((violation) => violation.code);
+      expect(codes).toEqual(
+        expect.arrayContaining([
+          'editor_export_track_id_duplicate',
+          'editor_export_clip_id_duplicate',
+          'editor_export_effect_invalid',
+          'editor_export_text_position_x_invalid',
+        ]),
+      );
+    }
+  });
+});

--- a/apps/server/api/src/collections/editor-projects/utils/editor-export-contract.util.ts
+++ b/apps/server/api/src/collections/editor-projects/utils/editor-export-contract.util.ts
@@ -628,14 +628,18 @@ function readTrack(
 }
 
 function addDuplicateIdViolations(
-  tracks: IEditorTrack[],
+  tracks: unknown[],
   violations: EditorExportContractViolation[],
 ): void {
   const trackIds = new Set<string>();
   const clipIds = new Set<string>();
 
   tracks.forEach((track, trackIndex) => {
-    if (trackIds.has(track.id)) {
+    if (!isRecord(track)) {
+      return;
+    }
+
+    if (isNonEmptyString(track.id) && trackIds.has(track.id)) {
       addViolation(
         violations,
         `tracks[${trackIndex}].id`,
@@ -643,10 +647,20 @@ function addDuplicateIdViolations(
         `Editor export track id "${track.id}" is duplicated.`,
       );
     }
-    trackIds.add(track.id);
+    if (isNonEmptyString(track.id)) {
+      trackIds.add(track.id);
+    }
+
+    if (!Array.isArray(track.clips)) {
+      return;
+    }
 
     track.clips.forEach((clip, clipIndex) => {
-      if (clipIds.has(clip.id)) {
+      if (!isRecord(clip)) {
+        return;
+      }
+
+      if (isNonEmptyString(clip.id) && clipIds.has(clip.id)) {
         addViolation(
           violations,
           `tracks[${trackIndex}].clips[${clipIndex}].id`,
@@ -654,7 +668,9 @@ function addDuplicateIdViolations(
           `Editor export clip id "${clip.id}" is duplicated.`,
         );
       }
-      clipIds.add(clip.id);
+      if (isNonEmptyString(clip.id)) {
+        clipIds.add(clip.id);
+      }
     });
   });
 }
@@ -717,6 +733,8 @@ export function buildValidatedEditorExportContract(
   const totalDurationFrames = isPositiveInteger(project.totalDurationFrames)
     ? project.totalDurationFrames
     : 0;
+  const rawTracks = Array.isArray(project.tracks) ? project.tracks : [];
+  addDuplicateIdViolations(rawTracks, violations);
   const tracks = Array.isArray(project.tracks)
     ? project.tracks
         .map((track, index) =>
@@ -724,8 +742,6 @@ export function buildValidatedEditorExportContract(
         )
         .filter((track): track is IEditorTrack => track !== null)
     : [];
-
-  addDuplicateIdViolations(tracks, violations);
 
   const hasVideoClip = tracks.some(
     (track) => track.type === EditorTrackType.VIDEO && track.clips.length > 0,

--- a/apps/server/api/src/collections/editor-projects/utils/editor-export-contract.util.ts
+++ b/apps/server/api/src/collections/editor-projects/utils/editor-export-contract.util.ts
@@ -1,0 +1,757 @@
+import {
+  EditorEffectType,
+  EditorTrackType,
+  EditorTransitionType,
+  IngredientFormat,
+} from '@genfeedai/enums';
+import {
+  EDITOR_EXPORT_CONTRACT_VERSION,
+  type IEditorClip,
+  type IEditorEffect,
+  type IEditorExportAssetReference,
+  type IEditorExportCompositionSnapshot,
+  type IEditorProjectSettings,
+  type IEditorTextOverlay,
+  type IEditorTrack,
+  type IEditorTransition,
+  type IValidatedEditorExportContract,
+} from '@genfeedai/interfaces';
+
+interface EditorExportProjectInput {
+  id?: unknown;
+  settings?: unknown;
+  totalDurationFrames?: unknown;
+  tracks?: unknown;
+}
+
+export interface EditorExportContractViolation {
+  code: string;
+  message: string;
+  path: string;
+}
+
+export class EditorExportContractValidationError extends Error {
+  readonly violations: EditorExportContractViolation[];
+
+  constructor(violations: EditorExportContractViolation[]) {
+    super(violations[0]?.message ?? 'Editor export contract is invalid.');
+    this.name = 'EditorExportContractValidationError';
+    this.violations = violations;
+  }
+}
+
+const editorEffectTypes = new Set<string>(Object.values(EditorEffectType));
+const editorTrackTypes = new Set<string>(Object.values(EditorTrackType));
+const editorTransitionTypes = new Set<string>(
+  Object.values(EditorTransitionType),
+);
+const ingredientFormats = new Set<string>(Object.values(IngredientFormat));
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) >= 0;
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) > 0;
+}
+
+function isPercentage(value: unknown): value is number {
+  return isFiniteNumber(value) && value >= 0 && value <= 100;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function addViolation(
+  violations: EditorExportContractViolation[],
+  path: string,
+  code: string,
+  message: string,
+): void {
+  violations.push({ code, message, path });
+}
+
+function readSettings(
+  value: unknown,
+  violations: EditorExportContractViolation[],
+): IEditorProjectSettings | null {
+  if (!isRecord(value)) {
+    addViolation(
+      violations,
+      'settings',
+      'editor_export_settings_required',
+      'Editor export settings are required.',
+    );
+    return null;
+  }
+
+  if (!ingredientFormats.has(String(value.format))) {
+    addViolation(
+      violations,
+      'settings.format',
+      'editor_export_format_invalid',
+      'Editor export format must be landscape, portrait, or square.',
+    );
+  }
+  if (!isPositiveInteger(value.width)) {
+    addViolation(
+      violations,
+      'settings.width',
+      'editor_export_width_invalid',
+      'Editor export width must be a positive integer.',
+    );
+  }
+  if (!isPositiveInteger(value.height)) {
+    addViolation(
+      violations,
+      'settings.height',
+      'editor_export_height_invalid',
+      'Editor export height must be a positive integer.',
+    );
+  }
+  if (!isPositiveInteger(value.fps) || value.fps > 120) {
+    addViolation(
+      violations,
+      'settings.fps',
+      'editor_export_fps_invalid',
+      'Editor export frame rate must be an integer between 1 and 120.',
+    );
+  }
+  if (!isNonEmptyString(value.backgroundColor)) {
+    addViolation(
+      violations,
+      'settings.backgroundColor',
+      'editor_export_background_invalid',
+      'Editor export background color is required.',
+    );
+  }
+
+  if (
+    !ingredientFormats.has(String(value.format)) ||
+    !isPositiveInteger(value.width) ||
+    !isPositiveInteger(value.height) ||
+    !isPositiveInteger(value.fps) ||
+    value.fps > 120 ||
+    !isNonEmptyString(value.backgroundColor)
+  ) {
+    return null;
+  }
+
+  return {
+    backgroundColor: value.backgroundColor,
+    format: value.format as IngredientFormat,
+    fps: value.fps,
+    height: value.height,
+    width: value.width,
+  };
+}
+
+function readEffect(
+  value: unknown,
+  path: string,
+  violations: EditorExportContractViolation[],
+): IEditorEffect | null {
+  if (!isRecord(value) || !editorEffectTypes.has(String(value.type))) {
+    addViolation(
+      violations,
+      `${path}.type`,
+      'editor_export_effect_invalid',
+      'Editor export effects must use a supported effect type.',
+    );
+    return null;
+  }
+  if (!isPercentage(value.intensity)) {
+    addViolation(
+      violations,
+      `${path}.intensity`,
+      'editor_export_effect_intensity_invalid',
+      'Editor export effect intensity must be between 0 and 100.',
+    );
+    return null;
+  }
+
+  return {
+    intensity: value.intensity,
+    type: value.type as EditorEffectType,
+  };
+}
+
+function readTransition(
+  value: unknown,
+  path: string,
+  clipDuration: number,
+  violations: EditorExportContractViolation[],
+): IEditorTransition | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (!isRecord(value) || !editorTransitionTypes.has(String(value.type))) {
+    addViolation(
+      violations,
+      `${path}.type`,
+      'editor_export_transition_invalid',
+      'Editor export transitions must use a supported transition type.',
+    );
+    return undefined;
+  }
+  if (!isNonNegativeInteger(value.duration) || value.duration > clipDuration) {
+    addViolation(
+      violations,
+      `${path}.duration`,
+      'editor_export_transition_duration_invalid',
+      'Editor export transition duration must fit within its clip.',
+    );
+    return undefined;
+  }
+
+  return {
+    duration: value.duration,
+    type: value.type as EditorTransitionType,
+  };
+}
+
+function readTextOverlay(
+  value: unknown,
+  path: string,
+  violations: EditorExportContractViolation[],
+): IEditorTextOverlay | null {
+  if (!isRecord(value)) {
+    addViolation(
+      violations,
+      path,
+      'editor_export_text_overlay_required',
+      'Text clips require a text overlay.',
+    );
+    return null;
+  }
+
+  if (!isNonEmptyString(value.text)) {
+    addViolation(
+      violations,
+      `${path}.text`,
+      'editor_export_text_required',
+      'Text overlay content is required.',
+    );
+  }
+  if (!isRecord(value.position)) {
+    addViolation(
+      violations,
+      `${path}.position`,
+      'editor_export_text_position_invalid',
+      'Text overlay position must contain percentage-based x and y values.',
+    );
+  } else {
+    if (!isPercentage(value.position.x)) {
+      addViolation(
+        violations,
+        `${path}.position.x`,
+        'editor_export_text_position_x_invalid',
+        'Text overlay x position must be between 0 and 100.',
+      );
+    }
+    if (!isPercentage(value.position.y)) {
+      addViolation(
+        violations,
+        `${path}.position.y`,
+        'editor_export_text_position_y_invalid',
+        'Text overlay y position must be between 0 and 100.',
+      );
+    }
+  }
+  if (!isFiniteNumber(value.fontSize) || value.fontSize <= 0) {
+    addViolation(
+      violations,
+      `${path}.fontSize`,
+      'editor_export_text_size_invalid',
+      'Text overlay font size must be greater than zero.',
+    );
+  }
+  if (!isNonEmptyString(value.color)) {
+    addViolation(
+      violations,
+      `${path}.color`,
+      'editor_export_text_color_invalid',
+      'Text overlay color is required.',
+    );
+  }
+  if (
+    value.fontWeight !== undefined &&
+    (!isFiniteNumber(value.fontWeight) || value.fontWeight <= 0)
+  ) {
+    addViolation(
+      violations,
+      `${path}.fontWeight`,
+      'editor_export_text_weight_invalid',
+      'Text overlay font weight must be greater than zero.',
+    );
+  }
+  if (
+    value.padding !== undefined &&
+    (!isFiniteNumber(value.padding) || value.padding < 0)
+  ) {
+    addViolation(
+      violations,
+      `${path}.padding`,
+      'editor_export_text_padding_invalid',
+      'Text overlay padding cannot be negative.',
+    );
+  }
+
+  if (
+    !isNonEmptyString(value.text) ||
+    !isRecord(value.position) ||
+    !isPercentage(value.position.x) ||
+    !isPercentage(value.position.y) ||
+    !isFiniteNumber(value.fontSize) ||
+    value.fontSize <= 0 ||
+    !isNonEmptyString(value.color)
+  ) {
+    return null;
+  }
+
+  return {
+    backgroundColor:
+      typeof value.backgroundColor === 'string'
+        ? value.backgroundColor
+        : undefined,
+    color: value.color,
+    fontFamily:
+      typeof value.fontFamily === 'string' ? value.fontFamily : undefined,
+    fontSize: value.fontSize,
+    fontWeight:
+      isFiniteNumber(value.fontWeight) && value.fontWeight > 0
+        ? value.fontWeight
+        : undefined,
+    padding:
+      isFiniteNumber(value.padding) && value.padding >= 0
+        ? value.padding
+        : undefined,
+    position: {
+      x: value.position.x,
+      y: value.position.y,
+    },
+    text: value.text,
+  };
+}
+
+function readClip(
+  value: unknown,
+  path: string,
+  trackType: EditorTrackType,
+  totalDurationFrames: number,
+  violations: EditorExportContractViolation[],
+): IEditorClip | null {
+  if (!isRecord(value)) {
+    addViolation(
+      violations,
+      path,
+      'editor_export_clip_invalid',
+      'Editor export clips must be objects.',
+    );
+    return null;
+  }
+
+  if (!isNonEmptyString(value.id)) {
+    addViolation(
+      violations,
+      `${path}.id`,
+      'editor_export_clip_id_required',
+      'Editor export clip id is required.',
+    );
+  }
+  if (!isNonNegativeInteger(value.startFrame)) {
+    addViolation(
+      violations,
+      `${path}.startFrame`,
+      'editor_export_clip_start_invalid',
+      'Editor export clip start frame must be a non-negative integer.',
+    );
+  }
+  if (!isPositiveInteger(value.durationFrames)) {
+    addViolation(
+      violations,
+      `${path}.durationFrames`,
+      'editor_export_clip_duration_invalid',
+      'Editor export clip duration must be a positive integer.',
+    );
+  }
+  if (
+    isNonNegativeInteger(value.startFrame) &&
+    isPositiveInteger(value.durationFrames) &&
+    value.startFrame + value.durationFrames > totalDurationFrames
+  ) {
+    addViolation(
+      violations,
+      `${path}.durationFrames`,
+      'editor_export_clip_out_of_bounds',
+      'Editor export clip must fit within the project duration.',
+    );
+  }
+  if (!isNonNegativeInteger(value.sourceStartFrame)) {
+    addViolation(
+      violations,
+      `${path}.sourceStartFrame`,
+      'editor_export_source_start_invalid',
+      'Editor export source start frame must be a non-negative integer.',
+    );
+  }
+  if (
+    !isPositiveInteger(value.sourceEndFrame) ||
+    (isNonNegativeInteger(value.sourceStartFrame) &&
+      value.sourceEndFrame <= value.sourceStartFrame)
+  ) {
+    addViolation(
+      violations,
+      `${path}.sourceEndFrame`,
+      'editor_export_source_end_invalid',
+      'Editor export source end frame must be after its source start frame.',
+    );
+  }
+  if (value.volume !== undefined && !isPercentage(value.volume)) {
+    addViolation(
+      violations,
+      `${path}.volume`,
+      'editor_export_clip_volume_invalid',
+      'Editor export clip volume must be between 0 and 100.',
+    );
+  }
+
+  const effects = Array.isArray(value.effects)
+    ? value.effects
+        .map((effect, index) =>
+          readEffect(effect, `${path}.effects[${index}]`, violations),
+        )
+        .filter((effect): effect is IEditorEffect => effect !== null)
+    : [];
+  if (!Array.isArray(value.effects)) {
+    addViolation(
+      violations,
+      `${path}.effects`,
+      'editor_export_effects_invalid',
+      'Editor export clip effects must be an array.',
+    );
+  }
+
+  const clipDuration = isPositiveInteger(value.durationFrames)
+    ? value.durationFrames
+    : 0;
+  const transitionIn = readTransition(
+    value.transitionIn,
+    `${path}.transitionIn`,
+    clipDuration,
+    violations,
+  );
+  const transitionOut = readTransition(
+    value.transitionOut,
+    `${path}.transitionOut`,
+    clipDuration,
+    violations,
+  );
+  const textOverlay =
+    trackType === EditorTrackType.TEXT
+      ? readTextOverlay(value.textOverlay, `${path}.textOverlay`, violations)
+      : undefined;
+
+  if (trackType !== EditorTrackType.TEXT) {
+    if (!isNonEmptyString(value.ingredientId)) {
+      addViolation(
+        violations,
+        `${path}.ingredientId`,
+        'editor_export_asset_id_required',
+        'Video and audio clips require an ingredient id.',
+      );
+    }
+    if (!isNonEmptyString(value.ingredientUrl)) {
+      addViolation(
+        violations,
+        `${path}.ingredientUrl`,
+        'editor_export_asset_url_required',
+        'Video and audio clips require an ingredient URL.',
+      );
+    }
+  }
+
+  if (
+    !isNonEmptyString(value.id) ||
+    !isNonNegativeInteger(value.startFrame) ||
+    !isPositiveInteger(value.durationFrames) ||
+    value.startFrame + value.durationFrames > totalDurationFrames ||
+    !isNonNegativeInteger(value.sourceStartFrame) ||
+    !isPositiveInteger(value.sourceEndFrame) ||
+    value.sourceEndFrame <= value.sourceStartFrame ||
+    !Array.isArray(value.effects) ||
+    (trackType === EditorTrackType.TEXT && !textOverlay) ||
+    (trackType !== EditorTrackType.TEXT &&
+      (!isNonEmptyString(value.ingredientId) ||
+        !isNonEmptyString(value.ingredientUrl)))
+  ) {
+    return null;
+  }
+
+  return {
+    durationFrames: value.durationFrames,
+    effects,
+    id: value.id,
+    ingredientId:
+      typeof value.ingredientId === 'string' ? value.ingredientId : '',
+    ingredientUrl:
+      typeof value.ingredientUrl === 'string' ? value.ingredientUrl : '',
+    sourceEndFrame: value.sourceEndFrame,
+    sourceStartFrame: value.sourceStartFrame,
+    startFrame: value.startFrame,
+    textOverlay: textOverlay ?? undefined,
+    thumbnailUrl:
+      typeof value.thumbnailUrl === 'string' ? value.thumbnailUrl : undefined,
+    transitionIn,
+    transitionOut,
+    volume: isFiniteNumber(value.volume) ? value.volume : undefined,
+  };
+}
+
+function readTrack(
+  value: unknown,
+  index: number,
+  totalDurationFrames: number,
+  violations: EditorExportContractViolation[],
+): IEditorTrack | null {
+  const path = `tracks[${index}]`;
+  if (!isRecord(value)) {
+    addViolation(
+      violations,
+      path,
+      'editor_export_track_invalid',
+      'Editor export tracks must be objects.',
+    );
+    return null;
+  }
+
+  if (!isNonEmptyString(value.id)) {
+    addViolation(
+      violations,
+      `${path}.id`,
+      'editor_export_track_id_required',
+      'Editor export track id is required.',
+    );
+  }
+  if (!editorTrackTypes.has(String(value.type))) {
+    addViolation(
+      violations,
+      `${path}.type`,
+      'editor_export_track_type_invalid',
+      'Editor export track type must be video, audio, or text.',
+    );
+  }
+  if (!isNonEmptyString(value.name)) {
+    addViolation(
+      violations,
+      `${path}.name`,
+      'editor_export_track_name_required',
+      'Editor export track name is required.',
+    );
+  }
+  if (typeof value.isMuted !== 'boolean') {
+    addViolation(
+      violations,
+      `${path}.isMuted`,
+      'editor_export_track_muted_invalid',
+      'Editor export track mute state must be boolean.',
+    );
+  }
+  if (typeof value.isLocked !== 'boolean') {
+    addViolation(
+      violations,
+      `${path}.isLocked`,
+      'editor_export_track_locked_invalid',
+      'Editor export track lock state must be boolean.',
+    );
+  }
+  if (!isPercentage(value.volume)) {
+    addViolation(
+      violations,
+      `${path}.volume`,
+      'editor_export_track_volume_invalid',
+      'Editor export track volume must be between 0 and 100.',
+    );
+  }
+  if (!Array.isArray(value.clips)) {
+    addViolation(
+      violations,
+      `${path}.clips`,
+      'editor_export_clips_invalid',
+      'Editor export track clips must be an array.',
+    );
+  }
+
+  if (
+    !isNonEmptyString(value.id) ||
+    !editorTrackTypes.has(String(value.type)) ||
+    !isNonEmptyString(value.name) ||
+    typeof value.isMuted !== 'boolean' ||
+    typeof value.isLocked !== 'boolean' ||
+    !isPercentage(value.volume) ||
+    !Array.isArray(value.clips)
+  ) {
+    return null;
+  }
+
+  const trackType = value.type as EditorTrackType;
+  const clips = value.clips
+    .map((clip, clipIndex) =>
+      readClip(
+        clip,
+        `${path}.clips[${clipIndex}]`,
+        trackType,
+        totalDurationFrames,
+        violations,
+      ),
+    )
+    .filter((clip): clip is IEditorClip => clip !== null);
+
+  return {
+    clips,
+    id: value.id,
+    isLocked: value.isLocked,
+    isMuted: value.isMuted,
+    name: value.name,
+    type: trackType,
+    volume: value.volume,
+  };
+}
+
+function addDuplicateIdViolations(
+  tracks: IEditorTrack[],
+  violations: EditorExportContractViolation[],
+): void {
+  const trackIds = new Set<string>();
+  const clipIds = new Set<string>();
+
+  tracks.forEach((track, trackIndex) => {
+    if (trackIds.has(track.id)) {
+      addViolation(
+        violations,
+        `tracks[${trackIndex}].id`,
+        'editor_export_track_id_duplicate',
+        `Editor export track id "${track.id}" is duplicated.`,
+      );
+    }
+    trackIds.add(track.id);
+
+    track.clips.forEach((clip, clipIndex) => {
+      if (clipIds.has(clip.id)) {
+        addViolation(
+          violations,
+          `tracks[${trackIndex}].clips[${clipIndex}].id`,
+          'editor_export_clip_id_duplicate',
+          `Editor export clip id "${clip.id}" is duplicated.`,
+        );
+      }
+      clipIds.add(clip.id);
+    });
+  });
+}
+
+function buildAssetManifest(
+  tracks: IEditorTrack[],
+): IEditorExportAssetReference[] {
+  return tracks.flatMap((track) => {
+    if (track.type === EditorTrackType.TEXT) {
+      return [];
+    }
+
+    return track.clips.map((clip) => ({
+      clipId: clip.id,
+      ingredientId: clip.ingredientId,
+      ingredientUrl: clip.ingredientUrl,
+      trackId: track.id,
+      type: track.type,
+    }));
+  });
+}
+
+export function buildValidatedEditorExportContract(
+  project: EditorExportProjectInput,
+): IValidatedEditorExportContract {
+  const violations: EditorExportContractViolation[] = [];
+
+  if (!isNonEmptyString(project.id)) {
+    addViolation(
+      violations,
+      'id',
+      'editor_export_project_id_required',
+      'Editor export project id is required.',
+    );
+  }
+  if (!isPositiveInteger(project.totalDurationFrames)) {
+    addViolation(
+      violations,
+      'totalDurationFrames',
+      'editor_export_duration_invalid',
+      'Editor export duration must be a positive integer.',
+    );
+  }
+  if (!Array.isArray(project.tracks) || project.tracks.length === 0) {
+    addViolation(
+      violations,
+      'tracks',
+      'editor_export_tracks_required',
+      'Editor export requires at least one track.',
+    );
+  }
+
+  const settings = readSettings(project.settings, violations);
+  const totalDurationFrames = isPositiveInteger(project.totalDurationFrames)
+    ? project.totalDurationFrames
+    : 0;
+  const tracks = Array.isArray(project.tracks)
+    ? project.tracks
+        .map((track, index) =>
+          readTrack(track, index, totalDurationFrames, violations),
+        )
+        .filter((track): track is IEditorTrack => track !== null)
+    : [];
+
+  addDuplicateIdViolations(tracks, violations);
+
+  const hasVideoClip = tracks.some(
+    (track) => track.type === EditorTrackType.VIDEO && track.clips.length > 0,
+  );
+  if (!hasVideoClip) {
+    addViolation(
+      violations,
+      'tracks',
+      'editor_export_video_required',
+      'Editor export requires at least one video clip.',
+    );
+  }
+
+  if (
+    violations.length > 0 ||
+    !settings ||
+    !isNonEmptyString(project.id) ||
+    totalDurationFrames === 0
+  ) {
+    throw new EditorExportContractValidationError(violations);
+  }
+
+  const snapshot: IEditorExportCompositionSnapshot = {
+    projectId: project.id,
+    settings,
+    totalDurationFrames,
+    tracks,
+    version: EDITOR_EXPORT_CONTRACT_VERSION,
+  };
+
+  return {
+    assetManifest: buildAssetManifest(tracks),
+    snapshot,
+  };
+}

--- a/apps/server/api/src/collections/editor-projects/utils/editor-export-contract.util.ts
+++ b/apps/server/api/src/collections/editor-projects/utils/editor-export-contract.util.ts
@@ -662,19 +662,25 @@ function addDuplicateIdViolations(
 function buildAssetManifest(
   tracks: IEditorTrack[],
 ): IEditorExportAssetReference[] {
-  return tracks.flatMap((track) => {
-    if (track.type === EditorTrackType.TEXT) {
-      return [];
-    }
+  const assetTracks = tracks.filter(
+    (
+      track,
+    ): track is IEditorTrack & {
+      type: EditorTrackType.AUDIO | EditorTrackType.VIDEO;
+    } =>
+      track.type === EditorTrackType.AUDIO ||
+      track.type === EditorTrackType.VIDEO,
+  );
 
-    return track.clips.map((clip) => ({
+  return assetTracks.flatMap((track) =>
+    track.clips.map((clip) => ({
       clipId: clip.id,
       ingredientId: clip.ingredientId,
       ingredientUrl: clip.ingredientUrl,
       trackId: track.id,
       type: track.type,
-    }));
-  });
+    })),
+  );
 }
 
 export function buildValidatedEditorExportContract(

--- a/packages/interfaces/src/editor/editor-export-contract.interface.ts
+++ b/packages/interfaces/src/editor/editor-export-contract.interface.ts
@@ -1,0 +1,28 @@
+import type { EditorTrackType } from '@genfeedai/enums';
+import type {
+  IEditorProjectSettings,
+  IEditorTrack,
+} from './editor-project.interface';
+
+export const EDITOR_EXPORT_CONTRACT_VERSION = 1 as const;
+
+export interface IEditorExportAssetReference {
+  clipId: string;
+  ingredientId: string;
+  ingredientUrl: string;
+  trackId: string;
+  type: Exclude<EditorTrackType, EditorTrackType.TEXT>;
+}
+
+export interface IEditorExportCompositionSnapshot {
+  projectId: string;
+  settings: IEditorProjectSettings;
+  totalDurationFrames: number;
+  tracks: IEditorTrack[];
+  version: typeof EDITOR_EXPORT_CONTRACT_VERSION;
+}
+
+export interface IValidatedEditorExportContract {
+  assetManifest: IEditorExportAssetReference[];
+  snapshot: IEditorExportCompositionSnapshot;
+}

--- a/packages/interfaces/src/editor/index.ts
+++ b/packages/interfaces/src/editor/index.ts
@@ -1,1 +1,2 @@
+export * from './editor-export-contract.interface';
 export * from './editor-project.interface';

--- a/packages/interfaces/src/index.ts
+++ b/packages/interfaces/src/index.ts
@@ -120,6 +120,7 @@ export * from './core/serializer.interface';
 export * from './core/socket-events.interface';
 export * from './core/sort.interface';
 export * from './creative/creative-pattern.interface';
+export * from './editor/editor-export-contract.interface';
 export * from './editor/editor-project.interface';
 export * from './elements/asset.interface';
 export * from './elements/blacklist.interface';


### PR DESCRIPTION
## Summary

Adds a versioned, server-safe editor export contract that validates settings, timeline structure, clip timing and source ranges, effects, transitions, text overlays, volume and mute state, and asset references. Render requests now build a deterministic snapshot before changing project state or creating ingredients and queue jobs.

## Related issue

Closes #1837
Refs #1790

## Scope

- Adds the v1 composition snapshot and normalized asset-manifest interfaces.
- Returns structured validation violations with stable codes and field paths, including duplicate IDs on otherwise malformed inputs.
- Keeps the current single-video/single-clip renderer limits explicit after contract validation and rejects audio tracks the legacy renderer cannot consume.
- Maps percentage text placement to the current renderer fixed-position capability.
- Excludes the multi-track Remotion renderer, queue snapshot persistence, UI work, and removal of legacy renderer limits; those remain in #1838 and #1839.
- No database migration, generated files, release steps, or external configuration changes.

## Verification

- `bunx @biomejs/biome@2.5.3 check <8 changed TypeScript files>` — passed locally.
- `bun scripts/run-secretlint.ts <8 changed TypeScript files>` — passed locally.
- `git diff --check` — passed locally.
- GitHub Actions — 25 checks passed, 0 failed, 0 pending; typecheck, build, format, lint, guards, OpenAPI drift, security scans, package/server/app/API selections, and the tests gate are green.
- Changed API tests — 436 files passed and 1 skipped; 4,020 tests passed and 1 skipped.
- Tests, typecheck, and build were intentionally not run on the local machine under repository policy; GitHub Actions supplied that evidence.

## Screenshots

Not applicable — server and shared-contract change only.

## Checklist

- [x] I reviewed the final diff for unrelated changes.
- [x] I ran the relevant focused checks or documented why they were left to CI.
- [x] I updated relevant documentation or explained why no documentation change is needed.
- [x] I documented migrations, release steps, or external configuration changes, or marked them not applicable.
- [x] I did not include secrets, credentials, personal data, customer data, or generated build output.