### PR TITLE
refactor(videos): extract provider dispatch service

### DIFF
--- a/apps/server/api/src/collections/videos/controllers/videos.controller.spec.ts
+++ b/apps/server/api/src/collections/videos/controllers/videos.controller.spec.ts
@@ -28,6 +28,7 @@ import { VideosController } from '@api/collections/videos/controllers/videos.con
 import type { CreateVideoDto } from '@api/collections/videos/dto/create-video.dto';
 import type { VideosQueryDto } from '@api/collections/videos/dto/videos-query.dto';
 import { VideoGenerationService } from '@api/collections/videos/services/video-generation.service';
+import { VideoGenerationProviderDispatchService } from '@api/collections/videos/services/video-generation-provider-dispatch.service';
 import { VideoMusicOrchestrationService } from '@api/collections/videos/services/video-music-orchestration.service';
 import { VideosService } from '@api/collections/videos/services/videos.service';
 import type { VoteDocument } from '@api/collections/votes/schemas/vote.schema';
@@ -388,6 +389,7 @@ describe('VideosController', () => {
         // resolves its constructor dependencies from the mocked providers
         // above. This catches constructor-dependency regressions that the
         // previous `new VideoGenerationService(...)` pattern silently missed.
+        VideoGenerationProviderDispatchService,
         VideoGenerationService,
       ],
     })

--- a/apps/server/api/src/collections/videos/services/video-generation-provider-dispatch.service.spec.ts
+++ b/apps/server/api/src/collections/videos/services/video-generation-provider-dispatch.service.spec.ts
@@ -1,0 +1,114 @@
+import type { DispatchVideoGenerationParams } from '@api/collections/videos/services/video-generation.types';
+import { VideoGenerationProviderDispatchService } from '@api/collections/videos/services/video-generation-provider-dispatch.service';
+import { MODEL_KEYS } from '@genfeedai/constants';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('VideoGenerationProviderDispatchService', () => {
+  const falService = {
+    generateVideo: vi.fn(),
+  };
+  const klingAIService = {
+    queueGenerateTextToVideo: vi.fn(),
+  };
+  const replicateService = {
+    generateTextToVideo: vi.fn(),
+  };
+
+  const service = new VideoGenerationProviderDispatchService(
+    falService as never,
+    klingAIService as never,
+    replicateService as never,
+  );
+
+  const buildParams = (
+    overrides: Partial<DispatchVideoGenerationParams> = {},
+  ): DispatchVideoGenerationParams => ({
+    duration: 8,
+    height: 1080,
+    imageUrl: 'https://cdn.example.com/reference.png',
+    model: MODEL_KEYS.KLINGAI_V2,
+    prompt: 'A cinematic sunrise',
+    promptParams: {
+      prompt: 'A cinematic sunrise',
+      resolution: '1080p',
+    },
+    width: 1920,
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('routes KlingAI models with the existing queue payload', async () => {
+    klingAIService.queueGenerateTextToVideo.mockResolvedValue('kling-job');
+
+    await expect(service.dispatch(buildParams())).resolves.toBe('kling-job');
+
+    expect(klingAIService.queueGenerateTextToVideo).toHaveBeenCalledWith(
+      'A cinematic sunrise',
+      {
+        height: 1080,
+        model: MODEL_KEYS.KLINGAI_V2,
+        width: 1920,
+      },
+    );
+    expect(falService.generateVideo).not.toHaveBeenCalled();
+    expect(replicateService.generateTextToVideo).not.toHaveBeenCalled();
+  });
+
+  it('routes FAL models and normalizes the returned URL', async () => {
+    falService.generateVideo.mockResolvedValue({
+      url: 'https://fal.example.com/video.mp4',
+    });
+    const params = buildParams({ model: MODEL_KEYS.FAL_VEO_3_1 });
+
+    await expect(service.dispatch(params)).resolves.toBe(
+      'https://fal.example.com/video.mp4',
+    );
+
+    expect(falService.generateVideo).toHaveBeenCalledWith(
+      MODEL_KEYS.FAL_VEO_3_1,
+      {
+        duration: 8,
+        image_url: 'https://cdn.example.com/reference.png',
+        prompt: 'A cinematic sunrise',
+      },
+    );
+    expect(klingAIService.queueGenerateTextToVideo).not.toHaveBeenCalled();
+    expect(replicateService.generateTextToVideo).not.toHaveBeenCalled();
+  });
+
+  it('omits absent optional FAL inputs', async () => {
+    falService.generateVideo.mockResolvedValue({ url: 'fal-job' });
+
+    await service.dispatch(
+      buildParams({
+        duration: undefined,
+        imageUrl: undefined,
+        model: MODEL_KEYS.FAL_PIXVERSE_V6,
+      }),
+    );
+
+    expect(falService.generateVideo).toHaveBeenCalledWith(
+      MODEL_KEYS.FAL_PIXVERSE_V6,
+      {
+        prompt: 'A cinematic sunrise',
+      },
+    );
+  });
+
+  it('uses Replicate as the fallback with the existing prompt parameters', async () => {
+    replicateService.generateTextToVideo.mockResolvedValue('replicate-job');
+    const params = buildParams({ model: 'replicate/video-model' });
+
+    await expect(service.dispatch(params)).resolves.toBe('replicate-job');
+
+    expect(replicateService.generateTextToVideo).toHaveBeenCalledWith(
+      'replicate/video-model',
+      params.promptParams,
+    );
+    expect(falService.generateVideo).not.toHaveBeenCalled();
+    expect(klingAIService.queueGenerateTextToVideo).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/api/src/collections/videos/services/video-generation-provider-dispatch.service.ts
+++ b/apps/server/api/src/collections/videos/services/video-generation-provider-dispatch.service.ts
@@ -1,0 +1,46 @@
+import { isFalDestination } from '@api/collections/models/utils/model-key.util';
+import { MODEL_KEYS } from '@genfeedai/constants';
+import { Injectable } from '@nestjs/common';
+import { FalService } from '@server/services/integrations/fal/services/fal.service';
+import { KlingAIService } from '@server/services/integrations/klingai/services/klingai.service';
+import { ReplicateService } from '@server/services/integrations/replicate/services/replicate.service';
+import type { DispatchVideoGenerationParams } from './video-generation.types';
+
+/**
+ * Owns provider selection and request normalization for standard video
+ * generation. Shared generation orchestration remains provider-agnostic.
+ */
+@Injectable()
+export class VideoGenerationProviderDispatchService {
+  constructor(
+    private readonly falService: FalService,
+    private readonly klingAIService: KlingAIService,
+    private readonly replicateService: ReplicateService,
+  ) {}
+
+  async dispatch(
+    params: DispatchVideoGenerationParams,
+  ): Promise<string | null> {
+    const { duration, height, imageUrl, model, prompt, promptParams, width } =
+      params;
+
+    if (model === MODEL_KEYS.KLINGAI_V2) {
+      return this.klingAIService.queueGenerateTextToVideo(prompt, {
+        height,
+        model,
+        width,
+      });
+    }
+
+    if (isFalDestination(model)) {
+      const result = await this.falService.generateVideo(model, {
+        prompt,
+        ...(duration && { duration }),
+        ...(imageUrl && { image_url: imageUrl }),
+      });
+      return result.url;
+    }
+
+    return this.replicateService.generateTextToVideo(model, promptParams);
+  }
+}

--- a/apps/server/api/src/collections/videos/services/video-generation.service.spec.ts
+++ b/apps/server/api/src/collections/videos/services/video-generation.service.spec.ts
@@ -1,6 +1,7 @@
 import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticated-user.interface';
 import { CreateVideoDto } from '@api/collections/videos/dto/create-video.dto';
 import { VideoGenerationService } from '@api/collections/videos/services/video-generation.service';
+import { VideoGenerationProviderDispatchService } from '@api/collections/videos/services/video-generation-provider-dispatch.service';
 import type { RequestWithContext as ExpressRequest } from '@api/common/middleware/request-context.middleware';
 import { MODEL_KEYS } from '@genfeedai/constants';
 import { LoggerService } from '@libs/logger/logger.service';
@@ -98,6 +99,11 @@ describe('VideoGenerationService', () => {
       generateTextToVideo: vi.fn().mockResolvedValue('replicate-gen'),
     };
     const falService = { generateVideo: vi.fn() };
+    const providerDispatchService = new VideoGenerationProviderDispatchService(
+      falService as never,
+      klingAIService as never,
+      replicateService as never,
+    );
     const metadataService = { patch: vi.fn().mockResolvedValue(undefined) };
     const videosService = {
       findOne: vi.fn(),
@@ -143,11 +149,10 @@ describe('VideoGenerationService', () => {
       assetsService as never,
       bookmarksService as never,
       creditsUtilsService as never,
-      falService as never,
+      providerDispatchService,
       failedGenerationService as never,
       ingredientsService as never,
       pollingService as never,
-      klingAIService as never,
       loggerService,
       metadataService as never,
       modelRegistrationService as never,
@@ -155,7 +160,6 @@ describe('VideoGenerationService', () => {
       organizationSettingsService as never,
       promptsService as never,
       promptBuilderService as never,
-      replicateService as never,
       sharedService as never,
       videoMusicOrchestrationService as never,
       videosService as never,

--- a/apps/server/api/src/collections/videos/services/video-generation.service.ts
+++ b/apps/server/api/src/collections/videos/services/video-generation.service.ts
@@ -11,14 +11,12 @@ import { MetadataEntity } from '@api/collections/metadata/entities/metadata.enti
 import { MetadataService } from '@api/collections/metadata/services/metadata.service';
 import { ModelRegistrationService } from '@api/collections/models/services/model-registration.service';
 import { ModelsService } from '@api/collections/models/services/models.service';
-import {
-  baseModelKey,
-  isFalDestination,
-} from '@api/collections/models/utils/model-key.util';
+import { baseModelKey } from '@api/collections/models/utils/model-key.util';
 import { OrganizationSettingsService } from '@api/collections/organization-settings/services/organization-settings.service';
 import { PromptEntity } from '@api/collections/prompts/entities/prompt.entity';
 import { PromptsService } from '@api/collections/prompts/services/prompts.service';
 import { CreateVideoDto } from '@api/collections/videos/dto/create-video.dto';
+import { VideoGenerationProviderDispatchService } from '@api/collections/videos/services/video-generation-provider-dispatch.service';
 import { VideoMusicOrchestrationService } from '@api/collections/videos/services/video-music-orchestration.service';
 import { VideosService } from '@api/collections/videos/services/videos.service';
 import type { RequestWithContext as ExpressRequest } from '@api/common/middleware/request-context.middleware';
@@ -39,7 +37,7 @@ import { FailedGenerationService } from '@api/shared/services/failed-generation/
 import { IngredientCompletionService } from '@api/shared/services/poll-until/ingredient-completion.service';
 import { SharedService } from '@api/shared/services/shared/shared.service';
 import { PopulatePatterns } from '@api/shared/utils/populate/populate.util';
-import { MODEL_KEYS, MODEL_OUTPUT_CAPABILITIES } from '@genfeedai/constants';
+import { MODEL_OUTPUT_CAPABILITIES } from '@genfeedai/constants';
 import {
   ActivityEntityModel,
   ActivityKey,
@@ -58,13 +56,9 @@ import { ConfigService } from '@libs/config/config.service';
 import { LoggerService } from '@libs/logger/logger.service';
 import { getUserRoomName } from '@libs/websockets/room-name.util';
 import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
-import { FalService } from '@server/services/integrations/fal/services/fal.service';
-import { KlingAIService } from '@server/services/integrations/klingai/services/klingai.service';
-import { ReplicateService } from '@server/services/integrations/replicate/services/replicate.service';
 import { PollTimeoutException } from '@server/shared/services/poll-until/poll-until.exception';
 import type {
   CreateVideoPlaceholderActivityParams,
-  DispatchVideoGenerationParams,
   PromptInput,
 } from './video-generation.types';
 
@@ -89,11 +83,10 @@ export class VideoGenerationService {
     private readonly assetsService: AssetsService,
     private readonly bookmarksService: BookmarksService,
     private readonly creditsUtilsService: CreditsUtilsService,
-    private readonly falService: FalService,
+    private readonly providerDispatchService: VideoGenerationProviderDispatchService,
     private readonly failedGenerationService: FailedGenerationService,
     private readonly ingredientsService: IngredientsService,
     private readonly ingredientCompletionService: IngredientCompletionService,
-    private readonly klingAIService: KlingAIService,
     private readonly loggerService: LoggerService,
     private readonly metadataService: MetadataService,
     private readonly modelRegistrationService: ModelRegistrationService,
@@ -101,7 +94,6 @@ export class VideoGenerationService {
     private readonly organizationSettingsService: OrganizationSettingsService,
     private readonly promptsService: PromptsService,
     private readonly promptBuilderService: PromptBuilderService,
-    private readonly replicateService: ReplicateService,
     private readonly sharedService: SharedService,
     private readonly videoMusicOrchestrationService: VideoMusicOrchestrationService,
     private readonly videosService: VideosService,
@@ -361,15 +353,16 @@ export class VideoGenerationService {
 
     try {
       // When generation is triggered, deduct credits
-      const generationId: string | null = await this.dispatchVideoGeneration({
-        duration: createVideoDto.duration,
-        height,
-        imageUrl: referenceImageUrls[0],
-        model,
-        prompt: promptInput.prompt || '',
-        promptParams,
-        width,
-      });
+      const generationId: string | null =
+        await this.providerDispatchService.dispatch({
+          duration: createVideoDto.duration,
+          height,
+          imageUrl: referenceImageUrls[0],
+          model,
+          prompt: promptInput.prompt || '',
+          promptParams,
+          width,
+        });
 
       if (generationId) {
         // Credit deduction is owned by CreditsInterceptor, which deducts the
@@ -511,7 +504,7 @@ export class VideoGenerationService {
 
             // Make separate API call for each output based on model
             const additionalGenerationId: string | null =
-              await this.dispatchVideoGeneration({
+              await this.providerDispatchService.dispatch({
                 duration: createVideoDto.duration,
                 height,
                 imageUrl: referenceImageUrls[0],
@@ -888,45 +881,6 @@ export class VideoGenerationService {
       deferred: false,
       modelKey: model,
     };
-  }
-
-  /**
-   * Single source of truth for provider routing. Every video output — the first
-   * and each additional one — flows through here, so FAL/Replicate/KlingAI
-   * routing can never diverge between outputs of the same request.
-   *
-   * - `KLINGAI_V2` uses its own queue-backed service.
-   * - Any `fal-ai/*` model (detected via {@link isFalDestination}) goes to FAL.
-   * - Everything else falls through to Replicate.
-   *
-   * @returns the external generation id/url, or null when the provider declined.
-   */
-  private async dispatchVideoGeneration(
-    params: DispatchVideoGenerationParams,
-  ): Promise<string | null> {
-    const { duration, height, imageUrl, model, prompt, promptParams, width } =
-      params;
-
-    if (model === MODEL_KEYS.KLINGAI_V2) {
-      // KlingAI uses its own service for queue management
-      return this.klingAIService.queueGenerateTextToVideo(prompt, {
-        height,
-        model,
-        width,
-      });
-    }
-
-    if (isFalDestination(model)) {
-      const falResult = await this.falService.generateVideo(model, {
-        prompt,
-        ...(duration && { duration }),
-        ...(imageUrl && { image_url: imageUrl }),
-      });
-      return falResult.url;
-    }
-
-    // All Replicate-based models (Google VEO, Imagen, Luma, Sora, etc.)
-    return this.replicateService.generateTextToVideo(model, promptParams);
   }
 
   /**

--- a/apps/server/api/src/collections/videos/videos.module.ts
+++ b/apps/server/api/src/collections/videos/videos.module.ts
@@ -23,6 +23,7 @@ import { VideosRelationshipsController } from '@api/collections/videos/controlle
 import { VideosUploadController } from '@api/collections/videos/controllers/upload/videos-upload.controller';
 import { VideosController } from '@api/collections/videos/controllers/videos.controller';
 import { VideoGenerationService } from '@api/collections/videos/services/video-generation.service';
+import { VideoGenerationProviderDispatchService } from '@api/collections/videos/services/video-generation-provider-dispatch.service';
 import { VideoMusicOrchestrationService } from '@api/collections/videos/services/video-music-orchestration.service';
 import { VideoProvenanceService } from '@api/collections/videos/services/video-provenance.service';
 import { VideosService } from '@api/collections/videos/services/videos.service';
@@ -97,6 +98,7 @@ import { forwardRef, Module } from '@nestjs/common';
     CreditsInterceptor,
     ModelRegistrationService,
     ModelsGuard,
+    VideoGenerationProviderDispatchService,
     VideoGenerationService,
     VideoMusicOrchestrationService,
     VideoProvenanceService,


### PR DESCRIPTION
## Summary

- extract KlingAI, FAL, and Replicate routing into a typed video provider dispatch service
- keep primary and multi-output generation on the same provider boundary
- reduce `VideoGenerationService` from 1,008 to 962 lines and remove its direct provider dependencies
- add focused routing coverage for KlingAI, FAL optional inputs/URL normalization, and Replicate fallback

## Related issue

Closes #1851

## Scope

Behavior-preserving standard video provider dispatch extraction only. Image adapters, files processor decomposition, provider additions, credits, polling, and broader generation orchestration remain out of scope under #1741.

## Verification

- `bunx @biomejs/biome@2.5.3 check <6 changed files>` — passed
- `bun run scripts/run-secretlint.ts <6 changed files>` — passed
- `git diff --cached --check` — passed
- static boundary assertions — 2 dispatcher call sites, no direct provider dependencies, 962-line orchestration service, module registration present
- `bun run check:di-value-imports` — blocked before analysis by the known Bun 1.3.14 TypeScript runtime import fault (`ts.ScriptTarget` is undefined)
- unit tests, typecheck, and build — intentionally left to PR CI per workstation policy

## Screenshots

Not applicable.

## Checklist

- [x] I reviewed the final diff for unrelated changes.
- [x] I ran the relevant focused checks or documented why they were left to CI.
- [x] I updated relevant documentation or explained why no documentation change is needed.
- [x] Migrations, release steps, and external configuration changes are not applicable.
- [x] I did not include secrets, credentials, personal data, customer data, or generated build output.