### PR TITLE
docs: align issue reference guidance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
 
 ## Related issue
 
-<!-- Use `Closes #123` when this PR fully resolves tracked work. Use `Refs #123` for context only. If no tracking issue exists, write `No-Issue` and explain why. Repositories may require a closing keyword for feat/fix PRs. -->
+<!-- Use a closing reference (`Closes #123`) only when this PR fully resolves tracked work. Use a non-closing reference (`Refs #123`) for context only. If no tracking issue exists, write `No-Issue` and explain why. A closing reference takes effect when the PR merges into the default branch. Repositories may require a closing keyword for feat/fix PRs. -->
 
 ## Scope
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,7 +147,10 @@ request, list exactly what you ran and any checks left to CI.
 ## Pull-request expectations
 
 - Keep the patch single-purpose and split unrelated work.
-- Link the issue with `Closes #123` only when this PR fully resolves it; use `Refs #123` otherwise. A closing keyword takes effect when the PR merges into the default branch.
+- Use a closing reference (`Closes #123`) only when the pull request fully
+  resolves tracked work. Use a non-closing reference (`Refs #123`) for context
+  only. If no tracking issue exists, write `No-Issue` and explain why. A closing
+  reference takes effect when the pull request merges into the default branch.
 - Explain user-visible behavior and repository-boundary effects.
 - Include focused verification commands and results.
 - Call out generated files, migrations, configuration changes, and external


### PR DESCRIPTION
## Summary

- align the pull-request template and contributor guide on closing versus non-closing issue references
- document the `No-Issue` path consistently in both contributor-facing surfaces
- clarify that closing references take effect after merge to the default branch

## Related issue

Closes #1666

## Scope

Documentation-only. No runtime code, public API, migration, generated file, or external configuration changes.

## Verification

- `git diff --check` — passed
- focused Node assertion across both documents — 8/8 contract assertions passed
- Biome — skipped because the repository configuration ignores both Markdown files
- Secretlint — blocked because this worktree cannot load `@secretlint/secretlint-rule-preset-recommend` or `@secretlint/secretlint-rule-no-homedir`; staged credential-pattern scan passed
- tests, typecheck, and build — skipped for this documentation-only change per workstation policy

## Screenshots

Not applicable.

## Checklist

- [x] I reviewed the final diff for unrelated changes.
- [x] I ran the relevant focused checks or documented why they were left to CI.
- [x] I updated relevant documentation or explained why no documentation change is needed.
- [x] Migrations, release steps, and external configuration changes are not applicable.
- [x] I did not include secrets, credentials, personal data, customer data, or generated build output.
