### PR TITLE
test(api): enforce multitenancy mode boundaries

### DIFF
--- a/apps/server/api/src/collections/credentials/services/credentials.service.spec.ts
+++ b/apps/server/api/src/collections/credentials/services/credentials.service.spec.ts
@@ -113,6 +113,21 @@ describe('CredentialsService', () => {
     });
   });
 
+  describe('tenant-scoped lookups', () => {
+    it('scopes handle reads to active credentials in the caller organization', async () => {
+      await service.findByHandle('@acme', orgId);
+
+      expect(prisma.credential.findFirst).toHaveBeenCalledWith({
+        where: {
+          externalHandle: { contains: 'acme', mode: 'insensitive' },
+          isConnected: true,
+          isDeleted: false,
+          organizationId: orgId,
+        },
+      });
+    });
+  });
+
   describe('encrypt-on-write boundary', () => {
     const SECRET = 'plaintext-access-token';
 
@@ -279,6 +294,27 @@ describe('CredentialsService', () => {
         'Failed to import credential avatar',
         expect.objectContaining({ credentialId: 'existing-id' }),
       );
+    });
+
+    it('rejects cross-org profile updates before upload or persistence', async () => {
+      prisma.credential.findFirst.mockResolvedValueOnce(null);
+
+      await expect(
+        service.updateExternalProfile('existing-id', 'foreign-org', {
+          avatarUrl: 'https://platform.example/avatar.jpg',
+          handle: 'acme',
+        }),
+      ).rejects.toThrow('Credential existing-id not found');
+
+      expect(prisma.credential.findFirst).toHaveBeenCalledWith({
+        where: {
+          id: 'existing-id',
+          isDeleted: false,
+          organizationId: 'foreign-org',
+        },
+      });
+      expect(filesClient.uploadToS3).not.toHaveBeenCalled();
+      expect(prisma.credential.update).not.toHaveBeenCalled();
     });
 
     it('preserves the previous avatar when S3 import fails', async () => {

--- a/apps/server/api/src/helpers/guards/api-access/api-access.guard.spec.ts
+++ b/apps/server/api/src/helpers/guards/api-access/api-access.guard.spec.ts
@@ -165,14 +165,14 @@ describe('ApiAccessGuard', () => {
       vi.stubEnv('GENFEED_CLOUD', undefined);
     });
 
-    it.each([SubscriptionTier.FREE, SubscriptionTier.BYOK])(
-      'allows %s tier off cloud (no managed tiers/billing)',
-      (tier) => {
-        vi.mocked(authUtil.getSubscriptionTier).mockReturnValue(tier);
-        const ctx = buildContext(buildUser());
-        expect(guard.canActivate(ctx)).toBe(true);
-      },
-    );
+    it.each([
+      SubscriptionTier.FREE,
+      SubscriptionTier.BYOK,
+    ])('allows %s tier off cloud (no managed tiers/billing)', (tier) => {
+      vi.mocked(authUtil.getSubscriptionTier).mockReturnValue(tier);
+      const ctx = buildContext(buildUser());
+      expect(guard.canActivate(ctx)).toBe(true);
+    });
 
     it('allows even with no user off cloud', () => {
       const ctx = buildContext(null);

--- a/apps/server/api/src/helpers/guards/api-access/api-access.guard.spec.ts
+++ b/apps/server/api/src/helpers/guards/api-access/api-access.guard.spec.ts
@@ -12,17 +12,6 @@ import {
 import { Test } from '@nestjs/testing';
 import { vi } from 'vitest';
 
-// Keep the deployment function togglable so both cloud (enforced) and
-// non-cloud (bypassed) paths are exercised.
-let mockCloudMode = true;
-vi.mock('@genfeedai/config', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@genfeedai/config')>();
-  return {
-    ...actual,
-    isCloudDeployment: () => mockCloudMode,
-  };
-});
-
 vi.mock('@api/helpers/utils/auth/auth.util', () => ({
   getIsSuperAdmin: vi.fn(),
   getSubscriptionTier: vi.fn(),
@@ -54,7 +43,8 @@ describe('ApiAccessGuard', () => {
   };
 
   beforeEach(async () => {
-    mockCloudMode = true;
+    vi.stubEnv('GENFEED_CLOUD', '1');
+    vi.stubEnv('NEXT_PUBLIC_GENFEED_CLOUD', undefined);
     mockLogger = {
       debug: vi.fn(),
       error: vi.fn(),
@@ -77,6 +67,7 @@ describe('ApiAccessGuard', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllEnvs();
   });
 
   it('is defined', () => {
@@ -171,16 +162,17 @@ describe('ApiAccessGuard', () => {
 
   describe('self-hosted / community / desktop (bypassed)', () => {
     beforeEach(() => {
-      mockCloudMode = false;
+      vi.stubEnv('GENFEED_CLOUD', undefined);
     });
 
-    it('allows free tier off cloud (no tiers/billing)', () => {
-      vi.mocked(authUtil.getSubscriptionTier).mockReturnValue(
-        SubscriptionTier.FREE,
-      );
-      const ctx = buildContext(buildUser());
-      expect(guard.canActivate(ctx)).toBe(true);
-    });
+    it.each([SubscriptionTier.FREE, SubscriptionTier.BYOK])(
+      'allows %s tier off cloud (no managed tiers/billing)',
+      (tier) => {
+        vi.mocked(authUtil.getSubscriptionTier).mockReturnValue(tier);
+        const ctx = buildContext(buildUser());
+        expect(guard.canActivate(ctx)).toBe(true);
+      },
+    );
 
     it('allows even with no user off cloud', () => {
       const ctx = buildContext(null);

--- a/apps/server/api/src/helpers/guards/combined-auth/combined-auth.guard.spec.ts
+++ b/apps/server/api/src/helpers/guards/combined-auth/combined-auth.guard.spec.ts
@@ -9,17 +9,7 @@ import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockedMode = vi.hoisted(() => ({
   betterAuthEnabled: true,
-  selfHosted: false,
 }));
-
-vi.mock('@genfeedai/config', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@genfeedai/config')>();
-
-  return {
-    ...actual,
-    isSelfHostedDeployment: () => mockedMode.selfHosted,
-  };
-});
 
 vi.mock('@genfeedai/auth-client/server', () => ({
   isBetterAuthEnabled: () => mockedMode.betterAuthEnabled,
@@ -55,7 +45,8 @@ describe('CombinedAuthGuard', () => {
   const instantiateGuard = async (
     mode: 'cloud' | 'hybrid' | 'local' = 'cloud',
   ) => {
-    mockedMode.selfHosted = mode !== 'cloud';
+    vi.stubEnv('GENFEED_CLOUD', mode === 'cloud' ? '1' : undefined);
+    vi.stubEnv('NEXT_PUBLIC_GENFEED_CLOUD', undefined);
     mockedMode.betterAuthEnabled = mode !== 'local';
     vi.resetModules();
 
@@ -100,8 +91,8 @@ describe('CombinedAuthGuard', () => {
   });
 
   afterAll(() => {
-    mockedMode.selfHosted = false;
     mockedMode.betterAuthEnabled = true;
+    vi.unstubAllEnvs();
   });
 
   it('is defined', () => {

--- a/apps/server/api/src/helpers/guards/member-credits/member-credits.guard.spec.ts
+++ b/apps/server/api/src/helpers/guards/member-credits/member-credits.guard.spec.ts
@@ -1,12 +1,3 @@
-let mockCloudMode = true;
-vi.mock('@genfeedai/config', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@genfeedai/config')>();
-  return {
-    ...actual,
-    isCloudDeployment: () => mockCloudMode,
-  };
-});
-
 import { MembersService } from '@api/collections/members/services/members.service';
 import { OrganizationSettingsService } from '@api/collections/organization-settings/services/organization-settings.service';
 import { UNLIMITED_SEATS_FAIR_USE_CEILING } from '@api/collections/organization-settings/utils/seat-policy.util';
@@ -50,7 +41,8 @@ describe('MemberCreditsGuard', () => {
   let membersService: { findAll: ReturnType<typeof vi.fn> };
 
   beforeEach(() => {
-    mockCloudMode = true;
+    vi.stubEnv('GENFEED_CLOUD', '1');
+    vi.stubEnv('NEXT_PUBLIC_GENFEED_CLOUD', undefined);
     organizationSettingsService = { findOne: vi.fn() };
     membersService = { findAll: vi.fn() };
 
@@ -65,6 +57,7 @@ describe('MemberCreditsGuard', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllEnvs();
   });
 
   it('returns true when under the free solo seat limit', async () => {
@@ -151,7 +144,7 @@ describe('MemberCreditsGuard', () => {
   });
 
   it('never seat-gates outside managed cloud', async () => {
-    mockCloudMode = false;
+    vi.stubEnv('GENFEED_CLOUD', undefined);
 
     await expect(guard.canActivate(createContext())).resolves.toBe(true);
     expect(organizationSettingsService.findOne).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

- exercise `CombinedAuthGuard`, `MemberCreditsGuard`, and `ApiAccessGuard` through the real `GENFEED_CLOUD` deployment contract instead of mocking config helpers
- pin cloud BYOK rejection and self-hosted Free/BYOK access behavior
- add credential read scoping and cross-organization write rejection assertions

## Verification

- `bunx biome check` on all four changed specs — passed
- `git diff --check` and staged filename/credential-pattern scans — passed
- Secretlint — blocked because this worktree cannot resolve `@secretlint/secretlint-rule-preset-recommend` and `@secretlint/secretlint-rule-no-homedir`
- Local tests, typecheck, and build — skipped per workstation policy; PR CI owns executable validation

Closes #1597