### PR TITLE
test(shell): align E2E gate with agent-first default

### DIFF
--- a/playwright/e2e/tests/core/automation-loop.spec.ts
+++ b/playwright/e2e/tests/core/automation-loop.spec.ts
@@ -33,9 +33,7 @@ test.describe('Core Automation Loop', () => {
   }) => {
     await automationPage.goto(`${BRAND_BASE}/workflows`);
 
-    await expect(automationPage).toHaveURL(
-      /\/test-org\/brand-1\/workflows$/,
-    );
+    await expect(automationPage).toHaveURL(/\/test-org\/brand-1\/workflows$/);
     await expect(
       automationPage.getByTestId('sidebar-shell').first(),
     ).toHaveAttribute('data-shell-section-label', 'Workspace');

--- a/playwright/e2e/tests/core/automation-loop.spec.ts
+++ b/playwright/e2e/tests/core/automation-loop.spec.ts
@@ -26,12 +26,21 @@ test.describe('Core Automation Loop', () => {
     await mockNodeTypes(automationPage, testNodeTypes);
   });
 
-  test('workflow library shows the main automation entry points', async ({
+  test('workflow library stays available inside the agent-first canvas', async ({
     automationPage,
   }) => {
     await automationPage.goto('/workflows');
 
     await expect(automationPage).toHaveURL(/\/workflows$/);
+    await expect(
+      automationPage.getByTestId('sidebar-shell').first(),
+    ).toHaveAttribute('data-shell-section-label', 'Workspace');
+    await expect(
+      automationPage.getByTestId('universal-workspace-shell'),
+    ).toHaveAttribute('data-workspace-surface', 'workflows');
+    await expect(
+      automationPage.getByTestId('workspace-canvas-layout'),
+    ).toBeVisible();
     await expect(
       automationPage.getByRole('heading', { name: 'Workflows' }),
     ).toBeVisible();
@@ -44,11 +53,6 @@ test.describe('Core Automation Loop', () => {
     await expect(
       automationPage.getByRole('link', { name: 'Autopilot' }).first(),
     ).toHaveAttribute('href', /\/orchestration\/autopilot$/);
-    await expect(
-      automationPage
-        .getByText('No workflows yet')
-        .or(automationPage.getByText(testWorkflows[0].name)),
-    ).toBeVisible();
   });
 
   test('template install flows into the editor bootstrap path', async ({

--- a/playwright/e2e/tests/core/automation-loop.spec.ts
+++ b/playwright/e2e/tests/core/automation-loop.spec.ts
@@ -14,6 +14,8 @@ import {
 } from '../../fixtures/test-data.fixture';
 import { WorkflowPage } from '../../pages/workflow.page';
 
+const BRAND_BASE = '/test-org/brand-1';
+
 test.describe('Core Automation Loop', () => {
   test.beforeEach(async ({ automationPage }) => {
     await mockActiveSubscription(automationPage, {
@@ -29,9 +31,11 @@ test.describe('Core Automation Loop', () => {
   test('workflow library stays available inside the agent-first canvas', async ({
     automationPage,
   }) => {
-    await automationPage.goto('/workflows');
+    await automationPage.goto(`${BRAND_BASE}/workflows`);
 
-    await expect(automationPage).toHaveURL(/\/workflows$/);
+    await expect(automationPage).toHaveURL(
+      /\/test-org\/brand-1\/workflows$/,
+    );
     await expect(
       automationPage.getByTestId('sidebar-shell').first(),
     ).toHaveAttribute('data-shell-section-label', 'Workspace');

--- a/playwright/e2e/tests/shell/page-context-contract.spec.ts
+++ b/playwright/e2e/tests/shell/page-context-contract.spec.ts
@@ -30,12 +30,12 @@ const CONTRACTS: PageContextContract[] = [
   {
     route: `${BRAND_BASE}/library/images`,
     currentApp: 'library',
-    sectionLabel: 'Library',
+    sectionLabel: 'Workspace',
   },
   {
     route: `${BRAND_BASE}/studio/image`,
     currentApp: 'studio',
-    sectionLabel: 'Studio',
+    sectionLabel: 'Workspace',
   },
   {
     route: `${BRAND_BASE}/posts/scheduled`,
@@ -46,8 +46,7 @@ const CONTRACTS: PageContextContract[] = [
   {
     route: `${BRAND_BASE}/orchestration/library`,
     currentApp: 'workflows',
-    sectionLabel: 'Workflows',
-    sidebarLabels: ['Runs', 'Workflows', 'Skills', 'Autopilot'],
+    sectionLabel: 'Workspace',
   },
 ];
 


### PR DESCRIPTION
## Summary
- assert the workflow library remains mounted inside the universal agent-first canvas
- update Library, Studio, and Workflows shell contracts to expect the permanent Workspace conversation sidebar
- remove the obsolete dedicated-shell navigation expectation that blocked the guarded production deploy

## Verification
- Biome formatting completed for both changed specs
-  passes
- local tests/builds intentionally not run; PR CI is the validation authority

## Context
Follow-up to #1833. Production run [29616484191](https://github.com/genfeedai/genfeed.ai/actions/runs/29616484191) correctly stopped before deployment because these E2E expectations still encoded the deleted feature-flag fallback UI.