### PR TITLE
fix(docker): derive server workspace closure

### DIFF
--- a/docker/Dockerfile.server
+++ b/docker/Dockerfile.server
@@ -42,68 +42,27 @@ ENV NODE_OPTIONS=--max-old-space-size=4096
 
 WORKDIR /usr/src/app
 
-# Copy the root manifest. The server image installs against a reduced
-# server-only workspace graph, so the repo-wide lockfile is not valid here.
-COPY package.json ./
-
-# Narrow the workspace graph to the packages needed for the unified server
-# image so Bun does not try to resolve unrelated web/mobile/extension apps.
-RUN node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json','utf8')); p.workspaces=['apps/server/*','packages/agent','packages/api-types','packages/auth-client','packages/client','packages/config','packages/constants','packages/contexts','packages/enums','packages/harness','packages/helpers','packages/hooks','packages/integrations','packages/interfaces','packages/models','packages/pricing','packages/prisma','packages/props','packages/queue-contracts','packages/serializers','packages/services','packages/storage','packages/tools','packages/types','packages/ui','packages/utils','packages/workflows','ee/packages/billing']; if (p.scripts) delete p.scripts.postinstall; if (p.dependencies?.resend==='^6.9.3') p.dependencies.resend='6.9.3'; fs.writeFileSync('package.json', JSON.stringify(p, null, 2)+'\n');"
-
-# Copy all 12 service package.json files for bun workspace resolution
-COPY apps/server/api/package.json ./apps/server/api/
-COPY apps/server/files/package.json ./apps/server/files/
-COPY apps/server/workers/package.json ./apps/server/workers/
-COPY apps/server/mcp/package.json ./apps/server/mcp/
-COPY apps/server/notifications/package.json ./apps/server/notifications/
-COPY apps/server/telegram/package.json ./apps/server/telegram/
-COPY apps/server/discord/package.json ./apps/server/discord/
-COPY apps/server/slack/package.json ./apps/server/slack/
-COPY apps/server/images/package.json ./apps/server/images/
-COPY apps/server/voices/package.json ./apps/server/voices/
-COPY apps/server/videos/package.json ./apps/server/videos/
-
-# Copy remaining workspace package.json files for Bun workspace resolution.
-# Match the reduced server-only workspace globs exactly.
-RUN --mount=type=bind,source=.,target=/ctx \
-    for f in \
-      /ctx/packages/agent/package.json \
-      /ctx/packages/api-types/package.json \
-      /ctx/packages/auth-client/package.json \
-      /ctx/packages/client/package.json \
-      /ctx/packages/config/package.json \
-      /ctx/packages/constants/package.json \
-      /ctx/packages/contexts/package.json \
-      /ctx/packages/enums/package.json \
-      /ctx/packages/harness/package.json \
-      /ctx/packages/helpers/package.json \
-      /ctx/packages/hooks/package.json \
-      /ctx/packages/integrations/package.json \
-      /ctx/packages/interfaces/package.json \
-      /ctx/packages/models/package.json \
-      /ctx/packages/pricing/package.json \
-      /ctx/packages/prisma/package.json \
-      /ctx/packages/props/package.json \
-      /ctx/packages/queue-contracts/package.json \
-      /ctx/packages/serializers/package.json \
-      /ctx/packages/services/package.json \
-      /ctx/packages/storage/package.json \
-      /ctx/packages/tools/package.json \
-      /ctx/packages/types/package.json \
-      /ctx/packages/ui/package.json \
-      /ctx/packages/utils/package.json \
-      /ctx/packages/workflows/package.json \
-      /ctx/ee/packages/billing/package.json \
-      /ctx/apps/server/*/package.json; do \
-      [ -f "$f" ] || continue; \
-      dir=$(echo "$f" | sed 's|^/ctx/||; s|/package.json$||'); \
-      mkdir -p "$dir" && cp "$f" "$dir/package.json"; \
-    done
+# Build the reduced server-only workspace graph from every apps/server/*
+# workspace plus its transitive local dependencies. EE billing is an explicit
+# build-flavor seed because webpack source-aliases it without an API manifest
+# dependency. The generated manifest-only tree keeps both paths out of a
+# handwritten Docker allowlist.
+RUN --mount=type=bind,source=.,target=/ctx,ro \
+    bun /ctx/scripts/docker/prepare-server-workspace.ts \
+      --repo-root /ctx \
+      --output-root /usr/src/app \
+      --seed-workspace ee/packages/billing
 
 # @genfeedai/prisma runs `prisma generate` during install, so its schema must
 # exist in the manifest-only dependency layer.
 COPY packages/prisma/prisma.config.mjs ./packages/prisma/prisma.config.mjs
 COPY packages/prisma/prisma/ ./packages/prisma/prisma/
+
+# Snapshot the manifest-only tree before bun install can add workspace-local
+# install artifacts. The production stage copies this clean tree, including the
+# Prisma schema required by `prisma migrate deploy`.
+RUN mkdir -p /server-workspace-manifests && \
+    cp -a package.json apps packages ee /server-workspace-manifests/
 
 # Root patchedDependencies are resolved during bun install, before the full
 # source tree is copied into the builder stage.
@@ -253,86 +212,17 @@ ENV PATH="/usr/local/bin:${PATH}"
 
 WORKDIR /usr/src/app
 
-# Create workspace directory structure for bun workspace resolution
-RUN mkdir -p apps/server/api \
-             apps/server/files \
-             apps/server/workers \
-             apps/server/mcp \
-             apps/server/notifications \
-             apps/server/telegram \
-             apps/server/discord \
-             apps/server/slack \
-             apps/server/images \
-             apps/server/voices \
-             apps/server/videos \
-             packages/agent \
-             packages/auth-client \
-             packages/client \
-             packages/config \
-             packages/constants \
-             packages/enums \
-             packages/harness \
-             packages/helpers \
-             packages/integrations \
-             packages/interfaces \
-             packages/models \
-             packages/pricing \
-             packages/prisma \
-             packages/props \
-             packages/serializers \
-             packages/services \
-             packages/storage \
-             packages/tools \
-             packages/types \
-             packages/utils \
-             packages/workflows \
-             ee/packages/billing
+# Copy the generated manifest-only workspace tree from base. This keeps
+# production workspace resolution in lockstep with the install graph without
+# copying shared-package source into the runtime image.
+COPY --from=base /server-workspace-manifests/package.json ./package.json
+COPY --from=base /server-workspace-manifests/apps/server/ ./apps/server/
+COPY --from=base /server-workspace-manifests/packages/ ./packages/
+COPY --from=base /server-workspace-manifests/ee/ ./ee/
 
-# Copy built artifacts and production dependencies from builder
+# Copy built artifacts and production dependencies from builder.
 COPY --from=builder /usr/src/app/apps/server/dist ./apps/server/dist
 COPY --from=builder /usr/src/app/node_modules ./node_modules
-COPY --from=builder /usr/src/app/package.json ./package.json
-
-# Prisma schema, migrations, and config — required so `prisma migrate deploy`
-# can run from this image at deploy time (production stage is otherwise dist-only).
-# (The hoisted install above puts the prisma CLI / prisma/config in the root
-# node_modules, so no per-package node_modules copy is needed.)
-COPY --from=builder /usr/src/app/packages/prisma/prisma ./packages/prisma/prisma
-COPY --from=builder /usr/src/app/packages/prisma/prisma.config.mjs ./packages/prisma/prisma.config.mjs
-
-# Copy all 12 service package.json files for bun workspace resolution
-COPY --from=builder /usr/src/app/apps/server/api/package.json ./apps/server/api/package.json
-COPY --from=builder /usr/src/app/apps/server/files/package.json ./apps/server/files/package.json
-COPY --from=builder /usr/src/app/apps/server/workers/package.json ./apps/server/workers/package.json
-COPY --from=builder /usr/src/app/apps/server/mcp/package.json ./apps/server/mcp/package.json
-COPY --from=builder /usr/src/app/apps/server/notifications/package.json ./apps/server/notifications/package.json
-COPY --from=builder /usr/src/app/apps/server/telegram/package.json ./apps/server/telegram/package.json
-COPY --from=builder /usr/src/app/apps/server/discord/package.json ./apps/server/discord/package.json
-COPY --from=builder /usr/src/app/apps/server/slack/package.json ./apps/server/slack/package.json
-COPY --from=builder /usr/src/app/apps/server/images/package.json ./apps/server/images/package.json
-COPY --from=builder /usr/src/app/apps/server/voices/package.json ./apps/server/voices/package.json
-COPY --from=builder /usr/src/app/apps/server/videos/package.json ./apps/server/videos/package.json
-COPY --from=builder /usr/src/app/packages/auth-client/package.json ./packages/auth-client/package.json
-COPY --from=builder /usr/src/app/packages/client/package.json ./packages/client/package.json
-COPY --from=builder /usr/src/app/packages/config/package.json ./packages/config/package.json
-COPY --from=builder /usr/src/app/packages/constants/package.json ./packages/constants/package.json
-COPY --from=builder /usr/src/app/packages/enums/package.json ./packages/enums/package.json
-COPY --from=builder /usr/src/app/packages/harness/package.json ./packages/harness/package.json
-COPY --from=builder /usr/src/app/packages/helpers/package.json ./packages/helpers/package.json
-COPY --from=builder /usr/src/app/packages/integrations/package.json ./packages/integrations/package.json
-COPY --from=builder /usr/src/app/packages/interfaces/package.json ./packages/interfaces/package.json
-COPY --from=builder /usr/src/app/packages/models/package.json ./packages/models/package.json
-COPY --from=builder /usr/src/app/packages/pricing/package.json ./packages/pricing/package.json
-COPY --from=builder /usr/src/app/packages/prisma/package.json ./packages/prisma/package.json
-COPY --from=builder /usr/src/app/packages/props/package.json ./packages/props/package.json
-COPY --from=builder /usr/src/app/packages/serializers/package.json ./packages/serializers/package.json
-COPY --from=builder /usr/src/app/packages/services/package.json ./packages/services/package.json
-COPY --from=builder /usr/src/app/packages/storage/package.json ./packages/storage/package.json
-COPY --from=builder /usr/src/app/packages/tools/package.json ./packages/tools/package.json
-COPY --from=builder /usr/src/app/packages/types/package.json ./packages/types/package.json
-COPY --from=builder /usr/src/app/packages/utils/package.json ./packages/utils/package.json
-COPY --from=builder /usr/src/app/packages/workflows/package.json ./packages/workflows/package.json
-COPY --from=builder /usr/src/app/ee/packages/billing/package.json ./ee/packages/billing/package.json
 
 # Create non-root user for security (with a real, writable home — spawned
 # tools like yt-dlp/whisper write caches to $HOME and EACCES otherwise)
@@ -351,18 +241,7 @@ RUN mkdir -p /usr/src/app/public/tmp \
         /usr/src/app/apps/server/files/logs && \
     chown appuser:appuser /usr/src/app && \
     chown -R appuser:appuser \
-        /usr/src/app/apps/server/dist \
-        /usr/src/app/apps/server/api \
-        /usr/src/app/apps/server/discord \
-        /usr/src/app/apps/server/files \
-        /usr/src/app/apps/server/images \
-        /usr/src/app/apps/server/mcp \
-        /usr/src/app/apps/server/notifications \
-        /usr/src/app/apps/server/slack \
-        /usr/src/app/apps/server/telegram \
-        /usr/src/app/apps/server/videos \
-        /usr/src/app/apps/server/voices \
-        /usr/src/app/apps/server/workers \
+        /usr/src/app/apps/server \
         /usr/src/app/public
 
 # RDS CA bundle — PrismaService passes this CA to PrismaPg for RDS DATABASE_URLs;

--- a/scripts/docker/prepare-server-workspace.test.ts
+++ b/scripts/docker/prepare-server-workspace.test.ts
@@ -1,0 +1,194 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  prepareServerWorkspace,
+  resolveServerWorkspaceClosure,
+} from './prepare-server-workspace';
+
+type TestManifest = {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  name: string;
+  optionalDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  private?: boolean;
+};
+
+describe('prepare-server-workspace', () => {
+  let outputRoot = '';
+  let repoRoot = '';
+  let testRoot = '';
+
+  beforeEach(() => {
+    testRoot = mkdtempSync(path.join(tmpdir(), 'server-workspace-'));
+    repoRoot = path.join(testRoot, 'repo');
+    outputRoot = path.join(testRoot, 'output');
+    mkdirSync(repoRoot, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(testRoot, { force: true, recursive: true });
+  });
+
+  it('derives the transitive closure from every server workspace', () => {
+    writeRootManifest({
+      dependencies: {
+        '@genfeedai/root-runtime': 'workspace:*',
+        resend: '^6.9.3',
+      },
+      scripts: {
+        postinstall: 'scripts/setup-skills.sh',
+        test: 'vitest',
+      },
+      workspaces: ['apps/server/*', 'apps/app', 'packages/*', 'ee/packages/*'],
+    });
+    writeWorkspace('apps/server/api', {
+      dependencies: { '@genfeedai/server': 'workspace:*' },
+      name: '@genfeedai/api',
+    });
+    writeWorkspace('apps/server/server', {
+      dependencies: { '@genfeedai/shared': 'workspace:*' },
+      name: '@genfeedai/server',
+    });
+    writeWorkspace('apps/server/new-service', {
+      devDependencies: { '@genfeedai/test-support': 'workspace:*' },
+      name: '@genfeedai/new-service',
+    });
+    writeWorkspace('packages/shared', {
+      optionalDependencies: { '@genfeedai/storage': 'workspace:*' },
+      name: '@genfeedai/shared',
+    });
+    writeWorkspace('packages/storage', {
+      name: '@genfeedai/storage',
+      peerDependencies: { '@genfeedai/types': 'workspace:*' },
+    });
+    writeWorkspace('packages/types', { name: '@genfeedai/types' });
+    writeWorkspace('packages/test-support', {
+      name: '@genfeedai/test-support',
+    });
+    writeWorkspace('packages/root-runtime', {
+      name: '@genfeedai/root-runtime',
+    });
+    writeWorkspace('packages/unrelated', { name: '@genfeedai/unrelated' });
+    writeWorkspace('apps/app', {
+      dependencies: { '@genfeedai/unrelated': 'workspace:*' },
+      name: '@genfeedai/app',
+    });
+    writeWorkspace('ee/packages/billing', {
+      name: '@genfeedai/billing',
+    });
+
+    const result = prepareServerWorkspace({
+      outputRoot,
+      repoRoot,
+      seedWorkspacePaths: ['ee/packages/billing'],
+    });
+
+    expect(result.serverWorkspaceCount).toBe(3);
+    expect(result.workspacePaths).toEqual([
+      'apps/server/api',
+      'apps/server/new-service',
+      'apps/server/server',
+      'ee/packages/billing',
+      'packages/root-runtime',
+      'packages/shared',
+      'packages/storage',
+      'packages/test-support',
+      'packages/types',
+    ]);
+    expect(existsSync(path.join(outputRoot, 'apps/app/package.json'))).toBe(
+      false,
+    );
+    expect(
+      existsSync(path.join(outputRoot, 'packages/unrelated/package.json')),
+    ).toBe(false);
+
+    const preparedRoot = readJson(path.join(outputRoot, 'package.json'));
+    expect(preparedRoot.workspaces).toEqual(result.workspacePaths);
+    expect(preparedRoot.scripts).toEqual({ test: 'vitest' });
+    expect(preparedRoot.dependencies).toEqual({
+      '@genfeedai/root-runtime': 'workspace:*',
+      resend: '6.9.3',
+    });
+  });
+
+  it('fails when a workspace dependency is missing from the repository graph', () => {
+    writeRootManifest({ workspaces: ['apps/server/*', 'packages/*'] });
+    writeWorkspace('apps/server/api', {
+      dependencies: { '@genfeedai/missing': 'workspace:*' },
+      name: '@genfeedai/api',
+    });
+
+    expect(() => resolveServerWorkspaceClosure(repoRoot)).toThrow(
+      'dependencies.@genfeedai/missing references a missing workspace package',
+    );
+  });
+
+  it('fails when workspace package names are ambiguous', () => {
+    writeRootManifest({ workspaces: ['apps/server/*', 'packages/*'] });
+    writeWorkspace('apps/server/api', { name: '@genfeedai/api' });
+    writeWorkspace('packages/api-shadow', { name: '@genfeedai/api' });
+
+    expect(() => resolveServerWorkspaceClosure(repoRoot)).toThrow(
+      'Duplicate workspace package name "@genfeedai/api"',
+    );
+  });
+
+  it('fails when an explicit build-flavor seed is not a workspace', () => {
+    writeRootManifest({ workspaces: ['apps/server/*', 'packages/*'] });
+    writeWorkspace('apps/server/api', { name: '@genfeedai/api' });
+
+    expect(() =>
+      resolveServerWorkspaceClosure(repoRoot, ['ee/packages/billing']),
+    ).toThrow(
+      'seed workspace "ee/packages/billing" was not found in the root workspace graph',
+    );
+  });
+
+  function writeRootManifest(
+    manifest: {
+      dependencies?: Record<string, string>;
+      scripts?: Record<string, string>;
+      workspaces: string[];
+    },
+  ): void {
+    writeJson('package.json', {
+      name: 'fixture',
+      private: true,
+      ...manifest,
+    });
+  }
+
+  function writeWorkspace(
+    workspacePath: string,
+    manifest: TestManifest,
+  ): void {
+    writeJson(`${workspacePath}/package.json`, {
+      private: true,
+      ...manifest,
+    });
+  }
+
+  function writeJson(relativePath: string, value: object): void {
+    const absolutePath = path.join(repoRoot, relativePath);
+    mkdirSync(path.dirname(absolutePath), { recursive: true });
+    writeFileSync(
+      absolutePath,
+      `${JSON.stringify(value, null, 2)}\n`,
+      'utf8',
+    );
+  }
+});
+
+function readJson(filePath: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(filePath, 'utf8')) as Record<string, unknown>;
+}

--- a/scripts/docker/prepare-server-workspace.test.ts
+++ b/scripts/docker/prepare-server-workspace.test.ts
@@ -154,13 +154,11 @@ describe('prepare-server-workspace', () => {
     );
   });
 
-  function writeRootManifest(
-    manifest: {
-      dependencies?: Record<string, string>;
-      scripts?: Record<string, string>;
-      workspaces: string[];
-    },
-  ): void {
+  function writeRootManifest(manifest: {
+    dependencies?: Record<string, string>;
+    scripts?: Record<string, string>;
+    workspaces: string[];
+  }): void {
     writeJson('package.json', {
       name: 'fixture',
       private: true,
@@ -168,10 +166,7 @@ describe('prepare-server-workspace', () => {
     });
   }
 
-  function writeWorkspace(
-    workspacePath: string,
-    manifest: TestManifest,
-  ): void {
+  function writeWorkspace(workspacePath: string, manifest: TestManifest): void {
     writeJson(`${workspacePath}/package.json`, {
       private: true,
       ...manifest,
@@ -181,11 +176,7 @@ describe('prepare-server-workspace', () => {
   function writeJson(relativePath: string, value: object): void {
     const absolutePath = path.join(repoRoot, relativePath);
     mkdirSync(path.dirname(absolutePath), { recursive: true });
-    writeFileSync(
-      absolutePath,
-      `${JSON.stringify(value, null, 2)}\n`,
-      'utf8',
-    );
+    writeFileSync(absolutePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
   }
 });
 

--- a/scripts/docker/prepare-server-workspace.ts
+++ b/scripts/docker/prepare-server-workspace.ts
@@ -1,0 +1,383 @@
+#!/usr/bin/env bun
+
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+} from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const DEPENDENCY_SECTIONS = [
+  'dependencies',
+  'devDependencies',
+  'optionalDependencies',
+  'peerDependencies',
+] as const;
+const SERVER_WORKSPACE_PREFIX = 'apps/server/';
+
+type DependencySection = (typeof DEPENDENCY_SECTIONS)[number];
+
+type PackageManifest = {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  name?: string;
+  optionalDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  scripts?: Record<string, string>;
+  workspaces?: string[];
+};
+
+type WorkspaceManifest = {
+  manifest: PackageManifest;
+  path: string;
+};
+
+export type PrepareServerWorkspaceOptions = {
+  outputRoot: string;
+  repoRoot: string;
+  seedWorkspacePaths?: string[];
+};
+
+export type PrepareServerWorkspaceResult = {
+  serverWorkspaceCount: number;
+  workspacePaths: string[];
+};
+
+function readManifest(filePath: string): PackageManifest {
+  const parsed = JSON.parse(readFileSync(filePath, 'utf8')) as unknown;
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`${filePath} must contain a JSON object.`);
+  }
+
+  return parsed as PackageManifest;
+}
+
+function toPosixPath(filePath: string): string {
+  return filePath.split(path.sep).join('/');
+}
+
+function expandWorkspacePattern(repoRoot: string, pattern: string): string[] {
+  const normalizedPattern = toPosixPath(pattern).replace(/\/+$/u, '');
+  const segments = normalizedPattern.split('/').filter(Boolean);
+  const matches: string[] = [];
+
+  const visit = (absoluteDir: string, segmentIndex: number): void => {
+    if (segmentIndex === segments.length) {
+      if (existsSync(path.join(absoluteDir, 'package.json'))) {
+        matches.push(toPosixPath(path.relative(repoRoot, absoluteDir)));
+      }
+      return;
+    }
+
+    const segment = segments[segmentIndex];
+    if (!segment) {
+      return;
+    }
+
+    if (segment === '*') {
+      if (!existsSync(absoluteDir)) {
+        return;
+      }
+
+      for (const entry of readdirSync(absoluteDir, { withFileTypes: true })) {
+        if (entry.isDirectory()) {
+          visit(path.join(absoluteDir, entry.name), segmentIndex + 1);
+        }
+      }
+      return;
+    }
+
+    if (segment.includes('*')) {
+      throw new Error(
+        `Unsupported workspace pattern "${pattern}". Wildcards must occupy a full path segment.`,
+      );
+    }
+
+    visit(path.join(absoluteDir, segment), segmentIndex + 1);
+  };
+
+  visit(repoRoot, 0);
+  return matches;
+}
+
+function discoverWorkspaces(
+  repoRoot: string,
+  rootManifest: PackageManifest,
+): WorkspaceManifest[] {
+  if (!Array.isArray(rootManifest.workspaces)) {
+    throw new Error('Root package.json must declare a workspaces array.');
+  }
+
+  const workspacePaths = [
+    ...new Set(
+      rootManifest.workspaces.flatMap((pattern) =>
+        expandWorkspacePattern(repoRoot, pattern),
+      ),
+    ),
+  ].sort((left, right) => left.localeCompare(right));
+
+  return workspacePaths.map((workspacePath) => ({
+    manifest: readManifest(path.join(repoRoot, workspacePath, 'package.json')),
+    path: workspacePath,
+  }));
+}
+
+function indexWorkspacesByName(
+  workspaces: WorkspaceManifest[],
+): Map<string, WorkspaceManifest> {
+  const workspaceByName = new Map<string, WorkspaceManifest>();
+
+  for (const workspace of workspaces) {
+    const packageName = workspace.manifest.name;
+    if (!packageName) {
+      throw new Error(`${workspace.path}/package.json is missing "name".`);
+    }
+
+    const existing = workspaceByName.get(packageName);
+    if (existing) {
+      throw new Error(
+        `Duplicate workspace package name "${packageName}" in ${existing.path} and ${workspace.path}.`,
+      );
+    }
+
+    workspaceByName.set(packageName, workspace);
+  }
+
+  return workspaceByName;
+}
+
+function collectLocalDependencies(
+  manifest: PackageManifest,
+  manifestPath: string,
+  workspaceByName: Map<string, WorkspaceManifest>,
+): WorkspaceManifest[] {
+  const localDependencies: WorkspaceManifest[] = [];
+
+  for (const section of DEPENDENCY_SECTIONS) {
+    for (const [packageName, version] of Object.entries(
+      manifest[section] ?? {},
+    )) {
+      const workspace = workspaceByName.get(packageName);
+      if (workspace) {
+        localDependencies.push(workspace);
+        continue;
+      }
+
+      if (version.startsWith('workspace:')) {
+        throw new Error(
+          `${manifestPath}: ${section}.${packageName} references a missing workspace package.`,
+        );
+      }
+    }
+  }
+
+  return localDependencies;
+}
+
+export function resolveServerWorkspaceClosure(
+  repoRoot: string,
+  seedWorkspacePaths: string[] = [],
+): PrepareServerWorkspaceResult {
+  const rootManifestPath = path.join(repoRoot, 'package.json');
+  const rootManifest = readManifest(rootManifestPath);
+  const workspaces = discoverWorkspaces(repoRoot, rootManifest);
+  const workspaceByName = indexWorkspacesByName(workspaces);
+  const serverWorkspaces = workspaces.filter((workspace) =>
+    workspace.path.startsWith(SERVER_WORKSPACE_PREFIX),
+  );
+  const workspaceByPath = new Map(
+    workspaces.map((workspace) => [workspace.path, workspace]),
+  );
+
+  if (serverWorkspaces.length === 0) {
+    throw new Error('No apps/server/* workspaces were discovered.');
+  }
+
+  const selectedByPath = new Map<string, WorkspaceManifest>();
+  const pending: WorkspaceManifest[] = [];
+  const select = (workspace: WorkspaceManifest): void => {
+    if (selectedByPath.has(workspace.path)) {
+      return;
+    }
+
+    selectedByPath.set(workspace.path, workspace);
+    pending.push(workspace);
+  };
+
+  for (const workspace of serverWorkspaces) {
+    select(workspace);
+  }
+
+  for (const seedWorkspacePath of seedWorkspacePaths) {
+    const normalizedSeedPath = toPosixPath(seedWorkspacePath).replace(
+      /\/+$/u,
+      '',
+    );
+    const workspace = workspaceByPath.get(normalizedSeedPath);
+    if (!workspace) {
+      throw new Error(
+        `Server-image seed workspace "${seedWorkspacePath}" was not found in the root workspace graph.`,
+      );
+    }
+
+    select(workspace);
+  }
+
+  for (const dependency of collectLocalDependencies(
+    rootManifest,
+    'package.json',
+    workspaceByName,
+  )) {
+    select(dependency);
+  }
+
+  while (pending.length > 0) {
+    const workspace = pending.shift();
+    if (!workspace) {
+      continue;
+    }
+
+    for (const dependency of collectLocalDependencies(
+      workspace.manifest,
+      `${workspace.path}/package.json`,
+      workspaceByName,
+    )) {
+      select(dependency);
+    }
+  }
+
+  return {
+    serverWorkspaceCount: serverWorkspaces.length,
+    workspacePaths: [...selectedByPath.keys()].sort((left, right) =>
+      left.localeCompare(right),
+    ),
+  };
+}
+
+function prepareRootManifest(
+  rootManifest: PackageManifest,
+  workspacePaths: string[],
+): PackageManifest {
+  const preparedManifest: PackageManifest = {
+    ...rootManifest,
+    workspaces: workspacePaths,
+  };
+
+  if (preparedManifest.scripts) {
+    preparedManifest.scripts = { ...preparedManifest.scripts };
+    delete preparedManifest.scripts.postinstall;
+  }
+
+  if (preparedManifest.dependencies?.resend === '^6.9.3') {
+    preparedManifest.dependencies = {
+      ...preparedManifest.dependencies,
+      resend: '6.9.3',
+    };
+  }
+
+  return preparedManifest;
+}
+
+export function prepareServerWorkspace(
+  options: PrepareServerWorkspaceOptions,
+): PrepareServerWorkspaceResult {
+  const repoRoot = path.resolve(options.repoRoot);
+  const outputRoot = path.resolve(options.outputRoot);
+
+  if (repoRoot === outputRoot) {
+    throw new Error('Output root must differ from the source repository root.');
+  }
+
+  const result = resolveServerWorkspaceClosure(
+    repoRoot,
+    options.seedWorkspacePaths,
+  );
+  const rootManifest = readManifest(path.join(repoRoot, 'package.json'));
+  const preparedRootManifest = prepareRootManifest(
+    rootManifest,
+    result.workspacePaths,
+  );
+
+  mkdirSync(outputRoot, { recursive: true });
+  for (const workspaceRoot of ['apps/server', 'packages', 'ee/packages']) {
+    mkdirSync(path.join(outputRoot, workspaceRoot), { recursive: true });
+  }
+
+  writeFileSync(
+    path.join(outputRoot, 'package.json'),
+    `${JSON.stringify(preparedRootManifest, null, 2)}\n`,
+    'utf8',
+  );
+
+  for (const workspacePath of result.workspacePaths) {
+    const outputDir = path.join(outputRoot, workspacePath);
+    mkdirSync(outputDir, { recursive: true });
+    copyFileSync(
+      path.join(repoRoot, workspacePath, 'package.json'),
+      path.join(outputDir, 'package.json'),
+    );
+  }
+
+  return result;
+}
+
+function parseArgs(argv: string[]): PrepareServerWorkspaceOptions {
+  const args: Partial<PrepareServerWorkspaceOptions> = {};
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const current = argv[index];
+    const next = argv[index + 1];
+
+    if (current === '--repo-root' && next) {
+      args.repoRoot = next;
+      index += 1;
+      continue;
+    }
+
+    if (current === '--output-root' && next) {
+      args.outputRoot = next;
+      index += 1;
+      continue;
+    }
+
+    if (current === '--seed-workspace' && next) {
+      args.seedWorkspacePaths = [
+        ...(args.seedWorkspacePaths ?? []),
+        next,
+      ];
+      index += 1;
+    }
+  }
+
+  if (!args.repoRoot || !args.outputRoot) {
+    throw new Error(
+      'Usage: bun scripts/docker/prepare-server-workspace.ts --repo-root <path> --output-root <path> [--seed-workspace <path>]',
+    );
+  }
+
+  return {
+    outputRoot: args.outputRoot,
+    repoRoot: args.repoRoot,
+    seedWorkspacePaths: args.seedWorkspacePaths,
+  };
+}
+
+function isMainModule(): boolean {
+  const entryPoint = process.argv[1];
+  return (
+    Boolean(entryPoint) &&
+    path.resolve(entryPoint) === path.resolve(fileURLToPath(import.meta.url))
+  );
+}
+
+if (isMainModule()) {
+  const result = prepareServerWorkspace(parseArgs(process.argv.slice(2)));
+  console.log(
+    `Prepared ${result.workspacePaths.length} server-image workspaces from ${result.serverWorkspaceCount} apps/server seeds.`,
+  );
+}

--- a/scripts/docker/prepare-server-workspace.ts
+++ b/scripts/docker/prepare-server-workspace.ts
@@ -4,8 +4,8 @@ import {
   copyFileSync,
   existsSync,
   mkdirSync,
-  readFileSync,
   readdirSync,
+  readFileSync,
   writeFileSync,
 } from 'node:fs';
 import path from 'node:path';
@@ -18,8 +18,6 @@ const DEPENDENCY_SECTIONS = [
   'peerDependencies',
 ] as const;
 const SERVER_WORKSPACE_PREFIX = 'apps/server/';
-
-type DependencySection = (typeof DEPENDENCY_SECTIONS)[number];
 
 type PackageManifest = {
   dependencies?: Record<string, string>;
@@ -346,10 +344,7 @@ function parseArgs(argv: string[]): PrepareServerWorkspaceOptions {
     }
 
     if (current === '--seed-workspace' && next) {
-      args.seedWorkspacePaths = [
-        ...(args.seedWorkspacePaths ?? []),
-        next,
-      ];
+      args.seedWorkspacePaths = [...(args.seedWorkspacePaths ?? []), next];
       index += 1;
     }
   }


### PR DESCRIPTION
## Summary

- derive the reduced Bun workspace graph from every `apps/server/*` workspace and its transitive local dependencies
- preserve EE billing as an explicit build-flavor seed, then snapshot the manifest-only tree before install for the production stage
- remove duplicated Docker workspace, manifest-copy, runtime-directory, and ownership lists
- add focused fixtures for new server workspaces, transitive dependencies, missing workspace references, duplicate package names, and missing flavor seeds

## Verification

- `bun scripts/docker/prepare-server-workspace.ts --repo-root . --output-root <temp> --seed-workspace ee/packages/billing` — passed; 39 workspaces from 12 server seeds, including `apps/server/server` and EE billing
- `bunx biome check scripts/docker/prepare-server-workspace.ts scripts/docker/prepare-server-workspace.test.ts` — passed
- `bun scripts/run-secretlint.ts docker/Dockerfile.server scripts/docker/prepare-server-workspace.ts scripts/docker/prepare-server-workspace.test.ts` — passed
- `git diff --check` and staged credential-pattern checks — passed
- local Vitest, typecheck, Docker build, and monorepo build — skipped per workstation policy; PR CI owns these checks

## Risk

The Docker build path changes before dependency installation, so the unified server image build is the authoritative end-to-end validation. The generated closure preserves the existing EE billing flavor seed and adds the previously omitted shared server workspace.

Closes #1665
