### PR TITLE
test(health): stabilize timestamp assertion

### DIFF
--- a/packages/libs/health/health.controller.spec.ts
+++ b/packages/libs/health/health.controller.spec.ts
@@ -13,6 +13,10 @@ describe('HealthController', () => {
     controller = module.get<HealthController>(HealthController);
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('should be defined', () => {
     expect(controller).toBeDefined();
   });
@@ -29,14 +33,17 @@ describe('HealthController', () => {
       expect(result).not.toHaveProperty('uptime');
     });
 
-    it('should return different timestamps on multiple calls', async () => {
+    it('should return different timestamps on multiple calls', () => {
+      vi.useFakeTimers().setSystemTime(new Date('2024-01-01T00:00:00.000Z'));
       const result1 = controller.check();
 
-      await new Promise((resolve) => setTimeout(resolve, 1));
-
+      vi.setSystemTime(new Date('2024-01-01T00:00:00.001Z'));
       const result2 = controller.check();
 
       expect(result1.timestamp).not.toBe(result2.timestamp);
+      expect(new Date(result2.timestamp).getTime()).toBeGreaterThan(
+        new Date(result1.timestamp).getTime(),
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

- replace the real 1 ms delay in the shared health controller spec with a deterministic Vitest system clock
- preserve the contract that later invocations emit later ISO timestamps
- restore real timers after each test to prevent suite leakage

## Related issue

Closes #1658

## Scope

Test-only change in `packages/libs/health`; no runtime, API, serializer, configuration, or dependency changes.

## Verification

- `bunx @biomejs/biome@2.5.3 check packages/libs/health/health.controller.spec.ts` — passed
- `bun scripts/run-secretlint.ts packages/libs/health/health.controller.spec.ts` — passed
- `git diff --cached --check` — passed before commit
- staged sensitive-path and credential-pattern scans — passed
- Vitest, typecheck, and build were not run locally under workstation policy; GitHub Actions owns that evidence

## Screenshots

Not applicable — test-only change.

## Risk

Low. The production health controller is unchanged; the assertion now controls time explicitly instead of depending on OS timer scheduling.

## Checklist

- [x] I reviewed the final diff for unrelated changes.
- [x] I ran the relevant focused checks or documented why they were left to CI.
- [x] I updated relevant documentation or explained why no documentation change is needed.
- [x] I documented migrations, release steps, or external configuration changes, or marked them not applicable.
- [x] I did not include secrets, credentials, personal data, customer data, or generated build output.
