### PR TITLE
fix(website): preserve paid seat entitlements

### DIFF
--- a/apps/website/app/(public)/pricing/page.spec.tsx
+++ b/apps/website/app/(public)/pricing/page.spec.tsx
@@ -6,13 +6,15 @@ import { describe, expect, it } from 'vitest';
 runPageModuleTests('apps/website/app/(public)/pricing/page', PageModule);
 
 describe('pricing metadata', () => {
-  it('reserves unlimited seats for Scale', async () => {
+  it('keeps seats unlimited across paid subscriptions', async () => {
     const parent = Promise.resolve({}) as ResolvingMetadata;
 
     const result = await PageModule.generateMetadata({}, parent);
 
-    expect(result.description).toContain('shared team seats');
-    expect(result.description).toContain('Scale unlocks unlimited seats');
-    expect(result.description).not.toContain('and unlimited team seats');
+    expect(result.description).toContain('unlimited team seats');
+    expect(result.description).toContain(
+      'Scale adds multi-organization workflows',
+    );
+    expect(result.description).not.toContain('Scale unlocks unlimited seats');
   });
 });

--- a/apps/website/app/(public)/pricing/page.spec.tsx
+++ b/apps/website/app/(public)/pricing/page.spec.tsx
@@ -1,4 +1,18 @@
 import * as PageModule from '@public/pricing/page';
 import { runPageModuleTests } from '@shared/pages/pageTestUtils';
+import type { ResolvingMetadata } from 'next';
+import { describe, expect, it } from 'vitest';
 
 runPageModuleTests('apps/website/app/(public)/pricing/page', PageModule);
+
+describe('pricing metadata', () => {
+  it('reserves unlimited seats for Scale', async () => {
+    const parent = Promise.resolve({}) as ResolvingMetadata;
+
+    const result = await PageModule.generateMetadata({}, parent);
+
+    expect(result.description).toContain('shared team seats');
+    expect(result.description).toContain('Scale unlocks unlimited seats');
+    expect(result.description).not.toContain('and unlimited team seats');
+  });
+});

--- a/apps/website/app/(public)/pricing/page.tsx
+++ b/apps/website/app/(public)/pricing/page.tsx
@@ -4,7 +4,7 @@ import PricingContent from '@public/pricing/pricing-content';
 
 export const generateMetadata = createPageMetadataWithCanonical(
   'Pricing',
-  'Free to sign up — credits buy the output you generate. Subscriptions from $49/mo include monthly credits at a better rate, paid API access, and shared team seats; Scale unlocks unlimited seats.',
+  'Free to sign up — credits buy the output you generate. Subscriptions from $49/mo include monthly credits at a better rate, paid API access, and unlimited team seats; Scale adds multi-organization workflows.',
   '/pricing',
 );
 

--- a/apps/website/app/(public)/pricing/page.tsx
+++ b/apps/website/app/(public)/pricing/page.tsx
@@ -4,7 +4,7 @@ import PricingContent from '@public/pricing/pricing-content';
 
 export const generateMetadata = createPageMetadataWithCanonical(
   'Pricing',
-  'Free to sign up — credits buy the output you generate. Subscriptions from $49/mo include monthly credits at a better rate, paid API access, and unlimited team seats.',
+  'Free to sign up — credits buy the output you generate. Subscriptions from $49/mo include monthly credits at a better rate, paid API access, and shared team seats; Scale unlocks unlimited seats.',
   '/pricing',
 );
 

--- a/apps/website/scripts/generate-llms-txt.ts
+++ b/apps/website/scripts/generate-llms-txt.ts
@@ -304,7 +304,7 @@ function buildLlmsFull(): string {
   s.push('## Pricing');
   s.push('');
   s.push(
-    'Genfeed is free to join: credits buy the output you generate (1 credit = $0.01 at the pay-as-you-go rate). Subscriptions include monthly credits at a ~40% better rate, paid API access, and shared team seats. Brands and connected channels are unlimited. Pay As You Go and Pro include one organization; Scale adds multi-organization workflows. Pro is $49/month with 8,000 credits included. Scale is $499/month with unlimited seats and an 80,000-credit shared pool. Enterprise is custom.',
+    'Genfeed is free to join: credits buy the output you generate (1 credit = $0.01 at the pay-as-you-go rate). Subscriptions include monthly credits at a ~40% better rate, paid API access, and unlimited team seats. Brands and connected channels are unlimited. Pay As You Go and Pro include one organization; Scale adds multi-organization workflows. Pro is $49/month with 8,000 credits included. Scale is $499/month with unlimited seats and an 80,000-credit shared pool. Enterprise is custom.',
   );
   s.push('');
 

--- a/apps/website/scripts/generate-llms-txt.ts
+++ b/apps/website/scripts/generate-llms-txt.ts
@@ -304,7 +304,7 @@ function buildLlmsFull(): string {
   s.push('## Pricing');
   s.push('');
   s.push(
-    'Genfeed is free to join: credits buy the output you generate (1 credit = $0.01 at the pay-as-you-go rate). Subscriptions include monthly credits at a ~40% better rate, paid API access, and unlimited team seats. Brands and connected channels are unlimited. Pay As You Go and Pro include one organization; Scale adds multi-organization workflows. Pro is $49/month with 8,000 credits included. Scale is $499/month with unlimited seats and an 80,000-credit shared pool. Enterprise is custom.',
+    'Genfeed is free to join: credits buy the output you generate (1 credit = $0.01 at the pay-as-you-go rate). Subscriptions include monthly credits at a ~40% better rate, paid API access, and shared team seats. Brands and connected channels are unlimited. Pay As You Go and Pro include one organization; Scale adds multi-organization workflows. Pro is $49/month with 8,000 credits included. Scale is $499/month with unlimited seats and an 80,000-credit shared pool. Enterprise is custom.',
   );
   s.push('');
 


### PR DESCRIPTION
## Summary

- reject the stale review premise that unlimited seats are Scale-only
- keep the canonical contract: FREE/BYOK is one seat; Pro, Scale, and Enterprise have unlimited seats
- distinguish Scale by multi-organization workflows and add focused metadata regression coverage
- keep the LLM-facing pricing summary aligned with `@genfeedai/pricing`

## Verification

- Fable 5 pricing audit: APPROVE after repairing the stale contract assumption
- Biome check passed for all changed files
- `git diff --check` passed
- staged Secretlint scan passed
- full tests, typecheck, and build deferred to PR CI under the local-machine policy

Closes #1491