### PR TITLE
refactor(images): extract provider dispatch service

### DIFF
--- a/apps/server/api/src/collections/images/controllers/operations/images-operations.controller.spec.ts
+++ b/apps/server/api/src/collections/images/controllers/operations/images-operations.controller.spec.ts
@@ -44,6 +44,7 @@ import { ImagesOperationsController } from '@api/collections/images/controllers/
 import type { CreateImageDto } from '@api/collections/images/dto/create-image.dto';
 import type { SplitImageDto } from '@api/collections/images/dto/split-image.dto';
 import { ImageGenerationService } from '@api/collections/images/services/image-generation.service';
+import { ImageGenerationProviderDispatchService } from '@api/collections/images/services/image-generation-provider-dispatch.service';
 import { ImagesService } from '@api/collections/images/services/images.service';
 import type { IngredientEntity } from '@api/collections/ingredients/entities/ingredient.entity';
 import { IngredientsService } from '@api/collections/ingredients/services/ingredients.service';
@@ -221,6 +222,7 @@ describe('ImagesOperationsController', () => {
       providers: [
         // Real service resolved from the mocks below; the controller delegates
         // create() to it, so the DI graph must be able to construct it.
+        ImageGenerationProviderDispatchService,
         ImageGenerationService,
         {
           provide: ConfigService,
@@ -446,36 +448,9 @@ describe('ImagesOperationsController', () => {
       })
       .compile();
 
-    // The image-generation workflow now lives in ImageGenerationService, built
-    // here from the same resolved mocks so the controller's create() delegate
-    // exercises the identical dependencies the assertions below observe.
-    const imageGenerationService = new ImageGenerationService(
-      module.get(ConfigService),
-      module.get(ActivitiesService),
-      module.get(AssetsService),
-      module.get(BrandsService),
-      module.get(ComfyUIService),
-      module.get(CreditsUtilsService),
-      module.get(FailedGenerationService),
-      module.get(FilesClientService),
-      module.get(FalService),
-      module.get(IngredientCompletionService),
-      module.get(ImagesService),
-      module.get(IngredientsService),
-      module.get(OrganizationSettingsService),
-      module.get(KlingAIService),
-      module.get(LeonardoAIService),
-      module.get(LoggerService),
-      module.get(MetadataService),
-      module.get(ModelRegistrationService),
-      module.get(ModelsService),
-      module.get(PromptBuilderService),
-      module.get(PromptsService),
-      module.get(ReplicateService),
-      module.get(RouterService),
-      module.get(SharedService),
-      module.get(NotificationsPublisherService),
-    );
+    // Resolve the same DI graph as ImagesModule so constructor changes cannot
+    // drift from this controller integration test.
+    const imageGenerationService = module.get(ImageGenerationService);
 
     controller = new ImagesOperationsController(
       module.get(ConfigService),

--- a/apps/server/api/src/collections/images/images.module.ts
+++ b/apps/server/api/src/collections/images/images.module.ts
@@ -13,6 +13,7 @@ import { ImagesRelationshipsController } from '@api/collections/images/controlle
 import { ImagesTransformationsController } from '@api/collections/images/controllers/transformations/images-transformations.controller';
 import { ImagesUploadsController } from '@api/collections/images/controllers/upload/images-uploads.controller';
 import { ImageGenerationService } from '@api/collections/images/services/image-generation.service';
+import { ImageGenerationProviderDispatchService } from '@api/collections/images/services/image-generation-provider-dispatch.service';
 import { ImagesService } from '@api/collections/images/services/images.service';
 import { IngredientsModule } from '@api/collections/ingredients/ingredients.module';
 import { MetadataModule } from '@api/collections/metadata/metadata.module';
@@ -90,6 +91,7 @@ import { forwardRef, Module } from '@nestjs/common';
   ],
   providers: [
     ImagesService,
+    ImageGenerationProviderDispatchService,
     ImageGenerationService,
     ModelRegistrationService,
     CreditsGuard,

--- a/apps/server/api/src/collections/images/services/image-generation-provider-dispatch.service.spec.ts
+++ b/apps/server/api/src/collections/images/services/image-generation-provider-dispatch.service.spec.ts
@@ -1,0 +1,260 @@
+import type { ImageGenerationContext } from '@api/collections/images/services/image-generation.types';
+import { ImageGenerationProviderDispatchService } from '@api/collections/images/services/image-generation-provider-dispatch.service';
+import { MODEL_KEYS } from '@genfeedai/constants';
+import { IngredientStatus } from '@genfeedai/enums';
+import { LoggerService } from '@libs/logger/logger.service';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('ImageGenerationProviderDispatchService', () => {
+  const activitiesService = {
+    create: vi.fn().mockResolvedValue({ id: 'activity-1' }),
+  };
+  const comfyUIService = {
+    generateImage: vi.fn(),
+  };
+  const failedGenerationService = {
+    handleFailedImageGeneration: vi.fn(),
+  };
+  const filesClientService = {
+    uploadToS3: vi.fn(),
+  };
+  const falService = {
+    generateImage: vi.fn(),
+  };
+  const imagesService = {
+    patch: vi.fn(),
+  };
+  const klingAIService = {
+    queueGenerateImage: vi.fn(),
+  };
+  const leonardoaiService = {
+    generateImage: vi.fn(),
+  };
+  const loggerService = {
+    error: vi.fn(),
+    log: vi.fn(),
+  } as unknown as LoggerService;
+  const metadataService = {
+    patch: vi.fn(),
+  };
+  const promptBuilderService = {
+    buildPrompt: vi.fn(),
+  };
+  const replicateService = {
+    generateTextToImage: vi.fn(),
+  };
+  const sharedService = {
+    saveDocuments: vi.fn(),
+  };
+  const websocketService = {
+    publishBackgroundTaskUpdate: vi.fn(),
+    publishVideoComplete: vi.fn(),
+  };
+
+  const service = new ImageGenerationProviderDispatchService(
+    activitiesService as never,
+    comfyUIService as never,
+    failedGenerationService as never,
+    filesClientService as never,
+    falService as never,
+    imagesService as never,
+    klingAIService as never,
+    leonardoaiService as never,
+    loggerService,
+    metadataService as never,
+    promptBuilderService as never,
+    replicateService as never,
+    sharedService as never,
+    websocketService as never,
+  );
+
+  const buildContext = (
+    overrides: Partial<ImageGenerationContext> = {},
+  ): ImageGenerationContext =>
+    ({
+      brand: { id: 'brand-1' },
+      brandPromptBranding: {},
+      createImageDto: {
+        height: 1080,
+        model: MODEL_KEYS.KLINGAI_V2,
+        prompt: 'A cinematic sunrise',
+        seed: 42,
+        width: 1920,
+      },
+      height: 1080,
+      ingredientData: { id: 'ingredient-1', parent: 'parent-1' },
+      metadataData: { id: 'metadata-1' },
+      model: MODEL_KEYS.KLINGAI_V2,
+      outputs: 1,
+      pendingIngredientIds: ['ingredient-1'],
+      promptBuilderBrand: { label: 'Brand' },
+      promptData: { id: 'prompt-1', original: 'A cinematic sunrise' },
+      publicMetadata: {
+        brand: 'brand-1',
+        organization: 'organization-1',
+        user: 'user-1',
+      },
+      referenceImageUrl: 'https://cdn.example.com/reference.png',
+      referenceImageUrls: ['https://cdn.example.com/reference.png'],
+      request: {},
+      style: 'cinematic',
+      user: { id: 'user-1' },
+      waitForCompletion: false,
+      websocketUrl: '/images/ingredient-1',
+      width: 1920,
+      ...overrides,
+    }) as unknown as ImageGenerationContext;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('routes KlingAI with the existing request and metadata normalization', async () => {
+    klingAIService.queueGenerateImage.mockResolvedValue('kling-job-1');
+    const context = buildContext();
+
+    const plan = await service.dispatch(context, 'klingai');
+    await plan?.generationPromise;
+
+    expect(klingAIService.queueGenerateImage).toHaveBeenCalledWith(
+      'A cinematic sunrise',
+      expect.objectContaining({
+        height: 1080,
+        model: MODEL_KEYS.KLINGAI_V2,
+        reference: 'https://cdn.example.com/reference.png',
+        style: 'cinematic',
+        width: 1920,
+      }),
+    );
+    expect(metadataService.patch).toHaveBeenCalledWith(
+      'metadata-1',
+      expect.objectContaining({
+        externalId: 'kling-job-1',
+        prompt: 'prompt-1',
+      }),
+    );
+    expect(plan?.kind).toBe('poll-single');
+  });
+
+  it('uploads and completes GenfeedAI output inline', async () => {
+    const imageBuffer = Buffer.from('image');
+    comfyUIService.generateImage.mockResolvedValue({ imageBuffer });
+    filesClientService.uploadToS3.mockResolvedValue({
+      height: 1080,
+      publicUrl: 'https://cdn.example.com/generated.png',
+      s3Key: 'images/generated.png',
+      size: imageBuffer.length,
+      width: 1920,
+    });
+    const context = buildContext({
+      model: MODEL_KEYS.GENFEED_AI_FLUX_DEV,
+    });
+
+    const plan = await service.dispatch(context, 'genfeedai');
+    await plan?.generationPromise;
+
+    expect(comfyUIService.generateImage).toHaveBeenCalledWith(
+      MODEL_KEYS.GENFEED_AI_FLUX_DEV,
+      {
+        faceImage: 'https://cdn.example.com/reference.png',
+        height: 1080,
+        prompt: 'A cinematic sunrise',
+        seed: 42,
+        width: 1920,
+      },
+    );
+    expect(imagesService.patch).toHaveBeenCalledWith(
+      'ingredient-1',
+      expect.objectContaining({
+        cdnUrl: 'https://cdn.example.com/generated.png',
+        s3Key: 'images/generated.png',
+        status: IngredientStatus.GENERATED,
+      }),
+    );
+    expect(websocketService.publishVideoComplete).toHaveBeenCalled();
+    expect(plan?.kind).toBe('inline');
+  });
+
+  it('fans out Fal outputs and tracks each placeholder', async () => {
+    falService.generateImage
+      .mockResolvedValueOnce({ url: 'https://fal.example.com/primary.png' })
+      .mockResolvedValueOnce({ url: 'https://fal.example.com/second.png' });
+    sharedService.saveDocuments.mockResolvedValue({
+      ingredientData: { id: 'ingredient-2', parent: 'parent-1' },
+      metadataData: { id: 'metadata-2' },
+    });
+    const context = buildContext({
+      model: MODEL_KEYS.FAL_NANO_BANANA_2,
+      outputs: 2,
+    });
+
+    const plan = await service.dispatch(context, 'fal');
+    await plan?.generationPromise;
+
+    expect(falService.generateImage).toHaveBeenCalledTimes(2);
+    expect(falService.generateImage).toHaveBeenCalledWith(
+      MODEL_KEYS.FAL_NANO_BANANA_2,
+      {
+        image_size: { height: 1080, width: 1920 },
+        image_url: 'https://cdn.example.com/reference.png',
+        prompt: 'A cinematic sunrise',
+        seed: 42,
+      },
+    );
+    expect(context.pendingIngredientIds).toEqual([
+      'ingredient-1',
+      'ingredient-2',
+    ]);
+    expect(activitiesService.create).toHaveBeenCalledTimes(1);
+    expect(plan?.kind).toBe('background-only');
+  });
+
+  it('normalizes batch Replicate outputs into indexed placeholders', async () => {
+    const model = MODEL_KEYS.REPLICATE_BYTEDANCE_SEEDREAM_5_LITE;
+    promptBuilderService.buildPrompt.mockResolvedValue({
+      input: { prompt: 'provider prompt' },
+    });
+    replicateService.generateTextToImage.mockResolvedValue('replicate-job');
+    sharedService.saveDocuments
+      .mockResolvedValueOnce({
+        ingredientData: { id: 'ingredient-2', parent: 'parent-1' },
+        metadataData: { id: 'metadata-2' },
+      })
+      .mockResolvedValueOnce({
+        ingredientData: { id: 'ingredient-3', parent: 'parent-1' },
+        metadataData: { id: 'metadata-3' },
+      });
+    const context = buildContext({ model, outputs: 3 });
+
+    const plan = await service.dispatch(context, 'replicate');
+    await plan?.generationPromise;
+
+    expect(promptBuilderService.buildPrompt).toHaveBeenCalledWith(
+      model,
+      expect.objectContaining({ outputs: 3 }),
+      'organization-1',
+    );
+    expect(replicateService.generateTextToImage).toHaveBeenCalledTimes(1);
+    expect(metadataService.patch.mock.calls).toEqual(
+      expect.arrayContaining([
+        [
+          'metadata-1',
+          expect.objectContaining({ externalId: 'replicate-job_0' }),
+        ],
+        [
+          'metadata-2',
+          expect.objectContaining({ externalId: 'replicate-job_1' }),
+        ],
+        [
+          'metadata-3',
+          expect.objectContaining({ externalId: 'replicate-job_2' }),
+        ],
+      ]),
+    );
+    expect(plan?.pollIds).toEqual([
+      'ingredient-1',
+      'ingredient-2',
+      'ingredient-3',
+    ]);
+  });
+});

--- a/apps/server/api/src/collections/images/services/image-generation-provider-dispatch.service.ts
+++ b/apps/server/api/src/collections/images/services/image-generation-provider-dispatch.service.ts
@@ -1,0 +1,699 @@
+import { ActivityEntity } from '@api/collections/activities/entities/activity.entity';
+import { ActivitiesService } from '@api/collections/activities/services/activities.service';
+import type {
+  ImageGenerationCompletionPlan,
+  ImageGenerationContext,
+  ImageGenerationProvider,
+  ImageGenerationSavedIngredient,
+} from '@api/collections/images/services/image-generation.types';
+import { ImagesService } from '@api/collections/images/services/images.service';
+import { MetadataEntity } from '@api/collections/metadata/entities/metadata.entity';
+import { MetadataService } from '@api/collections/metadata/services/metadata.service';
+import { WebSocketPaths } from '@api/helpers/utils/websocket/websocket.util';
+import { ComfyUIService } from '@api/services/integrations/comfyui/comfyui.service';
+import { NotificationsPublisherService } from '@api/services/notifications/publisher/notifications-publisher.service';
+import { PromptBuilderService } from '@api/services/prompt-builder/prompt-builder.service';
+import { FailedGenerationService } from '@api/shared/services/failed-generation/failed-generation.service';
+import { SharedService } from '@api/shared/services/shared/shared.service';
+import { MODEL_OUTPUT_CAPABILITIES } from '@genfeedai/constants';
+import {
+  ActivityEntityModel,
+  ActivityKey,
+  ActivitySource,
+  FileInputType,
+  IngredientCategory,
+  IngredientStatus,
+  MetadataExtension,
+  ModelCategory,
+} from '@genfeedai/enums';
+import { LoggerService } from '@libs/logger/logger.service';
+import { getErrorMessage } from '@libs/utils/error/get-error-message.util';
+import { getUserRoomName } from '@libs/websockets/room-name.util';
+import { Injectable } from '@nestjs/common';
+import { FilesClientService } from '@server/services/files-microservice/client/files-client.service';
+import { FalService } from '@server/services/integrations/fal/services/fal.service';
+import { KlingAIService } from '@server/services/integrations/klingai/services/klingai.service';
+import { LeonardoAIService } from '@server/services/integrations/leonardoai/services/leonardoai.service';
+import { ReplicateService } from '@server/services/integrations/replicate/services/replicate.service';
+
+/**
+ * Owns image-provider request construction, dispatch, normalization, and
+ * provider-specific multi-output fan-out. Shared validation, credits,
+ * persistence, polling, and response serialization remain in
+ * {@link ImageGenerationService}.
+ */
+@Injectable()
+export class ImageGenerationProviderDispatchService {
+  constructor(
+    private readonly activitiesService: ActivitiesService,
+    private readonly comfyUIService: ComfyUIService,
+    private readonly failedGenerationService: FailedGenerationService,
+    private readonly filesClientService: FilesClientService,
+    private readonly falService: FalService,
+    private readonly imagesService: ImagesService,
+    private readonly klingAIService: KlingAIService,
+    private readonly leonardoaiService: LeonardoAIService,
+    private readonly loggerService: LoggerService,
+    private readonly metadataService: MetadataService,
+    private readonly promptBuilderService: PromptBuilderService,
+    private readonly replicateService: ReplicateService,
+    private readonly sharedService: SharedService,
+    private readonly websocketService: NotificationsPublisherService,
+  ) {}
+
+  async dispatch(
+    context: ImageGenerationContext,
+    provider: ImageGenerationProvider,
+  ): Promise<ImageGenerationCompletionPlan | null> {
+    switch (provider) {
+      case 'genfeedai':
+        return this.dispatchGenfeedAi(context);
+      case 'klingai':
+        return this.dispatchKlingAI(context);
+      case 'fal':
+        return this.dispatchFal(context);
+      case 'leonardo':
+        return this.dispatchLeonardo(context);
+      case 'replicate':
+        return this.dispatchReplicate(context);
+      default:
+        return null;
+    }
+  }
+
+  async createPlaceholderActivity(
+    context: ImageGenerationContext,
+    ingredientId: string,
+  ): Promise<void> {
+    const activity = await this.activitiesService.create(
+      new ActivityEntity({
+        brand: context.brand.id,
+        entityId: ingredientId,
+        entityModel: ActivityEntityModel.INGREDIENT,
+        key: ActivityKey.IMAGE_PROCESSING,
+        organization: context.publicMetadata.organization,
+        source: ActivitySource.IMAGE_GENERATION,
+        user: context.publicMetadata.user,
+        value: JSON.stringify({
+          ingredientId: ingredientId.toString(),
+          model: context.model,
+          type: 'generation',
+        }),
+      }),
+    );
+
+    await this.websocketService.publishBackgroundTaskUpdate({
+      activityId: activity.id.toString(),
+      label: 'Image Generation',
+      progress: 0,
+      room: getUserRoomName(context.user.id),
+      status: 'processing',
+      taskId: ingredientId.toString(),
+      userId: context.user.id,
+    });
+  }
+
+  private async handleProviderFailure(
+    context: ImageGenerationContext,
+    error: unknown,
+    label: string,
+    ingredientId: ImageGenerationSavedIngredient['id'] = context.ingredientData
+      .id,
+  ): Promise<never> {
+    this.loggerService.error(`${label} failed`, error);
+    const errorMessage = getErrorMessage(error);
+
+    await this.failedGenerationService.handleFailedImageGeneration(
+      this.imagesService,
+      ingredientId,
+      WebSocketPaths.image(ingredientId),
+      context.publicMetadata,
+      getUserRoomName(context.user.id),
+      errorMessage,
+    );
+    throw error;
+  }
+
+  private dispatchGenfeedAi(
+    context: ImageGenerationContext,
+  ): ImageGenerationCompletionPlan {
+    const {
+      ingredientData,
+      metadataData,
+      promptData,
+      referenceImageUrl,
+      user,
+      websocketUrl,
+    } = context;
+
+    const generationPromise = (async () => {
+      const { imageBuffer } = await this.comfyUIService.generateImage(
+        context.model,
+        {
+          faceImage: referenceImageUrl || undefined,
+          height: context.height,
+          prompt: promptData.original,
+          seed: context.createImageDto.seed,
+          width: context.width,
+        },
+      );
+
+      const uploadMeta = await this.filesClientService.uploadToS3(
+        ingredientData.id.toString(),
+        'images',
+        {
+          contentType: 'image/png',
+          data: imageBuffer,
+          type: FileInputType.BUFFER,
+        },
+      );
+
+      await Promise.all([
+        this.metadataService.patch(
+          metadataData.id,
+          new MetadataEntity({
+            height: uploadMeta.height,
+            prompt: promptData.id,
+            size: uploadMeta.size,
+            width: uploadMeta.width,
+          }),
+        ),
+        this.imagesService.patch(ingredientData.id, {
+          cdnUrl:
+            typeof uploadMeta.publicUrl === 'string'
+              ? uploadMeta.publicUrl
+              : undefined,
+          prompt: promptData.id,
+          s3Key:
+            typeof uploadMeta.s3Key === 'string' ? uploadMeta.s3Key : undefined,
+          status: IngredientStatus.GENERATED,
+        }),
+        this.websocketService.publishVideoComplete(
+          websocketUrl,
+          {
+            id: ingredientData.id.toString(),
+            ingredientId: ingredientData.id.toString(),
+            status: 'completed',
+          },
+          user.id,
+          getUserRoomName(user.id),
+        ),
+      ]);
+
+      return ingredientData.id.toString();
+    })().catch((error: unknown) =>
+      this.handleProviderFailure(
+        context,
+        error,
+        'ComfyUIService generateImage',
+      ),
+    );
+
+    return { generationPromise, kind: 'inline' };
+  }
+
+  private dispatchKlingAI(
+    context: ImageGenerationContext,
+  ): ImageGenerationCompletionPlan {
+    const { createImageDto, metadataData, promptData, referenceImageUrl } =
+      context;
+
+    const generationPromise = this.klingAIService
+      .queueGenerateImage(promptData.original, {
+        ...createImageDto,
+        height: context.height,
+        model: context.model,
+        reference: referenceImageUrl || undefined,
+        style: context.style || 'realistic',
+        width: context.width,
+      })
+      .then(async (generationId) => {
+        if (!generationId) {
+          throw new Error('No generation ID returned from KlingAI');
+        }
+
+        await this.metadataService.patch(
+          metadataData.id,
+          new MetadataEntity({
+            externalId: generationId,
+            prompt: promptData.id,
+          }),
+        );
+
+        return generationId;
+      })
+      .catch((error: unknown) =>
+        this.handleProviderFailure(
+          context,
+          error,
+          'KlingAIService generateImage',
+        ),
+      );
+
+    return { generationPromise, kind: 'poll-single' };
+  }
+
+  private dispatchLeonardo(
+    context: ImageGenerationContext,
+  ): ImageGenerationCompletionPlan {
+    const { createImageDto, metadataData, promptData } = context;
+
+    const generationPromise = this.leonardoaiService
+      .generateImage(promptData.original, {
+        ...createImageDto,
+        height: context.height,
+        style: context.style || 'realistic',
+        width: context.width,
+      })
+      .then(async (generationId) => {
+        if (!generationId) {
+          throw new Error('No generation ID returned from LeonardoAI');
+        }
+
+        await this.metadataService.patch(
+          metadataData.id,
+          new MetadataEntity({
+            externalId: generationId,
+          }),
+        );
+
+        return generationId;
+      })
+      .catch((error: unknown) =>
+        this.handleProviderFailure(
+          context,
+          error,
+          'LeonardoAIService generateImage',
+        ),
+      );
+
+    return { generationPromise, kind: 'poll-single' };
+  }
+
+  private dispatchFal(
+    context: ImageGenerationContext,
+  ): ImageGenerationCompletionPlan {
+    const {
+      createImageDto,
+      height,
+      metadataData,
+      promptData,
+      referenceImageUrl,
+      width,
+    } = context;
+
+    const buildFalInput = (): Record<string, unknown> => ({
+      image_size: {
+        height,
+        width,
+      },
+      ...(referenceImageUrl ? { image_url: referenceImageUrl } : {}),
+      ...(createImageDto.seed !== undefined
+        ? { seed: createImageDto.seed }
+        : {}),
+      prompt: promptData.original,
+    });
+
+    const generationPromise = (async () => {
+      let primaryUrl: string;
+      try {
+        const falResult = await this.falService.generateImage(
+          context.model,
+          buildFalInput(),
+        );
+        await this.metadataService.patch(
+          metadataData.id,
+          new MetadataEntity({
+            externalId: falResult.url,
+            prompt: promptData.id,
+          }),
+        );
+        primaryUrl = falResult.url;
+      } catch (error: unknown) {
+        return this.handleProviderFailure(
+          context,
+          error,
+          'FalService generateImage',
+          context.ingredientData.id,
+        );
+      }
+
+      for (let i = 1; i < context.outputs; i++) {
+        await this.createFalAdditionalOutput(context, buildFalInput);
+      }
+
+      return primaryUrl;
+    })();
+
+    return { generationPromise, kind: 'background-only' };
+  }
+
+  private async createFalAdditionalOutput(
+    context: ImageGenerationContext,
+    buildFalInput: () => Record<string, unknown>,
+  ): Promise<void> {
+    const { createImageDto, brand, promptData, publicMetadata } = context;
+
+    let additionalIngredientId: ImageGenerationSavedIngredient['id'] | null =
+      null;
+    try {
+      const {
+        metadataData: additionalMetadata,
+        ingredientData: additionalIngredient,
+      } = await this.sharedService.saveDocuments(context.user, {
+        ...createImageDto,
+        brand: brand.id,
+        category: IngredientCategory.IMAGE,
+        extension: MetadataExtension.JPG,
+        model: context.model,
+        organization: publicMetadata.organization,
+        parent: context.ingredientData.parent,
+        prompt: promptData.id,
+        status: IngredientStatus.PROCESSING,
+      });
+      additionalIngredientId = additionalIngredient.id;
+
+      const additionalResult = await this.falService.generateImage(
+        context.model,
+        buildFalInput(),
+      );
+
+      await Promise.all([
+        this.metadataService.patch(
+          additionalMetadata.id,
+          new MetadataEntity({
+            externalId: additionalResult.url,
+            prompt: promptData.id,
+          }),
+        ),
+        this.imagesService.patch(additionalIngredient.id, {
+          prompt: promptData.id,
+        }),
+      ]);
+
+      try {
+        await this.createPlaceholderActivity(context, additionalIngredient.id);
+      } catch (activityError: unknown) {
+        this.loggerService.error(
+          'Failed to publish placeholder activity for additional output',
+          { error: activityError },
+        );
+      }
+
+      context.pendingIngredientIds.push(additionalIngredient.id.toString());
+    } catch (error: unknown) {
+      if (additionalIngredientId) {
+        return this.handleProviderFailure(
+          context,
+          error,
+          'FalService generateImage (additional output)',
+          additionalIngredientId,
+        );
+      }
+      this.loggerService.error(
+        'Fal additional output failed before its placeholder was created',
+        error,
+      );
+      throw error;
+    }
+  }
+
+  private async dispatchReplicate(
+    context: ImageGenerationContext,
+  ): Promise<ImageGenerationCompletionPlan> {
+    const {
+      createImageDto,
+      promptBuilderBrand,
+      brandPromptBranding,
+      promptData,
+    } = context;
+
+    const destination = context.model;
+    const modelCapability = MODEL_OUTPUT_CAPABILITIES[destination];
+    const isBatchSupported = modelCapability?.isBatchSupported ?? false;
+
+    const { input: promptParams } = await this.promptBuilderService.buildPrompt(
+      context.model,
+      {
+        blacklist: createImageDto.blacklist,
+        brand: promptBuilderBrand,
+        branding: brandPromptBranding,
+        brandingMode: createImageDto.brandingMode,
+        camera: createImageDto.camera,
+        fontFamily: createImageDto.fontFamily,
+        height: context.height,
+        isBrandingEnabled: createImageDto.isBrandingEnabled,
+        lens: createImageDto.lens,
+        lighting: createImageDto.lighting,
+        modelCategory: ModelCategory.IMAGE,
+        mood: createImageDto.mood,
+        outputs: isBatchSupported ? context.outputs : 1,
+        prompt: promptData.original,
+        promptTemplate: createImageDto.promptTemplate,
+        references: context.referenceImageUrls,
+        scene: createImageDto.scene,
+        seed: createImageDto.seed,
+        style: context.style || createImageDto.style || 'realistic',
+        tags: createImageDto.tags?.map((tag) => tag.toString()) || [],
+        useTemplate: createImageDto.useTemplate,
+        width: context.width,
+      },
+      context.publicMetadata.organization,
+    );
+
+    const pollIds: string[] = [context.ingredientData.id.toString()];
+
+    const generationPromise = (async () => {
+      let generationId: string;
+      try {
+        const id = await this.replicateService.generateTextToImage(
+          destination,
+          promptParams,
+        );
+        if (!id) {
+          throw new Error('No generation ID returned from Replicate');
+        }
+        generationId = id;
+      } catch (error: unknown) {
+        return this.handleProviderFailure(
+          context,
+          error,
+          'ReplicateService generateImage',
+          context.ingredientData.id,
+        );
+      }
+
+      if (isBatchSupported && context.outputs > 1) {
+        try {
+          await this.createReplicateBatchOutputs(
+            context,
+            destination,
+            generationId,
+            pollIds,
+          );
+        } catch (error: unknown) {
+          return this.handleProviderFailure(
+            context,
+            error,
+            'ReplicateService generateImage',
+            context.ingredientData.id,
+          );
+        }
+      } else if (context.outputs > 1) {
+        await this.createReplicateSequentialOutputs(
+          context,
+          destination,
+          generationId,
+          promptParams,
+          pollIds,
+        );
+      } else {
+        try {
+          await this.metadataService.patch(
+            context.metadataData.id,
+            new MetadataEntity({
+              externalId: generationId,
+            }),
+          );
+        } catch (error: unknown) {
+          return this.handleProviderFailure(
+            context,
+            error,
+            'ReplicateService generateImage',
+            context.ingredientData.id,
+          );
+        }
+      }
+
+      return generationId;
+    })();
+
+    return { generationPromise, kind: 'poll-multiple', pollIds };
+  }
+
+  private async createReplicateBatchOutputs(
+    context: ImageGenerationContext,
+    destination: string,
+    generationId: string,
+    pollIds: string[],
+  ): Promise<void> {
+    const { createImageDto, brand, promptData, publicMetadata } = context;
+
+    await this.metadataService.patch(
+      context.metadataData.id,
+      new MetadataEntity({
+        externalId: `${generationId}_0`,
+      }),
+    );
+
+    const additionalDocuments = await Promise.all(
+      Array.from({ length: context.outputs - 1 }, () => {
+        return this.sharedService.saveDocuments(context.user, {
+          ...createImageDto,
+          brand: brand.id,
+          category: IngredientCategory.IMAGE,
+          extension: MetadataExtension.JPG,
+          model: context.model,
+          organization: publicMetadata.organization,
+          parent: context.ingredientData.parent,
+          prompt: promptData.id,
+          status: IngredientStatus.PROCESSING,
+        });
+      }),
+    );
+
+    await Promise.all(
+      additionalDocuments.flatMap(
+        ({ metadataData: addMeta, ingredientData: addIngredient }, index) => {
+          const i = index + 1;
+          return [
+            this.metadataService.patch(
+              addMeta.id,
+              new MetadataEntity({
+                externalId: `${generationId}_${i}`,
+              }),
+            ),
+            this.imagesService.patch(addIngredient.id, {
+              prompt: promptData.id,
+            }),
+          ];
+        },
+      ),
+    );
+
+    await Promise.all(
+      additionalDocuments.map(({ ingredientData: addIngredient }) =>
+        this.createPlaceholderActivity(context, addIngredient.id),
+      ),
+    );
+
+    additionalDocuments.forEach(({ ingredientData: addIngredient }) => {
+      pollIds.push(addIngredient.id.toString());
+    });
+
+    this.loggerService.log(
+      'Created multiple placeholders for batch-capable model multi-output',
+      {
+        generationId,
+        isBatchSupported: true,
+        model: destination,
+        outputs: context.outputs,
+      },
+    );
+  }
+
+  private async createReplicateSequentialOutputs(
+    context: ImageGenerationContext,
+    destination: string,
+    generationId: string,
+    promptParams: Record<string, unknown>,
+    pollIds: string[],
+  ): Promise<void> {
+    const { createImageDto, brand, promptData, publicMetadata } = context;
+
+    try {
+      await this.metadataService.patch(
+        context.metadataData.id,
+        new MetadataEntity({
+          externalId: generationId,
+        }),
+      );
+    } catch (error: unknown) {
+      await this.handleProviderFailure(
+        context,
+        error,
+        'ReplicateService generateImage',
+        context.ingredientData.id,
+      );
+    }
+
+    for (let i = 1; i < context.outputs; i++) {
+      let additionalIngredientId: ImageGenerationSavedIngredient['id'] | null =
+        null;
+      try {
+        const {
+          metadataData: additionalMetadata,
+          ingredientData: additionalIngredient,
+        } = await this.sharedService.saveDocuments(context.user, {
+          ...createImageDto,
+          brand: brand.id,
+          category: IngredientCategory.IMAGE,
+          extension: MetadataExtension.JPG,
+          model: context.model,
+          organization: publicMetadata.organization,
+          parent: context.ingredientData.parent,
+          prompt: promptData.id,
+          status: IngredientStatus.PROCESSING,
+        });
+        additionalIngredientId = additionalIngredient.id;
+
+        const additionalGenerationId =
+          await this.replicateService.generateTextToImage(
+            destination,
+            promptParams,
+          );
+        if (!additionalGenerationId) {
+          throw new Error('No generation ID returned from Replicate');
+        }
+
+        await Promise.all([
+          this.metadataService.patch(
+            additionalMetadata.id,
+            new MetadataEntity({
+              externalId: additionalGenerationId,
+            }),
+          ),
+          this.imagesService.patch(additionalIngredient.id, {
+            prompt: promptData.id,
+          }),
+        ]);
+
+        await this.createPlaceholderActivity(context, additionalIngredient.id);
+        pollIds.push(additionalIngredient.id.toString());
+      } catch (error: unknown) {
+        if (additionalIngredientId) {
+          return this.handleProviderFailure(
+            context,
+            error,
+            'ReplicateService generateImage (additional output)',
+            additionalIngredientId,
+          );
+        }
+        this.loggerService.error(
+          'Replicate additional output failed before its placeholder was created',
+          error,
+        );
+        throw error;
+      }
+    }
+
+    this.loggerService.log(
+      'Created multiple API calls for non-batch model multi-output',
+      {
+        isBatchSupported: false,
+        model: destination,
+        outputs: context.outputs,
+      },
+    );
+  }
+}

--- a/apps/server/api/src/collections/images/services/image-generation.service.spec.ts
+++ b/apps/server/api/src/collections/images/services/image-generation.service.spec.ts
@@ -1,6 +1,7 @@
 import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticated-user.interface';
 import { CreateImageDto } from '@api/collections/images/dto/create-image.dto';
 import { ImageGenerationService } from '@api/collections/images/services/image-generation.service';
+import { ImageGenerationProviderDispatchService } from '@api/collections/images/services/image-generation-provider-dispatch.service';
 import type { RequestWithContext as ExpressRequest } from '@api/common/middleware/request-context.middleware';
 import { MODEL_KEYS } from '@genfeedai/constants';
 import { LoggerService } from '@libs/logger/logger.service';
@@ -157,32 +158,40 @@ const createService = () => {
     warn: vi.fn(),
   } as unknown as LoggerService;
 
-  const service = new ImageGenerationService(
-    configService as never,
+  const providerDispatchService = new ImageGenerationProviderDispatchService(
     activitiesService as never,
-    assetsService as never,
-    brandsService as never,
     comfyUIService as never,
-    creditsUtilsService as never,
     failedGenerationService as never,
     filesClientService as never,
     falService as never,
-    pollingService as never,
     imagesService as never,
-    ingredientsService as never,
-    organizationSettingsService as never,
     klingAIService as never,
     leonardoaiService as never,
     loggerService,
     metadataService as never,
+    promptBuilderService as never,
+    replicateService as never,
+    sharedService as never,
+    websocketService as never,
+  );
+
+  const service = new ImageGenerationService(
+    configService as never,
+    assetsService as never,
+    brandsService as never,
+    creditsUtilsService as never,
+    pollingService as never,
+    providerDispatchService,
+    imagesService as never,
+    ingredientsService as never,
+    organizationSettingsService as never,
+    loggerService,
     modelRegistrationService as never,
     modelsService as never,
     promptBuilderService as never,
     promptsService as never,
-    replicateService as never,
     routerService as never,
     sharedService as never,
-    websocketService as never,
   );
 
   return {

--- a/apps/server/api/src/collections/images/services/image-generation.service.ts
+++ b/apps/server/api/src/collections/images/services/image-generation.service.ts
@@ -1,15 +1,22 @@
 import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticated-user.interface';
-import { ActivityEntity } from '@api/collections/activities/entities/activity.entity';
-import { ActivitiesService } from '@api/collections/activities/services/activities.service';
 import { AssetsService } from '@api/collections/assets/services/assets.service';
 import { BrandsService } from '@api/collections/brands/services/brands.service';
 import { buildPromptBrandingFromBrand } from '@api/collections/brands/utils/brand-context.util';
 import { CreditsUtilsService } from '@api/collections/credits/services/credits.utils.service';
 import { CreateImageDto } from '@api/collections/images/dto/create-image.dto';
+import type {
+  ImageGenerationCompletionPlan,
+  ImageGenerationContext,
+  ImageGenerationProvider,
+  ImageGenerationPublicMetadata,
+  ImageGenerationResolvedBrand,
+  ImageGenerationResolvedPrompt,
+  ImageGenerationSavedIngredient,
+  ImageGenerationSavedMetadata,
+} from '@api/collections/images/services/image-generation.types';
+import { ImageGenerationProviderDispatchService } from '@api/collections/images/services/image-generation-provider-dispatch.service';
 import { ImagesService } from '@api/collections/images/services/images.service';
 import { IngredientsService } from '@api/collections/ingredients/services/ingredients.service';
-import { MetadataEntity } from '@api/collections/metadata/entities/metadata.entity';
-import { MetadataService } from '@api/collections/metadata/services/metadata.service';
 import { ModelRegistrationService } from '@api/collections/models/services/model-registration.service';
 import { ModelsService } from '@api/collections/models/services/models.service';
 import {
@@ -28,22 +35,14 @@ import { buildReferenceImageUrls } from '@api/helpers/utils/reference/reference.
 import { serializeSingle } from '@api/helpers/utils/response/response.util';
 import { WebSocketPaths } from '@api/helpers/utils/websocket/websocket.util';
 import { isEntityId } from '@api/helpers/validation/entity-id.validator';
-import { ComfyUIService } from '@api/services/integrations/comfyui/comfyui.service';
-import { NotificationsPublisherService } from '@api/services/notifications/publisher/notifications-publisher.service';
 import { PromptBuilderService } from '@api/services/prompt-builder/prompt-builder.service';
 import { RouterService } from '@api/services/router/router.service';
-import { FailedGenerationService } from '@api/shared/services/failed-generation/failed-generation.service';
 import { IngredientCompletionService } from '@api/shared/services/poll-until/ingredient-completion.service';
 import { SharedService } from '@api/shared/services/shared/shared.service';
 import { PopulatePatterns } from '@api/shared/utils/populate/populate.util';
 import { MODEL_KEYS, MODEL_OUTPUT_CAPABILITIES } from '@genfeedai/constants';
 import {
-  ActivityEntityModel,
-  ActivityKey,
-  ActivitySource,
-  FileInputType,
   IngredientCategory,
-  IngredientStatus,
   MetadataExtension,
   ModelCategory,
   PricingType,
@@ -54,14 +53,7 @@ import type { JsonApiSingleResponse } from '@genfeedai/interfaces';
 import { IngredientSerializer } from '@genfeedai/serializers';
 import { ConfigService } from '@libs/config/config.service';
 import { LoggerService } from '@libs/logger/logger.service';
-import { getErrorMessage } from '@libs/utils/error/get-error-message.util';
-import { getUserRoomName } from '@libs/websockets/room-name.util';
 import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
-import { FilesClientService } from '@server/services/files-microservice/client/files-client.service';
-import { FalService } from '@server/services/integrations/fal/services/fal.service';
-import { KlingAIService } from '@server/services/integrations/klingai/services/klingai.service';
-import { LeonardoAIService } from '@server/services/integrations/leonardoai/services/leonardoai.service';
-import { ReplicateService } from '@server/services/integrations/replicate/services/replicate.service';
 import { PollTimeoutException } from '@server/shared/services/poll-until/poll-until.exception';
 
 /** Populate patterns for every image read on the wait/serialize path. */
@@ -70,75 +62,6 @@ const IMAGE_POPULATE = [
   PopulatePatterns.metadataFull,
   PopulatePatterns.brandMinimal,
 ];
-
-/** The resolved provider an image-generation request routes to. */
-type ImageProvider =
-  | 'genfeedai'
-  | 'klingai'
-  | 'fal'
-  | 'leonardo'
-  | 'replicate'
-  | 'sdxl';
-
-/** Document types inferred from the underlying services (no `any`). */
-type ResolvedBrand = NonNullable<Awaited<ReturnType<BrandsService['findOne']>>>;
-type ResolvedPrompt = Awaited<ReturnType<PromptsService['create']>>;
-type SaveDocumentsResult = Awaited<ReturnType<SharedService['saveDocuments']>>;
-type SavedIngredient = SaveDocumentsResult['ingredientData'];
-type SavedMetadata = SaveDocumentsResult['metadataData'];
-type PublicMetadata = ReturnType<typeof getPublicMetadata>;
-
-/**
- * Per-request state threaded through the provider handlers and the shared
- * completion tail. Built once by {@link ImageGenerationService.generateImage}
- * after the placeholder documents exist, so every handler reads from one place
- * instead of the previous flat method's shared mutable locals.
- */
-interface GenerationContext {
-  brand: ResolvedBrand;
-  brandPromptBranding: ReturnType<typeof buildPromptBrandingFromBrand>;
-  createImageDto: CreateImageDto;
-  height: number;
-  ingredientData: SavedIngredient;
-  metadataData: SavedMetadata;
-  model: string;
-  outputs: number;
-  /** Mutated by handlers (Fal) that fan out additional background outputs. */
-  pendingIngredientIds: string[];
-  promptBuilderBrand: {
-    description?: string;
-    label: string;
-    primaryColor?: string;
-    secondaryColor?: string;
-    text?: string;
-  };
-  promptData: ResolvedPrompt;
-  publicMetadata: PublicMetadata;
-  referenceImageUrl: string | null;
-  referenceImageUrls: string[];
-  request: Request;
-  style?: string;
-  user: User;
-  waitForCompletion: boolean;
-  websocketUrl: string;
-  width: number;
-}
-
-/**
- * How the request should resolve once a provider has dispatched.
- *
- * - `inline` — GenfeedAi completes synchronously inside its promise; on wait we
- *   re-read the ingredient (no polling, no timeout recovery).
- * - `poll-single` — KlingAI/Leonardo poll one ingredient to completion.
- * - `poll-multiple` — Replicate polls every fanned-out ingredient id.
- * - `background-only` — Fal never blocks the request; always returns the
- *   placeholder immediately.
- */
-interface CompletionPlan {
-  generationPromise: Promise<unknown>;
-  kind: 'inline' | 'poll-single' | 'poll-multiple' | 'background-only';
-  pollIds?: string[];
-}
 
 /**
  * Owns the full image-generation workflow extracted out of
@@ -158,30 +81,21 @@ export class ImageGenerationService {
 
   constructor(
     private readonly configService: ConfigService,
-    private readonly activitiesService: ActivitiesService,
     private readonly assetsService: AssetsService,
     private readonly brandsService: BrandsService,
-    private readonly comfyUIService: ComfyUIService,
     private readonly creditsUtilsService: CreditsUtilsService,
-    private readonly failedGenerationService: FailedGenerationService,
-    private readonly filesClientService: FilesClientService,
-    private readonly falService: FalService,
     private readonly ingredientCompletionService: IngredientCompletionService,
+    private readonly imageGenerationProviderDispatchService: ImageGenerationProviderDispatchService,
     private readonly imagesService: ImagesService,
     private readonly ingredientsService: IngredientsService,
     private readonly organizationSettingsService: OrganizationSettingsService,
-    private readonly klingAIService: KlingAIService,
-    private readonly leonardoaiService: LeonardoAIService,
     private readonly loggerService: LoggerService,
-    private readonly metadataService: MetadataService,
     private readonly modelRegistrationService: ModelRegistrationService,
     private readonly modelsService: ModelsService,
     private readonly promptBuilderService: PromptBuilderService,
     private readonly promptsService: PromptsService,
-    private readonly replicateService: ReplicateService,
     private readonly routerService: RouterService,
     private readonly sharedService: SharedService,
-    private readonly websocketService: NotificationsPublisherService,
   ) {}
 
   async generateImage(
@@ -244,7 +158,7 @@ export class ImageGenerationService {
 
     const websocketUrl = WebSocketPaths.image(ingredientData.id);
 
-    const context: GenerationContext = {
+    const context: ImageGenerationContext = {
       brand,
       brandPromptBranding,
       createImageDto,
@@ -268,9 +182,15 @@ export class ImageGenerationService {
     };
 
     // Create activity + websocket update for image generation start
-    await this.createImagePlaceholderActivity(context, ingredientData.id);
+    await this.imageGenerationProviderDispatchService.createPlaceholderActivity(
+      context,
+      ingredientData.id,
+    );
 
-    const plan = await this.dispatchGeneration(context, provider);
+    const plan = await this.imageGenerationProviderDispatchService.dispatch(
+      context,
+      provider,
+    );
 
     return this.finishGeneration(context, plan);
   }
@@ -285,11 +205,11 @@ export class ImageGenerationService {
     createImageDto: CreateImageDto,
     request: Request,
   ): Promise<{
-    brand: ResolvedBrand;
+    brand: ImageGenerationResolvedBrand;
     model: string;
     promptOriginalText: string;
-    provider: ImageProvider;
-    publicMetadata: PublicMetadata;
+    provider: ImageGenerationProvider;
+    publicMetadata: ImageGenerationPublicMetadata;
   }> {
     this.loggerService.log(`${this.constructorName} create`, {
       ...createImageDto,
@@ -383,22 +303,22 @@ export class ImageGenerationService {
    * documents the generation flow operates on.
    */
   private async persistImageDocuments(params: {
-    brand: ResolvedBrand;
+    brand: ImageGenerationResolvedBrand;
     brandPromptBranding: ReturnType<typeof buildPromptBrandingFromBrand>;
     createImageDto: CreateImageDto;
     height: number;
     model: string;
-    promptBuilderBrand: GenerationContext['promptBuilderBrand'];
+    promptBuilderBrand: ImageGenerationContext['promptBuilderBrand'];
     promptOriginalText: string;
-    publicMetadata: PublicMetadata;
+    publicMetadata: ImageGenerationPublicMetadata;
     referenceImageUrls: string[];
     style?: string;
     user: User;
     width: number;
   }): Promise<{
-    ingredientData: SavedIngredient;
-    metadataData: SavedMetadata;
-    promptData: ResolvedPrompt;
+    ingredientData: ImageGenerationSavedIngredient;
+    metadataData: ImageGenerationSavedMetadata;
+    promptData: ImageGenerationResolvedPrompt;
   }> {
     const {
       brand,
@@ -497,7 +417,7 @@ export class ImageGenerationService {
   private async resolveImageModel(
     createImageDto: CreateImageDto,
     promptOriginalText: string,
-    brand: ResolvedBrand,
+    brand: ImageGenerationResolvedBrand,
     organizationSettings: { defaultImageModel?: unknown } | null,
   ): Promise<string> {
     if (createImageDto.autoSelectModel) {
@@ -643,7 +563,7 @@ export class ImageGenerationService {
    * match no known provider (the caller throws BAD_REQUEST), mirroring the
    * original flat guard.
    */
-  private classifyProvider(model: string): ImageProvider | null {
+  private classifyProvider(model: string): ImageGenerationProvider | null {
     const replicateModels: string[] = [
       MODEL_KEYS.REPLICATE_GOOGLE_IMAGEN_3,
       MODEL_KEYS.REPLICATE_GOOGLE_IMAGEN_4,
@@ -680,40 +600,14 @@ export class ImageGenerationService {
   }
 
   /**
-   * Dispatch map: route the resolved provider to its handler. SDXL has no
-   * external generation step, so it returns `null` and the request resolves to
-   * the placeholder. Adding a provider touches only a handler plus this switch.
-   */
-  private async dispatchGeneration(
-    context: GenerationContext,
-    provider: ImageProvider,
-  ): Promise<CompletionPlan | null> {
-    switch (provider) {
-      case 'genfeedai':
-        return this.dispatchGenfeedAi(context);
-      case 'klingai':
-        return this.dispatchKlingAI(context);
-      case 'fal':
-        return this.dispatchFal(context);
-      case 'leonardo':
-        return this.dispatchLeonardo(context);
-      case 'replicate':
-        return this.dispatchReplicate(context);
-      default:
-        // SDXL: placeholder only, no external generation.
-        return null;
-    }
-  }
-
-  /**
    * Finish a generation request: when waiting, await the provider promise and
    * serialize the completed ingredient (single source of truth for the
    * poll/serialize/timeout-recovery tail); otherwise return the placeholder and
    * let generation run in the background.
    */
   private async finishGeneration(
-    context: GenerationContext,
-    plan: CompletionPlan | null,
+    context: ImageGenerationContext,
+    plan: ImageGenerationCompletionPlan | null,
   ): Promise<JsonApiSingleResponse> {
     if (plan && context.waitForCompletion && plan.kind !== 'background-only') {
       try {
@@ -760,8 +654,8 @@ export class ImageGenerationService {
 
   /** Read the completed ingredient for the request's completion strategy. */
   private async resolveCompletedIngredient(
-    context: GenerationContext,
-    plan: CompletionPlan,
+    context: ImageGenerationContext,
+    plan: ImageGenerationCompletionPlan,
   ): Promise<unknown> {
     if (plan.kind === 'inline') {
       return this.imagesService.findOne(
@@ -797,7 +691,7 @@ export class ImageGenerationService {
    */
   private async throwGatewayTimeoutIfPending(
     error: unknown,
-    context: GenerationContext,
+    context: ImageGenerationContext,
   ): Promise<void> {
     if (!(error instanceof PollTimeoutException)) {
       return;
@@ -817,701 +711,6 @@ export class ImageGenerationService {
         HttpStatus.GATEWAY_TIMEOUT,
       );
     }
-  }
-
-  /**
-   * Single failure path for every provider: log, persist the failed state, and
-   * re-throw so the request rejects. Collapses the previously copy-pasted
-   * `handleFailedImageGeneration` call sites.
-   */
-  private async handleProviderFailure(
-    context: GenerationContext,
-    error: unknown,
-    label: string,
-    ingredientId: SavedIngredient['id'] = context.ingredientData.id,
-  ): Promise<never> {
-    this.loggerService.error(`${label} failed`, error);
-    const errorMessage = getErrorMessage(error);
-
-    // Attribute the failure to the specific output that failed, not always the
-    // primary ingredient. The websocket path is derived from the same id so the
-    // matching placeholder (not the first) receives the failure update. The
-    // default keeps every single-output provider call site on the primary id —
-    // and for the primary `WebSocketPaths.image(_id)` equals `context.websocketUrl`.
-    await this.failedGenerationService.handleFailedImageGeneration(
-      this.imagesService,
-      ingredientId,
-      WebSocketPaths.image(ingredientId),
-      context.publicMetadata,
-      getUserRoomName(context.user.id),
-      errorMessage,
-    );
-    throw error;
-  }
-
-  /**
-   * Create the IMAGE_PROCESSING activity and emit the matching background-task
-   * websocket update for a placeholder ingredient. Shared by the primary output
-   * and every multi-output fan-out path.
-   */
-  private async createImagePlaceholderActivity(
-    context: GenerationContext,
-    ingredientId: string,
-  ): Promise<void> {
-    const activity = await this.activitiesService.create(
-      new ActivityEntity({
-        brand: context.brand.id,
-        entityId: ingredientId,
-        entityModel: ActivityEntityModel.INGREDIENT,
-        key: ActivityKey.IMAGE_PROCESSING,
-        organization: context.publicMetadata.organization,
-        source: ActivitySource.IMAGE_GENERATION,
-        user: context.publicMetadata.user,
-        value: JSON.stringify({
-          ingredientId: ingredientId.toString(),
-          model: context.model,
-          type: 'generation',
-        }),
-      }),
-    );
-
-    await this.websocketService.publishBackgroundTaskUpdate({
-      activityId: activity.id.toString(),
-      label: 'Image Generation',
-      progress: 0,
-      room: getUserRoomName(context.user.id),
-      status: 'processing',
-      taskId: ingredientId.toString(),
-      userId: context.user.id,
-    });
-  }
-
-  /** GenfeedAi (ComfyUI): generate, upload, complete inline. */
-  private dispatchGenfeedAi(context: GenerationContext): CompletionPlan {
-    const {
-      ingredientData,
-      metadataData,
-      promptData,
-      referenceImageUrl,
-      user,
-      websocketUrl,
-    } = context;
-
-    const generationPromise = (async () => {
-      const { imageBuffer } = await this.comfyUIService.generateImage(
-        context.model,
-        {
-          faceImage: referenceImageUrl || undefined,
-          height: context.height,
-          prompt: promptData.original,
-          seed: context.createImageDto.seed,
-          width: context.width,
-        },
-      );
-
-      const uploadMeta = await this.filesClientService.uploadToS3(
-        ingredientData.id.toString(),
-        'images',
-        {
-          contentType: 'image/png',
-          data: imageBuffer,
-          type: FileInputType.BUFFER,
-        },
-      );
-
-      await Promise.all([
-        this.metadataService.patch(
-          metadataData.id,
-          new MetadataEntity({
-            height: uploadMeta.height,
-            prompt: promptData.id,
-            size: uploadMeta.size,
-            width: uploadMeta.width,
-          }),
-        ),
-        this.imagesService.patch(ingredientData.id, {
-          cdnUrl:
-            typeof uploadMeta.publicUrl === 'string'
-              ? uploadMeta.publicUrl
-              : undefined,
-          prompt: promptData.id,
-          s3Key:
-            typeof uploadMeta.s3Key === 'string' ? uploadMeta.s3Key : undefined,
-          status: IngredientStatus.GENERATED,
-        }),
-        this.websocketService.publishVideoComplete(
-          websocketUrl,
-          {
-            id: ingredientData.id.toString(),
-            ingredientId: ingredientData.id.toString(),
-            status: 'completed',
-          },
-          user.id,
-          getUserRoomName(user.id),
-        ),
-      ]);
-
-      return ingredientData.id.toString();
-    })().catch((error: unknown) =>
-      this.handleProviderFailure(
-        context,
-        error,
-        'ComfyUIService generateImage',
-      ),
-    );
-
-    return { generationPromise, kind: 'inline' };
-  }
-
-  /** Kling AI: queue generation, patch external id, poll on wait. */
-  private dispatchKlingAI(context: GenerationContext): CompletionPlan {
-    const { createImageDto, metadataData, promptData, referenceImageUrl } =
-      context;
-
-    const generationPromise = this.klingAIService
-      .queueGenerateImage(promptData.original, {
-        ...createImageDto,
-        height: context.height,
-        model: context.model,
-        reference: referenceImageUrl || undefined,
-        style: context.style || 'realistic',
-        width: context.width,
-      })
-      .then(async (generationId) => {
-        if (!generationId) {
-          throw new Error('No generation ID returned from KlingAI');
-        }
-
-        await this.metadataService.patch(
-          metadataData.id,
-          new MetadataEntity({
-            externalId: generationId,
-            prompt: promptData.id,
-          }),
-        );
-
-        return generationId;
-      })
-      .catch((error: unknown) =>
-        this.handleProviderFailure(
-          context,
-          error,
-          'KlingAIService generateImage',
-        ),
-      );
-
-    return { generationPromise, kind: 'poll-single' };
-  }
-
-  /** Leonardo: generate, patch external id, poll on wait. */
-  private dispatchLeonardo(context: GenerationContext): CompletionPlan {
-    const { createImageDto, metadataData, promptData } = context;
-
-    const generationPromise = this.leonardoaiService
-      .generateImage(promptData.original, {
-        ...createImageDto,
-        height: context.height,
-        style: context.style || 'realistic',
-        width: context.width,
-      })
-      .then(async (generationId) => {
-        if (!generationId) {
-          throw new Error('No generation ID returned from LeonardoAI');
-        }
-
-        await this.metadataService.patch(
-          metadataData.id,
-          new MetadataEntity({
-            externalId: generationId,
-          }),
-        );
-
-        return generationId;
-      })
-      .catch((error: unknown) =>
-        this.handleProviderFailure(
-          context,
-          error,
-          'LeonardoAIService generateImage',
-        ),
-      );
-
-    return { generationPromise, kind: 'poll-single' };
-  }
-
-  /**
-   * Fal: generate the primary output then, for multi-output requests, fan out
-   * additional outputs in the background. Fal never blocks the request.
-   */
-  private dispatchFal(context: GenerationContext): CompletionPlan {
-    const {
-      createImageDto,
-      height,
-      metadataData,
-      promptData,
-      referenceImageUrl,
-      width,
-    } = context;
-
-    const buildFalInput = (): Record<string, unknown> => ({
-      image_size: {
-        height,
-        width,
-      },
-      ...(referenceImageUrl ? { image_url: referenceImageUrl } : {}),
-      ...(createImageDto.seed !== undefined
-        ? { seed: createImageDto.seed }
-        : {}),
-      prompt: promptData.original,
-    });
-
-    const generationPromise = (async () => {
-      // Primary output: a failure here is attributed to the primary ingredient.
-      let primaryUrl: string;
-      try {
-        const falResult = await this.falService.generateImage(
-          context.model,
-          buildFalInput(),
-        );
-        await this.metadataService.patch(
-          metadataData.id,
-          new MetadataEntity({
-            externalId: falResult.url,
-            prompt: promptData.id,
-          }),
-        );
-        primaryUrl = falResult.url;
-      } catch (error: unknown) {
-        return this.handleProviderFailure(
-          context,
-          error,
-          'FalService generateImage',
-          context.ingredientData.id,
-        );
-      }
-
-      // Additional outputs sit outside the primary's catch: each owns its own
-      // failure attribution (see createFalAdditionalOutput), so a failed fan-out
-      // output marks that output rather than the already-succeeded primary.
-      // finishGeneration attaches an empty catch to the background promise, so a
-      // rejection after marking is intentional and not an unhandled rejection.
-      for (let i = 1; i < context.outputs; i++) {
-        await this.createFalAdditionalOutput(context, buildFalInput);
-      }
-
-      return primaryUrl;
-    })();
-
-    return { generationPromise, kind: 'background-only' };
-  }
-
-  /** Create one additional Fal output document, generate it, and track it. */
-  private async createFalAdditionalOutput(
-    context: GenerationContext,
-    buildFalInput: () => Record<string, unknown>,
-  ): Promise<void> {
-    const { createImageDto, brand, promptData, publicMetadata } = context;
-
-    // Capture the additional output's id as soon as its placeholder exists so a
-    // generation/patch failure marks that specific output, not the (already
-    // succeeded) primary.
-    let additionalIngredientId: SavedIngredient['id'] | null = null;
-    try {
-      const {
-        metadataData: additionalMetadata,
-        ingredientData: additionalIngredient,
-      } = await this.sharedService.saveDocuments(context.user, {
-        ...createImageDto,
-        brand: brand.id,
-        category: IngredientCategory.IMAGE,
-        extension: MetadataExtension.JPG,
-        model: context.model,
-        organization: publicMetadata.organization,
-        parent: context.ingredientData.parent,
-        prompt: promptData.id,
-        status: IngredientStatus.PROCESSING,
-      });
-      additionalIngredientId = additionalIngredient.id;
-
-      const additionalResult = await this.falService.generateImage(
-        context.model,
-        buildFalInput(),
-      );
-
-      await Promise.all([
-        this.metadataService.patch(
-          additionalMetadata.id,
-          new MetadataEntity({
-            externalId: additionalResult.url,
-            prompt: promptData.id,
-          }),
-        ),
-        this.imagesService.patch(additionalIngredient.id, {
-          prompt: promptData.id,
-        }),
-      ]);
-
-      // Activity creation + websocket publishing is post-success bookkeeping:
-      // a failure here must not mark the already-generated additional output as
-      // failed, so swallow (and log) instead of letting it reach the catch.
-      try {
-        await this.createImagePlaceholderActivity(
-          context,
-          additionalIngredient.id,
-        );
-      } catch (activityError: unknown) {
-        this.loggerService.error(
-          'Failed to publish placeholder activity for additional output',
-          { error: activityError },
-        );
-      }
-
-      context.pendingIngredientIds.push(additionalIngredient.id.toString());
-    } catch (error: unknown) {
-      // Mark the specific additional output that failed; never fall back to the
-      // primary, which is a different (already-succeeded) output.
-      if (additionalIngredientId) {
-        return this.handleProviderFailure(
-          context,
-          error,
-          'FalService generateImage (additional output)',
-          additionalIngredientId,
-        );
-      }
-      // The placeholder was never created (saveDocuments failed), so there is
-      // nothing to mark. Log so the dropped output is observable, then propagate
-      // to fail the request rather than swallowing it silently.
-      this.loggerService.error(
-        'Fal additional output failed before its placeholder was created',
-        error,
-      );
-      throw error;
-    }
-  }
-
-  /**
-   * Replicate: build provider-specific prompt params, dispatch, then handle
-   * batch vs sequential multi-output. Polls every fanned-out id on wait.
-   */
-  private async dispatchReplicate(
-    context: GenerationContext,
-  ): Promise<CompletionPlan> {
-    const {
-      createImageDto,
-      promptBuilderBrand,
-      brandPromptBranding,
-      promptData,
-    } = context;
-
-    const destination = context.model;
-    const modelCapability = MODEL_OUTPUT_CAPABILITIES[destination];
-    const isBatchSupported = modelCapability?.isBatchSupported ?? false;
-
-    // Build provider-specific prompt using the universal prompt builder with
-    // template support. NOTE: This must complete before we can start generation.
-    // Only batch-capable models yield every output from a single call, so they
-    // request `context.outputs`; non-batch models make a separate call per output
-    // (see createReplicateSequentialOutputs) and must request exactly one output
-    // per call — otherwise every one of those N calls over-requests N images.
-    const { input: promptParams } = await this.promptBuilderService.buildPrompt(
-      context.model,
-      {
-        blacklist: createImageDto.blacklist,
-        brand: promptBuilderBrand,
-        branding: brandPromptBranding,
-        brandingMode: createImageDto.brandingMode,
-        camera: createImageDto.camera,
-        fontFamily: createImageDto.fontFamily,
-        height: context.height,
-        isBrandingEnabled: createImageDto.isBrandingEnabled,
-        lens: createImageDto.lens,
-        lighting: createImageDto.lighting,
-        // Use model's category from DB (set by ModelsGuard), fallback to IMAGE
-        modelCategory: ModelCategory.IMAGE,
-        mood: createImageDto.mood,
-        outputs: isBatchSupported ? context.outputs : 1,
-        prompt: promptData.original,
-        // Template support
-        promptTemplate: createImageDto.promptTemplate,
-        references: context.referenceImageUrls,
-        scene: createImageDto.scene,
-        seed: createImageDto.seed,
-        style: context.style || createImageDto.style || 'realistic',
-        tags: createImageDto.tags?.map((tag) => tag.toString()) || [],
-        useTemplate: createImageDto.useTemplate,
-        width: context.width,
-      },
-      context.publicMetadata.organization,
-    );
-
-    // Track all placeholder ingredient IDs - start with first one
-    const pollIds: string[] = [context.ingredientData.id.toString()];
-
-    const generationPromise = (async () => {
-      // Primary generation: a failure here is attributed to the primary
-      // ingredient.
-      let generationId: string;
-      try {
-        const id = await this.replicateService.generateTextToImage(
-          destination,
-          promptParams,
-        );
-        if (!id) {
-          throw new Error('No generation ID returned from Replicate');
-        }
-        generationId = id;
-      } catch (error: unknown) {
-        return this.handleProviderFailure(
-          context,
-          error,
-          'ReplicateService generateImage',
-          context.ingredientData.id,
-        );
-      }
-
-      // Multi-output fan-out. createReplicateSequentialOutputs owns its own
-      // per-output failure attribution (a failed additional output marks that
-      // output, never the primary); the batch and single-output branches wrap
-      // their DB work here so a failure still tears down the primary placeholder.
-      if (isBatchSupported && context.outputs > 1) {
-        try {
-          await this.createReplicateBatchOutputs(
-            context,
-            destination,
-            generationId,
-            pollIds,
-          );
-        } catch (error: unknown) {
-          return this.handleProviderFailure(
-            context,
-            error,
-            'ReplicateService generateImage',
-            context.ingredientData.id,
-          );
-        }
-      } else if (context.outputs > 1) {
-        await this.createReplicateSequentialOutputs(
-          context,
-          destination,
-          generationId,
-          promptParams,
-          pollIds,
-        );
-      } else {
-        // Single output - use original external ID
-        try {
-          await this.metadataService.patch(
-            context.metadataData.id,
-            new MetadataEntity({
-              externalId: generationId,
-            }),
-          );
-        } catch (error: unknown) {
-          return this.handleProviderFailure(
-            context,
-            error,
-            'ReplicateService generateImage',
-            context.ingredientData.id,
-          );
-        }
-      }
-
-      return generationId;
-    })();
-
-    return { generationPromise, kind: 'poll-multiple', pollIds };
-  }
-
-  /**
-   * Batch-capable Replicate models: one API call yields multiple outputs.
-   * Create the remaining placeholder documents and index their external ids.
-   */
-  private async createReplicateBatchOutputs(
-    context: GenerationContext,
-    destination: string,
-    generationId: string,
-    pollIds: string[],
-  ): Promise<void> {
-    const { createImageDto, brand, promptData, publicMetadata } = context;
-
-    await this.metadataService.patch(
-      context.metadataData.id,
-      new MetadataEntity({
-        externalId: `${generationId}_0`,
-      }),
-    );
-
-    // Create additional placeholder documents for remaining outputs
-    const additionalDocuments = await Promise.all(
-      Array.from({ length: context.outputs - 1 }, () => {
-        return this.sharedService.saveDocuments(context.user, {
-          ...createImageDto,
-          brand: brand.id,
-          category: IngredientCategory.IMAGE,
-          extension: MetadataExtension.JPG,
-          model: context.model,
-          organization: publicMetadata.organization,
-          parent: context.ingredientData.parent,
-          prompt: promptData.id,
-          status: IngredientStatus.PROCESSING,
-        });
-      }),
-    );
-
-    // Update metadata and images in parallel
-    await Promise.all(
-      additionalDocuments.flatMap(
-        ({ metadataData: addMeta, ingredientData: addIngredient }, index) => {
-          const i = index + 1;
-          return [
-            this.metadataService.patch(
-              addMeta.id,
-              new MetadataEntity({
-                externalId: `${generationId}_${i}`,
-              }),
-            ),
-            this.imagesService.patch(addIngredient.id, {
-              prompt: promptData.id,
-            }),
-          ];
-        },
-      ),
-    );
-
-    // Create activities for each additional placeholder (batch model path)
-    await Promise.all(
-      additionalDocuments.map(({ ingredientData: addIngredient }) =>
-        this.createImagePlaceholderActivity(context, addIngredient.id),
-      ),
-    );
-
-    // Push additional ingredient IDs to tracking array for polling
-    additionalDocuments.forEach(({ ingredientData: addIngredient }) => {
-      pollIds.push(addIngredient.id.toString());
-    });
-
-    this.loggerService.log(
-      'Created multiple placeholders for batch-capable model multi-output',
-      {
-        generationId,
-        isBatchSupported: true,
-        model: destination,
-        outputs: context.outputs,
-      },
-    );
-  }
-
-  /**
-   * Non-batch Replicate models: make a separate API call per additional output,
-   * each with its own placeholder document and external id.
-   */
-  private async createReplicateSequentialOutputs(
-    context: GenerationContext,
-    destination: string,
-    generationId: string,
-    promptParams: Record<string, unknown>,
-    pollIds: string[],
-  ): Promise<void> {
-    const { createImageDto, brand, promptData, publicMetadata } = context;
-
-    try {
-      await this.metadataService.patch(
-        context.metadataData.id,
-        new MetadataEntity({
-          externalId: generationId,
-        }),
-      );
-    } catch (error: unknown) {
-      await this.handleProviderFailure(
-        context,
-        error,
-        'ReplicateService generateImage',
-        context.ingredientData.id,
-      );
-    }
-
-    // Make additional API calls for remaining outputs
-    // NOTE: Sequential because each needs unique generationId
-    for (let i = 1; i < context.outputs; i++) {
-      // Capture the additional output's id as soon as its placeholder exists so
-      // a generation/patch failure marks that specific output, not the primary.
-      let additionalIngredientId: SavedIngredient['id'] | null = null;
-      try {
-        const {
-          metadataData: additionalMetadata,
-          ingredientData: additionalIngredient,
-        } = await this.sharedService.saveDocuments(context.user, {
-          ...createImageDto,
-          brand: brand.id,
-          category: IngredientCategory.IMAGE,
-          extension: MetadataExtension.JPG,
-          model: context.model,
-          organization: publicMetadata.organization,
-          parent: context.ingredientData.parent,
-          prompt: promptData.id,
-          status: IngredientStatus.PROCESSING,
-        });
-        additionalIngredientId = additionalIngredient.id;
-
-        // Make separate API call for each output
-        const additionalGenerationId =
-          await this.replicateService.generateTextToImage(
-            destination,
-            promptParams,
-          );
-        if (!additionalGenerationId) {
-          throw new Error('No generation ID returned from Replicate');
-        }
-
-        await Promise.all([
-          this.metadataService.patch(
-            additionalMetadata.id,
-            new MetadataEntity({
-              externalId: additionalGenerationId,
-            }),
-          ),
-          this.imagesService.patch(additionalIngredient.id, {
-            prompt: promptData.id,
-          }),
-        ]);
-
-        await this.createImagePlaceholderActivity(
-          context,
-          additionalIngredient.id,
-        );
-
-        // Push this additional ingredient ID to tracking array for polling
-        pollIds.push(additionalIngredient.id.toString());
-      } catch (error: unknown) {
-        // Mark the specific additional output that failed; never fall back to
-        // the primary, which is a different output.
-        if (additionalIngredientId) {
-          return this.handleProviderFailure(
-            context,
-            error,
-            'ReplicateService generateImage (additional output)',
-            additionalIngredientId,
-          );
-        }
-        // The placeholder was never created (saveDocuments failed), so there is
-        // nothing to mark. Log so the dropped output is observable, then
-        // propagate to fail the request rather than swallowing it silently.
-        this.loggerService.error(
-          'Replicate additional output failed before its placeholder was created',
-          error,
-        );
-        throw error;
-      }
-    }
-
-    this.loggerService.log(
-      'Created multiple API calls for non-batch model multi-output',
-      {
-        isBatchSupported: false,
-        model: destination,
-        outputs: context.outputs,
-      },
-    );
   }
 
   /**

--- a/apps/server/api/src/collections/images/services/image-generation.types.ts
+++ b/apps/server/api/src/collections/images/services/image-generation.types.ts
@@ -1,0 +1,68 @@
+import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticated-user.interface';
+import type { BrandsService } from '@api/collections/brands/services/brands.service';
+import type { buildPromptBrandingFromBrand } from '@api/collections/brands/utils/brand-context.util';
+import type { CreateImageDto } from '@api/collections/images/dto/create-image.dto';
+import type { PromptsService } from '@api/collections/prompts/services/prompts.service';
+import type { RequestWithContext as Request } from '@api/common/middleware/request-context.middleware';
+import type { getPublicMetadata } from '@api/helpers/utils/auth/auth.util';
+import type { SharedService } from '@api/shared/services/shared/shared.service';
+
+export type ImageGenerationProvider =
+  | 'genfeedai'
+  | 'klingai'
+  | 'fal'
+  | 'leonardo'
+  | 'replicate'
+  | 'sdxl';
+
+export type ImageGenerationResolvedBrand = NonNullable<
+  Awaited<ReturnType<BrandsService['findOne']>>
+>;
+export type ImageGenerationResolvedPrompt = Awaited<
+  ReturnType<PromptsService['create']>
+>;
+export type ImageGenerationSaveDocumentsResult = Awaited<
+  ReturnType<SharedService['saveDocuments']>
+>;
+export type ImageGenerationSavedIngredient =
+  ImageGenerationSaveDocumentsResult['ingredientData'];
+export type ImageGenerationSavedMetadata =
+  ImageGenerationSaveDocumentsResult['metadataData'];
+export type ImageGenerationPublicMetadata = ReturnType<
+  typeof getPublicMetadata
+>;
+
+export interface ImageGenerationContext {
+  brand: ImageGenerationResolvedBrand;
+  brandPromptBranding: ReturnType<typeof buildPromptBrandingFromBrand>;
+  createImageDto: CreateImageDto;
+  height: number;
+  ingredientData: ImageGenerationSavedIngredient;
+  metadataData: ImageGenerationSavedMetadata;
+  model: string;
+  outputs: number;
+  pendingIngredientIds: string[];
+  promptBuilderBrand: {
+    description?: string;
+    label: string;
+    primaryColor?: string;
+    secondaryColor?: string;
+    text?: string;
+  };
+  promptData: ImageGenerationResolvedPrompt;
+  publicMetadata: ImageGenerationPublicMetadata;
+  referenceImageUrl: string | null;
+  referenceImageUrls: string[];
+  request: Request;
+  style?: string;
+  user: User;
+  waitForCompletion: boolean;
+  websocketUrl: string;
+  width: number;
+}
+
+export interface ImageGenerationCompletionPlan {
+  generationPromise: Promise<unknown>;
+  kind: 'inline' | 'poll-single' | 'poll-multiple' | 'background-only';
+  pollIds?: string[];
+}


### PR DESCRIPTION
## Summary

- extract GenfeedAI, KlingAI, FAL, LeonardoAI, Replicate, and SDXL dispatch into a typed image provider boundary
- preserve inline, polling, background-only, failure attribution, and batch/sequential multi-output behavior
- reduce `ImageGenerationService` from 1,551 to 750 lines and remove its direct provider dependencies
- add focused provider request, normalization, upload, and multi-output coverage

## Related issue

Closes #1855
Refs #1741

## Scope

Behavior-preserving image provider dispatch extraction only. Model resolution, validation, credits, persistence, activity lifecycle, polling, response serialization, provider additions, pricing, and files processor decomposition remain unchanged.

## Verification

Passed locally:

- `bunx @biomejs/biome@2.5.3 check <6 touched files>`
- `bun scripts/run-secretlint.ts <6 touched files>`
- `git diff --cached --check`
- staged sensitive-path and credential-pattern scans
- static provider-boundary assertions: main service 750 lines with no provider clients; dispatch service 699 lines, 14 dependencies; module registration present; no `any`

Skipped or blocked locally:

- unit tests, typecheck, and build are delegated to PR CI by workstation policy
- `bun scripts/check-di-value-imports.ts` cannot start under Bun 1.3.14 because the TypeScript runtime import exposes `ts.ScriptTarget` as undefined
- `check:runtime-complexity` is unavailable on recorded base `d734eff17` because that guard has not merged to `master`

## Residual risk

The extraction preserves the existing provider code and integration regression suite, but runtime and type evidence remains pending in GitHub Actions.

## Screenshots

Not applicable — backend-only refactor.

## Checklist

- [x] Final diff reviewed for correctness, security, regressions, dead code, and unrelated changes.
- [x] Focused local checks passed or blockers are documented.
- [x] No database, API contract, migration, release, or external configuration change.
- [x] No secrets, credentials, customer data, or generated output included.