### PR TITLE
fix(api): restore forwardRef ratchet

### DIFF
--- a/apps/server/api/src/services/video-completion/video-completion.module.ts
+++ b/apps/server/api/src/services/video-completion/video-completion.module.ts
@@ -12,7 +12,7 @@ import { forwardRef, Module } from '@nestjs/common';
   exports: [VideoCompletionService],
   imports: [
     RedisModule,
-    forwardRef(() => ClipProjectsCoreModule),
+    ClipProjectsCoreModule,
     forwardRef(() => EditorProjectsModule),
     forwardRef(() => FileQueueModule),
     forwardRef(() => IngredientsModule),


### PR DESCRIPTION
## Summary
- remove an unnecessary `forwardRef` around the cycle-free `ClipProjectsCoreModule` import
- restore the API module graph ratchet from 1076 to its 1075 ceiling

## Root cause
PR #1887 added the only new module-level `forwardRef`, but `VideoCompletionModule` is imported only by `AppModule`; there is no reverse Nest or ES-module path through clip projects. The production QA gate correctly blocked before deployment.

## Verification
- static `forwardRef(` count: 1075
- Biome check: pass
- secretlint: pass
- `git diff --check`: pass
- Fable 5 high-effort audit: APPROVE
- authoritative tests/typecheck/build: PR CI (local execution prohibited by workstation policy)