### PR TITLE
chore(agent): ratchet executor cleanup

### DIFF
--- a/scripts/architecture/check-agent-decomposition-size.ts
+++ b/scripts/architecture/check-agent-decomposition-size.ts
@@ -27,7 +27,7 @@ const AGENT_ORCHESTRATOR_TREE =
  */
 const RATCHET_CEILINGS: Record<string, number> = {
   'apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.ts': 5356,
-  'apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts': 9307,
+  'apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts': 9292,
   'apps/server/api/src/services/agent-orchestrator/tools/agent-tool-registry.ts': 1136,
 };
 


### PR DESCRIPTION
## Summary

- confirm the dead `&& true` guards and redundant `brandObjectId` alias from #929 are absent on current `master`
- lower the existing agent executor decomposition ceiling from 9,307 to the current 9,292 lines
- preserve the downward-only architecture ratchet so the cleanup is not replaced by silent executor growth

The source cleanup itself reached `master` through integration PR #943. This PR completes the selected issue by aligning the repository's existing enforcement ceiling with that cleaned source state.

## Verification

- `rg "&& true|brandObjectId" apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts` — no matches
- `wc -l apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts` — 9,292
- `bun run scripts/architecture/check-agent-decomposition-size.ts` — passed across 35 source files
- `bunx biome check scripts/architecture/check-agent-decomposition-size.ts apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts` — passed
- `git diff --check` — passed
- staged filename and credential-pattern scan — passed

Local tests, API typecheck, and build were skipped per workstation policy; PR CI owns those broad checks.

## Risk

Low: this changes only the existing static ceiling and does not alter runtime behavior.

Closes #929
Refs #519
