### PR TITLE
fix(workflows): label node icon actions

### DIFF
--- a/apps/app/src/features/workflows/components/ui/button/NodeButton.test.tsx
+++ b/apps/app/src/features/workflows/components/ui/button/NodeButton.test.tsx
@@ -1,0 +1,30 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { NodeIconButton } from './NodeButton';
+
+describe('NodeIconButton', () => {
+  it('uses its title as the accessible name for icon-only actions', () => {
+    render(
+      <NodeIconButton title="Copy webhook URL">
+        <span aria-hidden="true">copy</span>
+      </NodeIconButton>,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Copy webhook URL' }),
+    ).toHaveAttribute('title', 'Copy webhook URL');
+  });
+
+  it('preserves an explicit accessible name when it differs from the tooltip', () => {
+    render(
+      <NodeIconButton aria-label="Copy generated caption" title="Copy">
+        <span aria-hidden="true">copy</span>
+      </NodeIconButton>,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Copy generated caption' }),
+    ).toHaveAttribute('title', 'Copy');
+  });
+});

--- a/apps/app/src/features/workflows/components/ui/button/NodeButton.tsx
+++ b/apps/app/src/features/workflows/components/ui/button/NodeButton.tsx
@@ -57,11 +57,15 @@ export function NodeButton({
 export function NodeIconButton({
   className,
   children,
+  title,
+  'aria-label': ariaLabel,
   ...props
 }: React.ButtonHTMLAttributes<HTMLButtonElement>): React.JSX.Element {
   return (
     <Button
+      ariaLabel={ariaLabel ?? title}
       className={cn('p-1.5 hover:bg-muted transition flex-shrink-0', className)}
+      title={title}
       variant={ButtonVariant.UNSTYLED}
       {...props}
     >


### PR DESCRIPTION
Closes #1709

## Summary

- derive screen-reader names for icon-only workflow node actions from their existing title text
- preserve explicit aria-label overrides when tooltip and accessible copy differ
- add focused React Testing Library regression coverage for both paths

## Verification

- `bunx @biomejs/biome check apps/app/src/features/workflows/components/ui/button/NodeButton.tsx apps/app/src/features/workflows/components/ui/button/NodeButton.test.tsx` — passed
- `bun run design:lint` — passed with 0 errors (9 existing unused-token warnings)
- `bun run check:design-system` — passed
- `git diff --cached --check` — passed before commit
- focused unit test, typecheck, and broader suites were not run locally under the workstation policy; PR CI owns those checks

## Residual risk

The change is limited to accessible naming and does not alter click behavior or visual styling. Runtime test execution remains pending in CI.
