### PR TITLE
fix(publishing): harden approval execution leases

### DIFF
--- a/.changes/publish-approval-execution-leases.md
+++ b/.changes/publish-approval-execution-leases.md
@@ -1,0 +1,13 @@
+packages: @genfeedai/interfaces @genfeedai/queue-contracts
+
+Harden version-bound publish execution with explicit operation, version-pin,
+and execution-lease identities.
+
+Public contract changes:
+- `@genfeedai/interfaces` now owns the publish-approval service parameter and
+  result interfaces. `ClaimPublishExecutionParams` requires `operationId` and
+  `versionPinId`; `PublishExecutionClaim.alreadyPublished` is renamed to
+  `isAlreadyPublished` and includes `executionStartedAt`; provider completion
+  uses `CompletePublishExecutionParams`.
+- `@genfeedai/queue-contracts` exports `ContentPipelineJobData`, replacing the
+  API-local queue payload interface used by content-pipeline workers and tests.

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/trends/analytics-trends.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/trends/analytics-trends.test.tsx
@@ -476,6 +476,7 @@ describe('AnalyticsTrends', () => {
     mocks.findAllVideos.mockResolvedValue([
       makeVideo({
         brand: undefined,
+        createdAt: new Date().toISOString(),
         evaluation: undefined,
         id: 'video-without-analytics',
         metadataLabel: undefined,

--- a/apps/server/api/src/collections/publish-approvals/services/publish-approvals.service.spec.ts
+++ b/apps/server/api/src/collections/publish-approvals/services/publish-approvals.service.spec.ts
@@ -421,51 +421,50 @@ describe('PublishApprovalsService', () => {
   it.each([
     [true, PublishApprovalStatus.PUBLISHED, 'success'],
     [false, PublishApprovalStatus.FAILED, 'failure'],
-  ] as const)(
-    'records provider completion telemetry for success=%s',
-    async (isSuccess, completedStatus, outcome) => {
-      const executing = makeApproval({
-        status: PublishApprovalStatus.EXECUTING,
-      });
-      const completed = makeApproval({ status: completedStatus });
-      const publishApproval = {
-        findFirst: vi
-          .fn()
-          .mockResolvedValueOnce(executing)
-          .mockResolvedValueOnce(completed),
-        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
-      };
-      const logger = { log: vi.fn() };
-      const service = new PublishApprovalsService(
-        { publishApproval } as never,
-        {} as AgentArtifactReferenceService,
-        logger as never,
-      );
+  ] as const)('records provider completion telemetry for success=%s', async (isSuccess, completedStatus, outcome) => {
+    const executionStartedAt = new Date();
+    const executing = makeApproval({
+      status: PublishApprovalStatus.EXECUTING,
+      updatedAt: executionStartedAt,
+    });
+    const completed = makeApproval({ status: completedStatus });
+    const publishApproval = {
+      findFirst: vi
+        .fn()
+        .mockResolvedValueOnce(executing)
+        .mockResolvedValueOnce(completed),
+      updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+    };
+    const logger = { log: vi.fn() };
+    const service = new PublishApprovalsService(
+      { publishApproval } as never,
+      {} as AgentArtifactReferenceService,
+      logger as never,
+    );
 
-      await service.completeExecution({
-        approvalId: 'approval-1',
-        ...(!isSuccess ? { error: 'provider failed' } : {}),
-        executionStartedAt: NOW.toISOString(),
-        isSuccessful: isSuccess,
-        operationId: 'operation-1',
-        organizationId: 'org-1',
-        versionPinId: 'pin-1',
-      });
+    await service.completeExecution({
+      approvalId: 'approval-1',
+      ...(!isSuccess ? { error: 'provider failed' } : {}),
+      executionStartedAt: executionStartedAt.toISOString(),
+      isSuccessful: isSuccess,
+      operationId: 'operation-1',
+      organizationId: 'org-1',
+      versionPinId: 'pin-1',
+    });
 
-      expect(publishApproval.updateMany).toHaveBeenCalledWith(
-        expect.objectContaining({
-          data: expect.objectContaining({ status: completedStatus }),
-        }),
-      );
-      expect(logger.log).toHaveBeenCalledWith('conversation_shell_approval', {
-        action: 'execute',
-        integrity: 'matched',
-        organizationId: 'org-1',
-        outcome,
-        telemetryQueryVersion: 1,
-      });
-    },
-  );
+    expect(publishApproval.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: completedStatus }),
+      }),
+    );
+    expect(logger.log).toHaveBeenCalledWith('conversation_shell_approval', {
+      action: 'execute',
+      integrity: 'matched',
+      organizationId: 'org-1',
+      outcome,
+      telemetryQueryVersion: 1,
+    });
+  });
 
   it('allows only one queued execution claimant', async () => {
     const approval = makeApproval({ scopeDigest: scopeDigest() });
@@ -662,6 +661,35 @@ describe('PublishApprovalsService', () => {
         versionPinId: 'pin-1',
       }),
     ).rejects.toThrow('lease is stale or has been reclaimed');
+
+    expect(publishApproval.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('rejects completion after the execution lease expires', async () => {
+    const expiredAt = new Date(Date.now() - 16 * 60 * 1000);
+    const executing = makeApproval({
+      status: PublishApprovalStatus.EXECUTING,
+      updatedAt: expiredAt,
+    });
+    const publishApproval = {
+      findFirst: vi.fn().mockResolvedValue(executing),
+      updateMany: vi.fn(),
+    };
+    const service = new PublishApprovalsService(
+      { publishApproval } as never,
+      {} as AgentArtifactReferenceService,
+    );
+
+    await expect(
+      service.completeExecution({
+        approvalId: 'approval-1',
+        executionStartedAt: expiredAt.toISOString(),
+        isSuccessful: true,
+        operationId: 'operation-1',
+        organizationId: 'org-1',
+        versionPinId: 'pin-1',
+      }),
+    ).rejects.toThrow('lease has expired');
 
     expect(publishApproval.updateMany).not.toHaveBeenCalled();
   });

--- a/apps/server/api/src/collections/publish-approvals/services/publish-approvals.service.spec.ts
+++ b/apps/server/api/src/collections/publish-approvals/services/publish-approvals.service.spec.ts
@@ -227,6 +227,7 @@ describe('PublishApprovalsService', () => {
       post: {
         findFirst: vi.fn().mockResolvedValue(post),
         update: vi.fn().mockResolvedValue(post),
+        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
       },
       publishApproval,
     };
@@ -261,15 +262,73 @@ describe('PublishApprovalsService', () => {
     expect(replay.operationId).toBe(first.operationId);
     expect(publishApproval.create).not.toHaveBeenCalled();
     expect(publishApproval.update).not.toHaveBeenCalled();
-    expect(prisma.post.update).toHaveBeenCalledTimes(2);
-    expect(prisma.post.update).toHaveBeenNthCalledWith(2, {
-      data: {
-        publishApprovalId: 'approval-1',
-        reviewDecision: 'APPROVED',
-        reviewVersionPinId: 'pin-1',
-      },
-      where: { id: 'post-1' },
+    expect(prisma.post.updateMany).toHaveBeenCalledTimes(2);
+    expect(prisma.post.updateMany).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        data: {
+          publishApprovalId: 'approval-1',
+          reviewDecision: 'APPROVED',
+          reviewVersionPinId: 'pin-1',
+        },
+        where: expect.objectContaining({
+          id: 'post-1',
+          organizationId: 'org-1',
+          publishApprovals: {
+            some: expect.objectContaining({ id: 'approval-1' }),
+          },
+        }),
+      }),
+    );
+  });
+
+  it('fails an idempotent replay when approval eligibility changes before attach', async () => {
+    const existing = makeApproval({
+      scopeDigest: scopeDigest(),
+      status: PublishApprovalStatus.APPROVED,
     });
+    const publishApproval = {
+      findFirst: vi.fn().mockResolvedValue(existing),
+    };
+    const post = {
+      findFirst: vi.fn().mockResolvedValue(makePost()),
+      updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+    };
+    const service = new PublishApprovalsService(
+      { post, publishApproval } as never,
+      {
+        createOrReuseVersionPin: vi.fn().mockResolvedValue({ id: 'pin-1' }),
+      } as unknown as AgentArtifactReferenceService,
+    );
+
+    await expect(
+      service.createForCurrentPost({
+        actorUserId: 'user-1',
+        contextVersion: 4,
+        mode: 'scheduled',
+        organizationId: 'org-1',
+        postId: 'post-1',
+        transaction: { post, publishApproval } as never,
+      }),
+    ).rejects.toThrow('no longer eligible for activation');
+
+    expect(post.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          publishApprovals: {
+            some: expect.objectContaining({
+              id: 'approval-1',
+              status: {
+                in: expect.arrayContaining([
+                  PublishApprovalStatus.APPROVED,
+                  PublishApprovalStatus.PUBLISHED,
+                ]),
+              },
+            }),
+          },
+        }),
+      }),
+    );
   });
 
   it('fails closed and invalidates when the canonical brand drifts', async () => {
@@ -351,7 +410,8 @@ describe('PublishApprovalsService', () => {
       versionPinId: 'pin-1',
     });
 
-    expect(claim.alreadyPublished).toBe(true);
+    expect(claim.isAlreadyPublished).toBe(true);
+    expect(claim.executionStartedAt).toBeNull();
     expect(prisma.publishApproval.updateMany).not.toHaveBeenCalled();
     expect(
       artifactReferenceService.assertVersionPinCurrent,
@@ -361,43 +421,312 @@ describe('PublishApprovalsService', () => {
   it.each([
     [true, PublishApprovalStatus.PUBLISHED, 'success'],
     [false, PublishApprovalStatus.FAILED, 'failure'],
-  ] as const)('records provider completion telemetry for success=%s', async (isSuccess, completedStatus, outcome) => {
+  ] as const)(
+    'records provider completion telemetry for success=%s',
+    async (isSuccess, completedStatus, outcome) => {
+      const executing = makeApproval({
+        status: PublishApprovalStatus.EXECUTING,
+      });
+      const completed = makeApproval({ status: completedStatus });
+      const publishApproval = {
+        findFirst: vi
+          .fn()
+          .mockResolvedValueOnce(executing)
+          .mockResolvedValueOnce(completed),
+        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+      };
+      const logger = { log: vi.fn() };
+      const service = new PublishApprovalsService(
+        { publishApproval } as never,
+        {} as AgentArtifactReferenceService,
+        logger as never,
+      );
+
+      await service.completeExecution({
+        approvalId: 'approval-1',
+        ...(!isSuccess ? { error: 'provider failed' } : {}),
+        executionStartedAt: NOW.toISOString(),
+        isSuccessful: isSuccess,
+        operationId: 'operation-1',
+        organizationId: 'org-1',
+        versionPinId: 'pin-1',
+      });
+
+      expect(publishApproval.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ status: completedStatus }),
+        }),
+      );
+      expect(logger.log).toHaveBeenCalledWith('conversation_shell_approval', {
+        action: 'execute',
+        integrity: 'matched',
+        organizationId: 'org-1',
+        outcome,
+        telemetryQueryVersion: 1,
+      });
+    },
+  );
+
+  it('allows only one queued execution claimant', async () => {
+    const approval = makeApproval({ scopeDigest: scopeDigest() });
+    const publishApproval = {
+      findFirst: vi.fn().mockResolvedValue(approval),
+      updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+    };
+    const service = new PublishApprovalsService(
+      {
+        credential: {
+          findFirst: vi.fn().mockResolvedValue({ id: 'credential-1' }),
+        },
+        member: { findFirst: vi.fn().mockResolvedValue({ id: 'member-1' }) },
+        organization: {
+          findFirst: vi.fn().mockResolvedValue({ userId: 'user-1' }),
+        },
+        post: {
+          findFirst: vi
+            .fn()
+            .mockResolvedValue(makePost({ publishApprovalId: 'approval-1' })),
+        },
+        publishApproval,
+      } as never,
+      {
+        assertVersionPinCurrent: vi.fn(),
+      } as unknown as AgentArtifactReferenceService,
+    );
+
+    await expect(
+      service.claimForExecution({
+        approvalId: 'approval-1',
+        operationId: 'operation-1',
+        organizationId: 'org-1',
+        postId: 'post-1',
+        versionPinId: 'pin-1',
+      }),
+    ).rejects.toThrow('already executing');
+
+    expect(publishApproval.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          status: PublishApprovalStatus.QUEUED,
+          updatedAt: NOW,
+        }),
+      }),
+    );
+  });
+
+  it('resets an expired execution lease before claiming a retry', async () => {
+    const expiredAt = new Date('2026-07-13T20:00:00.000Z');
     const executing = makeApproval({
+      scopeDigest: scopeDigest(),
       status: PublishApprovalStatus.EXECUTING,
+      updatedAt: expiredAt,
     });
-    const completed = makeApproval({ status: completedStatus });
+    const queued = makeApproval({
+      lastError: 'Expired publish execution lease was reset for retry.',
+      scopeDigest: scopeDigest(),
+      status: PublishApprovalStatus.QUEUED,
+      updatedAt: NOW,
+    });
+    const reclaimed = makeApproval({
+      scopeDigest: scopeDigest(),
+      status: PublishApprovalStatus.EXECUTING,
+      updatedAt: new Date('2026-07-18T15:00:00.000Z'),
+    });
     const publishApproval = {
       findFirst: vi
         .fn()
         .mockResolvedValueOnce(executing)
-        .mockResolvedValueOnce(completed),
+        .mockResolvedValueOnce(queued)
+        .mockResolvedValueOnce(reclaimed),
+      updateMany: vi
+        .fn()
+        .mockResolvedValueOnce({ count: 1 })
+        .mockResolvedValueOnce({ count: 1 }),
+    };
+    const service = new PublishApprovalsService(
+      {
+        credential: {
+          findFirst: vi.fn().mockResolvedValue({ id: 'credential-1' }),
+        },
+        member: { findFirst: vi.fn().mockResolvedValue({ id: 'member-1' }) },
+        organization: {
+          findFirst: vi.fn().mockResolvedValue({ userId: 'user-1' }),
+        },
+        post: {
+          findFirst: vi
+            .fn()
+            .mockResolvedValue(makePost({ publishApprovalId: 'approval-1' })),
+        },
+        publishApproval,
+      } as never,
+      {
+        assertVersionPinCurrent: vi.fn(),
+      } as unknown as AgentArtifactReferenceService,
+    );
+
+    const claim = await service.claimForExecution({
+      approvalId: 'approval-1',
+      operationId: 'operation-1',
+      organizationId: 'org-1',
+      postId: 'post-1',
+      versionPinId: 'pin-1',
+    });
+
+    expect(claim.isAlreadyPublished).toBe(false);
+    expect(claim.executionStartedAt).toBe(reclaimed.updatedAt.toISOString());
+    expect(publishApproval.updateMany).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        data: expect.objectContaining({
+          lastError: 'Expired publish execution lease was reset for retry.',
+          status: PublishApprovalStatus.QUEUED,
+        }),
+        where: expect.objectContaining({
+          status: PublishApprovalStatus.EXECUTING,
+          updatedAt: expiredAt,
+        }),
+      }),
+    );
+    expect(publishApproval.updateMany).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        data: expect.objectContaining({
+          status: PublishApprovalStatus.EXECUTING,
+        }),
+        where: expect.objectContaining({
+          status: PublishApprovalStatus.QUEUED,
+          updatedAt: NOW,
+        }),
+      }),
+    );
+  });
+
+  it('releases post mutability after an execution lease expires', async () => {
+    const expired = makeApproval({
+      status: PublishApprovalStatus.EXECUTING,
+      updatedAt: new Date('2026-07-13T20:00:00.000Z'),
+    });
+    const publishApproval = {
+      findFirst: vi
+        .fn()
+        .mockResolvedValueOnce(expired)
+        .mockResolvedValueOnce(
+          makeApproval({ status: PublishApprovalStatus.QUEUED }),
+        ),
       updateMany: vi.fn().mockResolvedValue({ count: 1 }),
     };
-    const logger = { log: vi.fn() };
     const service = new PublishApprovalsService(
       { publishApproval } as never,
       {} as AgentArtifactReferenceService,
-      logger as never,
     );
 
-    await service.completeExecution(
-      'approval-1',
-      'org-1',
-      isSuccess,
-      isSuccess ? undefined : 'provider failed',
+    await expect(
+      service.assertPostMutable('org-1', 'post-1'),
+    ).resolves.toBeUndefined();
+
+    expect(publishApproval.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          status: PublishApprovalStatus.QUEUED,
+        }),
+        where: expect.objectContaining({
+          status: PublishApprovalStatus.EXECUTING,
+          updatedAt: expired.updatedAt,
+        }),
+      }),
+    );
+  });
+
+  it('rejects completion from a stale execution lease', async () => {
+    const publishApproval = {
+      findFirst: vi.fn().mockResolvedValue(
+        makeApproval({
+          status: PublishApprovalStatus.EXECUTING,
+          updatedAt: NOW,
+        }),
+      ),
+      updateMany: vi.fn(),
+    };
+    const service = new PublishApprovalsService(
+      { publishApproval } as never,
+      {} as AgentArtifactReferenceService,
+    );
+
+    await expect(
+      service.completeExecution({
+        approvalId: 'approval-1',
+        executionStartedAt: '2026-07-13T21:59:00.000Z',
+        isSuccessful: true,
+        operationId: 'operation-1',
+        organizationId: 'org-1',
+        versionPinId: 'pin-1',
+      }),
+    ).rejects.toThrow('lease is stale or has been reclaimed');
+
+    expect(publishApproval.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('rejects a status transition that loses its optimistic-lock race', async () => {
+    const publishApproval = {
+      findFirst: vi
+        .fn()
+        .mockResolvedValue(
+          makeApproval({ status: PublishApprovalStatus.APPROVED }),
+        ),
+      updateMany: vi.fn().mockResolvedValue({ count: 0 }),
+    };
+    const service = new PublishApprovalsService(
+      { publishApproval } as never,
+      {} as AgentArtifactReferenceService,
+    );
+
+    await expect(service.markQueued('approval-1', 'org-1')).rejects.toThrow(
+      `changed concurrently; expected status ${PublishApprovalStatus.APPROVED}`,
     );
 
     expect(publishApproval.updateMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        data: expect.objectContaining({ status: completedStatus }),
+        where: {
+          id: 'approval-1',
+          organizationId: 'org-1',
+          status: PublishApprovalStatus.APPROVED,
+        },
       }),
     );
-    expect(logger.log).toHaveBeenCalledWith('conversation_shell_approval', {
-      action: 'execute',
-      integrity: 'matched',
-      organizationId: 'org-1',
-      outcome,
-      telemetryQueryVersion: 1,
+  });
+
+  it('clears every post approval marker when invalidating queued approval state', async () => {
+    const approval = makeApproval();
+    const post = { updateMany: vi.fn().mockResolvedValue({ count: 1 }) };
+    const publishApproval = {
+      findMany: vi.fn().mockResolvedValue([approval]),
+      update: vi.fn().mockResolvedValue(approval),
+    };
+    const prisma = {
+      $transaction: vi.fn(async (callback) =>
+        callback({ post, publishApproval }),
+      ),
+      publishApproval,
+    };
+    const service = new PublishApprovalsService(
+      prisma as never,
+      {} as AgentArtifactReferenceService,
+    );
+
+    await service.invalidatePost(
+      'org-1',
+      'post-1',
+      'Canonical publish scope changed.',
+      'user-1',
+    );
+
+    expect(post.updateMany).toHaveBeenCalledWith({
+      data: {
+        publishApprovalId: null,
+        reviewDecision: null,
+        reviewVersionPinId: null,
+      },
+      where: { id: 'post-1', organizationId: 'org-1' },
     });
   });
 

--- a/apps/server/api/src/collections/publish-approvals/services/publish-approvals.service.ts
+++ b/apps/server/api/src/collections/publish-approvals/services/publish-approvals.service.ts
@@ -1,5 +1,6 @@
 export {
   type ClaimPublishExecutionParams,
+  type CompletePublishExecutionParams,
   type CreateCurrentPostPublishApprovalParams,
   type CreatePostPublishApprovalParams,
   PublishApprovalsService,

--- a/apps/server/api/src/services/content-orchestration/content-pipeline-queue.service.ts
+++ b/apps/server/api/src/services/content-orchestration/content-pipeline-queue.service.ts
@@ -2,18 +2,18 @@ import type {
   BatchPipelineConfig,
   PipelineConfig,
 } from '@api/services/content-orchestration/content-orchestration.service';
-import { CONTENT_PIPELINE_QUEUE } from '@genfeedai/queue-contracts';
+import {
+  CONTENT_PIPELINE_QUEUE,
+  type ContentPipelineJobData,
+} from '@genfeedai/queue-contracts';
 import { LoggerService } from '@libs/logger/logger.service';
 import { InjectQueue } from '@nestjs/bullmq';
 import { Injectable } from '@nestjs/common';
 import { Queue } from 'bullmq';
 
-export interface ContentqueryJobData {
-  type: 'generate-and-publish' | 'batch-generate';
-  config: PipelineConfig | BatchPipelineConfig;
-  personaId: string;
-  organizationId: string;
-}
+type ContentPipelineJobDataWithConfig = ContentPipelineJobData<
+  PipelineConfig | BatchPipelineConfig
+>;
 
 @Injectable()
 export class ContentqueryQueueService {
@@ -28,7 +28,7 @@ export class ContentqueryQueueService {
 
     // Use idempotencyKey as BullMQ jobId to prevent duplicates on retry
     if (config.idempotencyKey) {
-      jobOptions['jobId'] = config.idempotencyKey;
+      jobOptions.jobId = config.idempotencyKey;
     }
 
     const job = await this.contentqueryQueue.add(
@@ -38,7 +38,7 @@ export class ContentqueryQueueService {
         organizationId: config.organizationId,
         personaId: config.personaId,
         type: 'generate-and-publish',
-      } satisfies ContentqueryJobData,
+      } satisfies ContentPipelineJobDataWithConfig,
       jobOptions,
     );
 
@@ -49,7 +49,7 @@ export class ContentqueryQueueService {
       stepCount: config.steps.length,
     });
 
-    return job.id!;
+    return this.requireJobId(job.id);
   }
 
   async queueBatchGenerate(config: BatchPipelineConfig): Promise<string> {
@@ -58,7 +58,7 @@ export class ContentqueryQueueService {
       organizationId: config.organizationId,
       personaId: config.personaId,
       type: 'batch-generate',
-    } satisfies ContentqueryJobData);
+    } satisfies ContentPipelineJobDataWithConfig);
 
     this.logger.log('Queued batch-generate job', {
       count: config.count,
@@ -66,7 +66,7 @@ export class ContentqueryQueueService {
       personaId: config.personaId,
     });
 
-    return job.id!;
+    return this.requireJobId(job.id);
   }
 
   async getJobsByPersona(
@@ -90,7 +90,7 @@ export class ContentqueryQueueService {
 
     return jobs
       .filter((job) => {
-        const data = job.data as ContentqueryJobData;
+        const data = job.data as ContentPipelineJobDataWithConfig;
         return (
           data.personaId === personaId && data.organizationId === organizationId
         );
@@ -98,11 +98,18 @@ export class ContentqueryQueueService {
       .slice(0, 50)
       .map((job) => ({
         createdAt: new Date(job.timestamp).toISOString(),
-        id: job.id!,
+        id: this.requireJobId(job.id),
         status:
           job.returnvalue?.status ?? (job.failedReason ? 'failed' : 'pending'),
-        type: (job.data as ContentqueryJobData).type,
+        type: (job.data as ContentPipelineJobDataWithConfig).type,
       }));
+  }
+
+  private requireJobId(jobId: string | undefined): string {
+    if (!jobId) {
+      throw new Error('Content pipeline queue did not return a job id.');
+    }
+    return jobId;
   }
 }
 

--- a/apps/server/api/src/services/content-orchestration/content-pipeline-queue.service.ts
+++ b/apps/server/api/src/services/content-orchestration/content-pipeline-queue.service.ts
@@ -8,7 +8,7 @@ import {
 } from '@genfeedai/queue-contracts';
 import { LoggerService } from '@libs/logger/logger.service';
 import { InjectQueue } from '@nestjs/bullmq';
-import { Injectable } from '@nestjs/common';
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
 import { Queue } from 'bullmq';
 
 type ContentPipelineJobDataWithConfig = ContentPipelineJobData<
@@ -107,7 +107,9 @@ export class ContentqueryQueueService {
 
   private requireJobId(jobId: string | undefined): string {
     if (!jobId) {
-      throw new Error('Content pipeline queue did not return a job id.');
+      throw new InternalServerErrorException(
+        'Content pipeline queue did not return a job id.',
+      );
     }
     return jobId;
   }

--- a/apps/server/server/src/index.ts
+++ b/apps/server/server/src/index.ts
@@ -77,6 +77,7 @@ export type {
 } from './collections/models/model-record.types';
 export {
   type ClaimPublishExecutionParams,
+  type CompletePublishExecutionParams,
   type CreateCurrentPostPublishApprovalParams,
   type CreatePostPublishApprovalParams,
   PublishApprovalsService,

--- a/apps/server/server/src/publish-approvals/publish-approvals.service.ts
+++ b/apps/server/server/src/publish-approvals/publish-approvals.service.ts
@@ -16,11 +16,16 @@ import {
   TargetExecutionState,
 } from '@genfeedai/enums';
 import type {
+  ClaimPublishExecutionParams,
+  CompletePublishExecutionParams,
+  CreateCurrentPostPublishApprovalParams,
+  CreatePostPublishApprovalParams,
   IPublishApproval,
   IPublishApprovalDestination,
   IPublishApprovalPolicy,
   IPublishApprovalStatusTransition,
   IPublishScheduleIntent,
+  PublishExecutionClaim,
 } from '@genfeedai/interfaces';
 import {
   type Prisma,
@@ -35,6 +40,14 @@ import {
 } from '@nestjs/common';
 import { AgentArtifactReferenceService } from '@server/agent-artifacts/agent-artifact-reference.service';
 import type { ServerLogger, ServerPrisma } from '@server/server.dependencies';
+
+export type {
+  ClaimPublishExecutionParams,
+  CompletePublishExecutionParams,
+  CreateCurrentPostPublishApprovalParams,
+  CreatePostPublishApprovalParams,
+  PublishExecutionClaim,
+} from '@genfeedai/interfaces';
 
 class PublishApprovalNotFoundException extends HttpException {
   constructor(resource: string, identifier: string) {
@@ -57,6 +70,13 @@ const ACTIVE_APPROVAL_STATUSES = [
   PublishApprovalStatus.EXECUTING,
   PublishApprovalStatus.FAILED,
 ] as const;
+
+const ACTIVATABLE_APPROVAL_STATUSES = [
+  ...ACTIVE_APPROVAL_STATUSES,
+  PublishApprovalStatus.PUBLISHED,
+] as const;
+
+const PUBLISH_EXECUTION_LEASE_MS = 15 * 60 * 1000;
 
 type PublishApprovalRow = {
   actorUserId: string;
@@ -102,37 +122,6 @@ type ApprovalPost = {
   timezone: string;
 };
 
-export interface CreatePostPublishApprovalParams {
-  actorUserId: string;
-  body: unknown;
-  organizationId: string;
-  provenance?: Record<string, unknown>;
-  transaction?: Prisma.TransactionClient;
-}
-
-export interface ClaimPublishExecutionParams {
-  approvalId: string;
-  operationId?: string;
-  organizationId: string;
-  postId: string;
-  versionPinId?: string;
-}
-
-export interface CreateCurrentPostPublishApprovalParams {
-  actorUserId: string;
-  contextVersion?: number;
-  mode: 'immediate' | 'scheduled';
-  organizationId: string;
-  postId: string;
-  provenance?: Record<string, unknown>;
-  transaction?: Prisma.TransactionClient;
-}
-
-export interface PublishExecutionClaim {
-  alreadyPublished: boolean;
-  approval: IPublishApproval;
-}
-
 export class PublishApprovalsService {
   constructor(
     private readonly prisma: Pick<
@@ -156,15 +145,21 @@ export class PublishApprovalsService {
     organizationId: string,
     postId: string,
   ): Promise<void> {
-    const executing = await this.prisma.publishApproval.findFirst({
-      select: { id: true },
+    const executing = (await this.prisma.publishApproval.findFirst({
       where: {
         organizationId,
         postId,
         status: PublishApprovalStatus.EXECUTING,
       },
-    });
+    })) as PublishApprovalRow | null;
     if (executing) {
+      if (
+        executing.updatedAt.getTime() + PUBLISH_EXECUTION_LEASE_MS <=
+        Date.now()
+      ) {
+        await this.resetExpiredExecution(executing);
+        return;
+      }
       throw new ConflictException(
         'Cannot edit approved publish scope while provider execution is in flight.',
       );
@@ -172,7 +167,7 @@ export class PublishApprovalsService {
   }
 
   async createForCurrentPost(
-    params: CreateCurrentPostPublishApprovalParams,
+    params: CreateCurrentPostPublishApprovalParams<Prisma.TransactionClient>,
   ): Promise<IPublishApproval> {
     const post = await this.getPostOrThrow(
       params.organizationId,
@@ -207,7 +202,7 @@ export class PublishApprovalsService {
   }
 
   async createForPost(
-    params: CreatePostPublishApprovalParams,
+    params: CreatePostPublishApprovalParams<Prisma.TransactionClient>,
   ): Promise<IPublishApproval> {
     const client = params.transaction ?? this.prisma;
     const input = this.parseCreateInput(params.body);
@@ -417,34 +412,37 @@ export class PublishApprovalsService {
     params: ClaimPublishExecutionParams,
   ): Promise<PublishExecutionClaim> {
     try {
-      const approval = await this.getApprovalOrThrow(
+      let approval = await this.getApprovalOrThrow(
         params.organizationId,
         params.approvalId,
         params.postId,
       );
-      if (params.operationId && params.operationId !== approval.operationId) {
+      if (params.operationId !== approval.operationId) {
         throw new ConflictException(
           'Queued publish operation identity is stale.',
         );
       }
-      if (
-        params.versionPinId &&
-        params.versionPinId !== approval.artifactVersionPinId
-      ) {
+      if (params.versionPinId !== approval.artifactVersionPinId) {
         throw new ConflictException(
           'Queued artifact version identity is stale.',
         );
       }
-      if (
-        this.parseStatus(approval.status) === PublishApprovalStatus.PUBLISHED
-      ) {
+      const initialStatus = this.parseStatus(approval.status);
+      if (initialStatus === PublishApprovalStatus.PUBLISHED) {
         this.recordApprovalTelemetry(
           'execute',
           'success',
           'matched',
           params.organizationId,
         );
-        return { alreadyPublished: true, approval: this.toInterface(approval) };
+        return {
+          approval: this.toInterface(approval),
+          executionStartedAt: null,
+          isAlreadyPublished: true,
+        };
+      }
+      if (initialStatus === PublishApprovalStatus.EXECUTING) {
+        approval = await this.resetExpiredExecution(approval);
       }
 
       const post = await this.getPostOrThrow(
@@ -480,8 +478,10 @@ export class PublishApprovalsService {
         throw error;
       }
 
+      const executionStartedAt = new Date();
       const claimed = await this.prisma.publishApproval.updateMany({
         data: {
+          lastError: null,
           status: PublishApprovalStatus.EXECUTING,
           statusTransitions: this.toJson([
             ...this.readTransitions(approval.statusTransitions),
@@ -490,11 +490,13 @@ export class PublishApprovalsService {
               PublishApprovalStatus.EXECUTING,
             ),
           ]),
+          updatedAt: executionStartedAt,
         },
         where: {
           id: approval.id,
           organizationId: approval.organizationId,
           status: PublishApprovalStatus.QUEUED,
+          updatedAt: approval.updatedAt,
         },
       });
       if (claimed.count !== 1) {
@@ -508,7 +510,11 @@ export class PublishApprovalsService {
         params.approvalId,
         params.postId,
       );
-      return { alreadyPublished: false, approval: this.toInterface(updated) };
+      return {
+        approval: this.toInterface(updated),
+        executionStartedAt: updated.updatedAt.toISOString(),
+        isAlreadyPublished: false,
+      };
     } catch (error: unknown) {
       this.recordApprovalTelemetry(
         'execute',
@@ -521,23 +527,14 @@ export class PublishApprovalsService {
   }
 
   async completeExecution(
-    approvalId: string,
-    organizationId: string,
-    success: boolean,
-    error?: string,
+    params: CompletePublishExecutionParams,
   ): Promise<IPublishApproval> {
-    const approval = await this.transitionStatus(
-      approvalId,
-      organizationId,
-      success ? PublishApprovalStatus.PUBLISHED : PublishApprovalStatus.FAILED,
-      undefined,
-      error,
-    );
+    const approval = await this.completeClaimedExecution(params);
     this.recordApprovalTelemetry(
       'execute',
-      success ? 'success' : 'failure',
+      params.isSuccessful ? 'success' : 'failure',
       'matched',
-      organizationId,
+      params.organizationId,
     );
     return approval;
   }
@@ -608,6 +605,133 @@ export class PublishApprovalsService {
       'success',
       'not_applicable',
       organizationId,
+    );
+  }
+
+  private async completeClaimedExecution(
+    params: CompletePublishExecutionParams,
+  ): Promise<IPublishApproval> {
+    const current = await this.getApprovalOrThrow(
+      params.organizationId,
+      params.approvalId,
+    );
+    if (current.operationId !== params.operationId) {
+      throw new ConflictException(
+        'Publish completion operation identity is stale.',
+      );
+    }
+    if (current.artifactVersionPinId !== params.versionPinId) {
+      throw new ConflictException(
+        'Publish completion artifact version identity is stale.',
+      );
+    }
+
+    const from = this.parseStatus(current.status);
+    const next = params.isSuccessful
+      ? PublishApprovalStatus.PUBLISHED
+      : PublishApprovalStatus.FAILED;
+    if (from === next) {
+      return this.toInterface(current);
+    }
+    if (from !== PublishApprovalStatus.EXECUTING) {
+      throw new ConflictException(
+        `Publish approval cannot complete from ${from}.`,
+      );
+    }
+
+    const executionStartedAt = this.parseExecutionStartedAt(
+      params.executionStartedAt,
+    );
+    if (current.updatedAt.getTime() !== executionStartedAt.getTime()) {
+      throw new ConflictException(
+        'Publish execution lease is stale or has been reclaimed.',
+      );
+    }
+
+    const failureReason = params.isSuccessful
+      ? undefined
+      : (params.error ?? 'Provider execution failed.');
+    const completed = await this.prisma.publishApproval.updateMany({
+      data: {
+        ...(params.isSuccessful ? { executedAt: new Date() } : {}),
+        lastError: failureReason ?? null,
+        status: next,
+        statusTransitions: this.toJson([
+          ...this.readTransitions(current.statusTransitions),
+          this.transition(from, next, undefined, failureReason),
+        ]),
+      },
+      where: {
+        artifactVersionPinId: params.versionPinId,
+        id: current.id,
+        operationId: params.operationId,
+        organizationId: params.organizationId,
+        status: PublishApprovalStatus.EXECUTING,
+        updatedAt: executionStartedAt,
+      },
+    });
+    if (completed.count !== 1) {
+      throw new ConflictException(
+        'Publish execution lease changed before completion.',
+      );
+    }
+
+    const updated = await this.getApprovalOrThrow(
+      params.organizationId,
+      params.approvalId,
+    );
+    return this.toInterface(updated);
+  }
+
+  private async resetExpiredExecution(
+    approval: PublishApprovalRow,
+  ): Promise<PublishApprovalRow> {
+    const expiresAt = approval.updatedAt.getTime() + PUBLISH_EXECUTION_LEASE_MS;
+    if (expiresAt > Date.now()) {
+      throw new ConflictException(
+        'Publish approval is already executing with an active lease.',
+      );
+    }
+
+    const resetAt = new Date();
+    const reason = 'Expired publish execution lease was reset for retry.';
+    const reset = await this.prisma.publishApproval.updateMany({
+      data: {
+        lastError: reason,
+        status: PublishApprovalStatus.QUEUED,
+        statusTransitions: this.toJson([
+          ...this.readTransitions(approval.statusTransitions),
+          this.transition(
+            PublishApprovalStatus.EXECUTING,
+            PublishApprovalStatus.FAILED,
+            undefined,
+            reason,
+          ),
+          this.transition(
+            PublishApprovalStatus.FAILED,
+            PublishApprovalStatus.QUEUED,
+            undefined,
+            'Retry queued after expired execution lease.',
+          ),
+        ]),
+        updatedAt: resetAt,
+      },
+      where: {
+        id: approval.id,
+        organizationId: approval.organizationId,
+        status: PublishApprovalStatus.EXECUTING,
+        updatedAt: approval.updatedAt,
+      },
+    });
+    if (reset.count !== 1) {
+      throw new ConflictException(
+        'Publish execution lease changed before it could be reset.',
+      );
+    }
+    return this.getApprovalOrThrow(
+      approval.organizationId,
+      approval.id,
+      approval.postId,
     );
   }
 
@@ -776,23 +900,30 @@ export class PublishApprovalsService {
     approval: PublishApprovalRow,
     client: PublishApprovalTransaction = this.prisma,
   ): Promise<void> {
-    const status = this.parseStatus(approval.status);
-    if (
-      status === PublishApprovalStatus.INVALIDATED ||
-      status === PublishApprovalStatus.CANCELLED
-    ) {
-      throw new ConflictException(
-        'The matching approval was revoked; create a new version before approval.',
-      );
-    }
-    await client.post.update({
+    const activated = await client.post.updateMany({
       data: {
         publishApprovalId: approval.id,
         reviewDecision: 'APPROVED',
         reviewVersionPinId: approval.artifactVersionPinId,
       },
-      where: { id: post.id },
+      where: {
+        id: post.id,
+        isDeleted: false,
+        organizationId: post.organizationId,
+        publishApprovals: {
+          some: {
+            id: approval.id,
+            organizationId: approval.organizationId,
+            status: { in: [...ACTIVATABLE_APPROVAL_STATUSES] },
+          },
+        },
+      },
     });
+    if (activated.count !== 1) {
+      throw new ConflictException(
+        'The matching approval is no longer eligible for activation.',
+      );
+    }
   }
 
   private async getPostOrThrow(
@@ -927,6 +1058,16 @@ export class PublishApprovalsService {
       );
     }
     return result.data;
+  }
+
+  private parseExecutionStartedAt(value: string): Date {
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime()) || parsed.toISOString() !== value) {
+      throw new ConflictException(
+        'Publish execution lease timestamp is invalid.',
+      );
+    }
+    return parsed;
   }
 
   private readDestinations(

--- a/apps/server/server/src/publish-approvals/publish-approvals.service.ts
+++ b/apps/server/server/src/publish-approvals/publish-approvals.service.ts
@@ -647,6 +647,12 @@ export class PublishApprovalsService {
         'Publish execution lease is stale or has been reclaimed.',
       );
     }
+    if (
+      executionStartedAt.getTime() + PUBLISH_EXECUTION_LEASE_MS <=
+      Date.now()
+    ) {
+      throw new ConflictException('Publish execution lease has expired.');
+    }
 
     const failureReason = params.isSuccessful
       ? undefined

--- a/apps/server/workers/src/crons/posts/cron.posts.service.spec.ts
+++ b/apps/server/workers/src/crons/posts/cron.posts.service.spec.ts
@@ -93,7 +93,10 @@ describe('CronPostsService', () => {
       }),
     };
     publishApprovalsService = {
-      claimForExecution: vi.fn().mockResolvedValue({ alreadyPublished: false }),
+      claimForExecution: vi.fn().mockResolvedValue({
+        executionStartedAt: '2026-07-07T09:56:00.000Z',
+        isAlreadyPublished: false,
+      }),
       completeExecution: vi.fn().mockResolvedValue(undefined),
       markQueued: vi.fn().mockResolvedValue(undefined),
     };
@@ -661,6 +664,14 @@ describe('CronPostsService', () => {
         url: 'https://x.com/example/status/tweet-1',
       }),
     );
+    expect(publishApprovalsService.completeExecution).toHaveBeenCalledWith({
+      approvalId: 'approval-1',
+      executionStartedAt: '2026-07-07T09:56:00.000Z',
+      isSuccessful: true,
+      operationId: 'operation-1',
+      organizationId: 'org-1',
+      versionPinId: 'pin-1',
+    });
   });
 
   it('persists a grouped provider success even when the provider omits its id', async () => {

--- a/apps/server/workers/src/crons/posts/cron.posts.service.spec.ts
+++ b/apps/server/workers/src/crons/posts/cron.posts.service.spec.ts
@@ -417,6 +417,15 @@ describe('CronPostsService', () => {
     );
     expect(credentialsService.findOne).not.toHaveBeenCalled();
     expect(publisherFactory.getPublisher).not.toHaveBeenCalled();
+    expect(publishApprovalsService.completeExecution).toHaveBeenCalledWith({
+      approvalId: 'approval-1',
+      error: 'Canonical Post digest no longer matches pin.',
+      executionStartedAt: '2026-07-07T09:56:00.000Z',
+      isSuccessful: false,
+      operationId: 'operation-1',
+      organizationId: 'org-1',
+      versionPinId: 'pin-1',
+    });
   });
 
   it('rejects a queued pin when the durable Post pin was removed', async () => {

--- a/apps/server/workers/src/crons/posts/cron.posts.service.ts
+++ b/apps/server/workers/src/crons/posts/cron.posts.service.ts
@@ -181,20 +181,25 @@ export class CronPostsService {
     job: PostPublishJobData,
   ): Promise<PublishResult> {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
+    const { approvalId, operationId, versionPinId } = job;
+    if (!approvalId || !operationId || !versionPinId) {
+      return this.handleTerminalPublishValidationFailure(
+        post,
+        new Error(
+          'Publish execution requires an explicit version-bound approval identity.',
+        ),
+      );
+    }
+
     let executionStartedAt = '';
     try {
-      if (!job.approvalId || !job.operationId || !job.versionPinId) {
-        throw new Error(
-          'Publish execution requires an explicit version-bound approval identity.',
-        );
-      }
       await this.assertAgentPublishingScope(post);
       const claim = await this.publishApprovalsService.claimForExecution({
-        approvalId: job.approvalId,
-        operationId: job.operationId,
+        approvalId,
+        operationId,
         organizationId: job.organizationId,
         postId: job.postId,
-        versionPinId: job.versionPinId,
+        versionPinId,
       });
       if (claim.isAlreadyPublished) {
         return {
@@ -209,26 +214,26 @@ export class CronPostsService {
         throw new Error('Publish execution claim did not return a lease.');
       }
       executionStartedAt = claim.executionStartedAt;
-      await this.assertPublishVersionPin(post, job.versionPinId);
+      await this.assertPublishVersionPin(post, versionPinId);
     } catch (error: unknown) {
       if (executionStartedAt) {
         const errorMessage =
           error instanceof Error ? error.message : 'Publish validation failed';
         try {
           await this.publishApprovalsService.completeExecution({
-            approvalId: job.approvalId,
+            approvalId,
             error: errorMessage,
             executionStartedAt,
             isSuccessful: false,
-            operationId: job.operationId,
+            operationId,
             organizationId: job.organizationId,
-            versionPinId: job.versionPinId,
+            versionPinId,
           });
         } catch (completionError: unknown) {
           this.logger.error(
             'Failed to release publish approval after validation rejection',
             {
-              approvalId: job.approvalId,
+              approvalId,
               error:
                 completionError instanceof Error
                   ? completionError.message
@@ -243,13 +248,13 @@ export class CronPostsService {
     const result = await this.publishSinglePost(post);
 
     await this.publishApprovalsService.completeExecution({
-      approvalId: job.approvalId,
+      approvalId,
       ...(result.error ? { error: result.error } : {}),
       executionStartedAt,
       isSuccessful: result.success,
-      operationId: job.operationId,
+      operationId,
       organizationId: job.organizationId,
-      versionPinId: job.versionPinId,
+      versionPinId,
     });
 
     if (result.success) {

--- a/apps/server/workers/src/crons/posts/cron.posts.service.ts
+++ b/apps/server/workers/src/crons/posts/cron.posts.service.ts
@@ -181,6 +181,7 @@ export class CronPostsService {
     job: PostPublishJobData,
   ): Promise<PublishResult> {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
+    let executionStartedAt = '';
     try {
       if (!job.approvalId || !job.operationId || !job.versionPinId) {
         throw new Error(
@@ -195,7 +196,7 @@ export class CronPostsService {
         postId: job.postId,
         versionPinId: job.versionPinId,
       });
-      if (claim.alreadyPublished) {
+      if (claim.isAlreadyPublished) {
         return {
           externalId: this.readPostString(post, ['externalId']) ?? null,
           platform: post.platform,
@@ -204,18 +205,25 @@ export class CronPostsService {
           url: this.readPostString(post, ['url']) ?? '',
         };
       }
+      if (!claim.executionStartedAt) {
+        throw new Error('Publish execution claim did not return a lease.');
+      }
+      executionStartedAt = claim.executionStartedAt;
       await this.assertPublishVersionPin(post, job.versionPinId);
     } catch (error: unknown) {
       return this.handleTerminalPublishValidationFailure(post, error);
     }
     const result = await this.publishSinglePost(post);
 
-    await this.publishApprovalsService.completeExecution(
-      job.approvalId,
-      job.organizationId,
-      result.success,
-      result.error,
-    );
+    await this.publishApprovalsService.completeExecution({
+      approvalId: job.approvalId,
+      ...(result.error ? { error: result.error } : {}),
+      executionStartedAt,
+      isSuccessful: result.success,
+      operationId: job.operationId,
+      organizationId: job.organizationId,
+      versionPinId: job.versionPinId,
+    });
 
     if (result.success) {
       await this.activitiesService.create(

--- a/apps/server/workers/src/crons/posts/cron.posts.service.ts
+++ b/apps/server/workers/src/crons/posts/cron.posts.service.ts
@@ -211,6 +211,33 @@ export class CronPostsService {
       executionStartedAt = claim.executionStartedAt;
       await this.assertPublishVersionPin(post, job.versionPinId);
     } catch (error: unknown) {
+      if (executionStartedAt) {
+        const errorMessage =
+          error instanceof Error ? error.message : 'Publish validation failed';
+        try {
+          await this.publishApprovalsService.completeExecution({
+            approvalId: job.approvalId,
+            error: errorMessage,
+            executionStartedAt,
+            isSuccessful: false,
+            operationId: job.operationId,
+            organizationId: job.organizationId,
+            versionPinId: job.versionPinId,
+          });
+        } catch (completionError: unknown) {
+          this.logger.error(
+            'Failed to release publish approval after validation rejection',
+            {
+              approvalId: job.approvalId,
+              error:
+                completionError instanceof Error
+                  ? completionError.message
+                  : 'Unknown publish completion error',
+              postId: post.id,
+            },
+          );
+        }
+      }
       return this.handleTerminalPublishValidationFailure(post, error);
     }
     const result = await this.publishSinglePost(post);

--- a/apps/server/workers/src/processors/api/services/content-orchestration/content-pipeline.processor.spec.ts
+++ b/apps/server/workers/src/processors/api/services/content-orchestration/content-pipeline.processor.spec.ts
@@ -1,6 +1,6 @@
 import { ContentOrchestrationService } from '@api/services/content-orchestration/content-orchestration.service';
-import type { ContentqueryJobData } from '@api/services/content-orchestration/content-pipeline-queue.service';
 import { ImageTaskModel } from '@genfeedai/enums';
+import type { ContentPipelineJobData } from '@genfeedai/queue-contracts';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Test, TestingModule } from '@nestjs/testing';
 import { ContentPipelineProcessor } from '@workers/processors/api/services/content-orchestration/content-pipeline.processor';
@@ -83,7 +83,7 @@ describe('ContentPipelineProcessor', () => {
       };
 
       const result = await processor.process(
-        job as unknown as Job<ContentqueryJobData>,
+        job as unknown as Job<ContentPipelineJobData>,
       );
 
       expect(result).toEqual(expect.objectContaining({ status: 'completed' }));
@@ -118,7 +118,7 @@ describe('ContentPipelineProcessor', () => {
       };
 
       const result = await processor.process(
-        job as unknown as Job<ContentqueryJobData>,
+        job as unknown as Job<ContentPipelineJobData>,
       );
 
       expect(result).toEqual(
@@ -147,7 +147,7 @@ describe('ContentPipelineProcessor', () => {
       };
 
       await expect(
-        processor.process(job as unknown as Job<ContentqueryJobData>),
+        processor.process(job as unknown as Job<ContentPipelineJobData>),
       ).rejects.toThrow('Processing failed');
     });
 
@@ -163,7 +163,7 @@ describe('ContentPipelineProcessor', () => {
       };
 
       await expect(
-        processor.process(job as unknown as Job<ContentqueryJobData>),
+        processor.process(job as unknown as Job<ContentPipelineJobData>),
       ).rejects.toThrow('Unknown content pipeline job type');
     });
   });

--- a/apps/server/workers/src/processors/api/services/content-orchestration/content-pipeline.processor.ts
+++ b/apps/server/workers/src/processors/api/services/content-orchestration/content-pipeline.processor.ts
@@ -3,8 +3,10 @@ import {
   ContentOrchestrationService,
   type PipelineConfig,
 } from '@api/services/content-orchestration/content-orchestration.service';
-import { ContentqueryJobData } from '@api/services/content-orchestration/content-pipeline-queue.service';
-import { CONTENT_PIPELINE_QUEUE } from '@genfeedai/queue-contracts';
+import {
+  CONTENT_PIPELINE_QUEUE,
+  type ContentPipelineJobData,
+} from '@genfeedai/queue-contracts';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Processor, WorkerHost } from '@nestjs/bullmq';
 import { Job } from 'bullmq';
@@ -23,7 +25,7 @@ export class ContentqueryProcessor extends WorkerHost {
     super();
   }
 
-  async process(job: Job<ContentqueryJobData>): Promise<unknown> {
+  async process(job: Job<ContentPipelineJobData>): Promise<unknown> {
     const { data } = job;
     const caller = `${this.logContext} process`;
 

--- a/packages/interfaces/src/publisher/publish-approval.interface.ts
+++ b/packages/interfaces/src/publisher/publish-approval.interface.ts
@@ -49,3 +49,47 @@ export interface IPublishApproval {
   statusTransitions: IPublishApprovalStatusTransition[];
   updatedAt: string;
 }
+
+export interface ClaimPublishExecutionParams {
+  approvalId: string;
+  operationId: string;
+  organizationId: string;
+  postId: string;
+  versionPinId: string;
+}
+
+export interface CompletePublishExecutionParams {
+  approvalId: string;
+  error?: string;
+  executionStartedAt: string;
+  isSuccessful: boolean;
+  operationId: string;
+  organizationId: string;
+  versionPinId: string;
+}
+
+export interface CreateCurrentPostPublishApprovalParams<
+  TTransaction = unknown,
+> {
+  actorUserId: string;
+  contextVersion?: number;
+  mode: 'immediate' | 'scheduled';
+  organizationId: string;
+  postId: string;
+  provenance?: Record<string, unknown>;
+  transaction?: TTransaction;
+}
+
+export interface CreatePostPublishApprovalParams<TTransaction = unknown> {
+  actorUserId: string;
+  body: unknown;
+  organizationId: string;
+  provenance?: Record<string, unknown>;
+  transaction?: TTransaction;
+}
+
+export interface PublishExecutionClaim {
+  approval: IPublishApproval;
+  executionStartedAt: string | null;
+  isAlreadyPublished: boolean;
+}

--- a/packages/queue-contracts/src/job-data/content-pipeline-job.interface.ts
+++ b/packages/queue-contracts/src/job-data/content-pipeline-job.interface.ts
@@ -1,0 +1,12 @@
+/**
+ * Content pipeline queue contract.
+ *
+ * The API owns the concrete pipeline configuration while this shared envelope
+ * keeps queue producers, workers, and tests independent from the API app.
+ */
+export interface ContentPipelineJobData<TConfig = unknown> {
+  config: TConfig;
+  organizationId: string;
+  personaId: string;
+  type: 'generate-and-publish' | 'batch-generate';
+}

--- a/packages/queue-contracts/src/job-data/index.ts
+++ b/packages/queue-contracts/src/job-data/index.ts
@@ -14,6 +14,7 @@ export * from './campaign-job.interface';
 export * from './clip-analyze-job.interface';
 export * from './clip-factory-job.interface';
 export * from './content-optimization-job.interface';
+export * from './content-pipeline-job.interface';
 export * from './credit-deduction-job.interface';
 export * from './email-digest-job.interface';
 export * from './heygen-poll-job.interface';

--- a/scripts/architecture/workers-api-imports.baseline.ts
+++ b/scripts/architecture/workers-api-imports.baseline.ts
@@ -126,7 +126,6 @@ export const WORKERS_API_IMPORT_BASELINE: readonly string[] = [
   '@api/services/content-optimization/content-optimization.service',
   '@api/services/content-orchestration/content-orchestration.module',
   '@api/services/content-orchestration/content-orchestration.service',
-  '@api/services/content-orchestration/content-pipeline-queue.service',
   '@api/services/distribution/telegram/telegram-distribution.module',
   '@api/services/distribution/telegram/telegram-distribution.service',
   '@api/services/integrations/facebook/facebook.module',


### PR DESCRIPTION
## Summary

- atomically re-check approval eligibility when attaching an idempotent approval to a post
- require operation and version-pin identities, add a 15-minute execution lease with expired-state recovery, and reject stale completion writes
- move publish-approval service contracts into `@genfeedai/interfaces` and the content-pipeline job envelope into `@genfeedai/queue-contracts`
- expand focused regression coverage for idempotency, claim races, lease recovery, stale completion, optimistic transitions, marker clearing, and destination authorization

## Related issue

Closes #1724

## Verification

Passed locally:

- `bunx @biomejs/biome check <12 touched TypeScript files>`
- `bun scripts/run-secretlint.ts --no-glob <13 touched files>`
- `bun scripts/check-package-api-surface.ts --base-ref origin/master`
- `git diff --cached --check`
- staged sensitive-filename and credential-pattern scans
- static assertions confirm the inline service interfaces and API-local content-pipeline payload are removed

Skipped or blocked locally:

- unit tests, typecheck, and build are delegated to PR CI by workstation policy
- `bun scripts/check-di-value-imports.ts` and `bun run check:architecture` cannot start their TypeScript AST guards under Bun 1.3.14 because the runtime import exposes `ts.ScriptTarget` as undefined; the non-AST architecture guards passed

## Residual risk

The lease uses the approval row's `updatedAt` as its compare-and-swap token. A provider call that remains alive beyond 15 minutes could overlap a reclaimed attempt; completion state is protected, while provider-side duplicate prevention still depends on the existing stable operation identity and provider behavior.

## Checklist

- [x] Final diff reviewed for correctness, concurrency, security, regressions, dead code, and unrelated changes.
- [x] Public package changes include a migration note.
- [x] No schema migration, deployment, production operation, or external configuration change.
- [x] No secrets, credentials, customer data, or generated artifacts included.
