### PR TITLE
feat(clips): orchestrate deterministic clip jobs

### DIFF
--- a/apps/server/api/src/collections/clip-projects/clip-projects-core.module.ts
+++ b/apps/server/api/src/collections/clip-projects/clip-projects-core.module.ts
@@ -12,6 +12,7 @@ import { ClipProjectsService } from '@api/collections/clip-projects/clip-project
 import { ClipGenerationService } from '@api/collections/clip-projects/services/clip-generation.service';
 import { HighlightRewriteService } from '@api/collections/clip-projects/services/highlight-rewrite.service';
 import { RawCutClipService } from '@api/collections/clip-projects/services/raw-cut-clip.service';
+import { RawCutClipCompletionService } from '@api/collections/clip-projects/services/raw-cut-clip-completion.service';
 import { ClipResultsModule } from '@api/collections/clip-results/clip-results.module';
 import { CreditsModule } from '@api/collections/credits/credits.module';
 import { AvatarVideoModule } from '@api/services/avatar-video/avatar-video.module';
@@ -24,6 +25,7 @@ import { forwardRef, Module } from '@nestjs/common';
     ClipProjectsService,
     ClipGenerationService,
     HighlightRewriteService,
+    RawCutClipCompletionService,
     RawCutClipService,
   ],
   imports: [
@@ -37,6 +39,7 @@ import { forwardRef, Module } from '@nestjs/common';
     ClipProjectsService,
     ClipGenerationService,
     HighlightRewriteService,
+    RawCutClipCompletionService,
     RawCutClipService,
   ],
 })

--- a/apps/server/api/src/collections/clip-projects/clip-projects.service.spec.ts
+++ b/apps/server/api/src/collections/clip-projects/clip-projects.service.spec.ts
@@ -245,6 +245,7 @@ describe('ClipProjectsService', () => {
       data: expect.objectContaining({
         failedClipCount: 0,
         pendingClipCount: 1,
+        progress: 80,
         readyClipCount: 1,
       }),
       where: { id: 'project-1' },

--- a/apps/server/api/src/collections/clip-projects/clip-projects.service.ts
+++ b/apps/server/api/src/collections/clip-projects/clip-projects.service.ts
@@ -129,6 +129,7 @@ export class ClipProjectsService extends BaseService<
       pendingClipCount,
       readyClipCount,
     };
+    const settledClipCount = readyClipCount + failedClipCount;
 
     if (pendingClipCount === 0) {
       update.progress = 100;
@@ -140,6 +141,13 @@ export class ClipProjectsService extends BaseService<
         update.error = 'All clip generations failed.';
         update.status = 'failed';
       }
+    } else if (settledClipCount > 0) {
+      const currentProgress =
+        typeof project.progress === 'number' ? project.progress : 0;
+      update.progress = Math.max(
+        currentProgress,
+        Math.min(99, 60 + Math.floor((settledClipCount / results.length) * 40)),
+      );
     }
 
     if (!this.hasReconciliationChange(project, update)) {

--- a/apps/server/api/src/collections/clip-projects/services/clip-generation.service.spec.ts
+++ b/apps/server/api/src/collections/clip-projects/services/clip-generation.service.spec.ts
@@ -58,7 +58,7 @@ function createMockRawCutClipService(): Mocked<
 > {
   return {
     dispatchClip: vi.fn().mockResolvedValue({
-      jobId: 'trim-job-1',
+      jobId: 'raw-cut-trim-clip-result-1',
       providerName: 'raw-cut',
       status: 'queued',
     }),
@@ -416,17 +416,40 @@ describe('ClipGenerationService (raw-cut mode)', () => {
     );
   });
 
-  it('marks the clip extracting, then persists the caption SRT and job handle', async () => {
+  it('persists recovery metadata before dispatching the trim job', async () => {
+    rawCutClipService.dispatchClip.mockImplementationOnce(async () => {
+      expect(clipResultsService.patch).toHaveBeenCalledWith(
+        'clip-result-1',
+        expect.objectContaining({
+          captionSrt: EXPECTED_SRT,
+          providerJobId: 'raw-cut-trim-clip-result-1',
+          providerName: 'raw-cut',
+          sourceVideoS3Key: 'videos/source.mp4',
+          userId: '507f1f77bcf86cd799439013',
+        }),
+      );
+      return {
+        jobId: 'raw-cut-trim-clip-result-1',
+        providerName: 'raw-cut',
+        status: 'queued',
+      };
+    });
+
     await service.generateClips(makeRawCutInput());
 
     expect(clipResultsService.patch).toHaveBeenCalledWith('clip-result-1', {
       status: 'extracting',
     });
-    expect(clipResultsService.patch).toHaveBeenCalledWith('clip-result-1', {
-      captionSrt: EXPECTED_SRT,
-      providerJobId: 'trim-job-1',
-      providerName: 'raw-cut',
-    });
+    expect(clipResultsService.patch).toHaveBeenCalledWith(
+      'clip-result-1',
+      expect.objectContaining({
+        captionSrt: EXPECTED_SRT,
+        providerJobId: 'raw-cut-trim-clip-result-1',
+        providerName: 'raw-cut',
+        sourceVideoS3Key: 'videos/source.mp4',
+        userId: '507f1f77bcf86cd799439013',
+      }),
+    );
   });
 
   it('isolates a per-highlight failure and continues the batch', async () => {

--- a/apps/server/api/src/collections/clip-projects/services/clip-generation.service.ts
+++ b/apps/server/api/src/collections/clip-projects/services/clip-generation.service.ts
@@ -8,6 +8,7 @@ import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
 import { generateClipSrt, type TranscriptSegment } from './clip-srt.util';
 import {
+  getRawCutTrimJobId,
   RAW_CUT_PROVIDER_NAME,
   RawCutClipService,
 } from './raw-cut-clip.service';
@@ -70,7 +71,7 @@ export interface ClipGenerationResult {
  */
 interface ClipDispatchOutcome {
   jobId: string;
-  patch: Record<string, unknown>;
+  patch?: Record<string, unknown>;
 }
 
 /**
@@ -218,6 +219,18 @@ export class ClipGenerationService {
           highlight.start_time,
           highlight.end_time,
         );
+        const providerJobId = getRawCutTrimJobId(clipResultId);
+
+        await this.clipResultsService.patch(clipResultId, {
+          authProviderUserId,
+          captionSrt,
+          providerJobId,
+          providerName: RAW_CUT_PROVIDER_NAME,
+          room,
+          sourceVideoS3Key,
+          sourceVideoUrl,
+          userId,
+        });
 
         const dispatch = await this.rawCutClipService.dispatchClip({
           authProviderUserId,
@@ -234,11 +247,6 @@ export class ClipGenerationService {
 
         return {
           jobId: dispatch.jobId,
-          patch: {
-            captionSrt,
-            providerJobId: dispatch.jobId,
-            providerName: dispatch.providerName,
-          },
         };
       },
       failureProviderName: RAW_CUT_PROVIDER_NAME,
@@ -300,7 +308,9 @@ export class ClipGenerationService {
           index: i,
         });
 
-        await this.clipResultsService.patch(clipResultId, patch);
+        if (patch) {
+          await this.clipResultsService.patch(clipResultId, patch);
+        }
 
         providerJobIds.push(jobId);
         queuedClipCount += 1;
@@ -362,7 +372,7 @@ export class ClipGenerationService {
         summary: highlight.summary,
         tags: highlight.tags,
         title: highlight.title,
-        user: userId,
+        userId,
         viralityScore: highlight.virality_score,
       } as unknown as CreateClipResultDto,
     );

--- a/apps/server/api/src/collections/clip-projects/services/raw-cut-clip-completion.service.spec.ts
+++ b/apps/server/api/src/collections/clip-projects/services/raw-cut-clip-completion.service.spec.ts
@@ -162,11 +162,11 @@ describe('RawCutClipCompletionService', () => {
     expect(clipResultsService.patch).toHaveBeenNthCalledWith(1, 'clip-1', {
       captionedVideoS3Key: 'videos/clip-1.mp4',
       captionedVideoUrl: 'https://cdn.genfeed.ai/videos/clip-1.mp4',
-      projectReconciliationPending: true,
+      isProjectReconciliationPending: true,
       status: 'completed',
     });
     expect(clipResultsService.patch).toHaveBeenNthCalledWith(2, 'clip-1', {
-      projectReconciliationPending: false,
+      isProjectReconciliationPending: false,
     });
     expect(clipProjectsService.reconcileTerminalState).toHaveBeenCalledWith(
       'project-1',
@@ -190,11 +190,11 @@ describe('RawCutClipCompletionService', () => {
 
     expect(clipResultsService.patch).toHaveBeenNthCalledWith(1, 'clip-1', {
       error: 'ffmpeg failed',
-      projectReconciliationPending: true,
+      isProjectReconciliationPending: true,
       status: 'failed',
     });
     expect(clipResultsService.patch).toHaveBeenNthCalledWith(2, 'clip-1', {
-      projectReconciliationPending: false,
+      isProjectReconciliationPending: false,
     });
     expect(clipProjectsService.reconcileTerminalState).toHaveBeenCalledWith(
       'project-1',
@@ -272,7 +272,7 @@ describe('RawCutClipCompletionService', () => {
   it('does not downgrade a completed clip when a failure event is replayed', async () => {
     clipResultsService.findOne.mockResolvedValue(
       makeClip({
-        projectReconciliationPending: false,
+        isProjectReconciliationPending: false,
         status: 'completed',
       }),
     );
@@ -330,7 +330,7 @@ describe('RawCutClipCompletionService', () => {
 
   it('retries parent reconciliation from a durable terminal marker', async () => {
     const clip = makeClip({
-      projectReconciliationPending: true,
+      isProjectReconciliationPending: true,
       status: 'completed',
     });
     clipResultsService.countRawCutsPendingProjectReconciliation.mockResolvedValue(
@@ -347,7 +347,7 @@ describe('RawCutClipCompletionService', () => {
       'org-1',
     );
     expect(clipResultsService.patch).toHaveBeenCalledWith('clip-1', {
-      projectReconciliationPending: false,
+      isProjectReconciliationPending: false,
     });
   });
 

--- a/apps/server/api/src/collections/clip-projects/services/raw-cut-clip-completion.service.spec.ts
+++ b/apps/server/api/src/collections/clip-projects/services/raw-cut-clip-completion.service.spec.ts
@@ -1,4 +1,5 @@
 import type { ClipProjectsService } from '@api/collections/clip-projects/clip-projects.service';
+import type { RawCutClipService } from '@api/collections/clip-projects/services/raw-cut-clip.service';
 import { RawCutClipCompletionService } from '@api/collections/clip-projects/services/raw-cut-clip-completion.service';
 import type { ClipResultsService } from '@api/collections/clip-results/clip-results.service';
 import type { ClipResultDocument } from '@api/collections/clip-results/schemas/clip-result.schema';
@@ -11,6 +12,7 @@ function makeClip(
 ): ClipResultDocument {
   return {
     _id: 'clip-1',
+    authProviderUserId: 'auth-user-1',
     captionSrt: '1\n00:00:00,000 --> 00:00:03,000\nLaunch',
     createdAt: new Date(),
     data: {},
@@ -22,10 +24,14 @@ function makeClip(
     projectId: 'project-1',
     providerJobId: 'raw-cut-trim-clip-1',
     readiness: {},
+    room: 'room-1',
+    sourceVideoS3Key: 'videos/source.mp4',
+    startTime: 10,
+    endTime: 20,
     status: 'extracting',
     terminalAt: null,
     updatedAt: new Date(),
-    user: 'user-1',
+    userId: 'user-1',
     viralityScore: null,
     ...overrides,
   } as ClipResultDocument;
@@ -37,7 +43,10 @@ describe('RawCutClipCompletionService', () => {
     reconcileTerminalState: ReturnType<typeof vi.fn>;
   };
   let clipResultsService: {
+    countActiveRawCuts: ReturnType<typeof vi.fn>;
+    countRawCutsPendingProjectReconciliation: ReturnType<typeof vi.fn>;
     findActiveRawCuts: ReturnType<typeof vi.fn>;
+    findRawCutsPendingProjectReconciliation: ReturnType<typeof vi.fn>;
     findOne: ReturnType<typeof vi.fn>;
     patch: ReturnType<typeof vi.fn>;
   };
@@ -45,13 +54,19 @@ describe('RawCutClipCompletionService', () => {
     getJobStatus: ReturnType<typeof vi.fn>;
     processVideo: ReturnType<typeof vi.fn>;
   };
+  let rawCutClipService: {
+    dispatchClip: ReturnType<typeof vi.fn>;
+  };
 
   beforeEach(() => {
     clipProjectsService = {
       reconcileTerminalState: vi.fn().mockResolvedValue(undefined),
     };
     clipResultsService = {
+      countActiveRawCuts: vi.fn().mockResolvedValue(0),
+      countRawCutsPendingProjectReconciliation: vi.fn().mockResolvedValue(0),
       findActiveRawCuts: vi.fn().mockResolvedValue([]),
+      findRawCutsPendingProjectReconciliation: vi.fn().mockResolvedValue([]),
       findOne: vi.fn(),
       patch: vi.fn().mockResolvedValue(undefined),
     };
@@ -62,11 +77,19 @@ describe('RawCutClipCompletionService', () => {
         status: 'waiting',
       }),
     };
+    rawCutClipService = {
+      dispatchClip: vi.fn().mockResolvedValue({
+        jobId: 'raw-cut-trim-clip-1',
+        providerName: 'raw-cut',
+        status: 'waiting',
+      }),
+    };
 
     service = new RawCutClipCompletionService(
       clipProjectsService as unknown as ClipProjectsService,
       clipResultsService as unknown as ClipResultsService,
       fileQueueService as unknown as FileQueueService,
+      rawCutClipService as unknown as RawCutClipService,
       {
         debug: vi.fn(),
         error: vi.fn(),
@@ -94,12 +117,8 @@ describe('RawCutClipCompletionService', () => {
     });
 
     expect(handled).toBe(true);
-    expect(clipResultsService.patch).toHaveBeenNthCalledWith(1, 'clip-1', {
-      status: 'captioning',
-      videoS3Key: 'videos/clip-1.mp4',
-      videoUrl: 'https://cdn.genfeed.ai/videos/clip-1.mp4',
-    });
     expect(fileQueueService.processVideo).toHaveBeenCalledWith({
+      authProviderUserId: 'auth-user-1',
       id: 'raw-cut-caption-clip-1',
       ingredientId: 'clip-1',
       organizationId: 'org-1',
@@ -107,12 +126,16 @@ describe('RawCutClipCompletionService', () => {
         captionContent: '1\n00:00:00,000 --> 00:00:03,000\nLaunch',
         s3Key: 'videos/clip-1.mp4',
       },
+      room: 'room-1',
       type: 'add-captions',
       userId: 'user-1',
       websocketUrl: '/clips/clip-1',
     });
-    expect(clipResultsService.patch).toHaveBeenNthCalledWith(2, 'clip-1', {
+    expect(clipResultsService.patch).toHaveBeenCalledWith('clip-1', {
       providerJobId: 'raw-cut-caption-clip-1',
+      status: 'captioning',
+      videoS3Key: 'videos/clip-1.mp4',
+      videoUrl: 'https://cdn.genfeed.ai/videos/clip-1.mp4',
     });
   });
 
@@ -136,12 +159,14 @@ describe('RawCutClipCompletionService', () => {
       status: Status.COMPLETED,
     });
 
-    expect(clipResultsService.patch).toHaveBeenCalledWith('clip-1', {
+    expect(clipResultsService.patch).toHaveBeenNthCalledWith(1, 'clip-1', {
       captionedVideoS3Key: 'videos/clip-1.mp4',
       captionedVideoUrl: 'https://cdn.genfeed.ai/videos/clip-1.mp4',
+      projectReconciliationPending: true,
       status: 'completed',
-      videoS3Key: 'videos/clip-1.mp4',
-      videoUrl: 'https://cdn.genfeed.ai/videos/clip-1.mp4',
+    });
+    expect(clipResultsService.patch).toHaveBeenNthCalledWith(2, 'clip-1', {
+      projectReconciliationPending: false,
     });
     expect(clipProjectsService.reconcileTerminalState).toHaveBeenCalledWith(
       'project-1',
@@ -163,9 +188,13 @@ describe('RawCutClipCompletionService', () => {
       status: Status.FAILED,
     });
 
-    expect(clipResultsService.patch).toHaveBeenCalledWith('clip-1', {
+    expect(clipResultsService.patch).toHaveBeenNthCalledWith(1, 'clip-1', {
       error: 'ffmpeg failed',
+      projectReconciliationPending: true,
       status: 'failed',
+    });
+    expect(clipResultsService.patch).toHaveBeenNthCalledWith(2, 'clip-1', {
+      projectReconciliationPending: false,
     });
     expect(clipProjectsService.reconcileTerminalState).toHaveBeenCalledWith(
       'project-1',
@@ -176,6 +205,7 @@ describe('RawCutClipCompletionService', () => {
 
   it('polls active raw-cut jobs to recover a missed completion event', async () => {
     const clip = makeClip();
+    clipResultsService.countActiveRawCuts.mockResolvedValue(1);
     clipResultsService.findActiveRawCuts.mockResolvedValue([clip]);
     clipResultsService.findOne.mockResolvedValue(clip);
     fileQueueService.getJobStatus.mockResolvedValue({
@@ -195,6 +225,130 @@ describe('RawCutClipCompletionService', () => {
       'raw-cut-trim-clip-1',
     );
     expect(fileQueueService.processVideo).toHaveBeenCalled();
+  });
+
+  it('redispatches a durably described trim when the queue job is missing', async () => {
+    const clip = makeClip();
+    clipResultsService.countActiveRawCuts.mockResolvedValue(1);
+    clipResultsService.findActiveRawCuts.mockResolvedValue([clip]);
+    fileQueueService.getJobStatus.mockRejectedValue(new Error('not found'));
+
+    await service.reconcileActiveClips();
+
+    expect(rawCutClipService.dispatchClip).toHaveBeenCalledWith({
+      authProviderUserId: 'auth-user-1',
+      captionSrt: '1\n00:00:00,000 --> 00:00:03,000\nLaunch',
+      clipResultId: 'clip-1',
+      endTime: 20,
+      organizationId: 'org-1',
+      room: 'room-1',
+      sourceVideoS3Key: 'videos/source.mp4',
+      sourceVideoUrl: undefined,
+      startTime: 10,
+      userId: 'user-1',
+    });
+    expect(clipResultsService.patch).toHaveBeenCalledWith('clip-1', {
+      providerJobId: 'raw-cut-trim-clip-1',
+    });
+  });
+
+  it('keeps a stale but active queue job alive', async () => {
+    const clip = makeClip({
+      updatedAt: new Date(Date.now() - 3 * 60 * 60 * 1000),
+    });
+    clipResultsService.countActiveRawCuts.mockResolvedValue(1);
+    clipResultsService.findActiveRawCuts.mockResolvedValue([clip]);
+    fileQueueService.getJobStatus.mockResolvedValue({
+      jobId: 'raw-cut-trim-clip-1',
+      state: JobState.ACTIVE,
+    });
+
+    await service.reconcileActiveClips();
+
+    expect(clipResultsService.patch).not.toHaveBeenCalled();
+    expect(rawCutClipService.dispatchClip).not.toHaveBeenCalled();
+  });
+
+  it('does not downgrade a completed clip when a failure event is replayed', async () => {
+    clipResultsService.findOne.mockResolvedValue(
+      makeClip({
+        projectReconciliationPending: false,
+        status: 'completed',
+      }),
+    );
+
+    await service.handleCompletion({
+      error: 'late failure',
+      ingredientId: 'clip-1',
+      organizationId: 'org-1',
+      result: {
+        jobId: 'raw-cut-trim-clip-1',
+        jobType: 'clip-trim',
+      },
+      status: Status.FAILED,
+    });
+
+    expect(clipResultsService.patch).not.toHaveBeenCalled();
+    expect(clipProjectsService.reconcileTerminalState).not.toHaveBeenCalled();
+  });
+
+  it('leaves the trim stage retryable when caption queueing fails', async () => {
+    clipResultsService.findOne.mockResolvedValue(makeClip());
+    fileQueueService.processVideo.mockRejectedValueOnce(
+      new Error('queue unavailable'),
+    );
+
+    await expect(
+      service.handleCompletion({
+        ingredientId: 'clip-1',
+        organizationId: 'org-1',
+        result: {
+          jobId: 'raw-cut-trim-clip-1',
+          jobType: 'clip-trim',
+          s3Key: 'videos/clip-1.mp4',
+          url: 'https://cdn.genfeed.ai/videos/clip-1.mp4',
+        },
+        status: Status.COMPLETED,
+        userId: 'user-1',
+      }),
+    ).rejects.toThrow('queue unavailable');
+
+    expect(clipResultsService.patch).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unscoped completion before querying clip data', async () => {
+    await expect(
+      service.handleCompletion({
+        ingredientId: 'clip-1',
+        organizationId: '',
+        status: Status.COMPLETED,
+      }),
+    ).resolves.toBe(true);
+
+    expect(clipResultsService.findOne).not.toHaveBeenCalled();
+  });
+
+  it('retries parent reconciliation from a durable terminal marker', async () => {
+    const clip = makeClip({
+      projectReconciliationPending: true,
+      status: 'completed',
+    });
+    clipResultsService.countRawCutsPendingProjectReconciliation.mockResolvedValue(
+      1,
+    );
+    clipResultsService.findRawCutsPendingProjectReconciliation.mockResolvedValue(
+      [clip],
+    );
+
+    await service.reconcileActiveClips();
+
+    expect(clipProjectsService.reconcileTerminalState).toHaveBeenCalledWith(
+      'project-1',
+      'org-1',
+    );
+    expect(clipResultsService.patch).toHaveBeenCalledWith('clip-1', {
+      projectReconciliationPending: false,
+    });
   });
 
   it('ignores a duplicated trim event after the caption stage starts', async () => {

--- a/apps/server/api/src/collections/clip-projects/services/raw-cut-clip-completion.service.spec.ts
+++ b/apps/server/api/src/collections/clip-projects/services/raw-cut-clip-completion.service.spec.ts
@@ -1,0 +1,223 @@
+import type { ClipProjectsService } from '@api/collections/clip-projects/clip-projects.service';
+import { RawCutClipCompletionService } from '@api/collections/clip-projects/services/raw-cut-clip-completion.service';
+import type { ClipResultsService } from '@api/collections/clip-results/clip-results.service';
+import type { ClipResultDocument } from '@api/collections/clip-results/schemas/clip-result.schema';
+import type { FileQueueService } from '@api/services/files-microservice/queue/file-queue.service';
+import { JobState, Status } from '@genfeedai/enums';
+import type { LoggerService } from '@libs/logger/logger.service';
+
+function makeClip(
+  overrides: Partial<ClipResultDocument> = {},
+): ClipResultDocument {
+  return {
+    _id: 'clip-1',
+    captionSrt: '1\n00:00:00,000 --> 00:00:03,000\nLaunch',
+    createdAt: new Date(),
+    data: {},
+    id: 'clip-1',
+    isDeleted: false,
+    isSelected: false,
+    mode: 'raw-cut',
+    organizationId: 'org-1',
+    projectId: 'project-1',
+    providerJobId: 'raw-cut-trim-clip-1',
+    readiness: {},
+    status: 'extracting',
+    terminalAt: null,
+    updatedAt: new Date(),
+    user: 'user-1',
+    viralityScore: null,
+    ...overrides,
+  } as ClipResultDocument;
+}
+
+describe('RawCutClipCompletionService', () => {
+  let service: RawCutClipCompletionService;
+  let clipProjectsService: {
+    reconcileTerminalState: ReturnType<typeof vi.fn>;
+  };
+  let clipResultsService: {
+    findActiveRawCuts: ReturnType<typeof vi.fn>;
+    findOne: ReturnType<typeof vi.fn>;
+    patch: ReturnType<typeof vi.fn>;
+  };
+  let fileQueueService: {
+    getJobStatus: ReturnType<typeof vi.fn>;
+    processVideo: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    clipProjectsService = {
+      reconcileTerminalState: vi.fn().mockResolvedValue(undefined),
+    };
+    clipResultsService = {
+      findActiveRawCuts: vi.fn().mockResolvedValue([]),
+      findOne: vi.fn(),
+      patch: vi.fn().mockResolvedValue(undefined),
+    };
+    fileQueueService = {
+      getJobStatus: vi.fn(),
+      processVideo: vi.fn().mockResolvedValue({
+        jobId: 'raw-cut-caption-clip-1',
+        status: 'waiting',
+      }),
+    };
+
+    service = new RawCutClipCompletionService(
+      clipProjectsService as unknown as ClipProjectsService,
+      clipResultsService as unknown as ClipResultsService,
+      fileQueueService as unknown as FileQueueService,
+      {
+        debug: vi.fn(),
+        error: vi.fn(),
+        log: vi.fn(),
+        verbose: vi.fn(),
+        warn: vi.fn(),
+      } as unknown as LoggerService,
+    );
+  });
+
+  it('persists the trim output and queues deterministic caption burning', async () => {
+    clipResultsService.findOne.mockResolvedValue(makeClip());
+
+    const handled = await service.handleCompletion({
+      ingredientId: 'clip-1',
+      organizationId: 'org-1',
+      result: {
+        jobId: 'raw-cut-trim-clip-1',
+        jobType: 'clip-trim',
+        s3Key: 'videos/clip-1.mp4',
+        url: 'https://cdn.genfeed.ai/videos/clip-1.mp4',
+      },
+      status: Status.COMPLETED,
+      userId: 'user-1',
+    });
+
+    expect(handled).toBe(true);
+    expect(clipResultsService.patch).toHaveBeenNthCalledWith(1, 'clip-1', {
+      status: 'captioning',
+      videoS3Key: 'videos/clip-1.mp4',
+      videoUrl: 'https://cdn.genfeed.ai/videos/clip-1.mp4',
+    });
+    expect(fileQueueService.processVideo).toHaveBeenCalledWith({
+      id: 'raw-cut-caption-clip-1',
+      ingredientId: 'clip-1',
+      organizationId: 'org-1',
+      params: {
+        captionContent: '1\n00:00:00,000 --> 00:00:03,000\nLaunch',
+        s3Key: 'videos/clip-1.mp4',
+      },
+      type: 'add-captions',
+      userId: 'user-1',
+      websocketUrl: '/clips/clip-1',
+    });
+    expect(clipResultsService.patch).toHaveBeenNthCalledWith(2, 'clip-1', {
+      providerJobId: 'raw-cut-caption-clip-1',
+    });
+  });
+
+  it('persists the captioned output and reconciles the parent project', async () => {
+    clipResultsService.findOne.mockResolvedValue(
+      makeClip({
+        providerJobId: 'raw-cut-caption-clip-1',
+        status: 'captioning',
+      }),
+    );
+
+    await service.handleCompletion({
+      ingredientId: 'clip-1',
+      organizationId: 'org-1',
+      result: {
+        jobId: 'raw-cut-caption-clip-1',
+        jobType: 'add-captions',
+        s3Key: 'videos/clip-1.mp4',
+        url: 'https://cdn.genfeed.ai/videos/clip-1.mp4',
+      },
+      status: Status.COMPLETED,
+    });
+
+    expect(clipResultsService.patch).toHaveBeenCalledWith('clip-1', {
+      captionedVideoS3Key: 'videos/clip-1.mp4',
+      captionedVideoUrl: 'https://cdn.genfeed.ai/videos/clip-1.mp4',
+      status: 'completed',
+      videoS3Key: 'videos/clip-1.mp4',
+      videoUrl: 'https://cdn.genfeed.ai/videos/clip-1.mp4',
+    });
+    expect(clipProjectsService.reconcileTerminalState).toHaveBeenCalledWith(
+      'project-1',
+      'org-1',
+    );
+  });
+
+  it('isolates a failed media job to its clip result', async () => {
+    clipResultsService.findOne.mockResolvedValue(makeClip());
+
+    await service.handleCompletion({
+      error: 'ffmpeg failed',
+      ingredientId: 'clip-1',
+      organizationId: 'org-1',
+      result: {
+        jobId: 'raw-cut-trim-clip-1',
+        jobType: 'clip-trim',
+      },
+      status: Status.FAILED,
+    });
+
+    expect(clipResultsService.patch).toHaveBeenCalledWith('clip-1', {
+      error: 'ffmpeg failed',
+      status: 'failed',
+    });
+    expect(clipProjectsService.reconcileTerminalState).toHaveBeenCalledWith(
+      'project-1',
+      'org-1',
+    );
+    expect(fileQueueService.processVideo).not.toHaveBeenCalled();
+  });
+
+  it('polls active raw-cut jobs to recover a missed completion event', async () => {
+    const clip = makeClip();
+    clipResultsService.findActiveRawCuts.mockResolvedValue([clip]);
+    clipResultsService.findOne.mockResolvedValue(clip);
+    fileQueueService.getJobStatus.mockResolvedValue({
+      jobId: 'raw-cut-trim-clip-1',
+      result: {
+        jobId: 'raw-cut-trim-clip-1',
+        jobType: 'clip-trim',
+        s3Key: 'videos/clip-1.mp4',
+        url: 'https://cdn.genfeed.ai/videos/clip-1.mp4',
+      },
+      state: JobState.COMPLETED,
+    });
+
+    await service.reconcileActiveClips();
+
+    expect(fileQueueService.getJobStatus).toHaveBeenCalledWith(
+      'raw-cut-trim-clip-1',
+    );
+    expect(fileQueueService.processVideo).toHaveBeenCalled();
+  });
+
+  it('ignores a duplicated trim event after the caption stage starts', async () => {
+    clipResultsService.findOne.mockResolvedValue(
+      makeClip({
+        providerJobId: 'raw-cut-trim-clip-1',
+        status: 'captioning',
+      }),
+    );
+
+    await service.handleCompletion({
+      ingredientId: 'clip-1',
+      organizationId: 'org-1',
+      result: {
+        jobId: 'raw-cut-trim-clip-1',
+        jobType: 'clip-trim',
+        s3Key: 'videos/clip-1.mp4',
+        url: 'https://cdn.genfeed.ai/videos/clip-1.mp4',
+      },
+      status: Status.COMPLETED,
+    });
+
+    expect(clipResultsService.patch).not.toHaveBeenCalled();
+    expect(fileQueueService.processVideo).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/api/src/collections/clip-projects/services/raw-cut-clip-completion.service.ts
+++ b/apps/server/api/src/collections/clip-projects/services/raw-cut-clip-completion.service.ts
@@ -289,7 +289,7 @@ export class RawCutClipCompletionService {
     await this.clipResultsService.patch(clipResultId, {
       captionedVideoS3Key: s3Key,
       captionedVideoUrl: url,
-      projectReconciliationPending: true,
+      isProjectReconciliationPending: true,
       status: 'completed',
     });
     await this.reconcileProject(clipResultId, projectId, event.organizationId);
@@ -301,10 +301,10 @@ export class RawCutClipCompletionService {
     organizationId: string,
     error: string,
   ): Promise<void> {
-    const projectReconciliationPending = Boolean(projectId);
+    const isProjectReconciliationPending = Boolean(projectId);
     await this.clipResultsService.patch(clipResultId, {
       error,
-      projectReconciliationPending,
+      isProjectReconciliationPending,
       status: 'failed',
     });
 
@@ -403,20 +403,20 @@ export class RawCutClipCompletionService {
       organizationId,
     );
     await this.clipResultsService.patch(clipResultId, {
-      projectReconciliationPending: false,
+      isProjectReconciliationPending: false,
     });
   }
 
   private async reconcileProjectIfPending(
     clipResult: ClipResultDocument,
   ): Promise<void> {
-    if (clipResult.projectReconciliationPending !== true) {
+    if (clipResult.isProjectReconciliationPending !== true) {
       return;
     }
     const projectId = this.readProjectId(clipResult);
     if (!projectId) {
       await this.clipResultsService.patch(this.readId(clipResult), {
-        projectReconciliationPending: false,
+        isProjectReconciliationPending: false,
       });
       return;
     }

--- a/apps/server/api/src/collections/clip-projects/services/raw-cut-clip-completion.service.ts
+++ b/apps/server/api/src/collections/clip-projects/services/raw-cut-clip-completion.service.ts
@@ -1,6 +1,11 @@
 import { ClipProjectsService } from '@api/collections/clip-projects/clip-projects.service';
+import {
+  getRawCutCaptionJobId,
+  RawCutClipService,
+} from '@api/collections/clip-projects/services/raw-cut-clip.service';
 import { ClipResultsService } from '@api/collections/clip-results/clip-results.service';
 import type { ClipResultDocument } from '@api/collections/clip-results/schemas/clip-result.schema';
+import { isTerminalClipStatus } from '@api/collections/clip-shared/clip-terminal-contract.util';
 import { FileQueueService } from '@api/services/files-microservice/queue/file-queue.service';
 import { JobState, Status } from '@genfeedai/enums';
 import type { IJobStatusResponse } from '@genfeedai/interfaces';
@@ -17,6 +22,9 @@ export interface RawCutVideoCompletionEvent {
 }
 
 const RAW_CUT_RECONCILIATION_LIMIT = 100;
+const RAW_CUT_STALE_MS = 2 * 60 * 60 * 1000;
+
+class RawCutCompletionContractError extends Error {}
 
 @Injectable()
 export class RawCutClipCompletionService {
@@ -26,14 +34,24 @@ export class RawCutClipCompletionService {
     private readonly clipProjectsService: ClipProjectsService,
     private readonly clipResultsService: ClipResultsService,
     private readonly fileQueueService: FileQueueService,
+    private readonly rawCutClipService: RawCutClipService,
     private readonly logger: LoggerService,
   ) {}
 
   async handleCompletion(event: RawCutVideoCompletionEvent): Promise<boolean> {
+    const organizationId = this.readString(event.organizationId);
+    if (!organizationId) {
+      this.logger.warn(
+        `${this.logContext} ignored completion without an organization`,
+        { ingredientId: event.ingredientId },
+      );
+      return true;
+    }
+
     const clipResult = await this.clipResultsService.findOne({
       _id: event.ingredientId,
       isDeleted: false,
-      organization: event.organizationId,
+      organizationId,
     });
 
     if (clipResult?.mode !== 'raw-cut') {
@@ -47,6 +65,17 @@ export class RawCutClipCompletionService {
     const currentJobId = this.readString(clipResult.providerJobId);
     const eventJobId = this.readString(event.result?.jobId);
     const eventJobType = this.readString(event.result?.jobType);
+    const status = this.readString(clipResult.status);
+
+    if (status && isTerminalClipStatus(status)) {
+      await this.reconcileProjectIfPending(clipResult);
+      this.logger.log(`${this.logContext} ignored terminal completion replay`, {
+        clipResultId,
+        eventJobId,
+        status,
+      });
+      return true;
+    }
 
     if (eventJobId && currentJobId && eventJobId !== currentJobId) {
       this.logger.log(`${this.logContext} ignored stale completion event`, {
@@ -59,82 +88,133 @@ export class RawCutClipCompletionService {
 
     try {
       if (event.status === Status.FAILED) {
+        if (!this.isEventForStage(status, eventJobType)) {
+          this.logOutOfStageEvent(clipResultId, eventJobType, status);
+          return true;
+        }
         await this.failClip(
           clipResultId,
           projectId,
-          event.organizationId,
+          organizationId,
           event.error ?? 'Raw-cut media processing failed.',
         );
         return true;
       }
 
       if (
-        clipResult.status === 'extracting' &&
+        status === 'extracting' &&
         (!eventJobType || eventJobType === 'clip-trim')
       ) {
-        await this.completeTrim(clipResult, event);
+        await this.completeTrim(clipResult, { ...event, organizationId });
         return true;
       }
 
       if (
-        clipResult.status === 'captioning' &&
+        status === 'captioning' &&
         (!eventJobType || eventJobType === 'add-captions')
       ) {
-        await this.completeCaption(clipResult, event);
+        await this.completeCaption(clipResult, { ...event, organizationId });
         return true;
       }
     } catch (error: unknown) {
-      await this.failClip(
-        clipResultId,
-        projectId,
-        event.organizationId,
-        error instanceof Error
-          ? error.message
-          : 'Raw-cut completion handling failed.',
-      );
-      return true;
+      if (error instanceof RawCutCompletionContractError) {
+        await this.failClip(
+          clipResultId,
+          projectId,
+          organizationId,
+          error.message,
+        );
+        return true;
+      }
+      throw error;
     }
 
-    this.logger.log(
-      `${this.logContext} ignored out-of-stage completion event`,
-      {
-        clipResultId,
-        eventJobType,
-        status: clipResult.status,
-      },
-    );
+    this.logOutOfStageEvent(clipResultId, eventJobType, status);
     return true;
   }
 
   async reconcileActiveClips(): Promise<void> {
-    const activeClips = await this.clipResultsService.findActiveRawCuts(
-      RAW_CUT_RECONCILIATION_LIMIT,
-    );
+    const [activeCount, pendingProjectCount] = await Promise.all([
+      this.clipResultsService.countActiveRawCuts(),
+      this.clipResultsService.countRawCutsPendingProjectReconciliation(),
+    ]);
+    const [activeClips, pendingProjectClips] = await Promise.all([
+      activeCount > 0
+        ? this.clipResultsService.findActiveRawCuts(
+            RAW_CUT_RECONCILIATION_LIMIT,
+            this.getBatchOffset(activeCount),
+          )
+        : Promise.resolve([]),
+      pendingProjectCount > 0
+        ? this.clipResultsService.findRawCutsPendingProjectReconciliation(
+            RAW_CUT_RECONCILIATION_LIMIT,
+            this.getBatchOffset(pendingProjectCount),
+          )
+        : Promise.resolve([]),
+    ]);
     const results = await Promise.allSettled(
       activeClips.map(async (clipResult) => {
         const jobId = this.readString(clipResult.providerJobId);
         if (!jobId) {
+          if (this.isStale(clipResult.updatedAt)) {
+            await this.failClip(
+              this.readId(clipResult),
+              this.readProjectId(clipResult),
+              clipResult.organizationId,
+              'Raw-cut clip lost its processing job reference.',
+            );
+          }
           return;
         }
 
-        const job = await this.fileQueueService.getJobStatus(jobId);
+        let job: IJobStatusResponse;
+        try {
+          job = await this.fileQueueService.getJobStatus(jobId);
+        } catch (error: unknown) {
+          if (await this.redispatchTrimIfPossible(clipResult)) {
+            return;
+          }
+          if (this.isStale(clipResult.updatedAt)) {
+            await this.failClip(
+              this.readId(clipResult),
+              this.readProjectId(clipResult),
+              clipResult.organizationId,
+              'Raw-cut processing job is no longer available.',
+            );
+            return;
+          }
+          throw error;
+        }
+
         if (job.state !== JobState.COMPLETED && job.state !== JobState.FAILED) {
           return;
         }
 
+        const stageJobType =
+          clipResult.status === 'captioning' ? 'add-captions' : 'clip-trim';
         await this.handleCompletion({
           error: job.failedReason,
           ingredientId: this.readId(clipResult),
           organizationId: clipResult.organizationId,
-          result: this.readResult(job),
+          result: {
+            ...this.readResult(job),
+            jobId,
+            jobType: stageJobType,
+          },
           status:
             job.state === JobState.COMPLETED ? Status.COMPLETED : Status.FAILED,
-          userId: this.readString(clipResult.user),
+          userId: this.readCanonicalUserId(clipResult),
         });
       }),
     );
 
-    for (const result of results) {
+    const pendingProjectResults = await Promise.allSettled(
+      pendingProjectClips.map(async (clipResult) => {
+        await this.reconcileProjectIfPending(clipResult);
+      }),
+    );
+
+    for (const result of [...results, ...pendingProjectResults]) {
       if (result.status === 'rejected') {
         this.logger.error(
           `${this.logContext} failed to reconcile raw-cut clip`,
@@ -152,7 +232,7 @@ export class RawCutClipCompletionService {
     const projectId = this.requireProjectId(clipResult);
     const { s3Key, url } = this.readOutput(event.result, 'trim');
     const captionSrt = this.readString(clipResult.captionSrt);
-    const userId = event.userId ?? this.readString(clipResult.user);
+    const userId = event.userId ?? this.readCanonicalUserId(clipResult);
 
     if (!captionSrt) {
       await this.failClip(
@@ -174,40 +254,28 @@ export class RawCutClipCompletionService {
       return;
     }
 
+    const captionJobId = getRawCutCaptionJobId(clipResultId);
+    const captionJob = await this.fileQueueService.processVideo({
+      authProviderUserId: this.readString(clipResult.authProviderUserId),
+      id: captionJobId,
+      ingredientId: clipResultId,
+      organizationId: event.organizationId,
+      params: {
+        captionContent: captionSrt,
+        s3Key,
+      },
+      room: this.readString(clipResult.room),
+      type: 'add-captions',
+      userId,
+      websocketUrl: `/clips/${clipResultId}`,
+    });
+
     await this.clipResultsService.patch(clipResultId, {
+      providerJobId: captionJob.jobId,
       status: 'captioning',
       videoS3Key: s3Key,
       videoUrl: url,
     });
-
-    try {
-      const captionJobId = `raw-cut-caption-${clipResultId}`;
-      const captionJob = await this.fileQueueService.processVideo({
-        id: captionJobId,
-        ingredientId: clipResultId,
-        organizationId: event.organizationId,
-        params: {
-          captionContent: captionSrt,
-          s3Key,
-        },
-        type: 'add-captions',
-        userId,
-        websocketUrl: `/clips/${clipResultId}`,
-      });
-
-      await this.clipResultsService.patch(clipResultId, {
-        providerJobId: captionJob.jobId,
-      });
-    } catch (error: unknown) {
-      await this.failClip(
-        clipResultId,
-        projectId,
-        event.organizationId,
-        error instanceof Error
-          ? error.message
-          : 'Failed to queue raw-cut captions.',
-      );
-    }
   }
 
   private async completeCaption(
@@ -221,14 +289,10 @@ export class RawCutClipCompletionService {
     await this.clipResultsService.patch(clipResultId, {
       captionedVideoS3Key: s3Key,
       captionedVideoUrl: url,
+      projectReconciliationPending: true,
       status: 'completed',
-      videoS3Key: s3Key,
-      videoUrl: url,
     });
-    await this.clipProjectsService.reconcileTerminalState(
-      projectId,
-      event.organizationId,
-    );
+    await this.reconcileProject(clipResultId, projectId, event.organizationId);
   }
 
   private async failClip(
@@ -237,16 +301,15 @@ export class RawCutClipCompletionService {
     organizationId: string,
     error: string,
   ): Promise<void> {
+    const projectReconciliationPending = Boolean(projectId);
     await this.clipResultsService.patch(clipResultId, {
       error,
+      projectReconciliationPending,
       status: 'failed',
     });
 
     if (projectId) {
-      await this.clipProjectsService.reconcileTerminalState(
-        projectId,
-        organizationId,
-      );
+      await this.reconcileProject(clipResultId, projectId, organizationId);
     }
   }
 
@@ -258,7 +321,7 @@ export class RawCutClipCompletionService {
     const url = this.readString(result?.url);
 
     if (!s3Key || !url) {
-      throw new Error(
+      throw new RawCutCompletionContractError(
         `Raw-cut ${stage} job completed without a storage key and URL.`,
       );
     }
@@ -274,18 +337,146 @@ export class RawCutClipCompletionService {
       : {};
   }
 
+  private async redispatchTrimIfPossible(
+    clipResult: ClipResultDocument,
+  ): Promise<boolean> {
+    if (clipResult.status !== 'extracting') {
+      return false;
+    }
+
+    const captionSrt = this.readString(clipResult.captionSrt);
+    const endTime = this.readNumber(clipResult.endTime);
+    const sourceVideoS3Key = this.readString(clipResult.sourceVideoS3Key);
+    const sourceVideoUrl = this.readString(clipResult.sourceVideoUrl);
+    const startTime = this.readNumber(clipResult.startTime);
+    const userId = this.readCanonicalUserId(clipResult);
+
+    if (
+      !captionSrt ||
+      endTime === undefined ||
+      (!sourceVideoS3Key && !sourceVideoUrl) ||
+      startTime === undefined ||
+      !userId
+    ) {
+      return false;
+    }
+
+    const dispatch = await this.rawCutClipService.dispatchClip({
+      authProviderUserId: this.readString(clipResult.authProviderUserId),
+      captionSrt,
+      clipResultId: this.readId(clipResult),
+      endTime,
+      organizationId: clipResult.organizationId,
+      room: this.readString(clipResult.room),
+      sourceVideoS3Key,
+      sourceVideoUrl,
+      startTime,
+      userId,
+    });
+    await this.clipResultsService.patch(this.readId(clipResult), {
+      providerJobId: dispatch.jobId,
+    });
+    return true;
+  }
+
   private readId(clipResult: ClipResultDocument): string {
     return String(clipResult.id ?? clipResult._id);
   }
 
   private requireProjectId(clipResult: ClipResultDocument): string {
-    const projectId = this.readString(
-      clipResult.projectId ?? clipResult.project,
-    );
+    const projectId = this.readProjectId(clipResult);
     if (!projectId) {
-      throw new Error('Raw-cut clip result is missing its project id.');
+      throw new RawCutCompletionContractError(
+        'Raw-cut clip result is missing its project id.',
+      );
     }
     return projectId;
+  }
+
+  private async reconcileProject(
+    clipResultId: string,
+    projectId: string,
+    organizationId: string,
+  ): Promise<void> {
+    await this.clipProjectsService.reconcileTerminalState(
+      projectId,
+      organizationId,
+    );
+    await this.clipResultsService.patch(clipResultId, {
+      projectReconciliationPending: false,
+    });
+  }
+
+  private async reconcileProjectIfPending(
+    clipResult: ClipResultDocument,
+  ): Promise<void> {
+    if (clipResult.projectReconciliationPending !== true) {
+      return;
+    }
+    const projectId = this.readProjectId(clipResult);
+    if (!projectId) {
+      await this.clipResultsService.patch(this.readId(clipResult), {
+        projectReconciliationPending: false,
+      });
+      return;
+    }
+    await this.reconcileProject(
+      this.readId(clipResult),
+      projectId,
+      clipResult.organizationId,
+    );
+  }
+
+  private getBatchOffset(count: number): number {
+    if (count <= RAW_CUT_RECONCILIATION_LIMIT) {
+      return 0;
+    }
+    const minute = Math.floor(Date.now() / 60_000);
+    return (minute * RAW_CUT_RECONCILIATION_LIMIT) % count;
+  }
+
+  private isEventForStage(
+    status: string | undefined,
+    eventJobType: string | undefined,
+  ): boolean {
+    if (!eventJobType) {
+      return status === 'extracting' || status === 'captioning';
+    }
+    return (
+      (status === 'extracting' && eventJobType === 'clip-trim') ||
+      (status === 'captioning' && eventJobType === 'add-captions')
+    );
+  }
+
+  private isStale(updatedAt: Date): boolean {
+    return Date.now() - updatedAt.getTime() >= RAW_CUT_STALE_MS;
+  }
+
+  private logOutOfStageEvent(
+    clipResultId: string,
+    eventJobType: string | undefined,
+    status: string | undefined,
+  ): void {
+    this.logger.log(
+      `${this.logContext} ignored out-of-stage completion event`,
+      { clipResultId, eventJobType, status },
+    );
+  }
+
+  private readCanonicalUserId(
+    clipResult: ClipResultDocument,
+  ): string | undefined {
+    return this.readString(clipResult.userId ?? clipResult.user);
+  }
+
+  private readProjectId(clipResult: ClipResultDocument): string | undefined {
+    return this.readString(clipResult.projectId ?? clipResult.project);
+  }
+
+  private readNumber(value: unknown): number | undefined {
+    return typeof value === 'number' && Number.isFinite(value)
+      ? value
+      : undefined;
   }
 
   private readString(value: unknown): string | undefined {

--- a/apps/server/api/src/collections/clip-projects/services/raw-cut-clip-completion.service.ts
+++ b/apps/server/api/src/collections/clip-projects/services/raw-cut-clip-completion.service.ts
@@ -1,0 +1,294 @@
+import { ClipProjectsService } from '@api/collections/clip-projects/clip-projects.service';
+import { ClipResultsService } from '@api/collections/clip-results/clip-results.service';
+import type { ClipResultDocument } from '@api/collections/clip-results/schemas/clip-result.schema';
+import { FileQueueService } from '@api/services/files-microservice/queue/file-queue.service';
+import { JobState, Status } from '@genfeedai/enums';
+import type { IJobStatusResponse } from '@genfeedai/interfaces';
+import { LoggerService } from '@libs/logger/logger.service';
+import { Injectable } from '@nestjs/common';
+
+export interface RawCutVideoCompletionEvent {
+  error?: string;
+  ingredientId: string;
+  organizationId: string;
+  result?: Record<string, unknown>;
+  status: Status.COMPLETED | Status.FAILED;
+  userId?: string;
+}
+
+const RAW_CUT_RECONCILIATION_LIMIT = 100;
+
+@Injectable()
+export class RawCutClipCompletionService {
+  private readonly logContext = 'RawCutClipCompletionService';
+
+  constructor(
+    private readonly clipProjectsService: ClipProjectsService,
+    private readonly clipResultsService: ClipResultsService,
+    private readonly fileQueueService: FileQueueService,
+    private readonly logger: LoggerService,
+  ) {}
+
+  async handleCompletion(event: RawCutVideoCompletionEvent): Promise<boolean> {
+    const clipResult = await this.clipResultsService.findOne({
+      _id: event.ingredientId,
+      isDeleted: false,
+      organization: event.organizationId,
+    });
+
+    if (clipResult?.mode !== 'raw-cut') {
+      return false;
+    }
+
+    const clipResultId = this.readId(clipResult);
+    const projectId = this.readString(
+      clipResult.projectId ?? clipResult.project,
+    );
+    const currentJobId = this.readString(clipResult.providerJobId);
+    const eventJobId = this.readString(event.result?.jobId);
+    const eventJobType = this.readString(event.result?.jobType);
+
+    if (eventJobId && currentJobId && eventJobId !== currentJobId) {
+      this.logger.log(`${this.logContext} ignored stale completion event`, {
+        clipResultId,
+        currentJobId,
+        eventJobId,
+      });
+      return true;
+    }
+
+    try {
+      if (event.status === Status.FAILED) {
+        await this.failClip(
+          clipResultId,
+          projectId,
+          event.organizationId,
+          event.error ?? 'Raw-cut media processing failed.',
+        );
+        return true;
+      }
+
+      if (
+        clipResult.status === 'extracting' &&
+        (!eventJobType || eventJobType === 'clip-trim')
+      ) {
+        await this.completeTrim(clipResult, event);
+        return true;
+      }
+
+      if (
+        clipResult.status === 'captioning' &&
+        (!eventJobType || eventJobType === 'add-captions')
+      ) {
+        await this.completeCaption(clipResult, event);
+        return true;
+      }
+    } catch (error: unknown) {
+      await this.failClip(
+        clipResultId,
+        projectId,
+        event.organizationId,
+        error instanceof Error
+          ? error.message
+          : 'Raw-cut completion handling failed.',
+      );
+      return true;
+    }
+
+    this.logger.log(
+      `${this.logContext} ignored out-of-stage completion event`,
+      {
+        clipResultId,
+        eventJobType,
+        status: clipResult.status,
+      },
+    );
+    return true;
+  }
+
+  async reconcileActiveClips(): Promise<void> {
+    const activeClips = await this.clipResultsService.findActiveRawCuts(
+      RAW_CUT_RECONCILIATION_LIMIT,
+    );
+    const results = await Promise.allSettled(
+      activeClips.map(async (clipResult) => {
+        const jobId = this.readString(clipResult.providerJobId);
+        if (!jobId) {
+          return;
+        }
+
+        const job = await this.fileQueueService.getJobStatus(jobId);
+        if (job.state !== JobState.COMPLETED && job.state !== JobState.FAILED) {
+          return;
+        }
+
+        await this.handleCompletion({
+          error: job.failedReason,
+          ingredientId: this.readId(clipResult),
+          organizationId: clipResult.organizationId,
+          result: this.readResult(job),
+          status:
+            job.state === JobState.COMPLETED ? Status.COMPLETED : Status.FAILED,
+          userId: this.readString(clipResult.user),
+        });
+      }),
+    );
+
+    for (const result of results) {
+      if (result.status === 'rejected') {
+        this.logger.error(
+          `${this.logContext} failed to reconcile raw-cut clip`,
+          result.reason,
+        );
+      }
+    }
+  }
+
+  private async completeTrim(
+    clipResult: ClipResultDocument,
+    event: RawCutVideoCompletionEvent,
+  ): Promise<void> {
+    const clipResultId = this.readId(clipResult);
+    const projectId = this.requireProjectId(clipResult);
+    const { s3Key, url } = this.readOutput(event.result, 'trim');
+    const captionSrt = this.readString(clipResult.captionSrt);
+    const userId = event.userId ?? this.readString(clipResult.user);
+
+    if (!captionSrt) {
+      await this.failClip(
+        clipResultId,
+        projectId,
+        event.organizationId,
+        'Raw-cut clip is missing its caption track.',
+      );
+      return;
+    }
+
+    if (!userId) {
+      await this.failClip(
+        clipResultId,
+        projectId,
+        event.organizationId,
+        'Raw-cut clip is missing its canonical user id.',
+      );
+      return;
+    }
+
+    await this.clipResultsService.patch(clipResultId, {
+      status: 'captioning',
+      videoS3Key: s3Key,
+      videoUrl: url,
+    });
+
+    try {
+      const captionJobId = `raw-cut-caption-${clipResultId}`;
+      const captionJob = await this.fileQueueService.processVideo({
+        id: captionJobId,
+        ingredientId: clipResultId,
+        organizationId: event.organizationId,
+        params: {
+          captionContent: captionSrt,
+          s3Key,
+        },
+        type: 'add-captions',
+        userId,
+        websocketUrl: `/clips/${clipResultId}`,
+      });
+
+      await this.clipResultsService.patch(clipResultId, {
+        providerJobId: captionJob.jobId,
+      });
+    } catch (error: unknown) {
+      await this.failClip(
+        clipResultId,
+        projectId,
+        event.organizationId,
+        error instanceof Error
+          ? error.message
+          : 'Failed to queue raw-cut captions.',
+      );
+    }
+  }
+
+  private async completeCaption(
+    clipResult: ClipResultDocument,
+    event: RawCutVideoCompletionEvent,
+  ): Promise<void> {
+    const clipResultId = this.readId(clipResult);
+    const projectId = this.requireProjectId(clipResult);
+    const { s3Key, url } = this.readOutput(event.result, 'caption');
+
+    await this.clipResultsService.patch(clipResultId, {
+      captionedVideoS3Key: s3Key,
+      captionedVideoUrl: url,
+      status: 'completed',
+      videoS3Key: s3Key,
+      videoUrl: url,
+    });
+    await this.clipProjectsService.reconcileTerminalState(
+      projectId,
+      event.organizationId,
+    );
+  }
+
+  private async failClip(
+    clipResultId: string,
+    projectId: string | undefined,
+    organizationId: string,
+    error: string,
+  ): Promise<void> {
+    await this.clipResultsService.patch(clipResultId, {
+      error,
+      status: 'failed',
+    });
+
+    if (projectId) {
+      await this.clipProjectsService.reconcileTerminalState(
+        projectId,
+        organizationId,
+      );
+    }
+  }
+
+  private readOutput(
+    result: Record<string, unknown> | undefined,
+    stage: 'caption' | 'trim',
+  ): { s3Key: string; url: string } {
+    const s3Key = this.readString(result?.s3Key);
+    const url = this.readString(result?.url);
+
+    if (!s3Key || !url) {
+      throw new Error(
+        `Raw-cut ${stage} job completed without a storage key and URL.`,
+      );
+    }
+
+    return { s3Key, url };
+  }
+
+  private readResult(job: IJobStatusResponse): Record<string, unknown> {
+    return job.result !== null &&
+      typeof job.result === 'object' &&
+      !Array.isArray(job.result)
+      ? (job.result as Record<string, unknown>)
+      : {};
+  }
+
+  private readId(clipResult: ClipResultDocument): string {
+    return String(clipResult.id ?? clipResult._id);
+  }
+
+  private requireProjectId(clipResult: ClipResultDocument): string {
+    const projectId = this.readString(
+      clipResult.projectId ?? clipResult.project,
+    );
+    if (!projectId) {
+      throw new Error('Raw-cut clip result is missing its project id.');
+    }
+    return projectId;
+  }
+
+  private readString(value: unknown): string | undefined {
+    return typeof value === 'string' && value.length > 0 ? value : undefined;
+  }
+}

--- a/apps/server/api/src/collections/clip-projects/services/raw-cut-clip.service.spec.ts
+++ b/apps/server/api/src/collections/clip-projects/services/raw-cut-clip.service.spec.ts
@@ -65,6 +65,7 @@ describe('RawCutClipService', () => {
     expect(fileQueueService.processVideo).toHaveBeenCalledTimes(1);
     expect(fileQueueService.processVideo).toHaveBeenCalledWith(
       expect.objectContaining({
+        id: 'raw-cut-trim-clip-result-1',
         ingredientId: 'clip-result-1',
         organizationId: '507f1f77bcf86cd799439011',
         type: 'clip-trim',

--- a/apps/server/api/src/collections/clip-projects/services/raw-cut-clip.service.ts
+++ b/apps/server/api/src/collections/clip-projects/services/raw-cut-clip.service.ts
@@ -87,6 +87,7 @@ export class RawCutClipService {
 
     const response = await this.fileQueueService.processVideo({
       authProviderUserId,
+      id: `raw-cut-trim-${clipResultId}`,
       ingredientId: clipResultId,
       organizationId,
       params: {

--- a/apps/server/api/src/collections/clip-projects/services/raw-cut-clip.service.ts
+++ b/apps/server/api/src/collections/clip-projects/services/raw-cut-clip.service.ts
@@ -1,9 +1,18 @@
 import { FileQueueService } from '@api/services/files-microservice/queue/file-queue.service';
+import { RAW_CUT_JOB_PREFIX } from '@genfeedai/interfaces';
 import { LoggerService } from '@libs/logger/logger.service';
 import { BadRequestException, Injectable } from '@nestjs/common';
 
 /** Provider name recorded on deterministic clip-results. */
 export const RAW_CUT_PROVIDER_NAME = 'raw-cut';
+
+export function getRawCutCaptionJobId(clipResultId: string): string {
+  return `${RAW_CUT_JOB_PREFIX}caption-${clipResultId}`;
+}
+
+export function getRawCutTrimJobId(clipResultId: string): string {
+  return `${RAW_CUT_JOB_PREFIX}trim-${clipResultId}`;
+}
 
 export interface RawCutDispatchInput {
   /** Clip-result id — used as the files-service ingredient id + callback key. */
@@ -87,7 +96,7 @@ export class RawCutClipService {
 
     const response = await this.fileQueueService.processVideo({
       authProviderUserId,
-      id: `raw-cut-trim-${clipResultId}`,
+      id: getRawCutTrimJobId(clipResultId),
       ingredientId: clipResultId,
       organizationId,
       params: {

--- a/apps/server/api/src/collections/clip-results/clip-results.service.spec.ts
+++ b/apps/server/api/src/collections/clip-results/clip-results.service.spec.ts
@@ -235,6 +235,22 @@ describe('ClipResultsService', () => {
     );
   });
 
+  it('returns a bounded oldest-first set of active raw-cut clips', async () => {
+    prisma.clipResult.findMany.mockResolvedValue([]);
+
+    await service.findActiveRawCuts(25);
+
+    expect(prisma.clipResult.findMany).toHaveBeenCalledWith({
+      orderBy: { updatedAt: 'asc' },
+      take: 25,
+      where: {
+        isDeleted: false,
+        mode: 'raw-cut',
+        status: { in: ['extracting', 'captioning'] },
+      },
+    });
+  });
+
   it('resolves a project clip result by id, mongo id, or provider job id for handoff', async () => {
     prisma.clipResult.findFirst.mockResolvedValue({
       data: { title: 'Clip' },

--- a/apps/server/api/src/collections/clip-results/clip-results.service.spec.ts
+++ b/apps/server/api/src/collections/clip-results/clip-results.service.spec.ts
@@ -50,6 +50,7 @@ function createPrisma() {
       },
     },
     clipResult: {
+      count: vi.fn(),
       create: vi.fn(),
       findFirst: vi.fn(),
       findMany: vi.fn(),
@@ -241,7 +242,8 @@ describe('ClipResultsService', () => {
     await service.findActiveRawCuts(25);
 
     expect(prisma.clipResult.findMany).toHaveBeenCalledWith({
-      orderBy: { updatedAt: 'asc' },
+      orderBy: [{ updatedAt: 'asc' }, { id: 'asc' }],
+      skip: 0,
       take: 25,
       where: {
         isDeleted: false,

--- a/apps/server/api/src/collections/clip-results/clip-results.service.ts
+++ b/apps/server/api/src/collections/clip-results/clip-results.service.ts
@@ -146,7 +146,7 @@ export class ClipResultsService extends BaseService<
       where: {
         data: {
           equals: true,
-          path: ['projectReconciliationPending'],
+          path: ['isProjectReconciliationPending'],
         },
         isDeleted: false,
         mode: 'raw-cut',
@@ -166,7 +166,7 @@ export class ClipResultsService extends BaseService<
       where: {
         data: {
           equals: true,
-          path: ['projectReconciliationPending'],
+          path: ['isProjectReconciliationPending'],
         },
         isDeleted: false,
         mode: 'raw-cut',

--- a/apps/server/api/src/collections/clip-results/clip-results.service.ts
+++ b/apps/server/api/src/collections/clip-results/clip-results.service.ts
@@ -113,14 +113,64 @@ export class ClipResultsService extends BaseService<
     return result ? this.normalizeDocument(result) : null;
   }
 
-  async findActiveRawCuts(limit = 100): Promise<ClipResultDocument[]> {
+  async countActiveRawCuts(): Promise<number> {
+    return this.delegate.count({
+      where: {
+        isDeleted: false,
+        mode: 'raw-cut',
+        status: { in: ['extracting', 'captioning'] },
+      },
+    });
+  }
+
+  async findActiveRawCuts(
+    limit = 100,
+    skip = 0,
+  ): Promise<ClipResultDocument[]> {
     const results = await this.delegate.findMany({
-      orderBy: { updatedAt: 'asc' },
+      orderBy: [{ updatedAt: 'asc' }, { id: 'asc' }],
+      skip,
       take: limit,
       where: {
         isDeleted: false,
         mode: 'raw-cut',
         status: { in: ['extracting', 'captioning'] },
+      },
+    });
+
+    return this.normalizeDocuments(results);
+  }
+
+  async countRawCutsPendingProjectReconciliation(): Promise<number> {
+    return this.delegate.count({
+      where: {
+        data: {
+          equals: true,
+          path: ['projectReconciliationPending'],
+        },
+        isDeleted: false,
+        mode: 'raw-cut',
+        status: { in: ['completed', 'failed'] },
+      },
+    });
+  }
+
+  async findRawCutsPendingProjectReconciliation(
+    limit = 100,
+    skip = 0,
+  ): Promise<ClipResultDocument[]> {
+    const results = await this.delegate.findMany({
+      orderBy: [{ terminalAt: 'asc' }, { id: 'asc' }],
+      skip,
+      take: limit,
+      where: {
+        data: {
+          equals: true,
+          path: ['projectReconciliationPending'],
+        },
+        isDeleted: false,
+        mode: 'raw-cut',
+        status: { in: ['completed', 'failed'] },
       },
     });
 

--- a/apps/server/api/src/collections/clip-results/clip-results.service.ts
+++ b/apps/server/api/src/collections/clip-results/clip-results.service.ts
@@ -113,6 +113,20 @@ export class ClipResultsService extends BaseService<
     return result ? this.normalizeDocument(result) : null;
   }
 
+  async findActiveRawCuts(limit = 100): Promise<ClipResultDocument[]> {
+    const results = await this.delegate.findMany({
+      orderBy: { updatedAt: 'asc' },
+      take: limit,
+      where: {
+        isDeleted: false,
+        mode: 'raw-cut',
+        status: { in: ['extracting', 'captioning'] },
+      },
+    });
+
+    return this.normalizeDocuments(results);
+  }
+
   async findProjectResultForHandoff(input: {
     clipResultId: string;
     organizationId: string;

--- a/apps/server/api/src/collections/clip-results/schemas/clip-result.schema.ts
+++ b/apps/server/api/src/collections/clip-results/schemas/clip-result.schema.ts
@@ -37,7 +37,7 @@ export interface ClipResultDocument extends ClipResultRecord {
   captionSrt?: string | null;
   thumbnailUrl?: string | null;
   authProviderUserId?: string | null;
-  projectReconciliationPending?: boolean;
+  isProjectReconciliationPending?: boolean;
   room?: string | null;
   sourceVideoS3Key?: string | null;
   sourceVideoUrl?: string | null;

--- a/apps/server/api/src/collections/clip-results/schemas/clip-result.schema.ts
+++ b/apps/server/api/src/collections/clip-results/schemas/clip-result.schema.ts
@@ -36,6 +36,13 @@ export interface ClipResultDocument extends ClipResultRecord {
   captionedVideoS3Key?: string | null;
   captionSrt?: string | null;
   thumbnailUrl?: string | null;
+  authProviderUserId?: string | null;
+  projectReconciliationPending?: boolean;
+  room?: string | null;
+  sourceVideoS3Key?: string | null;
+  sourceVideoUrl?: string | null;
+  user?: string | null;
+  userId?: string | null;
   [key: string]: unknown;
 }
 

--- a/apps/server/api/src/collections/clip-results/schemas/clip-result.schema.ts
+++ b/apps/server/api/src/collections/clip-results/schemas/clip-result.schema.ts
@@ -41,7 +41,6 @@ export interface ClipResultDocument extends ClipResultRecord {
   room?: string | null;
   sourceVideoS3Key?: string | null;
   sourceVideoUrl?: string | null;
-  user?: string | null;
   userId?: string | null;
   [key: string]: unknown;
 }

--- a/apps/server/api/src/services/video-completion/video-completion.module.ts
+++ b/apps/server/api/src/services/video-completion/video-completion.module.ts
@@ -1,6 +1,4 @@
 import { ClipProjectsCoreModule } from '@api/collections/clip-projects/clip-projects-core.module';
-import { RawCutClipCompletionService } from '@api/collections/clip-projects/services/raw-cut-clip-completion.service';
-import { ClipResultsModule } from '@api/collections/clip-results/clip-results.module';
 import { EditorProjectsModule } from '@api/collections/editor-projects/editor-projects.module';
 import { IngredientsModule } from '@api/collections/ingredients/ingredients.module';
 import { MetadataModule } from '@api/collections/metadata/metadata.module';
@@ -15,13 +13,12 @@ import { forwardRef, Module } from '@nestjs/common';
   imports: [
     RedisModule,
     forwardRef(() => ClipProjectsCoreModule),
-    forwardRef(() => ClipResultsModule),
     forwardRef(() => EditorProjectsModule),
     forwardRef(() => FileQueueModule),
     forwardRef(() => IngredientsModule),
     forwardRef(() => MetadataModule),
     forwardRef(() => NotificationsPublisherModule),
   ],
-  providers: [RawCutClipCompletionService, VideoCompletionService],
+  providers: [VideoCompletionService],
 })
 export class VideoCompletionModule {}

--- a/apps/server/api/src/services/video-completion/video-completion.module.ts
+++ b/apps/server/api/src/services/video-completion/video-completion.module.ts
@@ -1,3 +1,6 @@
+import { ClipProjectsCoreModule } from '@api/collections/clip-projects/clip-projects-core.module';
+import { RawCutClipCompletionService } from '@api/collections/clip-projects/services/raw-cut-clip-completion.service';
+import { ClipResultsModule } from '@api/collections/clip-results/clip-results.module';
 import { EditorProjectsModule } from '@api/collections/editor-projects/editor-projects.module';
 import { IngredientsModule } from '@api/collections/ingredients/ingredients.module';
 import { MetadataModule } from '@api/collections/metadata/metadata.module';
@@ -11,12 +14,14 @@ import { forwardRef, Module } from '@nestjs/common';
   exports: [VideoCompletionService],
   imports: [
     RedisModule,
+    forwardRef(() => ClipProjectsCoreModule),
+    forwardRef(() => ClipResultsModule),
     forwardRef(() => EditorProjectsModule),
     forwardRef(() => FileQueueModule),
     forwardRef(() => IngredientsModule),
     forwardRef(() => MetadataModule),
     forwardRef(() => NotificationsPublisherModule),
   ],
-  providers: [VideoCompletionService],
+  providers: [RawCutClipCompletionService, VideoCompletionService],
 })
 export class VideoCompletionModule {}

--- a/apps/server/api/src/services/video-completion/video-completion.service.spec.ts
+++ b/apps/server/api/src/services/video-completion/video-completion.service.spec.ts
@@ -1,3 +1,4 @@
+import { RawCutClipCompletionService } from '@api/collections/clip-projects/services/raw-cut-clip-completion.service';
 import { EditorProjectsService } from '@api/collections/editor-projects/editor-projects.service';
 import { IngredientsService } from '@api/collections/ingredients/services/ingredients.service';
 import { MetadataService } from '@api/collections/metadata/services/metadata.service';
@@ -27,6 +28,10 @@ describe('VideoCompletionService', () => {
     publishMediaFailed: ReturnType<typeof vi.fn>;
     publishVideoComplete: ReturnType<typeof vi.fn>;
   };
+  let rawCutClipCompletionService: {
+    handleCompletion: ReturnType<typeof vi.fn>;
+    reconcileActiveClips: ReturnType<typeof vi.fn>;
+  };
 
   const mockIngredientId = '507f1f77bcf86cd799439011';
   const mockUserId = '507f1f77bcf86cd799439012';
@@ -49,6 +54,10 @@ describe('VideoCompletionService', () => {
     notificationsPublisher = {
       publishMediaFailed: vi.fn().mockResolvedValue(undefined),
       publishVideoComplete: vi.fn().mockResolvedValue(undefined),
+    };
+    rawCutClipCompletionService = {
+      handleCompletion: vi.fn().mockResolvedValue(false),
+      reconcileActiveClips: vi.fn().mockResolvedValue(undefined),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -85,6 +94,10 @@ describe('VideoCompletionService', () => {
         {
           provide: NotificationsPublisherService,
           useValue: notificationsPublisher,
+        },
+        {
+          provide: RawCutClipCompletionService,
+          useValue: rawCutClipCompletionService,
         },
         {
           provide: LoggerService,
@@ -477,5 +490,37 @@ describe('VideoCompletionService', () => {
       output,
       'job-123',
     );
+  });
+
+  it('routes raw-cut events without treating clip results as ingredients', async () => {
+    rawCutClipCompletionService.handleCompletion.mockResolvedValue(true);
+    await service.onModuleInit();
+    const subscribeCallback = (redisService.subscribe as vi.Mock).mock
+      .calls[0][1];
+    const event = {
+      ingredientId: 'clip-result-1',
+      organizationId: mockOrganizationId,
+      result: {
+        jobId: 'raw-cut-trim-clip-result-1',
+        jobType: 'clip-trim',
+      },
+      status: 'completed',
+      timestamp: new Date().toISOString(),
+    };
+
+    await subscribeCallback(event);
+
+    expect(rawCutClipCompletionService.handleCompletion).toHaveBeenCalledWith(
+      event,
+    );
+    expect(ingredientsService.patch).not.toHaveBeenCalled();
+  });
+
+  it('polls raw-cut jobs during reconciliation', async () => {
+    await service.reconcileRawCutClips();
+
+    expect(
+      rawCutClipCompletionService.reconcileActiveClips,
+    ).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/server/api/src/services/video-completion/video-completion.service.spec.ts
+++ b/apps/server/api/src/services/video-completion/video-completion.service.spec.ts
@@ -6,7 +6,7 @@ import { CacheService } from '@api/services/cache/services/cache.service';
 import { FileQueueService } from '@api/services/files-microservice/queue/file-queue.service';
 import { NotificationsPublisherService } from '@api/services/notifications/publisher/notifications-publisher.service';
 import { VideoCompletionService } from '@api/services/video-completion/video-completion.service';
-import { IngredientStatus } from '@genfeedai/enums';
+import { IngredientStatus, Status } from '@genfeedai/enums';
 import { LoggerService } from '@libs/logger/logger.service';
 import { RedisService } from '@libs/redis/redis.service';
 import { ConflictException } from '@nestjs/common';

--- a/apps/server/api/src/services/video-completion/video-completion.service.spec.ts
+++ b/apps/server/api/src/services/video-completion/video-completion.service.spec.ts
@@ -2,6 +2,7 @@ import { RawCutClipCompletionService } from '@api/collections/clip-projects/serv
 import { EditorProjectsService } from '@api/collections/editor-projects/editor-projects.service';
 import { IngredientsService } from '@api/collections/ingredients/services/ingredients.service';
 import { MetadataService } from '@api/collections/metadata/services/metadata.service';
+import { CacheService } from '@api/services/cache/services/cache.service';
 import { FileQueueService } from '@api/services/files-microservice/queue/file-queue.service';
 import { NotificationsPublisherService } from '@api/services/notifications/publisher/notifications-publisher.service';
 import { VideoCompletionService } from '@api/services/video-completion/video-completion.service';
@@ -32,6 +33,9 @@ describe('VideoCompletionService', () => {
     handleCompletion: ReturnType<typeof vi.fn>;
     reconcileActiveClips: ReturnType<typeof vi.fn>;
   };
+  let cacheService: {
+    withLock: ReturnType<typeof vi.fn>;
+  };
 
   const mockIngredientId = '507f1f77bcf86cd799439011';
   const mockUserId = '507f1f77bcf86cd799439012';
@@ -58,6 +62,13 @@ describe('VideoCompletionService', () => {
     rawCutClipCompletionService = {
       handleCompletion: vi.fn().mockResolvedValue(false),
       reconcileActiveClips: vi.fn().mockResolvedValue(undefined),
+    };
+    cacheService = {
+      withLock: vi
+        .fn()
+        .mockImplementation(
+          async (_key: string, run: () => Promise<void>) => await run(),
+        ),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -98,6 +109,10 @@ describe('VideoCompletionService', () => {
         {
           provide: RawCutClipCompletionService,
           useValue: rawCutClipCompletionService,
+        },
+        {
+          provide: CacheService,
+          useValue: cacheService,
         },
         {
           provide: LoggerService,
@@ -516,9 +531,34 @@ describe('VideoCompletionService', () => {
     expect(ingredientsService.patch).not.toHaveBeenCalled();
   });
 
+  it('never falls through raw-cut events to ingredient persistence', async () => {
+    rawCutClipCompletionService.handleCompletion.mockResolvedValue(false);
+
+    await service.onModuleInit();
+    const subscribeCallback = (redisService.subscribe as vi.Mock).mock
+      .calls[0][1];
+    await subscribeCallback({
+      ingredientId: 'clip-result-1',
+      organizationId: mockOrganizationId.toString(),
+      result: {
+        jobId: 'raw-cut-trim-clip-result-1',
+      },
+      status: Status.COMPLETED,
+      timestamp: new Date().toISOString(),
+    });
+
+    expect(rawCutClipCompletionService.handleCompletion).toHaveBeenCalled();
+    expect(ingredientsService.patch).not.toHaveBeenCalled();
+  });
+
   it('polls raw-cut jobs during reconciliation', async () => {
     await service.reconcileRawCutClips();
 
+    expect(cacheService.withLock).toHaveBeenCalledWith(
+      'raw-cut-clip-reconciliation',
+      expect.any(Function),
+      300,
+    );
     expect(
       rawCutClipCompletionService.reconcileActiveClips,
     ).toHaveBeenCalledTimes(1);

--- a/apps/server/api/src/services/video-completion/video-completion.service.ts
+++ b/apps/server/api/src/services/video-completion/video-completion.service.ts
@@ -1,3 +1,4 @@
+import { RawCutClipCompletionService } from '@api/collections/clip-projects/services/raw-cut-clip-completion.service';
 import { EditorProjectsService } from '@api/collections/editor-projects/editor-projects.service';
 import { IngredientsService } from '@api/collections/ingredients/services/ingredients.service';
 import { MetadataService } from '@api/collections/metadata/services/metadata.service';
@@ -59,6 +60,7 @@ export class VideoCompletionService implements OnModuleInit {
     private readonly ingredientsService: IngredientsService,
     private readonly metadataService: MetadataService,
     private readonly notificationsPublisher: NotificationsPublisherService,
+    private readonly rawCutClipCompletionService: RawCutClipCompletionService,
     private readonly logger: LoggerService,
   ) {}
 
@@ -91,6 +93,10 @@ export class VideoCompletionService implements OnModuleInit {
         } else {
           await this.failEditorRender(data.editorRender);
         }
+        return;
+      }
+
+      if (await this.rawCutClipCompletionService.handleCompletion(data)) {
         return;
       }
 
@@ -200,6 +206,11 @@ export class VideoCompletionService implements OnModuleInit {
         this.logger.error('Failed to reconcile editor render', result.reason);
       }
     }
+  }
+
+  @Cron(CronExpression.EVERY_MINUTE)
+  async reconcileRawCutClips(): Promise<void> {
+    await this.rawCutClipCompletionService.reconcileActiveClips();
   }
 
   private async completeEditorRender(

--- a/apps/server/api/src/services/video-completion/video-completion.service.ts
+++ b/apps/server/api/src/services/video-completion/video-completion.service.ts
@@ -3,6 +3,7 @@ import { EditorProjectsService } from '@api/collections/editor-projects/editor-p
 import { IngredientsService } from '@api/collections/ingredients/services/ingredients.service';
 import { MetadataService } from '@api/collections/metadata/services/metadata.service';
 import { WebSocketPaths } from '@api/helpers/utils/websocket/websocket.util';
+import { CacheService } from '@api/services/cache/services/cache.service';
 import { FileQueueService } from '@api/services/files-microservice/queue/file-queue.service';
 import { NotificationsPublisherService } from '@api/services/notifications/publisher/notifications-publisher.service';
 import {
@@ -17,6 +18,7 @@ import {
   type IEditorRenderOutputMetadata,
   type IJobStatusResponse,
   parseEditorRenderOutputMetadata,
+  RAW_CUT_JOB_PREFIX,
 } from '@genfeedai/interfaces';
 import { LoggerService } from '@libs/logger/logger.service';
 import { RedisService } from '@libs/redis/redis.service';
@@ -50,6 +52,8 @@ type VideoCompletionEvent = {
 };
 
 const EDITOR_RENDER_STALE_MS = 45 * 60 * 1000;
+const RAW_CUT_RECONCILIATION_LOCK = 'raw-cut-clip-reconciliation';
+const RAW_CUT_RECONCILIATION_LOCK_TTL_SECONDS = 300;
 
 @Injectable()
 export class VideoCompletionService implements OnModuleInit {
@@ -61,6 +65,7 @@ export class VideoCompletionService implements OnModuleInit {
     private readonly metadataService: MetadataService,
     private readonly notificationsPublisher: NotificationsPublisherService,
     private readonly rawCutClipCompletionService: RawCutClipCompletionService,
+    private readonly cacheService: CacheService,
     private readonly logger: LoggerService,
   ) {}
 
@@ -96,7 +101,8 @@ export class VideoCompletionService implements OnModuleInit {
         return;
       }
 
-      if (await this.rawCutClipCompletionService.handleCompletion(data)) {
+      if (this.isRawCutCompletion(data)) {
+        await this.rawCutClipCompletionService.handleCompletion(data);
         return;
       }
 
@@ -210,7 +216,18 @@ export class VideoCompletionService implements OnModuleInit {
 
   @Cron(CronExpression.EVERY_MINUTE)
   async reconcileRawCutClips(): Promise<void> {
-    await this.rawCutClipCompletionService.reconcileActiveClips();
+    await this.cacheService.withLock(
+      RAW_CUT_RECONCILIATION_LOCK,
+      async () => {
+        await this.rawCutClipCompletionService.reconcileActiveClips();
+      },
+      RAW_CUT_RECONCILIATION_LOCK_TTL_SECONDS,
+    );
+  }
+
+  private isRawCutCompletion(data: VideoCompletionEvent): boolean {
+    const jobId = data.result?.jobId;
+    return typeof jobId === 'string' && jobId.startsWith(RAW_CUT_JOB_PREFIX);
   }
 
   private async completeEditorRender(

--- a/apps/server/files/src/processors/video.processor.spec.ts
+++ b/apps/server/files/src/processors/video.processor.spec.ts
@@ -119,11 +119,15 @@ const createMockJob = <T = VideoJobData>(
   name: string,
   data: T,
   id = 'job-123',
+  overrides: Partial<Job<T>> = {},
 ): Job<T> =>
   ({
+    attemptsMade: 0,
     data,
     id,
     name,
+    opts: { attempts: 3 },
+    ...overrides,
   }) as unknown as Job<T>;
 
 describe('VideoProcessor', () => {
@@ -262,7 +266,11 @@ describe('VideoProcessor', () => {
       const data = createMockJobData({
         params: { captionContent: 'Test captions' },
       });
-      const job = createMockJob(JOB_TYPES.ADD_CAPTIONS, data);
+      const job = createMockJob(
+        JOB_TYPES.ADD_CAPTIONS,
+        data,
+        'raw-cut-caption-clip-1',
+      );
 
       await processor.process(job);
 
@@ -627,14 +635,18 @@ describe('VideoProcessor', () => {
       const data = createMockJobData({
         params: { captionContent: '1\n00:00:00,000 --> 00:00:05,000\nHello' },
       });
-      const job = createMockJob(JOB_TYPES.ADD_CAPTIONS, data);
+      const job = createMockJob(
+        JOB_TYPES.ADD_CAPTIONS,
+        data,
+        'raw-cut-caption-clip-1',
+      );
 
       const result = await processor.handleAddCaptions(job);
 
       expect(result.success).toBe(true);
       expect(result).toEqual(
         expect.objectContaining({
-          jobId: 'job-123',
+          jobId: 'raw-cut-caption-clip-1',
           jobType: JOB_TYPES.ADD_CAPTIONS,
           url: expect.any(String),
         }),
@@ -646,7 +658,7 @@ describe('VideoProcessor', () => {
         expect.objectContaining({
           ingredientId: data.ingredientId,
           result: expect.objectContaining({
-            jobId: 'job-123',
+            jobId: 'raw-cut-caption-clip-1',
             jobType: JOB_TYPES.ADD_CAPTIONS,
           }),
           status: 'completed',
@@ -656,7 +668,12 @@ describe('VideoProcessor', () => {
 
     it('should handle caption errors', async () => {
       const data = createMockJobData({ params: { captionContent: '' } });
-      const job = createMockJob(JOB_TYPES.ADD_CAPTIONS, data);
+      const job = createMockJob(
+        JOB_TYPES.ADD_CAPTIONS,
+        data,
+        'raw-cut-caption-clip-1',
+        { attemptsMade: 2 },
+      );
       ffmpegService.addCaptions.mockRejectedValue(new Error('Caption failed'));
 
       await expect(processor.handleAddCaptions(job)).rejects.toThrow();
@@ -666,11 +683,42 @@ describe('VideoProcessor', () => {
         expect.objectContaining({
           ingredientId: data.ingredientId,
           result: expect.objectContaining({
-            jobId: 'job-123',
+            jobId: 'raw-cut-caption-clip-1',
             jobType: JOB_TYPES.ADD_CAPTIONS,
           }),
           status: 'failed',
         }),
+      );
+    });
+
+    it('does not publish a failed completion before retries are exhausted', async () => {
+      const data = createMockJobData({ params: { captionContent: '' } });
+      const job = createMockJob(
+        JOB_TYPES.ADD_CAPTIONS,
+        data,
+        'raw-cut-caption-clip-1',
+      );
+      ffmpegService.addCaptions.mockRejectedValue(new Error('Caption failed'));
+
+      await expect(processor.handleAddCaptions(job)).rejects.toThrow();
+
+      expect(redisService.publish).not.toHaveBeenCalledWith(
+        'video-processing-complete',
+        expect.objectContaining({ status: 'failed' }),
+      );
+    });
+
+    it('does not publish ordinary ingredient caption jobs as raw-cut completions', async () => {
+      const data = createMockJobData({
+        params: { captionContent: '1\n00:00:00,000 --> 00:00:05,000\nHello' },
+      });
+      const job = createMockJob(JOB_TYPES.ADD_CAPTIONS, data);
+
+      await processor.handleAddCaptions(job);
+
+      expect(redisService.publish).not.toHaveBeenCalledWith(
+        'video-processing-complete',
+        expect.anything(),
       );
     });
   });
@@ -851,7 +899,11 @@ describe('VideoProcessor', () => {
       const data = createMockJobData({
         params: { endTime: 40, startTime: 10 },
       });
-      const job = createMockJob(JOB_TYPES.CLIP_TRIM, data);
+      const job = createMockJob(
+        JOB_TYPES.CLIP_TRIM,
+        data,
+        'raw-cut-trim-clip-1',
+      );
 
       const result = await processor.handleClipTrim(job);
 
@@ -862,7 +914,7 @@ describe('VideoProcessor', () => {
         'video-processing-complete',
         expect.objectContaining({
           result: expect.objectContaining({
-            jobId: 'job-123',
+            jobId: 'raw-cut-trim-clip-1',
             jobType: JOB_TYPES.CLIP_TRIM,
           }),
           status: 'completed',
@@ -874,6 +926,27 @@ describe('VideoProcessor', () => {
         10,
         30, // duration = endTime - startTime
         expect.any(Function),
+      );
+    });
+
+    it('does not publish a failed trim completion before retries are exhausted', async () => {
+      const data = createMockJobData({
+        params: { endTime: 40, startTime: 10 },
+      });
+      const job = createMockJob(
+        JOB_TYPES.CLIP_TRIM,
+        data,
+        'raw-cut-trim-clip-1',
+      );
+      ffmpegService.trimVideo.mockRejectedValueOnce(
+        new Error('Clip trim failed'),
+      );
+
+      await expect(processor.handleClipTrim(job)).rejects.toThrow();
+
+      expect(redisService.publish).not.toHaveBeenCalledWith(
+        'video-processing-complete',
+        expect.objectContaining({ status: 'failed' }),
       );
     });
 
@@ -935,7 +1008,12 @@ describe('VideoProcessor', () => {
       const data = createMockJobData({
         params: { endTime: 40, startTime: 10 },
       });
-      const job = createMockJob(JOB_TYPES.CLIP_TRIM, data);
+      const job = createMockJob(
+        JOB_TYPES.CLIP_TRIM,
+        data,
+        'raw-cut-trim-clip-1',
+        { attemptsMade: 2 },
+      );
       const error = new Error('Clip trim failed');
       ffmpegService.trimVideo.mockRejectedValueOnce(error);
 
@@ -947,7 +1025,7 @@ describe('VideoProcessor', () => {
         'video-processing-complete',
         expect.objectContaining({
           result: expect.objectContaining({
-            jobId: 'job-123',
+            jobId: 'raw-cut-trim-clip-1',
             jobType: JOB_TYPES.CLIP_TRIM,
           }),
           status: 'failed',

--- a/apps/server/files/src/processors/video.processor.spec.ts
+++ b/apps/server/files/src/processors/video.processor.spec.ts
@@ -632,8 +632,26 @@ describe('VideoProcessor', () => {
       const result = await processor.handleAddCaptions(job);
 
       expect(result.success).toBe(true);
+      expect(result).toEqual(
+        expect.objectContaining({
+          jobId: 'job-123',
+          jobType: JOB_TYPES.ADD_CAPTIONS,
+          url: expect.any(String),
+        }),
+      );
       expect(ffmpegService.addCaptions).toHaveBeenCalled();
       expect(webSocketService.emitSuccess).toHaveBeenCalled();
+      expect(redisService.publish).toHaveBeenCalledWith(
+        'video-processing-complete',
+        expect.objectContaining({
+          ingredientId: data.ingredientId,
+          result: expect.objectContaining({
+            jobId: 'job-123',
+            jobType: JOB_TYPES.ADD_CAPTIONS,
+          }),
+          status: 'completed',
+        }),
+      );
     });
 
     it('should handle caption errors', async () => {
@@ -643,6 +661,17 @@ describe('VideoProcessor', () => {
 
       await expect(processor.handleAddCaptions(job)).rejects.toThrow();
       expect(webSocketService.emitError).toHaveBeenCalled();
+      expect(redisService.publish).toHaveBeenCalledWith(
+        'video-processing-complete',
+        expect.objectContaining({
+          ingredientId: data.ingredientId,
+          result: expect.objectContaining({
+            jobId: 'job-123',
+            jobType: JOB_TYPES.ADD_CAPTIONS,
+          }),
+          status: 'failed',
+        }),
+      );
     });
   });
 
@@ -829,6 +858,16 @@ describe('VideoProcessor', () => {
       expect(result.success).toBe(true);
       expect(result.s3Key).toBeDefined();
       expect(result.url).toBeDefined();
+      expect(redisService.publish).toHaveBeenCalledWith(
+        'video-processing-complete',
+        expect.objectContaining({
+          result: expect.objectContaining({
+            jobId: 'job-123',
+            jobType: JOB_TYPES.CLIP_TRIM,
+          }),
+          status: 'completed',
+        }),
+      );
       expect(ffmpegService.trimVideo).toHaveBeenCalledWith(
         expect.any(String),
         expect.any(String),
@@ -904,6 +943,16 @@ describe('VideoProcessor', () => {
         'Clip trim failed',
       );
       expect(webSocketService.emitError).toHaveBeenCalled();
+      expect(redisService.publish).toHaveBeenCalledWith(
+        'video-processing-complete',
+        expect.objectContaining({
+          result: expect.objectContaining({
+            jobId: 'job-123',
+            jobType: JOB_TYPES.CLIP_TRIM,
+          }),
+          status: 'failed',
+        }),
+      );
     });
   });
 

--- a/apps/server/files/src/processors/video.processor.ts
+++ b/apps/server/files/src/processors/video.processor.ts
@@ -14,6 +14,7 @@ import {
   JobResult,
   VideoJobData,
 } from '@files/shared/interfaces/job.interface';
+import { RAW_CUT_JOB_PREFIX } from '@genfeedai/interfaces';
 import { LoggerService } from '@libs/logger/logger.service';
 import { RedisService } from '@libs/redis/redis.service';
 import { getErrorMessage } from '@libs/utils/error/get-error-message.util';
@@ -31,6 +32,14 @@ interface VideoCompletionResult {
   duration?: number;
   startTime?: number;
   endTime?: number;
+}
+
+function isFinalAttempt(job: Job<VideoJobData>): boolean {
+  return job.attemptsMade + 1 >= (job.opts.attempts ?? 1);
+}
+
+function isRawCutJob(job: Job<VideoJobData>): boolean {
+  return String(job.id).startsWith(RAW_CUT_JOB_PREFIX);
 }
 
 @Processor(QUEUE_NAMES.VIDEO_PROCESSING)
@@ -314,13 +323,20 @@ export class VideoProcessor extends WorkerHost {
         success: true,
         url,
       };
-      await this.publishVideoCompletion(
-        ingredientId,
-        job.data.userId,
-        job.data.organizationId,
-        'completed',
-        result,
-      );
+      if (isRawCutJob(job)) {
+        await this.publishVideoCompletion(
+          ingredientId,
+          job.data.userId,
+          job.data.organizationId,
+          'completed',
+          {
+            jobId: result.jobId,
+            jobType: result.jobType,
+            s3Key: result.s3Key,
+            url: result.url,
+          },
+        );
+      }
       return result;
     } catch (error: unknown) {
       const message = getErrorMessage(error);
@@ -331,17 +347,19 @@ export class VideoProcessor extends WorkerHost {
         authProviderUserId,
         room,
       );
-      await this.publishVideoCompletion(
-        ingredientId,
-        job.data.userId,
-        job.data.organizationId,
-        'failed',
-        {
-          jobId: String(job.id),
-          jobType: JOB_TYPES.ADD_CAPTIONS,
-        },
-        message,
-      );
+      if (isRawCutJob(job) && isFinalAttempt(job)) {
+        await this.publishVideoCompletion(
+          ingredientId,
+          job.data.userId,
+          job.data.organizationId,
+          'failed',
+          {
+            jobId: String(job.id),
+            jobType: JOB_TYPES.ADD_CAPTIONS,
+          },
+          message,
+        );
+      }
       throw error;
     }
   }
@@ -642,17 +660,19 @@ export class VideoProcessor extends WorkerHost {
         authProviderUserId,
         room,
       );
-      await this.publishVideoCompletion(
-        ingredientId,
-        job.data.userId,
-        job.data.organizationId,
-        'failed',
-        {
-          jobId: String(job.id),
-          jobType: JOB_TYPES.CLIP_TRIM,
-        },
-        message,
-      );
+      if (isRawCutJob(job) && isFinalAttempt(job)) {
+        await this.publishVideoCompletion(
+          ingredientId,
+          job.data.userId,
+          job.data.organizationId,
+          'failed',
+          {
+            jobId: String(job.id),
+            jobType: JOB_TYPES.CLIP_TRIM,
+          },
+          message,
+        );
+      }
       throw error;
     }
   }

--- a/apps/server/files/src/processors/video.processor.ts
+++ b/apps/server/files/src/processors/video.processor.ts
@@ -22,6 +22,8 @@ import { Inject } from '@nestjs/common';
 import { Job } from 'bullmq';
 
 interface VideoCompletionResult {
+  jobId?: string;
+  jobType?: string;
   ingredientId?: string;
   outputPath?: string;
   s3Key?: string;
@@ -293,7 +295,7 @@ export class VideoProcessor extends WorkerHost {
         ),
       );
 
-      const { s3Key } = await this.uploadAndEmitSuccess(
+      const { s3Key, url } = await this.uploadAndEmitSuccess(
         outputPath,
         ingredientId,
         'videos',
@@ -304,7 +306,22 @@ export class VideoProcessor extends WorkerHost {
       );
 
       this.ffmpegService.cleanupTempFiles(ingredientId, 'captions');
-      return { outputPath, s3Key, success: true };
+      const result = {
+        jobId: String(job.id),
+        jobType: JOB_TYPES.ADD_CAPTIONS,
+        outputPath,
+        s3Key,
+        success: true,
+        url,
+      };
+      await this.publishVideoCompletion(
+        ingredientId,
+        job.data.userId,
+        job.data.organizationId,
+        'completed',
+        result,
+      );
+      return result;
     } catch (error: unknown) {
       const message = getErrorMessage(error);
       this.logger.error(`Captions job failed: ${message}`);
@@ -313,6 +330,17 @@ export class VideoProcessor extends WorkerHost {
         message,
         authProviderUserId,
         room,
+      );
+      await this.publishVideoCompletion(
+        ingredientId,
+        job.data.userId,
+        job.data.organizationId,
+        'failed',
+        {
+          jobId: String(job.id),
+          jobType: JOB_TYPES.ADD_CAPTIONS,
+        },
+        message,
       );
       throw error;
     }
@@ -589,13 +617,22 @@ export class VideoProcessor extends WorkerHost {
           duration,
           endTime,
           ingredientId,
+          jobId: String(job.id),
+          jobType: JOB_TYPES.CLIP_TRIM,
           s3Key,
           startTime,
           url,
         },
       );
 
-      return { outputPath, s3Key, success: true, url };
+      return {
+        jobId: String(job.id),
+        jobType: JOB_TYPES.CLIP_TRIM,
+        outputPath,
+        s3Key,
+        success: true,
+        url,
+      };
     } catch (error: unknown) {
       const message = getErrorMessage(error);
       this.logger.error(`Clip trim job failed: ${message}`);
@@ -604,6 +641,17 @@ export class VideoProcessor extends WorkerHost {
         message,
         authProviderUserId,
         room,
+      );
+      await this.publishVideoCompletion(
+        ingredientId,
+        job.data.userId,
+        job.data.organizationId,
+        'failed',
+        {
+          jobId: String(job.id),
+          jobType: JOB_TYPES.CLIP_TRIM,
+        },
+        message,
       );
       throw error;
     }

--- a/apps/server/files/src/queues/video-queue.service.spec.ts
+++ b/apps/server/files/src/queues/video-queue.service.spec.ts
@@ -1,5 +1,6 @@
-import { QUEUE_NAMES } from '@files/queues/queue.constants';
+import { JOB_TYPES, QUEUE_NAMES } from '@files/queues/queue.constants';
 import { VideoQueueService } from '@files/queues/video-queue.service';
+import type { VideoJobData } from '@files/shared/interfaces/job.interface';
 import { getQueueToken } from '@nestjs/bullmq';
 import { Test, type TestingModule } from '@nestjs/testing';
 
@@ -32,5 +33,47 @@ describe('VideoQueueService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  it('uses the request id for deterministic caption jobs', async () => {
+    const data = {
+      createdAt: new Date(),
+      id: 'caption-job-1',
+      ingredientId: 'clip-1',
+      metadata: { websocketUrl: '/clips/clip-1' },
+      organizationId: 'org-1',
+      params: {},
+      type: JOB_TYPES.ADD_CAPTIONS,
+      userId: 'user-1',
+    } as VideoJobData;
+
+    await service.addCaptionsJob(data);
+
+    expect(mockQueue.add).toHaveBeenCalledWith(
+      JOB_TYPES.ADD_CAPTIONS,
+      data,
+      expect.objectContaining({ jobId: 'caption-job-1' }),
+    );
+  });
+
+  it('uses the request id for deterministic clip trim jobs', async () => {
+    const data = {
+      createdAt: new Date(),
+      id: 'clip-trim-job-1',
+      ingredientId: 'clip-1',
+      metadata: { websocketUrl: '/clips/clip-1' },
+      organizationId: 'org-1',
+      params: {},
+      type: JOB_TYPES.CLIP_TRIM,
+      userId: 'user-1',
+    } as VideoJobData;
+
+    await service.addClipTrimJob(data);
+
+    expect(mockQueue.add).toHaveBeenCalledWith(
+      JOB_TYPES.CLIP_TRIM,
+      data,
+      expect.objectContaining({ jobId: 'clip-trim-job-1' }),
+    );
   });
 });

--- a/apps/server/files/src/queues/video-queue.service.spec.ts
+++ b/apps/server/files/src/queues/video-queue.service.spec.ts
@@ -38,7 +38,7 @@ describe('VideoQueueService', () => {
   it('uses the request id for deterministic caption jobs', async () => {
     const data = {
       createdAt: new Date(),
-      id: 'caption-job-1',
+      id: 'raw-cut-caption-clip-1',
       ingredientId: 'clip-1',
       metadata: { websocketUrl: '/clips/clip-1' },
       organizationId: 'org-1',
@@ -52,14 +52,14 @@ describe('VideoQueueService', () => {
     expect(mockQueue.add).toHaveBeenCalledWith(
       JOB_TYPES.ADD_CAPTIONS,
       data,
-      expect.objectContaining({ jobId: 'caption-job-1' }),
+      expect.objectContaining({ jobId: 'raw-cut-caption-clip-1' }),
     );
   });
 
   it('uses the request id for deterministic clip trim jobs', async () => {
     const data = {
       createdAt: new Date(),
-      id: 'clip-trim-job-1',
+      id: 'raw-cut-trim-clip-1',
       ingredientId: 'clip-1',
       metadata: { websocketUrl: '/clips/clip-1' },
       organizationId: 'org-1',
@@ -73,7 +73,28 @@ describe('VideoQueueService', () => {
     expect(mockQueue.add).toHaveBeenCalledWith(
       JOB_TYPES.CLIP_TRIM,
       data,
-      expect.objectContaining({ jobId: 'clip-trim-job-1' }),
+      expect.objectContaining({ jobId: 'raw-cut-trim-clip-1' }),
+    );
+  });
+
+  it('does not deduplicate ordinary jobs by their request id', async () => {
+    const data = {
+      createdAt: new Date(),
+      id: 'video-123',
+      ingredientId: 'ingredient-1',
+      metadata: { websocketUrl: '/ingredients/ingredient-1' },
+      organizationId: 'org-1',
+      params: {},
+      type: JOB_TYPES.ADD_CAPTIONS,
+      userId: 'user-1',
+    } as VideoJobData;
+
+    await service.addCaptionsJob(data);
+
+    expect(mockQueue.add).toHaveBeenCalledWith(
+      JOB_TYPES.ADD_CAPTIONS,
+      data,
+      expect.not.objectContaining({ jobId: expect.anything() }),
     );
   });
 });

--- a/apps/server/files/src/queues/video-queue.service.ts
+++ b/apps/server/files/src/queues/video-queue.service.ts
@@ -116,7 +116,13 @@ export class VideoQueueService extends BaseQueueService<VideoJobData> {
   }
 
   async addCaptionsJob(data: VideoJobData): Promise<Job<VideoJobData>> {
-    return this.addJob(JOB_TYPES.ADD_CAPTIONS, data, 'captions');
+    return this.addJob(
+      JOB_TYPES.ADD_CAPTIONS,
+      data,
+      'captions',
+      undefined,
+      data.id,
+    );
   }
 
   async addGifConversionJob(data: VideoJobData): Promise<Job<VideoJobData>> {
@@ -154,7 +160,13 @@ export class VideoQueueService extends BaseQueueService<VideoJobData> {
   }
 
   async addClipTrimJob(data: VideoJobData): Promise<Job<VideoJobData>> {
-    return this.addJob(JOB_TYPES.CLIP_TRIM, data, 'clip trim');
+    return this.addJob(
+      JOB_TYPES.CLIP_TRIM,
+      data,
+      'clip trim',
+      undefined,
+      data.id,
+    );
   }
 
   async addExtractFramesJob(data: VideoJobData): Promise<Job<VideoJobData>> {

--- a/apps/server/files/src/queues/video-queue.service.ts
+++ b/apps/server/files/src/queues/video-queue.service.ts
@@ -7,6 +7,7 @@ import {
 } from '@files/queues/queue.constants';
 import type { VideoJobData } from '@files/shared/interfaces/job.interface';
 import { BaseQueueService } from '@files/shared/services/base-queue/base-queue.service';
+import { RAW_CUT_JOB_PREFIX } from '@genfeedai/interfaces';
 import { InjectQueue } from '@nestjs/bullmq';
 import { Injectable } from '@nestjs/common';
 import type { Job, Queue } from 'bullmq';
@@ -91,6 +92,10 @@ const VIDEO_JOB_CONFIGS: Partial<Record<JobType, JobConfig>> = {
   },
 };
 
+function getRawCutJobId(data: VideoJobData): string | undefined {
+  return data.id.startsWith(RAW_CUT_JOB_PREFIX) ? data.id : undefined;
+}
+
 @Injectable()
 export class VideoQueueService extends BaseQueueService<VideoJobData> {
   protected readonly jobConfigs = VIDEO_JOB_CONFIGS;
@@ -121,7 +126,7 @@ export class VideoQueueService extends BaseQueueService<VideoJobData> {
       data,
       'captions',
       undefined,
-      data.id,
+      getRawCutJobId(data),
     );
   }
 
@@ -165,7 +170,7 @@ export class VideoQueueService extends BaseQueueService<VideoJobData> {
       data,
       'clip trim',
       undefined,
-      data.id,
+      getRawCutJobId(data),
     );
   }
 

--- a/apps/server/files/src/shared/interfaces/job.interface.ts
+++ b/apps/server/files/src/shared/interfaces/job.interface.ts
@@ -237,6 +237,8 @@ export interface JobProgress {
 
 export interface JobResult {
   success: boolean;
+  jobId?: string;
+  jobType?: string;
   outputPath?: string;
   s3Key?: string;
   url?: string;

--- a/packages/interfaces/src/services/file-queue.interface.ts
+++ b/packages/interfaces/src/services/file-queue.interface.ts
@@ -59,6 +59,9 @@ export interface IJobResponse {
   ingredientId: string;
 }
 
+/** Wire-level prefix for deterministic raw-cut media jobs. */
+export const RAW_CUT_JOB_PREFIX = 'raw-cut-' as const;
+
 export interface IJobStatusResponse {
   jobId: string;
   state: JobState;

--- a/scripts/architecture/check-platform-cron-boundary.ts
+++ b/scripts/architecture/check-platform-cron-boundary.ts
@@ -97,6 +97,13 @@ export const PLATFORM_CRON_ALLOWLIST: CronBoundaryEntry[] = [
       'Platform recovery for durable editor render completion after missed Redis pub/sub events or API restarts.',
   },
   {
+    file: 'apps/server/api/src/services/video-completion/video-completion.service.ts',
+    id: 'raw-cut-clip-reconciliation',
+    methodName: 'reconcileRawCutClips',
+    reason:
+      'Platform recovery for deterministic raw-cut clip jobs after missed Redis pub/sub events or API restarts.',
+  },
+  {
     file: 'apps/server/api/src/collections/trends/services/trends-warmup.service.ts',
     id: 'trends-warmup',
     methodName: 'warmGlobalTrendDatasets',


### PR DESCRIPTION
## Summary
- chain raw-cut trim completion into deterministic caption jobs
- persist stage outputs and isolate per-clip failures while reconciling project progress
- publish stage-aware file-worker completion events with bounded polling recovery

## Verification
- `bunx @biomejs/biome@2.5.3 check <15 changed files>` (passes; two pre-existing non-null assertion warnings remain in video.processor.ts)
- `git diff --check`
- staged secret-pattern scan
- focused specs added/updated but not run locally per repository machine policy; PR CI owns tests, typecheck, and builds

## Residual risk
- Redis completion delivery is backed by a once-per-minute recovery pass over the 100 oldest active raw-cut jobs. Larger backlogs drain in bounded batches.

Closes #1237