### PR TITLE
refactor(trends): extract corpus freshness service

### DIFF
--- a/apps/server/api/src/collections/trends/services/modules/trend-corpus-freshness.service.spec.ts
+++ b/apps/server/api/src/collections/trends/services/modules/trend-corpus-freshness.service.spec.ts
@@ -1,0 +1,293 @@
+import { TrendCorpusFreshnessService } from '@api/collections/trends/services/modules/trend-corpus-freshness.service';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import { Test, TestingModule } from '@nestjs/testing';
+
+type ReferenceDoc = {
+  createdAt: Date;
+  data: Record<string, unknown>;
+  id: string;
+  lastSeenAt: Date;
+  platform: string;
+};
+
+type TrendDoc = {
+  createdAt: Date;
+  data: Record<string, unknown>;
+  id: string;
+  lastSeenAt: Date;
+  organizationId: string | null;
+  platform: string;
+  updatedAt: Date;
+};
+
+const referenceDocs: ReferenceDoc[] = [
+  {
+    createdAt: new Date('2026-06-01T00:00:00.000Z'),
+    data: {
+      authorHandle: 'creator',
+      firstSeenAt: '2026-06-01T00:00:00.000Z',
+      lastSeenAt: '2026-06-12T00:00:00.000Z',
+      matchedTrendTopics: ['ai tools'],
+      platform: 'tiktok',
+      sourceClassification: {
+        capturedAt: '2026-06-01T00:00:00.000Z',
+        confidence: 'medium',
+        freshnessWindowDays: 2,
+        intendedUse: 'organic_trend_discovery',
+        sourceKind: 'public_platform_reference',
+        sourceLabel: 'TikTok',
+      },
+    },
+    id: 'ref_tiktok',
+    lastSeenAt: new Date('2026-06-12T00:00:00.000Z'),
+    platform: 'tiktok',
+  },
+  {
+    createdAt: new Date('2026-06-02T00:00:00.000Z'),
+    data: {
+      authorHandle: 'designer',
+      firstSeenAt: '2026-06-02T00:00:00.000Z',
+      lastSeenAt: '2026-06-10T00:00:00.000Z',
+      matchedTrendTopics: ['design'],
+      platform: 'instagram',
+      sourceClassification: {
+        capturedAt: '2026-06-02T00:00:00.000Z',
+        confidence: 'medium',
+        freshnessWindowDays: 30,
+        intendedUse: 'organic_trend_discovery',
+        sourceKind: 'public_platform_reference',
+        sourceLabel: 'Instagram',
+      },
+    },
+    id: 'ref_instagram',
+    lastSeenAt: new Date('2026-06-10T00:00:00.000Z'),
+    platform: 'instagram',
+  },
+];
+
+const makeTrend = (
+  id: string,
+  platform: string,
+  metadata: Record<string, unknown>,
+  organizationId: string | null = null,
+): TrendDoc => ({
+  createdAt: new Date('2026-06-10T00:00:00.000Z'),
+  data: {
+    expiresAt: '2026-07-01T00:00:00.000Z',
+    isCurrent: true,
+    metadata,
+    platform,
+  },
+  id,
+  lastSeenAt: new Date('2026-06-12T00:00:00.000Z'),
+  organizationId,
+  platform,
+  updatedAt: new Date('2026-06-12T00:00:00.000Z'),
+});
+
+const trendDocs: TrendDoc[] = [
+  makeTrend(
+    'trend_live',
+    'tiktok',
+    {
+      source: 'apify',
+      sourcePreviewCachedAt: '2026-06-12T00:00:00.000Z',
+      sourcePreviewState: 'live',
+    },
+    'org_1',
+  ),
+  makeTrend('trend_empty', 'youtube', {
+    source: 'apify',
+    sourcePreviewCachedAt: '2026-06-13T00:00:00.000Z',
+    sourcePreviewState: 'empty',
+  }),
+  makeTrend('trend_fallback', 'instagram', {
+    source: 'apify',
+    sourcePreviewCachedAt: '2026-06-11T00:00:00.000Z',
+    sourcePreviewState: 'fallback',
+  }),
+  makeTrend('trend_stale', 'twitter', {
+    source: 'apify',
+    sourcePreviewCachedAt: '2026-06-01T00:00:00.000Z',
+    sourcePreviewState: 'live',
+  }),
+  makeTrend('trend_prelaunch', 'linkedin', {
+    prelaunchCorpus: true,
+    source: 'public-reference',
+    sourcePreviewCachedAt: '2026-06-01T00:00:00.000Z',
+    sourcePreviewState: 'fallback',
+  }),
+];
+
+describe('TrendCorpusFreshnessService', () => {
+  let service: TrendCorpusFreshnessService;
+  let prisma: {
+    trend: { findMany: ReturnType<typeof vi.fn> };
+    trendSourceReference: { findMany: ReturnType<typeof vi.fn> };
+  };
+
+  beforeEach(async () => {
+    prisma = {
+      trend: {
+        findMany: vi.fn(({ where }) =>
+          Promise.resolve(
+            where.platform
+              ? trendDocs.filter((doc) => doc.platform === where.platform)
+              : trendDocs,
+          ),
+        ),
+      },
+      trendSourceReference: {
+        findMany: vi.fn(({ where }) =>
+          Promise.resolve(
+            where.platform
+              ? referenceDocs.filter((doc) => doc.platform === where.platform)
+              : referenceDocs,
+          ),
+        ),
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        TrendCorpusFreshnessService,
+        { provide: PrismaService, useValue: prisma },
+      ],
+    }).compile();
+
+    service = module.get(TrendCorpusFreshnessService);
+  });
+
+  it('reports freshness segments and every live provider failure class', async () => {
+    const result = await service.getCorpusFreshnessHealth({
+      isPlatformAdmin: true,
+      now: new Date('2026-06-14T00:00:00.000Z'),
+    });
+
+    expect(result.status).toBe('stale');
+    expect(result.summary).toMatchObject({
+      activeTrends: 5,
+      failingProviders: 3,
+      freshSegments: 2,
+      referenceRecords: 2,
+      staleSegments: 0,
+      totalSegments: 2,
+    });
+    expect(result.segments).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          platform: 'tiktok',
+          provider: 'TikTok',
+          status: 'healthy',
+        }),
+        expect.objectContaining({
+          platform: 'instagram',
+          provider: 'Instagram',
+          status: 'healthy',
+        }),
+      ]),
+    );
+    expect(result.providerFailures.map((failure) => failure.reason)).toEqual([
+      'fallback_source_preview',
+      'stale_source_preview',
+      'empty_source_preview',
+    ]);
+    expect(
+      result.providerFailures.some(
+        (failure) => failure.provider === 'public-reference',
+      ),
+    ).toBe(false);
+  });
+
+  it('marks segments stale when their source windows expire', async () => {
+    const result = await service.getCorpusFreshnessHealth({
+      isPlatformAdmin: true,
+      now: new Date('2026-07-20T00:00:00.000Z'),
+      sourcePreviewStaleAfterDays: 100,
+    });
+
+    expect(result.status).toBe('stale');
+    expect(result.summary.staleSegments).toBe(2);
+    expect(result.segments).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          platform: 'tiktok',
+          staleReferenceCount: 1,
+          status: 'stale',
+        }),
+        expect.objectContaining({
+          platform: 'instagram',
+          staleReferenceCount: 1,
+          status: 'stale',
+        }),
+      ]),
+    );
+  });
+
+  it('filters both corpus queries by platform and preserves record caps', async () => {
+    const result = await service.getCorpusFreshnessHealth({
+      isPlatformAdmin: true,
+      now: new Date('2026-06-14T00:00:00.000Z'),
+      platform: 'tiktok',
+    });
+
+    expect(result.summary.platforms).toEqual(['tiktok']);
+    expect(result.summary.referenceRecords).toBe(1);
+    expect(result.summary.failingProviders).toBe(0);
+    expect(prisma.trendSourceReference.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        take: 5000,
+        where: { isDeleted: false, platform: 'tiktok' },
+      }),
+    );
+    expect(prisma.trend.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        take: 2000,
+        where: { isDeleted: false, platform: 'tiktok' },
+      }),
+    );
+  });
+
+  it('scopes non-admin trend health to the caller organization and global rows', async () => {
+    await service.getCorpusFreshnessHealth({
+      now: new Date('2026-06-14T00:00:00.000Z'),
+      organizationId: 'org_1',
+    });
+
+    expect(prisma.trend.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          OR: [{ organizationId: 'org_1' }, { organizationId: null }],
+          isDeleted: false,
+        },
+      }),
+    );
+  });
+
+  it('restricts non-admin callers without an organization to global trends', async () => {
+    await service.getCorpusFreshnessHealth({
+      now: new Date('2026-06-14T00:00:00.000Z'),
+    });
+
+    expect(prisma.trend.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          OR: [{ organizationId: null }],
+          isDeleted: false,
+        },
+      }),
+    );
+  });
+
+  it('keeps the platform-admin trend aggregate cross-organization', async () => {
+    await service.getCorpusFreshnessHealth({
+      isPlatformAdmin: true,
+      now: new Date('2026-06-14T00:00:00.000Z'),
+      organizationId: 'org_1',
+    });
+
+    const trendWhere = prisma.trend.findMany.mock.calls.at(-1)?.[0]?.where;
+    expect(trendWhere).toEqual({ isDeleted: false });
+    expect(trendWhere).not.toHaveProperty('OR');
+  });
+});

--- a/apps/server/api/src/collections/trends/services/modules/trend-corpus-freshness.service.ts
+++ b/apps/server/api/src/collections/trends/services/modules/trend-corpus-freshness.service.ts
@@ -1,0 +1,512 @@
+import type {
+  TrendCorpusFreshnessResult,
+  TrendCorpusFreshnessSegment,
+  TrendCorpusFreshnessStatus,
+  TrendProviderFailureSummary,
+  TrendSourceClassification,
+  TrendSourceIntendedUse,
+  TrendSourceKind,
+} from '@api/collections/trends/interfaces/trend.interfaces';
+import {
+  DEFAULT_SOURCE_FRESHNESS_WINDOW_DAYS_BY_KIND as DEFAULT_FRESHNESS_WINDOW_DAYS_BY_SOURCE_KIND,
+  normalizeTrendSourceClassification,
+} from '@api/collections/trends/utils/trend-source-classification.util';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import type { Prisma } from '@genfeedai/prisma';
+import { Injectable } from '@nestjs/common';
+
+export interface TrendCorpusFreshnessHealthOptions {
+  isPlatformAdmin?: boolean;
+  now?: Date;
+  organizationId?: string;
+  platform?: string;
+  sourcePreviewStaleAfterDays?: number;
+}
+
+interface ReferenceHealthData {
+  authorHandle?: string;
+  firstSeenAt?: string;
+  lastSeenAt?: string;
+  matchedTrendTopics?: string[];
+  platform?: string;
+  publishedAt?: string;
+  sourceClassification?: TrendSourceClassification;
+}
+
+interface ReferenceHealthDoc {
+  createdAt: Date;
+  data: unknown;
+  id: string;
+  lastSeenAt?: Date | null;
+  platform?: string | null;
+}
+
+interface TrendHealthDoc {
+  createdAt?: Date;
+  data: unknown;
+  id: string;
+  lastSeenAt?: Date | null;
+  platform?: string | null;
+  updatedAt?: Date;
+}
+
+interface FreshnessSegmentAccumulator {
+  freshnessWindowDays: number;
+  intendedUse: TrendSourceIntendedUse;
+  latestSeenAt?: Date;
+  oldestSeenAt?: Date;
+  platform: string;
+  provider: string;
+  referenceCount: number;
+  sourceKind: TrendSourceKind;
+  staleReferenceCount: number;
+}
+
+interface ProviderFailureAccumulator {
+  affectedTrendCount: number;
+  latestObservedAt?: Date;
+  message: string;
+  platform: string;
+  provider: string;
+  reason: TrendProviderFailureSummary['reason'];
+  retryAction: string;
+  severity: TrendProviderFailureSummary['severity'];
+}
+
+const DEFAULT_SOURCE_PREVIEW_STALE_AFTER_DAYS = 3;
+const MAX_CORPUS_FRESHNESS_REFERENCE_RECORDS = 5000;
+const MAX_CORPUS_FRESHNESS_TREND_RECORDS = 2000;
+
+/**
+ * Owns corpus-health queries, tenant scoping, freshness aggregation, and
+ * provider-failure projection.
+ */
+@Injectable()
+export class TrendCorpusFreshnessService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async getCorpusFreshnessHealth(
+    options: TrendCorpusFreshnessHealthOptions = {},
+  ): Promise<TrendCorpusFreshnessResult> {
+    const now = options.now ?? new Date();
+    const sourcePreviewStaleAfterDays =
+      options.sourcePreviewStaleAfterDays ??
+      DEFAULT_SOURCE_PREVIEW_STALE_AFTER_DAYS;
+
+    const [referenceDocs, trendDocs] = await Promise.all([
+      this.prisma.trendSourceReference.findMany({
+        orderBy: [{ platform: 'asc' }, { lastSeenAt: 'asc' }],
+        select: {
+          createdAt: true,
+          data: true,
+          id: true,
+          lastSeenAt: true,
+          platform: true,
+        },
+        take: MAX_CORPUS_FRESHNESS_REFERENCE_RECORDS,
+        where: {
+          ...(options.platform ? { platform: options.platform } : {}),
+          isDeleted: false,
+        },
+      }) as Promise<ReferenceHealthDoc[]>,
+      this.prisma.trend.findMany({
+        orderBy: [{ platform: 'asc' }, { updatedAt: 'asc' }],
+        select: {
+          createdAt: true,
+          data: true,
+          id: true,
+          lastSeenAt: true,
+          platform: true,
+          updatedAt: true,
+        },
+        take: MAX_CORPUS_FRESHNESS_TREND_RECORDS,
+        where: this.buildFreshnessTrendWhere(options),
+      }) as Promise<TrendHealthDoc[]>,
+    ]);
+
+    const segments = this.buildFreshnessSegments(referenceDocs, now);
+    const providerFailures = this.buildProviderFailures(
+      trendDocs,
+      now,
+      sourcePreviewStaleAfterDays,
+    );
+    const activeTrends = trendDocs.filter((doc) =>
+      this.isCurrentTrend(doc, now),
+    ).length;
+    const status = this.resolveCorpusFreshnessStatus(
+      referenceDocs.length,
+      segments,
+      providerFailures,
+    );
+    const platforms = Array.from(
+      new Set(
+        [
+          ...segments.map((segment) => segment.platform),
+          ...providerFailures.map((failure) => failure.platform),
+        ].filter(Boolean),
+      ),
+    ).sort();
+
+    return {
+      generatedAt: now.toISOString(),
+      providerFailures,
+      segments,
+      status,
+      summary: {
+        activeTrends,
+        failingProviders: providerFailures.length,
+        freshSegments: segments.filter(
+          (segment) => segment.status === 'healthy',
+        ).length,
+        platforms,
+        referenceRecords: referenceDocs.length,
+        staleSegments: segments.filter(
+          (segment) =>
+            segment.status === 'stale' || segment.status === 'degraded',
+        ).length,
+        totalSegments: segments.length,
+      },
+      thresholds: {
+        defaultFreshnessWindowDaysBySourceKind:
+          DEFAULT_FRESHNESS_WINDOW_DAYS_BY_SOURCE_KIND,
+        recordLimits: {
+          referenceRecords: MAX_CORPUS_FRESHNESS_REFERENCE_RECORDS,
+          trends: MAX_CORPUS_FRESHNESS_TREND_RECORDS,
+        },
+        sourcePreviewStaleAfterDays,
+      },
+    };
+  }
+
+  /**
+   * Trend rows are organization-scoped or global. Platform admins receive the
+   * cross-organization pipeline view; other callers receive their organization
+   * plus the global baseline.
+   */
+  private buildFreshnessTrendWhere(
+    options: TrendCorpusFreshnessHealthOptions,
+  ): Prisma.TrendWhereInput {
+    const where: Prisma.TrendWhereInput = {
+      ...(options.platform ? { platform: options.platform } : {}),
+      isDeleted: false,
+    };
+
+    if (options.isPlatformAdmin) {
+      return where;
+    }
+
+    where.OR = options.organizationId
+      ? [{ organizationId: options.organizationId }, { organizationId: null }]
+      : [{ organizationId: null }];
+
+    return where;
+  }
+
+  private buildFreshnessSegments(
+    referenceDocs: ReferenceHealthDoc[],
+    now: Date,
+  ): TrendCorpusFreshnessSegment[] {
+    const bySegment = new Map<string, FreshnessSegmentAccumulator>();
+
+    for (const doc of referenceDocs) {
+      const data = this.asRecord(doc.data) as ReferenceHealthData;
+      const classification = this.resolveSourceClassification(
+        data.sourceClassification,
+        {
+          capturedAt: data.firstSeenAt,
+          platform:
+            this.readString(doc.platform) ?? this.readString(data.platform),
+          sourceAuthor: data.authorHandle,
+          sourceTimestamp: data.publishedAt ?? data.lastSeenAt,
+          sourceTopic: data.matchedTrendTopics?.[0],
+        },
+      );
+      const platform =
+        this.readString(doc.platform) ??
+        this.readString(data.platform) ??
+        'unknown';
+      const sourceKind =
+        classification?.sourceKind ?? 'public_platform_reference';
+      const intendedUse =
+        classification?.intendedUse ?? 'organic_trend_discovery';
+      const provider = classification?.sourceLabel ?? platform;
+      const freshnessWindowDays =
+        classification?.freshnessWindowDays ??
+        DEFAULT_FRESHNESS_WINDOW_DAYS_BY_SOURCE_KIND[sourceKind];
+      const segmentId = [
+        'reference-corpus',
+        sourceKind,
+        intendedUse,
+        platform,
+        provider,
+      ].join(':');
+      const seenAt =
+        this.readDate(doc.lastSeenAt) ??
+        this.readDate(data.lastSeenAt) ??
+        this.readDate(doc.createdAt) ??
+        now;
+      const stale = this.calculateAgeDays(now, seenAt) > freshnessWindowDays;
+      const accumulator = bySegment.get(segmentId) ?? {
+        freshnessWindowDays,
+        intendedUse,
+        platform,
+        provider,
+        referenceCount: 0,
+        sourceKind,
+        staleReferenceCount: 0,
+      };
+
+      accumulator.referenceCount += 1;
+      accumulator.staleReferenceCount += stale ? 1 : 0;
+      accumulator.latestSeenAt =
+        accumulator.latestSeenAt == null || seenAt > accumulator.latestSeenAt
+          ? seenAt
+          : accumulator.latestSeenAt;
+      accumulator.oldestSeenAt =
+        accumulator.oldestSeenAt == null || seenAt < accumulator.oldestSeenAt
+          ? seenAt
+          : accumulator.oldestSeenAt;
+      bySegment.set(segmentId, accumulator);
+    }
+
+    return Array.from(bySegment.entries())
+      .map(([id, segment]) => ({
+        freshnessWindowDays: segment.freshnessWindowDays,
+        id,
+        intendedUse: segment.intendedUse,
+        latestSeenAt: segment.latestSeenAt?.toISOString(),
+        oldestSeenAt: segment.oldestSeenAt?.toISOString(),
+        platform: segment.platform,
+        provider: segment.provider,
+        referenceCount: segment.referenceCount,
+        sourceKind: segment.sourceKind,
+        staleReferenceCount: segment.staleReferenceCount,
+        status: this.resolveSegmentStatus(
+          segment.referenceCount,
+          segment.staleReferenceCount,
+        ),
+      }))
+      .sort((left, right) => left.id.localeCompare(right.id));
+  }
+
+  private buildProviderFailures(
+    trendDocs: TrendHealthDoc[],
+    now: Date,
+    sourcePreviewStaleAfterDays: number,
+  ): TrendProviderFailureSummary[] {
+    const failures = new Map<string, ProviderFailureAccumulator>();
+
+    for (const doc of trendDocs) {
+      if (!this.isCurrentTrend(doc, now)) {
+        continue;
+      }
+
+      const data = this.asRecord(doc.data);
+      const metadata = this.asRecord(data.metadata);
+      if (metadata.prelaunchCorpus === true) {
+        continue;
+      }
+
+      const sourcePreviewState = this.readString(metadata.sourcePreviewState);
+      const cachedAt = this.readDate(metadata.sourcePreviewCachedAt);
+      const observedAt =
+        cachedAt ??
+        this.readDate(doc.updatedAt) ??
+        this.readDate(doc.lastSeenAt) ??
+        this.readDate(doc.createdAt);
+      const platform =
+        this.readString(doc.platform) ??
+        this.readString(data.platform) ??
+        'unknown';
+      const provider =
+        this.readString(metadata.source) ??
+        this.readString(metadata.sourceProvider) ??
+        platform;
+
+      if (sourcePreviewState === 'empty') {
+        this.recordProviderFailure(failures, {
+          message:
+            'The trend source preview produced no usable source references.',
+          observedAt,
+          platform,
+          provider,
+          reason: 'empty_source_preview',
+          retryAction: `Refresh ${platform} trends and inspect provider fetch logs.`,
+          severity: 'error',
+        });
+        continue;
+      }
+
+      if (sourcePreviewState === 'fallback') {
+        this.recordProviderFailure(failures, {
+          message:
+            'The trend source preview is using fallback references instead of live provider data.',
+          observedAt,
+          platform,
+          provider,
+          reason: 'fallback_source_preview',
+          retryAction: `Refresh ${platform} trends and verify provider credentials or rate limits.`,
+          severity: 'warning',
+        });
+      }
+
+      if (
+        cachedAt &&
+        this.calculateAgeDays(now, cachedAt) > sourcePreviewStaleAfterDays
+      ) {
+        this.recordProviderFailure(failures, {
+          message:
+            'The cached trend source preview is older than the freshness threshold.',
+          observedAt: cachedAt,
+          platform,
+          provider,
+          reason: 'stale_source_preview',
+          retryAction: `Run source-preview precompute or refresh ${platform} trends.`,
+          severity: 'warning',
+        });
+      }
+    }
+
+    return Array.from(failures.values())
+      .map((failure) => ({
+        affectedTrendCount: failure.affectedTrendCount,
+        latestObservedAt: failure.latestObservedAt?.toISOString(),
+        message: failure.message,
+        platform: failure.platform,
+        provider: failure.provider,
+        reason: failure.reason,
+        retryAction: failure.retryAction,
+        severity: failure.severity,
+      }))
+      .sort((left, right) =>
+        `${left.platform}:${left.provider}:${left.reason}`.localeCompare(
+          `${right.platform}:${right.provider}:${right.reason}`,
+        ),
+      );
+  }
+
+  private recordProviderFailure(
+    failures: Map<string, ProviderFailureAccumulator>,
+    input: {
+      message: string;
+      observedAt?: Date;
+      platform: string;
+      provider: string;
+      reason: TrendProviderFailureSummary['reason'];
+      retryAction: string;
+      severity: TrendProviderFailureSummary['severity'];
+    },
+  ): void {
+    const key = [input.platform, input.provider, input.reason].join(':');
+    const existing = failures.get(key) ?? {
+      affectedTrendCount: 0,
+      message: input.message,
+      platform: input.platform,
+      provider: input.provider,
+      reason: input.reason,
+      retryAction: input.retryAction,
+      severity: input.severity,
+    };
+
+    existing.affectedTrendCount += 1;
+    existing.latestObservedAt =
+      input.observedAt != null &&
+      (existing.latestObservedAt == null ||
+        input.observedAt > existing.latestObservedAt)
+        ? input.observedAt
+        : existing.latestObservedAt;
+    failures.set(key, existing);
+  }
+
+  private resolveSegmentStatus(
+    referenceCount: number,
+    staleReferenceCount: number,
+  ): TrendCorpusFreshnessStatus {
+    if (referenceCount === 0) {
+      return 'empty';
+    }
+
+    if (staleReferenceCount === 0) {
+      return 'healthy';
+    }
+
+    return staleReferenceCount === referenceCount ? 'stale' : 'degraded';
+  }
+
+  private resolveCorpusFreshnessStatus(
+    referenceCount: number,
+    segments: TrendCorpusFreshnessSegment[],
+    providerFailures: TrendProviderFailureSummary[],
+  ): TrendCorpusFreshnessStatus {
+    if (referenceCount === 0) {
+      return 'empty';
+    }
+
+    if (
+      providerFailures.some((failure) => failure.severity === 'error') ||
+      segments.some((segment) => segment.status === 'stale')
+    ) {
+      return 'stale';
+    }
+
+    if (
+      providerFailures.length > 0 ||
+      segments.some((segment) => segment.status === 'degraded')
+    ) {
+      return 'degraded';
+    }
+
+    return 'healthy';
+  }
+
+  private resolveSourceClassification(
+    value: unknown,
+    defaults: {
+      capturedAt?: Date | string;
+      platform?: string;
+      sourceAuthor?: string;
+      sourceTimestamp?: Date | string;
+      sourceTopic?: string;
+    } = {},
+  ): TrendSourceClassification | undefined {
+    return normalizeTrendSourceClassification({
+      ...defaults,
+      value,
+    });
+  }
+
+  private isCurrentTrend(doc: TrendHealthDoc, now: Date): boolean {
+    const data = this.asRecord(doc.data);
+    const expiresAt = this.readDate(data.expiresAt);
+    return data.isCurrent === true && (!expiresAt || expiresAt > now);
+  }
+
+  private calculateAgeDays(now: Date, date: Date): number {
+    return (now.getTime() - date.getTime()) / (24 * 60 * 60 * 1000);
+  }
+
+  private asRecord(value: unknown): Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {};
+  }
+
+  private readDate(value: unknown): Date | undefined {
+    if (value instanceof Date && !Number.isNaN(value.getTime())) {
+      return value;
+    }
+
+    if (typeof value !== 'string' || value.length === 0) {
+      return undefined;
+    }
+
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? undefined : date;
+  }
+
+  private readString(value: unknown): string | undefined {
+    return typeof value === 'string' && value.trim().length > 0
+      ? value
+      : undefined;
+  }
+}

--- a/apps/server/api/src/collections/trends/services/trend-reference-corpus.service.spec.ts
+++ b/apps/server/api/src/collections/trends/services/trend-reference-corpus.service.spec.ts
@@ -1,4 +1,5 @@
 import type { TrendSourceItem } from '@api/collections/trends/interfaces/trend.interfaces';
+import { TrendCorpusFreshnessService } from '@api/collections/trends/services/modules/trend-corpus-freshness.service';
 import { TrendReferenceCorpusService } from '@api/collections/trends/services/trend-reference-corpus.service';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { LoggerService } from '@libs/logger/logger.service';
@@ -432,14 +433,38 @@ describe('TrendReferenceCorpusService', () => {
     log: vi.fn(),
     warn: vi.fn(),
   };
+  const trendCorpusFreshnessService = {
+    getCorpusFreshnessHealth: vi.fn(),
+  };
 
   let service: TrendReferenceCorpusService;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    trendCorpusFreshnessService.getCorpusFreshnessHealth.mockResolvedValue({
+      generatedAt: '2026-06-14T00:00:00.000Z',
+      providerFailures: [],
+      segments: [],
+      status: 'healthy',
+      summary: {
+        activeTrends: 1,
+        failingProviders: 0,
+        freshSegments: 1,
+        platforms: ['tiktok'],
+        referenceRecords: 1,
+        staleSegments: 0,
+        totalSegments: 1,
+      },
+      thresholds: {
+        defaultFreshnessWindowDaysBySourceKind: {},
+        recordLimits: { referenceRecords: 5000, trends: 2000 },
+        sourcePreviewStaleAfterDays: 3,
+      },
+    });
     service = new TrendReferenceCorpusService(
       prisma as unknown as PrismaService,
       loggerService as unknown as LoggerService,
+      trendCorpusFreshnessService as unknown as TrendCorpusFreshnessService,
     );
   });
 
@@ -898,158 +923,19 @@ describe('TrendReferenceCorpusService', () => {
     );
   });
 
-  it('reports corpus freshness segments and provider failures', async () => {
-    const result = await service.getCorpusFreshnessHealth({
+  it('delegates corpus freshness health without changing the public contract', async () => {
+    const options = {
       isPlatformAdmin: true,
       now: new Date('2026-06-14T00:00:00.000Z'),
-    });
+      platform: 'tiktok',
+    };
 
-    expect(result.status).toBe('stale');
-    expect(result.summary).toMatchObject({
-      activeTrends: 4,
-      failingProviders: 2,
-      freshSegments: 3,
-      referenceRecords: 3,
-      staleSegments: 0,
-      totalSegments: 3,
-    });
-    expect(result.segments).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          platform: 'tiktok',
-          provider: 'TikTok',
-          sourceKind: 'public_platform_reference',
-          status: 'healthy',
-        }),
-        expect.objectContaining({
-          platform: 'instagram',
-          provider: 'instagram',
-          sourceKind: 'public_platform_reference',
-          status: 'healthy',
-        }),
-      ]),
-    );
-    expect(result.providerFailures).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          affectedTrendCount: 1,
-          platform: 'youtube',
-          provider: 'apify',
-          reason: 'empty_source_preview',
-          severity: 'error',
-        }),
-        expect.objectContaining({
-          affectedTrendCount: 1,
-          platform: 'instagram',
-          provider: 'apify',
-          reason: 'fallback_source_preview',
-          severity: 'warning',
-        }),
-      ]),
-    );
+    const result = await service.getCorpusFreshnessHealth(options);
+
+    expect(result.status).toBe('healthy');
     expect(
-      result.providerFailures.some(
-        (failure) => failure.provider === 'public-reference',
-      ),
-    ).toBe(false);
-  });
-
-  it('marks reference segments stale when last seen exceeds source windows', async () => {
-    const result = await service.getCorpusFreshnessHealth({
-      isPlatformAdmin: true,
-      now: new Date('2026-06-20T00:00:00.000Z'),
-      sourcePreviewStaleAfterDays: 30,
-    });
-
-    expect(result.status).toBe('stale');
-    expect(result.summary.staleSegments).toBe(2);
-    expect(result.segments).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          platform: 'tiktok',
-          referenceCount: 1,
-          staleReferenceCount: 1,
-          status: 'stale',
-        }),
-        expect.objectContaining({
-          platform: 'instagram',
-          referenceCount: 1,
-          staleReferenceCount: 1,
-          status: 'stale',
-        }),
-      ]),
-    );
-  });
-
-  it('filters corpus health by platform', async () => {
-    const result = await service.getCorpusFreshnessHealth({
-      isPlatformAdmin: true,
-      now: new Date('2026-06-14T00:00:00.000Z'),
-      platform: 'tiktok',
-    });
-
-    expect(result.summary.platforms).toEqual(['tiktok']);
-    expect(result.summary.referenceRecords).toBe(1);
-    expect(result.summary.failingProviders).toBe(0);
-    expect(result.segments).toHaveLength(1);
-    expect(result.segments[0]).toMatchObject({
-      platform: 'tiktok',
-      provider: 'TikTok',
-    });
-    expect(prisma.trendSourceReference.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: {
-          isDeleted: false,
-          platform: 'tiktok',
-        },
-      }),
-    );
-  });
-
-  it('scopes the Trend aggregate to the caller org + global rows for non-admins', async () => {
-    await service.getCorpusFreshnessHealth({
-      now: new Date('2026-06-14T00:00:00.000Z'),
-      organizationId: 'org_1',
-    });
-
-    expect(prisma.trend.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({
-          OR: [{ organizationId: 'org_1' }, { organizationId: null }],
-          isDeleted: false,
-        }),
-      }),
-    );
-    // Never a bare cross-org read for a tenant.
-    const trendWhere = prisma.trend.findMany.mock.calls.at(-1)?.[0]?.where;
-    expect(trendWhere).not.toHaveProperty('organizationId');
-  });
-
-  it('restricts a non-admin with no org to global (null-org) Trend rows only', async () => {
-    await service.getCorpusFreshnessHealth({
-      now: new Date('2026-06-14T00:00:00.000Z'),
-    });
-
-    expect(prisma.trend.findMany).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: expect.objectContaining({
-          OR: [{ organizationId: null }],
-          isDeleted: false,
-        }),
-      }),
-    );
-  });
-
-  it('does not org-scope the Trend aggregate for platform admins (global view)', async () => {
-    await service.getCorpusFreshnessHealth({
-      isPlatformAdmin: true,
-      now: new Date('2026-06-14T00:00:00.000Z'),
-      organizationId: 'org_1',
-    });
-
-    const trendWhere = prisma.trend.findMany.mock.calls.at(-1)?.[0]?.where;
-    expect(trendWhere).toEqual({ isDeleted: false });
-    expect(trendWhere).not.toHaveProperty('OR');
+      trendCorpusFreshnessService.getCorpusFreshnessHealth,
+    ).toHaveBeenCalledWith(options);
   });
 
   it('resolves metadata source URLs before creating org-scoped remix lineage', async () => {

--- a/apps/server/api/src/collections/trends/services/trend-reference-corpus.service.ts
+++ b/apps/server/api/src/collections/trends/services/trend-reference-corpus.service.ts
@@ -1,8 +1,6 @@
 import { createHash } from 'node:crypto';
 import type {
   TrendCorpusFreshnessResult,
-  TrendCorpusFreshnessSegment,
-  TrendCorpusFreshnessStatus,
   TrendPromptReferenceBrandSuitability,
   TrendPromptReferenceFreshnessStatus,
   TrendPromptReferencePack,
@@ -10,7 +8,6 @@ import type {
   TrendPromptReferencePackResult,
   TrendPromptReferencePackSource,
   TrendPromptReferencePackType,
-  TrendProviderFailureSummary,
   TrendSourceAccountResult,
   TrendSourceAccountSummary,
   TrendSourceClassification,
@@ -22,9 +19,10 @@ import type {
   TrendSourceReferenceResult,
 } from '@api/collections/trends/interfaces/trend.interfaces';
 import {
-  DEFAULT_SOURCE_FRESHNESS_WINDOW_DAYS_BY_KIND as DEFAULT_FRESHNESS_WINDOW_DAYS_BY_SOURCE_KIND,
-  normalizeTrendSourceClassification,
-} from '@api/collections/trends/utils/trend-source-classification.util';
+  type TrendCorpusFreshnessHealthOptions,
+  TrendCorpusFreshnessService,
+} from '@api/collections/trends/services/modules/trend-corpus-freshness.service';
+import { normalizeTrendSourceClassification } from '@api/collections/trends/utils/trend-source-classification.util';
 import { SecurityUtil } from '@api/helpers/utils/security/security.util';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { Prisma } from '@genfeedai/prisma';
@@ -70,62 +68,6 @@ interface PromptReferencePackQueryOptions {
   types?: TrendPromptReferencePackType[];
 }
 
-interface CorpusFreshnessHealthOptions {
-  now?: Date;
-  platform?: string;
-  sourcePreviewStaleAfterDays?: number;
-  /**
-   * Caller's organization. Non-admin callers only see their own + global
-   * (null-org) Trend rows in the aggregate. Ignored when isPlatformAdmin.
-   */
-  organizationId?: string;
-  /**
-   * When true (platform admins/ops), the Trend aggregate spans every
-   * organization — the global pipeline-health view. Non-admins are org-scoped.
-   */
-  isPlatformAdmin?: boolean;
-}
-
-interface ReferenceHealthDoc {
-  createdAt: Date;
-  data: unknown;
-  id: string;
-  lastSeenAt?: Date | null;
-  platform?: string | null;
-}
-
-interface TrendHealthDoc {
-  createdAt?: Date;
-  data: unknown;
-  id: string;
-  lastSeenAt?: Date | null;
-  platform?: string | null;
-  updatedAt?: Date;
-}
-
-interface FreshnessSegmentAccumulator {
-  freshnessWindowDays: number;
-  intendedUse: TrendSourceIntendedUse;
-  latestSeenAt?: Date;
-  oldestSeenAt?: Date;
-  platform: string;
-  provider: string;
-  referenceCount: number;
-  sourceKind: TrendSourceKind;
-  staleReferenceCount: number;
-}
-
-interface ProviderFailureAccumulator {
-  affectedTrendCount: number;
-  latestObservedAt?: Date;
-  message: string;
-  platform: string;
-  provider: string;
-  reason: TrendProviderFailureSummary['reason'];
-  retryAction: string;
-  severity: TrendProviderFailureSummary['severity'];
-}
-
 interface ReferenceRecordData {
   authorHandle?: string;
   canonicalUrl: string;
@@ -158,14 +100,12 @@ const PROMPT_REFERENCE_PACK_TYPES: TrendPromptReferencePackType[] = [
   'references',
   'constraints',
 ];
-const DEFAULT_SOURCE_PREVIEW_STALE_AFTER_DAYS = 3;
-const MAX_CORPUS_FRESHNESS_REFERENCE_RECORDS = 5000;
-const MAX_CORPUS_FRESHNESS_TREND_RECORDS = 2000;
 @Injectable()
 export class TrendReferenceCorpusService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly loggerService: LoggerService,
+    private readonly trendCorpusFreshnessService: TrendCorpusFreshnessService,
   ) {}
 
   async syncTrendReferences(
@@ -778,381 +718,9 @@ export class TrendReferenceCorpusService {
   }
 
   async getCorpusFreshnessHealth(
-    options: CorpusFreshnessHealthOptions = {},
+    options: TrendCorpusFreshnessHealthOptions = {},
   ): Promise<TrendCorpusFreshnessResult> {
-    const now = options.now ?? new Date();
-    const sourcePreviewStaleAfterDays =
-      options.sourcePreviewStaleAfterDays ??
-      DEFAULT_SOURCE_PREVIEW_STALE_AFTER_DAYS;
-
-    const [referenceDocs, trendDocs] = await Promise.all([
-      this.prisma.trendSourceReference.findMany({
-        orderBy: [{ platform: 'asc' }, { lastSeenAt: 'asc' }],
-        select: {
-          createdAt: true,
-          data: true,
-          id: true,
-          lastSeenAt: true,
-          platform: true,
-        },
-        take: MAX_CORPUS_FRESHNESS_REFERENCE_RECORDS,
-        where: {
-          ...(options.platform ? { platform: options.platform } : {}),
-          isDeleted: false,
-        },
-      }) as Promise<ReferenceHealthDoc[]>,
-      this.prisma.trend.findMany({
-        orderBy: [{ platform: 'asc' }, { updatedAt: 'asc' }],
-        select: {
-          createdAt: true,
-          data: true,
-          id: true,
-          lastSeenAt: true,
-          platform: true,
-          updatedAt: true,
-        },
-        take: MAX_CORPUS_FRESHNESS_TREND_RECORDS,
-        where: this.buildFreshnessTrendWhere(options),
-      }) as Promise<TrendHealthDoc[]>,
-    ]);
-
-    const segments = this.buildFreshnessSegments(referenceDocs, now);
-    const providerFailures = this.buildProviderFailures(
-      trendDocs,
-      now,
-      sourcePreviewStaleAfterDays,
-    );
-    const activeTrends = trendDocs.filter((doc) =>
-      this.isCurrentTrend(doc, now),
-    ).length;
-    const status = this.resolveCorpusFreshnessStatus(
-      referenceDocs.length,
-      segments,
-      providerFailures,
-    );
-    const platforms = Array.from(
-      new Set(
-        [
-          ...segments.map((segment) => segment.platform),
-          ...providerFailures.map((failure) => failure.platform),
-        ].filter(Boolean),
-      ),
-    ).sort();
-
-    return {
-      generatedAt: now.toISOString(),
-      providerFailures,
-      segments,
-      status,
-      summary: {
-        activeTrends,
-        failingProviders: providerFailures.length,
-        freshSegments: segments.filter(
-          (segment) => segment.status === 'healthy',
-        ).length,
-        platforms,
-        referenceRecords: referenceDocs.length,
-        staleSegments: segments.filter(
-          (segment) =>
-            segment.status === 'stale' || segment.status === 'degraded',
-        ).length,
-        totalSegments: segments.length,
-      },
-      thresholds: {
-        defaultFreshnessWindowDaysBySourceKind:
-          DEFAULT_FRESHNESS_WINDOW_DAYS_BY_SOURCE_KIND,
-        recordLimits: {
-          referenceRecords: MAX_CORPUS_FRESHNESS_REFERENCE_RECORDS,
-          trends: MAX_CORPUS_FRESHNESS_TREND_RECORDS,
-        },
-        sourcePreviewStaleAfterDays,
-      },
-    };
-  }
-
-  /**
-   * Tenant-scope the Trend portion of the freshness aggregate. Trend rows are
-   * org-scoped-or-global (organizationId is nullable): personalized rows carry
-   * an organizationId, generic rows are null. Platform admins get the full
-   * cross-org view (global pipeline health); everyone else sees only their own
-   * org's rows plus the global/null baseline — never another tenant's trends.
-   * The shared TrendSourceReference corpus (no organizationId column) is global
-   * for all callers and is scoped separately.
-   */
-  private buildFreshnessTrendWhere(
-    options: CorpusFreshnessHealthOptions,
-  ): Prisma.TrendWhereInput {
-    const where: Prisma.TrendWhereInput = {
-      ...(options.platform ? { platform: options.platform } : {}),
-      isDeleted: false,
-    };
-
-    if (options.isPlatformAdmin) {
-      return where;
-    }
-
-    where.OR = options.organizationId
-      ? [{ organizationId: options.organizationId }, { organizationId: null }]
-      : [{ organizationId: null }];
-
-    return where;
-  }
-
-  private buildFreshnessSegments(
-    referenceDocs: ReferenceHealthDoc[],
-    now: Date,
-  ): TrendCorpusFreshnessSegment[] {
-    const bySegment = new Map<string, FreshnessSegmentAccumulator>();
-
-    for (const doc of referenceDocs) {
-      const data = this.asRecord(doc.data) as unknown as ReferenceRecordData;
-      const classification = this.resolveSourceClassification(
-        data.sourceClassification,
-        {
-          capturedAt: data.firstSeenAt,
-          platform:
-            this.readString(doc.platform) ?? this.readString(data.platform),
-          sourceAuthor: data.authorHandle,
-          sourceTimestamp: data.publishedAt ?? data.lastSeenAt,
-          sourceTopic: data.matchedTrendTopics?.[0],
-        },
-      );
-      const platform =
-        this.readString(doc.platform) ??
-        this.readString(data.platform) ??
-        'unknown';
-      const sourceKind =
-        classification?.sourceKind ?? 'public_platform_reference';
-      const intendedUse =
-        classification?.intendedUse ?? 'organic_trend_discovery';
-      const provider = classification?.sourceLabel ?? platform;
-      const freshnessWindowDays =
-        classification?.freshnessWindowDays ??
-        DEFAULT_FRESHNESS_WINDOW_DAYS_BY_SOURCE_KIND[sourceKind];
-      const segmentId = [
-        'reference-corpus',
-        sourceKind,
-        intendedUse,
-        platform,
-        provider,
-      ].join(':');
-      const seenAt =
-        this.readDate(doc.lastSeenAt) ??
-        this.readDate(data.lastSeenAt) ??
-        this.readDate(doc.createdAt) ??
-        now;
-      const stale = this.calculateAgeDays(now, seenAt) > freshnessWindowDays;
-      const accumulator = bySegment.get(segmentId) ?? {
-        freshnessWindowDays,
-        intendedUse,
-        platform,
-        provider,
-        referenceCount: 0,
-        sourceKind,
-        staleReferenceCount: 0,
-      };
-
-      accumulator.referenceCount += 1;
-      accumulator.staleReferenceCount += stale ? 1 : 0;
-      accumulator.latestSeenAt =
-        accumulator.latestSeenAt == null || seenAt > accumulator.latestSeenAt
-          ? seenAt
-          : accumulator.latestSeenAt;
-      accumulator.oldestSeenAt =
-        accumulator.oldestSeenAt == null || seenAt < accumulator.oldestSeenAt
-          ? seenAt
-          : accumulator.oldestSeenAt;
-      bySegment.set(segmentId, accumulator);
-    }
-
-    return Array.from(bySegment.entries())
-      .map(([id, segment]) => ({
-        freshnessWindowDays: segment.freshnessWindowDays,
-        id,
-        intendedUse: segment.intendedUse,
-        latestSeenAt: segment.latestSeenAt?.toISOString(),
-        oldestSeenAt: segment.oldestSeenAt?.toISOString(),
-        platform: segment.platform,
-        provider: segment.provider,
-        referenceCount: segment.referenceCount,
-        sourceKind: segment.sourceKind,
-        staleReferenceCount: segment.staleReferenceCount,
-        status: this.resolveSegmentStatus(
-          segment.referenceCount,
-          segment.staleReferenceCount,
-        ),
-      }))
-      .sort((left, right) => left.id.localeCompare(right.id));
-  }
-
-  private buildProviderFailures(
-    trendDocs: TrendHealthDoc[],
-    now: Date,
-    sourcePreviewStaleAfterDays: number,
-  ): TrendProviderFailureSummary[] {
-    const failures = new Map<string, ProviderFailureAccumulator>();
-
-    for (const doc of trendDocs) {
-      if (!this.isCurrentTrend(doc, now)) {
-        continue;
-      }
-
-      const data = this.asRecord(doc.data);
-      const metadata = this.asRecord(data.metadata);
-      if (metadata.prelaunchCorpus === true) {
-        continue;
-      }
-
-      const sourcePreviewState = this.readString(metadata.sourcePreviewState);
-      const cachedAt = this.readDate(metadata.sourcePreviewCachedAt);
-      const observedAt =
-        cachedAt ??
-        this.readDate(doc.updatedAt) ??
-        this.readDate(doc.lastSeenAt) ??
-        this.readDate(doc.createdAt);
-      const platform =
-        this.readString(doc.platform) ??
-        this.readString(data.platform) ??
-        'unknown';
-      const provider =
-        this.readString(metadata.source) ??
-        this.readString(metadata.sourceProvider) ??
-        platform;
-
-      if (sourcePreviewState === 'empty') {
-        this.recordProviderFailure(failures, {
-          message:
-            'The trend source preview produced no usable source references.',
-          observedAt,
-          platform,
-          provider,
-          reason: 'empty_source_preview',
-          retryAction: `Refresh ${platform} trends and inspect provider fetch logs.`,
-          severity: 'error',
-        });
-        continue;
-      }
-
-      if (sourcePreviewState === 'fallback') {
-        this.recordProviderFailure(failures, {
-          message:
-            'The trend source preview is using fallback references instead of live provider data.',
-          observedAt,
-          platform,
-          provider,
-          reason: 'fallback_source_preview',
-          retryAction: `Refresh ${platform} trends and verify provider credentials or rate limits.`,
-          severity: 'warning',
-        });
-      }
-
-      if (
-        cachedAt &&
-        this.calculateAgeDays(now, cachedAt) > sourcePreviewStaleAfterDays
-      ) {
-        this.recordProviderFailure(failures, {
-          message:
-            'The cached trend source preview is older than the freshness threshold.',
-          observedAt: cachedAt,
-          platform,
-          provider,
-          reason: 'stale_source_preview',
-          retryAction: `Run source-preview precompute or refresh ${platform} trends.`,
-          severity: 'warning',
-        });
-      }
-    }
-
-    return Array.from(failures.values())
-      .map((failure) => ({
-        affectedTrendCount: failure.affectedTrendCount,
-        latestObservedAt: failure.latestObservedAt?.toISOString(),
-        message: failure.message,
-        platform: failure.platform,
-        provider: failure.provider,
-        reason: failure.reason,
-        retryAction: failure.retryAction,
-        severity: failure.severity,
-      }))
-      .sort((left, right) =>
-        `${left.platform}:${left.provider}:${left.reason}`.localeCompare(
-          `${right.platform}:${right.provider}:${right.reason}`,
-        ),
-      );
-  }
-
-  private recordProviderFailure(
-    failures: Map<string, ProviderFailureAccumulator>,
-    input: {
-      message: string;
-      observedAt?: Date;
-      platform: string;
-      provider: string;
-      reason: TrendProviderFailureSummary['reason'];
-      retryAction: string;
-      severity: TrendProviderFailureSummary['severity'];
-    },
-  ): void {
-    const key = [input.platform, input.provider, input.reason].join(':');
-    const existing = failures.get(key) ?? {
-      affectedTrendCount: 0,
-      message: input.message,
-      platform: input.platform,
-      provider: input.provider,
-      reason: input.reason,
-      retryAction: input.retryAction,
-      severity: input.severity,
-    };
-
-    existing.affectedTrendCount += 1;
-    existing.latestObservedAt =
-      input.observedAt != null &&
-      (existing.latestObservedAt == null ||
-        input.observedAt > existing.latestObservedAt)
-        ? input.observedAt
-        : existing.latestObservedAt;
-    failures.set(key, existing);
-  }
-
-  private resolveSegmentStatus(
-    referenceCount: number,
-    staleReferenceCount: number,
-  ): TrendCorpusFreshnessStatus {
-    if (referenceCount === 0) {
-      return 'empty';
-    }
-
-    if (staleReferenceCount === 0) {
-      return 'healthy';
-    }
-
-    return staleReferenceCount === referenceCount ? 'stale' : 'degraded';
-  }
-
-  private resolveCorpusFreshnessStatus(
-    referenceCount: number,
-    segments: TrendCorpusFreshnessSegment[],
-    providerFailures: TrendProviderFailureSummary[],
-  ): TrendCorpusFreshnessStatus {
-    if (referenceCount === 0) {
-      return 'empty';
-    }
-
-    if (
-      providerFailures.some((failure) => failure.severity === 'error') ||
-      segments.some((segment) => segment.status === 'stale')
-    ) {
-      return 'stale';
-    }
-
-    if (
-      providerFailures.length > 0 ||
-      segments.some((segment) => segment.status === 'degraded')
-    ) {
-      return 'degraded';
-    }
-
-    return 'healthy';
+    return this.trendCorpusFreshnessService.getCorpusFreshnessHealth(options);
   }
 
   private resolveSourceClassification(
@@ -1169,16 +737,6 @@ export class TrendReferenceCorpusService {
       ...defaults,
       value,
     });
-  }
-
-  private isCurrentTrend(doc: TrendHealthDoc, now: Date): boolean {
-    const data = this.asRecord(doc.data);
-    const expiresAt = this.readDate(data.expiresAt);
-    return data.isCurrent === true && (!expiresAt || expiresAt > now);
-  }
-
-  private calculateAgeDays(now: Date, date: Date): number {
-    return (now.getTime() - date.getTime()) / (24 * 60 * 60 * 1000);
   }
 
   private buildReferenceSourceClassification(input: {
@@ -1202,31 +760,6 @@ export class TrendReferenceCorpusService {
       value:
         input.sourceItem.sourceClassification ?? input.existingClassification,
     });
-  }
-
-  private asRecord(value: unknown): Record<string, unknown> {
-    return typeof value === 'object' && value !== null && !Array.isArray(value)
-      ? (value as Record<string, unknown>)
-      : {};
-  }
-
-  private readDate(value: unknown): Date | undefined {
-    if (value instanceof Date && !Number.isNaN(value.getTime())) {
-      return value;
-    }
-
-    if (typeof value !== 'string' || value.length === 0) {
-      return undefined;
-    }
-
-    const date = new Date(value);
-    return Number.isNaN(date.getTime()) ? undefined : date;
-  }
-
-  private readString(value: unknown): string | undefined {
-    return typeof value === 'string' && value.trim().length > 0
-      ? value
-      : undefined;
   }
 
   private async resolveSourceReferenceIds(

--- a/apps/server/api/src/collections/trends/trends.module.ts
+++ b/apps/server/api/src/collections/trends/trends.module.ts
@@ -5,6 +5,7 @@ import { ModelsModule } from '@api/collections/models/models.module';
 import { TrendsController } from '@api/collections/trends/controllers/trends.controller';
 import { TrendAnalysisService } from '@api/collections/trends/services/modules/trend-analysis.service';
 import { TrendContentIdeasService } from '@api/collections/trends/services/modules/trend-content-ideas.service';
+import { TrendCorpusFreshnessService } from '@api/collections/trends/services/modules/trend-corpus-freshness.service';
 import { TrendFetchService } from '@api/collections/trends/services/modules/trend-fetch.service';
 import { TrendFilteringService } from '@api/collections/trends/services/modules/trend-filtering.service';
 import { TrendPrelaunchCorpusService } from '@api/collections/trends/services/modules/trend-prelaunch-corpus.service';
@@ -55,6 +56,7 @@ import { forwardRef, Module } from '@nestjs/common';
   ],
   providers: [
     TrendAnalysisService,
+    TrendCorpusFreshnessService,
     TrendContentIdeasService,
     TrendFetchService,
     TrendFilteringService,


### PR DESCRIPTION
## Summary

- extract corpus freshness queries, tenant scoping, segment aggregation, and provider-failure projection into `TrendCorpusFreshnessService`
- preserve `TrendReferenceCorpusService.getCorpusFreshnessHealth()` as the public compatibility boundary
- register the focused provider and move freshness regression coverage to a colocated spec
- reduce `TrendReferenceCorpusService` from 1,922 to 1,455 lines without changing response contracts or project schema

## Related issue

Closes #1853
Refs #1740

## Scope

Behavior-preserving trend corpus freshness extraction only. Prompt packs, corpus sync/query behavior, metric semantics, providers, schemas, and API response shapes are unchanged.

## Verification

Passed locally:

- `bunx @biomejs/biome@2.5.3 check <5 touched files>`
- `bun scripts/run-secretlint.ts <5 touched files>`
- `git diff --check`
- static query-boundary, provider-registration, no-`any`, sensitive-path, and credential-pattern assertions

Skipped locally:

- focused tests, typecheck, and build per workstation resource policy; PR CI owns them
- `bun scripts/check-di-value-imports.ts` could not start because Bun 1.3.14 exposes an undefined TypeScript runtime import (`ts.ScriptTarget`)

## Residual risk

The extraction preserves the existing implementation and test cases, but runtime/type evidence remains pending in GitHub Actions.

## Screenshots

Not applicable.