### PR TITLE
test(app): harden Better Auth lifecycle isolation

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.spec.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.spec.tsx
@@ -35,23 +35,6 @@ vi.mock('@genfeedai/auth-client/react', () => ({
   }),
 }));
 
-// Stop the real Better Auth browser client (a module-level `createAuthClient`
-// singleton in @genfeedai/auth-client) from mounting its nanostores session
-// store. That store schedules a broadcast-channel session-refresh timer that
-// fires AFTER this test's jsdom `window` is torn down, throwing
-// "ReferenceError: window is not defined" from cleanupBroadcastSetup — a benign
-// teardown race that vitest v4 counts as a fatal unhandled error.
-vi.mock('better-auth/react', () => ({
-  createAuthClient: () => ({
-    $fetch: vi.fn().mockResolvedValue({ data: null }),
-    getSession: vi.fn().mockResolvedValue({ data: null }),
-    signIn: { magicLink: vi.fn() },
-    signOut: vi.fn(),
-    signUp: {},
-    useSession: vi.fn(() => ({ data: null, isPending: false })),
-  }),
-}));
-
 vi.mock('@contexts/user/brand-context/brand-context', () => ({
   useBrand: () => ({
     brandId: 'brand-1',

--- a/apps/app/tests/better-auth-react.stub.ts
+++ b/apps/app/tests/better-auth-react.stub.ts
@@ -1,0 +1,16 @@
+import { vi } from 'vitest';
+
+export function createAuthClient() {
+  return {
+    $fetch: vi.fn().mockResolvedValue({ data: null }),
+    getSession: vi.fn().mockResolvedValue({ data: null }),
+    signIn: { email: vi.fn(), magicLink: vi.fn(), social: vi.fn() },
+    signOut: vi.fn(),
+    signUp: { email: vi.fn() },
+    useSession: vi.fn(() => ({
+      data: null,
+      error: null,
+      isPending: false,
+    })),
+  };
+}

--- a/apps/app/tests/better-auth-react.stub.ts
+++ b/apps/app/tests/better-auth-react.stub.ts
@@ -2,8 +2,12 @@ import { vi } from 'vitest';
 
 export function createAuthClient() {
   return {
-    $fetch: vi.fn().mockResolvedValue({ data: null }),
-    getSession: vi.fn().mockResolvedValue({ data: null }),
+    $fetch: vi.fn().mockResolvedValue({ data: null, error: null }),
+    getSession: vi.fn().mockResolvedValue({ data: null, error: null }),
+    requestPasswordReset: vi
+      .fn()
+      .mockResolvedValue({ data: null, error: null }),
+    resetPassword: vi.fn().mockResolvedValue({ data: null, error: null }),
     signIn: { email: vi.fn(), magicLink: vi.fn(), social: vi.fn() },
     signOut: vi.fn(),
     signUp: { email: vi.fn() },

--- a/apps/app/vitest.config.mts
+++ b/apps/app/vitest.config.mts
@@ -11,6 +11,16 @@ export default mergeConfig(
     resolve: {
       alias: [
         {
+          // Resolve Better Auth to a timer-free test implementation before
+          // dependency externalization. Runtime vi.mock interception no longer
+          // covers the package-local realpath used by Better Auth 1.6.23.
+          find: /^better-auth\/react$/,
+          replacement: path.resolve(
+            __dirname,
+            './tests/better-auth-react.stub.ts',
+          ),
+        },
+        {
           find: 'server-only',
           replacement: path.resolve(__dirname, './tests/server-only.stub.ts'),
         },

--- a/apps/app/vitest.setup.ts
+++ b/apps/app/vitest.setup.ts
@@ -1,27 +1,7 @@
 import '@testing-library/jest-dom/vitest';
 import { cleanup } from '@testing-library/react';
-import { afterEach, vi } from 'vitest';
+import { afterEach } from 'vitest';
 import './tests/server-only.stub';
-
-// Global: stop the real Better Auth browser client from mounting. `@genfeedai/
-// auth-client` creates a module-level `createAuthClient` singleton whose
-// nanostores session store schedules a broadcast-channel refresh timer. That
-// timer fires AFTER a test's jsdom `window` is torn down, throwing
-// "ReferenceError: window is not defined" from cleanupBroadcastSetup — which
-// vitest v4 counts as a fatal unhandled error and fails the whole run even when
-// every test passes. Mocking createAuthClient here neutralises the timer across
-// the entire app suite; per-file hook mocks (@genfeedai/auth-client/react) are a
-// different module and still take precedence where present.
-vi.mock('better-auth/react', () => ({
-  createAuthClient: () => ({
-    $fetch: vi.fn().mockResolvedValue({ data: null }),
-    getSession: vi.fn().mockResolvedValue({ data: null }),
-    signIn: { email: vi.fn(), magicLink: vi.fn(), social: vi.fn() },
-    signOut: vi.fn(),
-    signUp: { email: vi.fn() },
-    useSession: vi.fn(() => ({ data: null, error: null, isPending: false })),
-  }),
-}));
 
 // Explicitly unmount React trees and clear the jsdom document after every test.
 // RTL auto-cleanup already runs when a global afterEach exists, but making it


### PR DESCRIPTION
## Summary

- resolve `better-auth/react` to a timer-free app-test stub before Vitest dependency externalization
- remove duplicated runtime mocks from global setup and the workspace spec
- prevent Better Auth nanostores cleanup timers from firing after jsdom teardown

## Root cause

Better Auth 1.6.23 is resolved through a package-local realpath that bypasses the existing runtime `vi.mock` interception. The real module-level auth client therefore mounts its session store, and its delayed broadcast-channel cleanup reads `window` after Vitest has destroyed jsdom. Two independent CI runs reproduced the fatal unhandled error after all assertions passed.

## Verification

- focused Biome check: clean
- `git diff --check`: clean
- staged secret scan: clean
- app tests/typecheck/build delegated to PR CI per workstation policy
