### PR TITLE
feat(website): reposition homepage for agent distribution

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/trends/analytics-trends.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/trends/analytics-trends.test.tsx
@@ -487,7 +487,7 @@ describe('AnalyticsTrends', () => {
     renderAnalyticsTrends();
 
     await waitFor(() => {
-      expect(mocks.viralVideoProps).toHaveBeenLastCalledWith(
+      expect(mocks.viralVideoProps).toHaveBeenCalledWith(
         expect.objectContaining({
           videos: [
             expect.objectContaining({

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/trends/analytics-trends.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/analytics/trends/analytics-trends.test.tsx
@@ -476,6 +476,7 @@ describe('AnalyticsTrends', () => {
     mocks.findAllVideos.mockResolvedValue([
       makeVideo({
         brand: undefined,
+        createdAt: new Date().toISOString(),
         evaluation: undefined,
         id: 'video-without-analytics',
         metadataLabel: undefined,
@@ -487,7 +488,7 @@ describe('AnalyticsTrends', () => {
     renderAnalyticsTrends();
 
     await waitFor(() => {
-      expect(mocks.viralVideoProps).toHaveBeenCalledWith(
+      expect(mocks.viralVideoProps).toHaveBeenLastCalledWith(
         expect.objectContaining({
           videos: [
             expect.objectContaining({

--- a/apps/website/app/(public)/(home)/home-content.spec.tsx
+++ b/apps/website/app/(public)/(home)/home-content.spec.tsx
@@ -1,0 +1,54 @@
+import HomeContent from '@public/(home)/home-content';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@web-components/home/_hero', () => ({
+  default: () => <section data-testid="home-hero">Hero</section>,
+}));
+
+vi.mock('@web-components/home/_how', () => ({
+  default: () => <section data-testid="home-distribution-loop">Loop</section>,
+}));
+
+vi.mock('@web-components/home/_formats', () => ({
+  default: () => <section data-testid="home-formats">Formats</section>,
+}));
+
+vi.mock('@web-components/home/_proof', () => ({
+  default: () => <section>Proof</section>,
+}));
+
+vi.mock('@web-components/proof/ProofTestimonials', () => ({
+  default: () => <section>Testimonials</section>,
+}));
+
+vi.mock('@web-components/home/_audiences', () => ({
+  default: () => <section>Audiences</section>,
+}));
+
+vi.mock('@web-components/home/_credits', () => ({
+  default: () => <section>Credits</section>,
+}));
+
+vi.mock('@web-components/home/_faq', () => ({
+  default: () => <section>FAQ</section>,
+}));
+
+vi.mock('@web-components/home/_cta', () => ({
+  default: () => <section>CTA</section>,
+}));
+
+vi.mock('@web-components/home/_footer', () => ({
+  default: () => <footer>Footer</footer>,
+}));
+
+describe('HomeContent', () => {
+  it('explains the distribution loop in the first two sections', () => {
+    const { container } = render(<HomeContent />);
+    const sections = Array.from(container.children);
+
+    expect(sections[0]).toBe(screen.getByTestId('home-hero'));
+    expect(sections[1]).toBe(screen.getByTestId('home-distribution-loop'));
+    expect(sections[2]).toBe(screen.getByTestId('home-formats'));
+  });
+});

--- a/apps/website/app/(public)/(home)/home-content.tsx
+++ b/apps/website/app/(public)/(home)/home-content.tsx
@@ -15,8 +15,8 @@ export default function HomeContent() {
   return (
     <>
       <HomeHero />
-      <HomeFormats />
       <HomeHow />
+      <HomeFormats />
       <HomeProof />
       <ProofTestimonials context="landing" />
       <HomeAudiences />

--- a/apps/website/app/(public)/(home)/page.spec.tsx
+++ b/apps/website/app/(public)/(home)/page.spec.tsx
@@ -1,4 +1,28 @@
 import * as PageModule from '@public/(home)/page';
 import { runPageModuleTests } from '@shared/pages/pageTestUtils';
+import type { ResolvingMetadata } from 'next';
+import { describe, expect, it } from 'vitest';
 
 runPageModuleTests('apps/website/app/(public)/(home)/page', PageModule);
+
+describe('homepage metadata', () => {
+  it('positions Genfeed as AI-agent distribution infrastructure', async () => {
+    const parent = Promise.resolve({
+      openGraph: { images: ['https://cdn.genfeed.ai/previous.jpg'] },
+    }) as ResolvingMetadata;
+
+    const result = await PageModule.generateMetadata({}, parent);
+
+    expect(result.title).toBe(
+      'Genfeed.ai | Distribution infrastructure for AI agents',
+    );
+    expect(result.description).toMatch(
+      /connect claude code or codex through mcp/i,
+    );
+    expect(result.openGraph?.title).toBe(result.title);
+    expect(result.twitter?.title).toBe(result.title);
+    expect(result.openGraph?.images).toEqual([
+      'https://cdn.genfeed.ai/previous.jpg',
+    ]);
+  });
+});

--- a/apps/website/app/(public)/(home)/page.tsx
+++ b/apps/website/app/(public)/(home)/page.tsx
@@ -2,7 +2,7 @@ import { metadata } from '@helpers/media/metadata/metadata.helper';
 import HomeContent from '@public/(home)/home-content';
 import type { Metadata, ResolvingMetadata } from 'next';
 
-export const HOME_PAGE_TITLE =
+const HOME_PAGE_TITLE =
   'Genfeed.ai | Distribution infrastructure for AI agents';
 
 export async function generateMetadata(

--- a/apps/website/app/(public)/(home)/page.tsx
+++ b/apps/website/app/(public)/(home)/page.tsx
@@ -2,6 +2,9 @@ import { metadata } from '@helpers/media/metadata/metadata.helper';
 import HomeContent from '@public/(home)/home-content';
 import type { Metadata, ResolvingMetadata } from 'next';
 
+export const HOME_PAGE_TITLE =
+  'Genfeed.ai | Distribution infrastructure for AI agents';
+
 export async function generateMetadata(
   _params: unknown,
   parent: ResolvingMetadata,
@@ -16,13 +19,14 @@ export async function generateMetadata(
     openGraph: {
       description: metadata.description,
       images: [...previousImages],
-      title: `${metadata.name} | ${metadata.description}`,
+      title: HOME_PAGE_TITLE,
       url: metadata.url,
     },
-    title: `${metadata.name} | ${metadata.description}`,
+    title: HOME_PAGE_TITLE,
     twitter: {
       description: metadata.description,
       images: [...previousImages],
+      title: HOME_PAGE_TITLE,
     },
   };
 }

--- a/apps/website/app/layout.tsx
+++ b/apps/website/app/layout.tsx
@@ -19,11 +19,11 @@ export const metadata = createAppMetadata({
   metadataBase: 'https://genfeed.ai',
   overrides: {
     keywords:
-      'genfeed,genfeed.ai,ai content generation,b2b content,video generation,image generation,ai avatars,content automation,marketing automation,ai agents',
+      'genfeed,genfeed.ai,MCP,AI agent distribution,Claude Code,Codex,content publishing,content analytics,self-hosted AI',
     openGraph: {
       description,
       images: {
-        alt: 'Genfeed.ai - AI-powered content generation platform',
+        alt: 'Genfeed.ai - distribution infrastructure for AI agents',
         height: 836,
         type: 'image/jpeg',
         url: cards.default,
@@ -57,11 +57,11 @@ const organizationJsonLd = {
   description,
   foundingDate: '2024',
   knowsAbout: [
-    'AI content generation',
-    'video generation',
-    'image generation',
-    'content marketing',
-    'marketing automation',
+    'Model Context Protocol',
+    'AI agent distribution',
+    'content approvals',
+    'multi-platform publishing',
+    'content analytics',
   ],
   logo: cdnAsset('/assets/logo.png'),
   name: 'Genfeed',

--- a/apps/website/packages/components/_topbar.spec.tsx
+++ b/apps/website/packages/components/_topbar.spec.tsx
@@ -1,9 +1,80 @@
-import * as Module from '@ui/shell/topbars/WebsiteTopbar';
-import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import WebsiteTopbar from '@ui/shell/topbars/WebsiteTopbar';
+import { describe, expect, it, vi } from 'vitest';
 
-describe('topbar Component', () => {
-  it('exports a default component', () => {
-    expect(Module).toHaveProperty('default');
-    expect(typeof Module.default).toBe('function');
+vi.mock('@genfeedai/hooks/auth/use-auth-identity/use-auth-identity', () => ({
+  useAuthIdentity: () => ({ isSignedIn: false }),
+}));
+
+vi.mock('@genfeedai/services/core/environment.service', () => ({
+  EnvironmentService: {
+    apps: {
+      app: 'https://app.genfeed.ai',
+    },
+    calendly: 'https://calendly.com/genfeed/demo',
+    mcpConnectHref: 'https://app.genfeed.ai/connect',
+  },
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/',
+}));
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+describe('WebsiteTopbar', () => {
+  it('prioritizes MCP with the simplified developer navigation', () => {
+    render(<WebsiteTopbar />);
+
+    expect(screen.getByRole('link', { name: /connect mcp/i })).toHaveAttribute(
+      'href',
+      'https://app.genfeed.ai/connect',
+    );
+    expect(screen.getByRole('link', { name: /book a demo/i })).toHaveAttribute(
+      'href',
+      'https://calendly.com/genfeed/demo',
+    );
+    expect(screen.getByRole('link', { name: 'Pricing' })).toHaveAttribute(
+      'href',
+      '/pricing',
+    );
+    expect(screen.getByRole('link', { name: 'Docs' })).toHaveAttribute(
+      'href',
+      'https://docs.genfeed.ai',
+    );
+    expect(
+      screen.queryByRole('button', { name: /use cases/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('exposes MCP, publishing, control plane, analytics, and self-hosting', () => {
+    render(<WebsiteTopbar />);
+
+    fireEvent.mouseEnter(screen.getByRole('button', { name: /product/i }));
+
+    for (const destination of [
+      'MCP Server',
+      'Publishing',
+      'Control Plane',
+      'Analytics',
+      'Self-hosting',
+    ]) {
+      expect(
+        screen.getByRole('link', { name: new RegExp(destination, 'i') }),
+      ).toBeInTheDocument();
+    }
   });
 });

--- a/apps/website/packages/components/home/_audiences.spec.tsx
+++ b/apps/website/packages/components/home/_audiences.spec.tsx
@@ -22,6 +22,7 @@ vi.mock('@services/core/environment.service', () => ({
     apps: {
       app: 'https://app.genfeed.ai',
     },
+    mcpConnectHref: 'https://app.genfeed.ai/connect',
   },
 }));
 
@@ -32,18 +33,18 @@ describe('HomeAudiences', () => {
     expect(
       screen.getByRole('heading', {
         level: 2,
-        name: /for creators and agencies\./i,
+        name: /for developers and distribution teams\./i,
       }),
     ).toBeInTheDocument();
   });
 
-  it('splits creators (self-serve) from agencies (demo)', () => {
+  it('splits developer self-serve from the agency demo path', () => {
     render(<HomeAudiences />);
 
     expect(
       screen.getByRole('heading', {
         level: 3,
-        name: /post daily without a team\./i,
+        name: /keep your ai client\. add a control plane\./i,
       }),
     ).toBeInTheDocument();
     expect(
@@ -52,10 +53,13 @@ describe('HomeAudiences', () => {
         name: /run every client's creative from one place\./i,
       }),
     ).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /create now/i })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: /connect mcp/i })).toHaveAttribute(
       'href',
-      expect.stringContaining('plan=payg'),
+      'https://app.genfeed.ai/connect',
     );
+    expect(
+      screen.getByRole('link', { name: /explore the mcp server/i }),
+    ).toHaveAttribute('href', '/mcp');
     expect(
       screen.getByRole('link', { name: /genfeed for agencies/i }),
     ).toHaveAttribute('href', '/use-cases/agencies');

--- a/apps/website/packages/components/home/_audiences.tsx
+++ b/apps/website/packages/components/home/_audiences.tsx
@@ -15,10 +15,10 @@ import { LuArrowRight, LuCheck } from 'react-icons/lu';
 const EYEBROW_CLASS =
   'text-xs font-bold uppercase tracking-widest text-surface/65';
 
-const CREATOR_BENEFITS: AudienceBenefit[] = [
-  { label: '10x your output, three posts a week becomes thirty' },
-  { label: 'Save 15+ hours a week you used to spend editing' },
-  { label: 'Track revenue per post, not just likes' },
+const DEVELOPER_BENEFITS: AudienceBenefit[] = [
+  { label: 'Use Claude Code, Codex, or any MCP client' },
+  { label: 'Review and approve content before it ships' },
+  { label: 'Track performance across every channel' },
 ];
 
 const AGENCY_BENEFITS: AudienceBenefit[] = [
@@ -28,7 +28,6 @@ const AGENCY_BENEFITS: AudienceBenefit[] = [
 ];
 
 export default function HomeAudiences(): React.ReactElement {
-  const signUpHref = `${EnvironmentService.apps.app}/sign-up?plan=payg`;
   const proPlan = getProPlan();
   const proPlanPrice = proPlan.launchPrice ?? proPlan.price;
   const proPlanCopy =
@@ -48,11 +47,11 @@ export default function HomeAudiences(): React.ReactElement {
             as="h2"
             className="text-4xl font-semibold leading-tight tracking-[-0.03em] sm:text-5xl"
           >
-            For creators and agencies.
+            For developers and distribution teams.
           </Heading>
           <Text className="max-w-2xl text-base leading-7 gen-text-muted">
-            Start self-serve as a creator, or bring your whole client roster and
-            let AI run the creative volume.
+            Connect your AI client self-serve, or bring your whole client roster
+            and run distribution through one supervised control plane.
           </Text>
         </VStack>
 
@@ -60,13 +59,15 @@ export default function HomeAudiences(): React.ReactElement {
           <div className="flex flex-col gap-5 bg-background p-8">
             <HStack className="items-center gap-2 text-surface/72">
               <HiUser className="size-4" />
-              <Text className={EYEBROW_CLASS}>Solo creators</Text>
+              <Text className={EYEBROW_CLASS}>
+                Developers &amp; solo operators
+              </Text>
             </HStack>
             <Heading as="h3" className="text-2xl font-semibold text-surface">
-              Post daily without a team.
+              Keep your AI client. Add a control plane.
             </Heading>
             <ul className="flex flex-col gap-3">
-              {CREATOR_BENEFITS.map((benefit) => (
+              {DEVELOPER_BENEFITS.map((benefit) => (
                 <li key={benefit.label} className="flex items-start gap-3">
                   <LuCheck className="mt-0.5 size-4 shrink-0 text-surface/70" />
                   <Text className="text-sm leading-6 text-surface/72">
@@ -82,19 +83,23 @@ export default function HomeAudiences(): React.ReactElement {
               <ButtonTracked
                 asChild
                 size={ButtonSize.PUBLIC}
-                trackingData={{ action: 'signup_creators_audience' }}
+                trackingData={{ action: 'connect_mcp_audience' }}
                 trackingName="audience_cta_click"
               >
-                <a href={signUpHref} rel="noopener noreferrer" target="_blank">
-                  Create now
+                <a
+                  href={EnvironmentService.mcpConnectHref}
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Connect MCP
                   <LuArrowRight className="size-4" />
                 </a>
               </ButtonTracked>
               <Link
-                href="/use-cases/creators"
+                href="/mcp"
                 className="text-sm font-medium text-surface/72 underline-offset-4 hover:text-surface hover:underline"
               >
-                Genfeed for creators →
+                Explore the MCP server →
               </Link>
             </HStack>
           </div>

--- a/apps/website/packages/components/home/_cta.spec.tsx
+++ b/apps/website/packages/components/home/_cta.spec.tsx
@@ -1,9 +1,30 @@
-import * as Module from '@web-components/home/_cta';
-import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import HomeCTA from '@web-components/home/_cta';
+import { describe, expect, it, vi } from 'vitest';
 
-describe('Cta Component', () => {
-  it('exports a default component', () => {
-    expect(Module).toHaveProperty('default');
-    expect(typeof Module.default).toBe('function');
+vi.mock('@services/core/environment.service', () => ({
+  EnvironmentService: {
+    calendly: 'https://calendly.com/genfeed/demo',
+    mcpConnectHref: 'https://app.genfeed.ai/connect',
+  },
+}));
+
+describe('HomeCTA', () => {
+  it('repeats the Connect MCP primary and demo secondary actions', () => {
+    render(<HomeCTA />);
+
+    expect(
+      screen.getByRole('heading', {
+        level: 2,
+        name: /give your ai agent a way to ship\./i,
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByRole('link').map((link) => link.textContent?.trim()),
+    ).toEqual(['Connect MCP', 'Book a Demo']);
+    expect(screen.getByRole('link', { name: /connect mcp/i })).toHaveAttribute(
+      'href',
+      'https://app.genfeed.ai/connect',
+    );
   });
 });

--- a/apps/website/packages/components/home/_cta.tsx
+++ b/apps/website/packages/components/home/_cta.tsx
@@ -9,8 +9,6 @@ import { Text } from '@ui/typography/text';
 import { LuArrowRight } from 'react-icons/lu';
 
 export default function HomeCTA(): React.ReactElement {
-  const signUpHref = `${EnvironmentService.apps.app}/sign-up?plan=payg`;
-
   return (
     <section className="gen-section-spacing-xl relative overflow-hidden gen-grain">
       <div className="container mx-auto px-6 relative z-10">
@@ -19,27 +17,31 @@ export default function HomeCTA(): React.ReactElement {
             as="h2"
             className="text-5xl font-semibold leading-none tracking-[-0.03em] sm:text-6xl md:text-7xl"
           >
-            Start creating in minutes.
+            Give your AI agent a way to ship.
           </Heading>
 
           <Text
             as="p"
             className="text-lg md:text-xl gen-text-muted max-w-xl leading-relaxed"
           >
-            Sign up and turn one brief into a full campaign: images, video,
-            voice, and copy. Book a demo if you&apos;re rolling this out across
-            a team or client roster.
+            Connect Claude Code or Codex through MCP, keep publishing under
+            human control, and measure the result. Book a demo if you&apos;re
+            rolling this out across a team or client roster.
           </Text>
 
           <HStack className="flex-wrap justify-center gap-3">
             <ButtonTracked
               asChild
               size={ButtonSize.PUBLIC}
-              trackingData={{ action: 'signup_bottom_cta' }}
+              trackingData={{ action: 'connect_mcp_bottom_cta' }}
               trackingName="cta_final_click"
             >
-              <a href={signUpHref} target="_blank" rel="noopener noreferrer">
-                Create now
+              <a
+                href={EnvironmentService.mcpConnectHref}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Connect MCP
                 <LuArrowRight className="size-4" />
               </a>
             </ButtonTracked>

--- a/apps/website/packages/components/home/_footer.tsx
+++ b/apps/website/packages/components/home/_footer.tsx
@@ -94,7 +94,7 @@ export default function HomeFooter(): React.ReactElement {
         variant="default"
         showNewsletter
         showBookCall
-        brandTagline="The AI studio for content. Start free, pay as you go for what you create."
+        brandTagline="Open-source distribution infrastructure for AI agents. Review, publish, and measure every output."
       />
     </footer>
   );

--- a/apps/website/packages/components/home/_hero.spec.tsx
+++ b/apps/website/packages/components/home/_hero.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { HOME_OUTPUT_WALL_ASSETS } from '@web-components/home/_assets';
 import type { ImgHTMLAttributes } from 'react';
 import { describe, expect, it, vi } from 'vitest';
@@ -27,29 +27,72 @@ vi.mock('@services/core/environment.service', () => ({
       app: 'https://app.genfeed.ai',
     },
     calendly: 'https://calendly.com/genfeed/demo',
+    mcpConnectHref: 'https://app.genfeed.ai/connect',
   },
 }));
 
 describe('HomeHero', () => {
-  it('renders one primary heading with both CTAs', () => {
+  it('leads with the developer distribution promise and CTA hierarchy', () => {
     render(<HomeHero />);
 
     expect(screen.getAllByRole('heading', { level: 1 })).toHaveLength(1);
     expect(
-      screen.getByRole('link', { name: /create now/i }),
+      screen.getByRole('heading', {
+        level: 1,
+        name: /your product deserves to be discovered\./i,
+      }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('link', { name: /book a demo/i }),
+      screen.getByText(/distribution infrastructure for ai agents/i),
     ).toBeInTheDocument();
+    expect(
+      screen.getByText(/one prompt\. publish everywhere\./i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/connect claude code, codex, or any mcp client/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByRole('link').map((link) => link.textContent?.trim()),
+    ).toEqual(['Connect MCP', 'Book a Demo']);
   });
 
-  it('points the primary CTA at the pay-as-you-go sign-up', () => {
+  it('points the primary CTA at the canonical Connect Genfeed flow', () => {
     render(<HomeHero />);
 
-    expect(screen.getByRole('link', { name: /create now/i })).toHaveAttribute(
+    expect(screen.getByRole('link', { name: /connect mcp/i })).toHaveAttribute(
       'href',
-      expect.stringContaining('plan=payg'),
+      'https://app.genfeed.ai/connect',
     );
+  });
+
+  it('tracks Connect MCP separately from Book a Demo', () => {
+    const listener = vi.fn();
+    window.addEventListener('genfeed:marketing:button-click', listener);
+    render(<HomeHero />);
+
+    fireEvent.click(screen.getByRole('link', { name: /connect mcp/i }));
+    fireEvent.click(screen.getByRole('link', { name: /book a demo/i }));
+
+    expect(listener).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        detail: {
+          trackingData: { action: 'connect_mcp_hero' },
+          trackingName: 'hero_cta_click',
+        },
+      }),
+    );
+    expect(listener).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        detail: {
+          trackingData: { action: 'book_demo_hero' },
+          trackingName: 'hero_cta_click',
+        },
+      }),
+    );
+
+    window.removeEventListener('genfeed:marketing:button-click', listener);
   });
 
   it('renders a CDN-backed generated output wall instead of static wall art', () => {

--- a/apps/website/packages/components/home/_hero.tsx
+++ b/apps/website/packages/components/home/_hero.tsx
@@ -16,10 +16,10 @@ interface HeroMetric {
 }
 
 const HERO_METRICS: HeroMetric[] = [
-  { label: 'generated for launch', value: '42 assets' },
-  { label: 'covered in one pass', value: '9 channels' },
-  { label: 'estimated output cost', value: '$184' },
-  { label: 'best hook rate', value: '31%' },
+  { label: 'approved for launch', value: '42 assets' },
+  { label: 'published from one brief', value: '9 channels' },
+  { label: 'held for human review', value: '3 drafts' },
+  { label: 'measured in analytics', value: '31% hook rate' },
 ];
 
 const HERO_WALL_ITEMS = [
@@ -74,28 +74,36 @@ const HERO_WALL_ITEMS = [
 ] as const;
 
 export default function HomeHero(): React.ReactElement {
-  const signUpHref = `${EnvironmentService.apps.app}/sign-up?plan=payg`;
-
   return (
     <section className="relative overflow-hidden border-b border-edge/5 bg-background">
       <div className="container mx-auto px-6">
         <div className="grid min-h-[calc(100svh-5.5rem)] items-center gap-12 py-14 lg:grid-cols-[minmax(0,1.05fr)_minmax(440px,0.95fr)] lg:gap-14 lg:py-16 xl:gap-20">
           <div className="max-w-[42rem] self-center">
+            <Text className="mb-5 text-xs font-bold uppercase tracking-[0.16em] text-surface/65">
+              Distribution infrastructure for AI agents
+            </Text>
             <Heading
               as="h1"
-              className="hero-headline max-w-[42rem] whitespace-normal text-[2.5rem] font-semibold leading-[1.02] tracking-[-0.035em] text-surface sm:whitespace-nowrap sm:text-5xl md:text-[3.5rem] lg:text-[3.5rem] xl:text-[4rem] 2xl:text-[4.5rem]"
+              className="hero-headline max-w-[44rem] text-[2.5rem] font-semibold leading-[1.02] tracking-[-0.035em] text-surface sm:text-5xl md:text-[3.5rem] lg:text-[3.5rem] xl:text-[4rem] 2xl:text-[4.5rem]"
             >
-              <span className="block">One prompt.</span>
-              <span className="block text-surface/60">Publish everywhere.</span>
+              Your product deserves to be discovered.
             </Heading>
 
             <Text
               as="p"
-              className="hero-description mt-6 max-w-xl text-base leading-7 text-surface/62 md:text-lg"
+              className="mt-6 text-xl font-semibold tracking-[-0.02em] text-surface md:text-2xl"
             >
-              It becomes the full internet campaign: images, reels, ads,
-              articles, captions, newsletters, voice, clips, and the readout
-              that tells you what worked.
+              One prompt. Publish everywhere.
+            </Text>
+
+            <Text
+              as="p"
+              className="hero-description mt-4 max-w-2xl text-base leading-7 text-surface/62 md:text-lg"
+            >
+              Connect Claude Code, Codex, or any MCP client. Genfeed turns your
+              product brief into platform-native content, distributes it across
+              every channel, and brings approvals, scheduling, and performance
+              back into one control plane.
             </Text>
 
             <HStack className="mt-8 flex-wrap gap-3">
@@ -103,11 +111,15 @@ export default function HomeHero(): React.ReactElement {
                 asChild
                 size={ButtonSize.PUBLIC}
                 className="hero-cta"
-                trackingData={{ action: 'signup_payg_hero' }}
+                trackingData={{ action: 'connect_mcp_hero' }}
                 trackingName="hero_cta_click"
               >
-                <a href={signUpHref} rel="noopener noreferrer" target="_blank">
-                  Create now
+                <a
+                  href={EnvironmentService.mcpConnectHref}
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  Connect MCP
                   <LuArrowRight className="size-4" />
                 </a>
               </ButtonTracked>
@@ -162,7 +174,7 @@ export default function HomeHero(): React.ReactElement {
 
             <div className="relative z-10 mx-3 -mt-12 overflow-hidden rounded-md bg-edge/10 shadow-border-strong lg:mx-8">
               <p className="border-b border-edge/5 bg-background/95 px-4 py-2 text-[11px] font-bold uppercase tracking-[0.14em] text-surface/45 backdrop-blur">
-                Sample campaign readout
+                Sample distribution readout
               </p>
               <div className="grid sm:grid-cols-4">
                 {HERO_METRICS.map((metric) => (

--- a/apps/website/packages/components/home/_how.spec.tsx
+++ b/apps/website/packages/components/home/_how.spec.tsx
@@ -9,22 +9,29 @@ describe('HomeHow', () => {
     expect(
       screen.getByRole('heading', {
         level: 2,
-        name: /brief in, campaign out\./i,
+        name: /your ai client creates\. genfeed controls distribution\./i,
       }),
     ).toBeInTheDocument();
   });
 
-  it('renders all three steps', () => {
+  it('renders the complete agent-to-analytics lifecycle as an ordered list', () => {
     render(<HomeHow />);
 
     for (const title of [
-      'Start from a brief',
-      'Generate every format',
-      'Publish and track',
+      'Create in your AI client',
+      'Route through Genfeed',
+      'Approve and publish',
+      'Measure what shipped',
     ]) {
       expect(
         screen.getByRole('heading', { level: 3, name: title }),
       ).toBeInTheDocument();
     }
+
+    expect(screen.getByRole('list')).toHaveAttribute(
+      'aria-labelledby',
+      'distribution-loop-heading',
+    );
+    expect(screen.getAllByRole('listitem')).toHaveLength(4);
   });
 });

--- a/apps/website/packages/components/home/_how.tsx
+++ b/apps/website/packages/components/home/_how.tsx
@@ -11,21 +11,27 @@ const EYEBROW_CLASS =
 const HOW_STEPS: HowStep[] = [
   {
     description:
-      'Describe the campaign, brand, or product. One prompt sets the direction for everything that follows.',
+      'Keep Claude Code or Codex as your workbench. Connect once through the standard MCP transport.',
     step: '01',
-    title: 'Start from a brief',
+    title: 'Create in your AI client',
   },
   {
     description:
-      'Images, reels, ads, articles, captions, voice, and clips, produced from that single brief, on brand.',
+      'Curated, scoped actions send assets and distribution work into the right brand workspace.',
     step: '02',
-    title: 'Generate every format',
+    title: 'Route through Genfeed',
   },
   {
     description:
-      'Ship across every channel, then see which posts and ads actually drove results.',
+      'Review the output, enforce brand policy, and require human approval before consequential actions.',
     step: '03',
-    title: 'Publish and track',
+    title: 'Approve and publish',
+  },
+  {
+    description:
+      'Track channel performance, content outcomes, and the full audit trail in one analytics layer.',
+    step: '04',
+    title: 'Measure what shipped',
   },
 ];
 
@@ -34,22 +40,26 @@ export default function HomeHow(): React.ReactElement {
     <section id="how" className="gen-section-spacing-lg border-b border-edge/5">
       <div className="container mx-auto px-6">
         <VStack className="mb-10 max-w-3xl gap-4">
-          <Text className={EYEBROW_CLASS}>How it works</Text>
+          <Text className={EYEBROW_CLASS}>Agent to outcome</Text>
           <Heading
+            id="distribution-loop-heading"
             as="h2"
             className="text-4xl font-semibold leading-tight tracking-[-0.03em] sm:text-5xl"
           >
-            Brief in, campaign out.
+            Your AI client creates. Genfeed controls distribution.
           </Heading>
           <Text className="max-w-2xl text-base leading-7 gen-text-muted">
-            Three steps. No tool-switching, no production bottleneck between the
-            idea and the post.
+            Claude Code and Codex stay focused on the work. Genfeed adds scoped
+            MCP actions, approvals, publishing, and analytics around it.
           </Text>
         </VStack>
 
-        <div className="grid grid-cols-1 gap-px bg-edge/5 sm:grid-cols-3">
+        <ol
+          aria-labelledby="distribution-loop-heading"
+          className="grid grid-cols-1 gap-px bg-edge/5 sm:grid-cols-2 lg:grid-cols-4"
+        >
           {HOW_STEPS.map((item) => (
-            <div
+            <li
               key={item.step}
               className="flex flex-col gap-3 bg-background p-8"
             >
@@ -62,9 +72,9 @@ export default function HomeHow(): React.ReactElement {
               <Text className="text-sm leading-6 text-surface/70">
                 {item.description}
               </Text>
-            </div>
+            </li>
           ))}
-        </div>
+        </ol>
       </div>
     </section>
   );

--- a/packages/helpers/src/media/metadata/metadata.helper.ts
+++ b/packages/helpers/src/media/metadata/metadata.helper.ts
@@ -8,8 +8,16 @@ export const metadata = {
     default: cdnAsset('/assets/cards/default.jpg'),
   },
   description:
-    'AI-powered content generation platform for your business. Create professional videos, images, and marketing materials at scale with autonomous AI agents.',
-  keywords: ['genfeed', 'genfeed.ai', 'publisher', 'studio', 'storyboard'],
+    'Open-source distribution infrastructure for AI agents. Connect Claude Code or Codex through MCP, then approve, publish, and measure content from one human control plane.',
+  keywords: [
+    'genfeed',
+    'genfeed.ai',
+    'MCP',
+    'AI agent distribution',
+    'publisher',
+    'analytics',
+    'self-hosted',
+  ],
   name: 'Genfeed.ai',
   url: 'https://genfeed.ai',
 };

--- a/packages/services/core/environment.service.test.ts
+++ b/packages/services/core/environment.service.test.ts
@@ -94,6 +94,9 @@ describe('EnvironmentService', () => {
         'https://marketplace.genfeed.ai',
       );
       expect(EnvironmentService.apps.website).toBe('https://genfeed.ai');
+      expect(EnvironmentService.mcpConnectHref).toBe(
+        'https://app.genfeed.ai/connect',
+      );
     });
 
     // Note: App endpoints are initialized at module load time, so dynamic testing

--- a/packages/services/core/environment.service.ts
+++ b/packages/services/core/environment.service.ts
@@ -240,6 +240,10 @@ export const EnvironmentService = {
     process.env.NEXT_PUBLIC_CALENDLY_URL ||
     'https://calendly.com/vincent-genfeed/30min',
 
+  get mcpConnectHref(): string {
+    return `${this.apps.app}/connect`;
+  },
+
   get cdnUrl(): string {
     return (
       getDesktopEnvironmentOverrides().cdnUrl ||

--- a/packages/ui/src/components/shell/topbars/WebsiteTopbar.tsx
+++ b/packages/ui/src/components/shell/topbars/WebsiteTopbar.tsx
@@ -3,141 +3,60 @@
 import { ButtonSize, ButtonVariant } from '@genfeedai/enums';
 import { useAuthIdentity } from '@genfeedai/hooks/auth/use-auth-identity/use-auth-identity';
 import { EnvironmentService } from '@genfeedai/services/core/environment.service';
-import { Button } from '@ui/primitives/button';
+import ButtonTracked from '@ui/buttons/tracked/ButtonTracked';
 import TopbarPublic from '@ui/topbars/public/TopbarPublic';
 import {
-  HiArrowPath,
-  HiBuildingOffice2,
   HiChartBar,
-  HiMagnifyingGlass,
-  HiMegaphone,
+  HiCommandLine,
   HiPaperAirplane,
-  HiRectangleStack,
-  HiRocketLaunch,
-  HiShoppingCart,
-  HiSparkles,
-  HiSquares2X2,
-  HiStar,
-  HiUserCircle,
-  HiUserGroup,
+  HiServerStack,
+  HiShieldCheck,
 } from 'react-icons/hi2';
 
 const PRODUCT_LINKS = [
   {
-    description: 'Generate every format in one workspace',
-    group: 'Create',
-    href: '/studio',
-    icon: HiSparkles,
-    label: 'Studio',
+    description: 'Connect Claude Code, Codex, and other MCP clients',
+    href: '/mcp',
+    icon: HiCommandLine,
+    label: 'MCP Server',
   },
   {
-    description: 'Every asset your team reuses',
-    group: 'Create',
-    href: '/library',
-    icon: HiRectangleStack,
-    label: 'Library',
-  },
-  {
-    description: "Find what's working now",
-    group: 'Create',
-    href: '/research',
-    icon: HiMagnifyingGlass,
-    label: 'Research',
-  },
-  {
-    description: 'Prompt packs and creative recipes',
-    group: 'Create',
-    href: '/skills',
-    icon: HiSquares2X2,
-    label: 'Skills',
-  },
-  {
-    description: 'Plan, schedule, and publish everywhere',
-    group: 'Operate',
+    description: 'Review, schedule, and publish across every channel',
     href: '/publisher',
     icon: HiPaperAirplane,
-    label: 'Publisher',
+    label: 'Publishing',
   },
   {
-    description: 'Automate your content pipeline',
-    group: 'Operate',
-    href: '/workflows',
-    icon: HiArrowPath,
-    label: 'Workflows',
+    description: 'Approvals, assets, integrations, and audit in one place',
+    href: '/features',
+    icon: HiShieldCheck,
+    label: 'Control Plane',
   },
   {
     description: 'Track revenue, not vanity metrics',
-    group: 'Operate',
     href: '/analytics',
     icon: HiChartBar,
     label: 'Analytics',
   },
   {
-    description: 'Your autonomous content team',
-    group: 'Operate',
-    href: '/agents',
-    icon: HiUserGroup,
-    label: 'Agents',
+    description: 'Own the stack, data, keys, and deployment',
+    href: '/self-hosted',
+    icon: HiServerStack,
+    label: 'Self-hosting',
   },
 ];
 
-const USE_CASES_LINKS = [
-  {
-    description: '10x output, track what converts',
-    group: 'Creators',
-    href: '/use-cases/creators',
-    icon: HiUserCircle,
-    label: 'Content Creators',
-  },
-  {
-    description: 'Virtual influencers that post 24/7',
-    group: 'Creators',
-    href: '/use-cases/ai-influencers',
-    icon: HiStar,
-    label: 'AI Influencers',
-  },
-  {
-    description: 'Launch and grow without a team',
-    group: 'Creators',
-    href: '/use-cases/founders',
-    icon: HiRocketLaunch,
-    label: 'Founders',
-  },
-  {
-    description: 'Scale client content, white-label',
-    group: 'Business',
-    href: '/use-cases/agencies',
-    icon: HiBuildingOffice2,
-    label: 'Agencies',
-  },
-  {
-    description: 'Campaign content and reporting',
-    group: 'Business',
-    href: '/use-cases/marketers',
-    icon: HiMegaphone,
-    label: 'Marketers',
-  },
-  {
-    description: 'Product content at scale',
-    group: 'Business',
-    href: '/use-cases/ecommerce',
-    icon: HiShoppingCart,
-    label: 'E-commerce',
-  },
+const NAV_LINKS = [
+  { href: '/pricing', label: 'Pricing' },
+  { href: 'https://docs.genfeed.ai', label: 'Docs' },
 ];
-
-const NAV_LINKS = [{ href: '/pricing', label: 'Pricing' }];
 
 export default function WebsiteTopbar() {
   const { isSignedIn } = useAuthIdentity();
-  const signUpHref = `${EnvironmentService.apps.app}/sign-up?plan=payg`;
 
   return (
     <TopbarPublic
-      dropdowns={[
-        { items: PRODUCT_LINKS, label: 'Product' },
-        { items: USE_CASES_LINKS, label: 'Use Cases' },
-      ]}
+      dropdowns={[{ items: PRODUCT_LINKS, label: 'Product' }]}
       navLinks={NAV_LINKS}
       rightContent={
         <div className="flex items-center gap-6">
@@ -149,29 +68,37 @@ export default function WebsiteTopbar() {
               >
                 Log in
               </a>
-              <Button
+              <ButtonTracked
                 asChild
                 size={ButtonSize.PUBLIC}
                 variant={ButtonVariant.OUTLINE}
                 className="hidden h-9 px-5 text-sm uppercase xl:inline-flex"
+                trackingData={{ action: 'book_demo_topbar' }}
+                trackingName="topbar_cta_click"
               >
                 <a
                   href={EnvironmentService.calendly}
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  Book Demo
+                  Book a Demo
                 </a>
-              </Button>
-              <Button
+              </ButtonTracked>
+              <ButtonTracked
                 asChild
                 size={ButtonSize.PUBLIC}
                 className="h-9 px-5 text-sm uppercase"
+                trackingData={{ action: 'connect_mcp_topbar' }}
+                trackingName="topbar_cta_click"
               >
-                <a href={signUpHref} target="_blank" rel="noopener noreferrer">
-                  Create now
+                <a
+                  href={EnvironmentService.mcpConnectHref}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Connect MCP
                 </a>
-              </Button>
+              </ButtonTracked>
             </>
           ) : (
             <a


### PR DESCRIPTION
## Summary

- lead the homepage with the confirmed discovery-focused hierarchy: “Your product deserves to be discovered,” “One prompt. Publish everywhere,” Connect MCP, and Book a Demo
- move the Claude Code/Codex → Genfeed → approval/publish → analytics lifecycle into the second section while retaining the generated-output wall and measurable outcome proof
- simplify the shared website navigation around MCP, publishing, the control plane, analytics, self-hosting, pricing, docs, and demo
- use one canonical `EnvironmentService.mcpConnectHref` contract for the upcoming guided Connect Genfeed flow and distinguish Connect MCP/demo interactions in existing marketing tracking
- update homepage/site metadata and structured positioning for AI-agent distribution infrastructure
- add focused coverage for hierarchy, destinations, tracking, lifecycle semantics, section order, navigation, metadata, and the canonical connect URL

## User impact

Developers now see the product outcome first, understand how Claude Code or Codex reaches supervised distribution within the first two sections, and can enter the MCP connection path without losing the managed-demo route or broader output, pricing, self-hosting, services, and proof surfaces.

## Verification

- `bunx @biomejs/biome@2.5.3 check <19 changed files>` — passed
- `bun run design:lint` — passed with 0 errors and 9 pre-existing unused-token warnings
- `bun run check:design-system` — passed
- focused `scripts/ui/control-guard.ts` over changed production TSX — passed with no raw controls
- exact source acceptance assertions for the locked hero hierarchy and four lifecycle stages — passed
- `git diff --cached --check` — passed
- `scripts/run-secretlint.ts` over all staged files — passed
- staged sensitive-filename and credential-pattern scans — passed
- the repository-wide UI guard completed all other checks but its existing nested-card scanner hit a local TypeScript runtime import error; the focused changed-file UI guard passed

Local tests, typecheck, build, Vitest, and E2E were intentionally not run under workstation policy. PR CI is the authoritative evidence for those gates.

## Dependency note

The CTA targets the stable `https://app.genfeed.ai/connect` contract owned by #1863. This avoids a temporary homepage URL while the guided Connect Genfeed flow lands.

## Checklist

- [x] Connect MCP is the primary CTA; Book a Demo is secondary
- [x] the first two sections explain Claude/Codex → Genfeed → approval/publish → analytics
- [x] generated assets and measurable distribution outcomes remain visible
- [x] pricing, self-hosting, docs, services, and demo destinations remain reachable
- [x] responsive composition uses existing breakpoints and shared UI primitives
- [x] marketing tracking distinguishes MCP connection from demo intent
- [x] SEO metadata and structured positioning are updated
- [x] scoped changes were formatted, reviewed, and secret-scanned
- [x] required PR CI is green — [CI run](https://github.com/genfeedai/genfeed.ai/actions/runs/29653753474)

Closes #1865
