### PR TITLE
refactor(workflows): share system workflow metadata contract

### DIFF
--- a/apps/app/src/features/workflows/pages/library/useWorkflowLibraryPage.test.ts
+++ b/apps/app/src/features/workflows/pages/library/useWorkflowLibraryPage.test.ts
@@ -1,4 +1,5 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
+import { buildSystemWorkflowMetadata } from '@genfeedai/interfaces';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { WorkflowSummary } from '@/features/workflows/services/workflow-api';
 import { useWorkflowLibraryPage } from './useWorkflowLibraryPage';
@@ -160,11 +161,9 @@ describe('useWorkflowLibraryPage — handleToggleSchedule', () => {
         _id: 'system-wf',
         isScheduleEnabled: true,
         metadata: {
-          systemWorkflow: {
-            immutable: true,
-            kind: 'system-workflow',
-            owner: 'genfeed',
-          },
+          systemWorkflow: buildSystemWorkflowMetadata({
+            canonicalId: 'daily-trends-digest',
+          }),
         },
         name: 'Daily Trends Digest',
         schedule: '0 7 * * *',
@@ -219,11 +218,9 @@ describe('useWorkflowLibraryPage — workflow duplication and deletion', () => {
       makeWorkflow({
         _id: 'system-wf',
         metadata: {
-          systemWorkflow: {
-            immutable: true,
-            kind: 'system-workflow',
-            owner: 'genfeed',
-          },
+          systemWorkflow: buildSystemWorkflowMetadata({
+            canonicalId: 'daily-trends-digest',
+          }),
         },
         name: 'Daily Trends Digest',
       }),

--- a/apps/app/src/features/workflows/pages/library/useWorkflowLibraryPage.test.ts
+++ b/apps/app/src/features/workflows/pages/library/useWorkflowLibraryPage.test.ts
@@ -1,5 +1,5 @@
-import { act, renderHook, waitFor } from '@testing-library/react';
 import { buildSystemWorkflowMetadata } from '@genfeedai/interfaces';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { WorkflowSummary } from '@/features/workflows/services/workflow-api';
 import { useWorkflowLibraryPage } from './useWorkflowLibraryPage';

--- a/apps/app/src/features/workflows/services/workflow-api.test.ts
+++ b/apps/app/src/features/workflows/services/workflow-api.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildSystemWorkflowMetadata } from '@genfeedai/interfaces';
 
 const mocks = vi.hoisted(() => ({
   brandsFindAll: vi.fn(),
@@ -145,11 +146,9 @@ describe('WorkflowApiService', () => {
     expect(
       isCanonicalSystemWorkflow({
         metadata: {
-          systemWorkflow: {
-            immutable: true,
-            kind: 'system-workflow',
-            owner: 'genfeed',
-          },
+          systemWorkflow: buildSystemWorkflowMetadata({
+            canonicalId: 'daily-trends-digest',
+          }),
         },
       }),
     ).toBe(true);
@@ -160,6 +159,19 @@ describe('WorkflowApiService', () => {
           duplicatedFromSystemWorkflow: {
             canonicalId: 'daily-trends-digest',
             sourceWorkflowId: 'system-workflow-1',
+          },
+        },
+      }),
+    ).toBe(false);
+
+    expect(
+      isCanonicalSystemWorkflow({
+        metadata: {
+          systemWorkflow: {
+            canonicalId: 'daily-trends-digest',
+            immutable: true,
+            kind: 'system-workflow',
+            owner: 'genfeed',
           },
         },
       }),

--- a/apps/app/src/features/workflows/services/workflow-api.test.ts
+++ b/apps/app/src/features/workflows/services/workflow-api.test.ts
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { buildSystemWorkflowMetadata } from '@genfeedai/interfaces';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   brandsFindAll: vi.fn(),
@@ -172,6 +172,19 @@ describe('WorkflowApiService', () => {
             immutable: true,
             kind: 'system-workflow',
             owner: 'genfeed',
+          },
+        },
+      }),
+    ).toBe(true);
+
+    expect(
+      isCanonicalSystemWorkflow({
+        metadata: {
+          systemWorkflow: {
+            canonicalId: 'daily-trends-digest',
+            immutable: true,
+            kind: 'system-workflow',
+            owner: 'tenant',
           },
         },
       }),

--- a/apps/app/src/features/workflows/services/workflow-api.ts
+++ b/apps/app/src/features/workflows/services/workflow-api.ts
@@ -83,9 +83,9 @@ export interface WorkflowSummary {
   isScheduleEnabled?: boolean;
 }
 
-export function isCanonicalSystemWorkflow(
-  workflow: { metadata?: unknown },
-): boolean {
+export function isCanonicalSystemWorkflow(workflow: {
+  metadata?: unknown;
+}): boolean {
   return getSystemWorkflowMetadata(workflow.metadata)?.immutable === true;
 }
 

--- a/apps/app/src/features/workflows/services/workflow-api.ts
+++ b/apps/app/src/features/workflows/services/workflow-api.ts
@@ -1,5 +1,10 @@
 import { API_ENDPOINTS } from '@genfeedai/constants';
 import { WorkflowLifecycle } from '@genfeedai/enums';
+import {
+  getSystemWorkflowMetadata,
+  type SystemWorkflowDuplicateMetadata,
+  type SystemWorkflowMetadata,
+} from '@genfeedai/interfaces';
 import type { NodeGroup } from '@genfeedai/workflows/ui';
 import {
   deserializeCollection,
@@ -51,8 +56,8 @@ export interface CloudWorkflowData {
 }
 
 export type WorkflowMetadata = Record<string, unknown> & {
-  duplicatedFromSystemWorkflow?: Record<string, unknown>;
-  systemWorkflow?: Record<string, unknown>;
+  duplicatedFromSystemWorkflow?: SystemWorkflowDuplicateMetadata;
+  systemWorkflow?: SystemWorkflowMetadata;
 };
 
 /** Lightweight workflow summary for list views */
@@ -79,16 +84,9 @@ export interface WorkflowSummary {
 }
 
 export function isCanonicalSystemWorkflow(
-  workflow: Pick<WorkflowSummary, 'metadata'>,
+  workflow: { metadata?: unknown },
 ): boolean {
-  const systemWorkflow = workflow.metadata?.systemWorkflow;
-
-  return (
-    Boolean(systemWorkflow) &&
-    systemWorkflow?.kind === 'system-workflow' &&
-    systemWorkflow?.owner === 'genfeed' &&
-    systemWorkflow?.immutable === true
-  );
+  return getSystemWorkflowMetadata(workflow.metadata)?.immutable === true;
 }
 
 /** Payload for PATCH /workflows/:id (schedule fields) */

--- a/apps/server/api/src/collections/workflows/system-workflow.contract.spec.ts
+++ b/apps/server/api/src/collections/workflows/system-workflow.contract.spec.ts
@@ -3,6 +3,8 @@ import {
   buildSystemWorkflowMetadata,
   buildSystemWorkflowUpgradeMetadata,
   getSystemWorkflowDuplicateMetadata,
+  getSystemWorkflowMetadata,
+  isProtectedSystemWorkflowMetadata,
 } from '@api/collections/workflows/system-workflow.contract';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -95,5 +97,28 @@ describe('system workflow contract', () => {
       upgradeEligible: true,
       upgradeStatus: 'upgrade_available',
     });
+  });
+
+  it('rejects incomplete canonical and duplicate metadata', () => {
+    const incompleteCanonical = {
+      systemWorkflow: {
+        canonicalId: 'scheduled-post-publishing',
+        immutable: true,
+        kind: 'system-workflow',
+        owner: 'genfeed',
+      },
+    };
+    const incompleteDuplicate = {
+      duplicatedFromSystemWorkflow: {
+        canonicalId: 'scheduled-post-publishing',
+        sourceWorkflowId: 'workflow-source-1',
+      },
+    };
+
+    expect(getSystemWorkflowMetadata(incompleteCanonical)).toBeNull();
+    expect(isProtectedSystemWorkflowMetadata(incompleteCanonical)).toBe(false);
+    expect(
+      getSystemWorkflowDuplicateMetadata(incompleteDuplicate),
+    ).toBeNull();
   });
 });

--- a/apps/server/api/src/collections/workflows/system-workflow.contract.spec.ts
+++ b/apps/server/api/src/collections/workflows/system-workflow.contract.spec.ts
@@ -80,9 +80,12 @@ describe('system workflow contract', () => {
     });
 
     expect(duplicate).not.toBeNull();
+    if (!duplicate) {
+      throw new Error('Expected valid duplicate system workflow metadata.');
+    }
 
     const upgradeMetadata = buildSystemWorkflowUpgradeMetadata(
-      duplicate!,
+      duplicate,
       buildSystemWorkflowMetadata({
         canonicalId: 'scheduled-post-publishing',
         changeSummary: 'Add retry provenance.',
@@ -99,8 +102,8 @@ describe('system workflow contract', () => {
     });
   });
 
-  it('rejects incomplete canonical and duplicate metadata', () => {
-    const incompleteCanonical = {
+  it('normalizes legacy canonical and duplicate metadata', () => {
+    const legacyCanonical = {
       systemWorkflow: {
         canonicalId: 'scheduled-post-publishing',
         immutable: true,
@@ -108,17 +111,23 @@ describe('system workflow contract', () => {
         owner: 'genfeed',
       },
     };
-    const incompleteDuplicate = {
+    const legacyDuplicate = {
       duplicatedFromSystemWorkflow: {
         canonicalId: 'scheduled-post-publishing',
         sourceWorkflowId: 'workflow-source-1',
       },
     };
 
-    expect(getSystemWorkflowMetadata(incompleteCanonical)).toBeNull();
-    expect(isProtectedSystemWorkflowMetadata(incompleteCanonical)).toBe(false);
-    expect(
-      getSystemWorkflowDuplicateMetadata(incompleteDuplicate),
-    ).toBeNull();
+    expect(getSystemWorkflowMetadata(legacyCanonical)).toMatchObject({
+      canonicalId: 'scheduled-post-publishing',
+      version: 1,
+    });
+    expect(isProtectedSystemWorkflowMetadata(legacyCanonical)).toBe(true);
+    expect(getSystemWorkflowDuplicateMetadata(legacyDuplicate)).toMatchObject({
+      canonicalId: 'scheduled-post-publishing',
+      sourceWorkflowId: 'workflow-source-1',
+      sourceWorkflowVersion: 1,
+      upgradeEligible: false,
+    });
   });
 });

--- a/apps/server/api/src/collections/workflows/system-workflow.contract.ts
+++ b/apps/server/api/src/collections/workflows/system-workflow.contract.ts
@@ -1,10 +1,11 @@
+export type {
+  BuildSystemWorkflowMetadataInput,
+  SystemWorkflowCredentialPolicy,
+  SystemWorkflowDuplicateMetadata,
+  SystemWorkflowMetadata,
+  SystemWorkflowUpgradeStatus,
+} from '@genfeedai/interfaces';
 export {
-  SYSTEM_WORKFLOW_DUPLICATE_METADATA_KEY,
-  SYSTEM_WORKFLOW_METADATA_KEY,
-  SYSTEM_WORKFLOW_OWNER,
-  SYSTEM_WORKFLOW_PRODUCTIZATION_ISSUE,
-  SYSTEM_WORKFLOW_TEMPLATE_CHANGE_SUMMARY,
-  SYSTEM_WORKFLOW_TEMPLATE_VERSION,
   buildSystemWorkflowDuplicateMetadata,
   buildSystemWorkflowMetadata,
   buildSystemWorkflowUpgradeMetadata,
@@ -12,12 +13,10 @@ export {
   getSystemWorkflowDuplicateMetadata,
   getSystemWorkflowMetadata,
   isProtectedSystemWorkflowMetadata,
-} from '@genfeedai/interfaces';
-
-export type {
-  BuildSystemWorkflowMetadataInput,
-  SystemWorkflowCredentialPolicy,
-  SystemWorkflowDuplicateMetadata,
-  SystemWorkflowMetadata,
-  SystemWorkflowUpgradeStatus,
+  SYSTEM_WORKFLOW_DUPLICATE_METADATA_KEY,
+  SYSTEM_WORKFLOW_METADATA_KEY,
+  SYSTEM_WORKFLOW_OWNER,
+  SYSTEM_WORKFLOW_PRODUCTIZATION_ISSUE,
+  SYSTEM_WORKFLOW_TEMPLATE_CHANGE_SUMMARY,
+  SYSTEM_WORKFLOW_TEMPLATE_VERSION,
 } from '@genfeedai/interfaces';

--- a/apps/server/api/src/collections/workflows/system-workflow.contract.ts
+++ b/apps/server/api/src/collections/workflows/system-workflow.contract.ts
@@ -1,204 +1,23 @@
-export const SYSTEM_WORKFLOW_METADATA_KEY = 'systemWorkflow';
-export const SYSTEM_WORKFLOW_DUPLICATE_METADATA_KEY =
-  'duplicatedFromSystemWorkflow';
-export const SYSTEM_WORKFLOW_OWNER = 'genfeed';
-export const SYSTEM_WORKFLOW_PRODUCTIZATION_ISSUE = 1011;
-export const SYSTEM_WORKFLOW_TEMPLATE_VERSION = 1;
-export const SYSTEM_WORKFLOW_TEMPLATE_CHANGE_SUMMARY =
-  'Initial system workflow template version.';
+export {
+  SYSTEM_WORKFLOW_DUPLICATE_METADATA_KEY,
+  SYSTEM_WORKFLOW_METADATA_KEY,
+  SYSTEM_WORKFLOW_OWNER,
+  SYSTEM_WORKFLOW_PRODUCTIZATION_ISSUE,
+  SYSTEM_WORKFLOW_TEMPLATE_CHANGE_SUMMARY,
+  SYSTEM_WORKFLOW_TEMPLATE_VERSION,
+  buildSystemWorkflowDuplicateMetadata,
+  buildSystemWorkflowMetadata,
+  buildSystemWorkflowUpgradeMetadata,
+  getMetadataRecord,
+  getSystemWorkflowDuplicateMetadata,
+  getSystemWorkflowMetadata,
+  isProtectedSystemWorkflowMetadata,
+} from '@genfeedai/interfaces';
 
-export type SystemWorkflowCredentialPolicy =
-  | 'tenant-connected-account'
-  | 'system-policy';
-
-export type SystemWorkflowUpgradeStatus = 'current' | 'upgrade_available';
-
-export type SystemWorkflowMetadata = {
-  canonicalId: string;
-  changeSummary: string;
-  credentialPolicy: SystemWorkflowCredentialPolicy;
-  duplicable: boolean;
-  immutable: boolean;
-  kind: 'system-workflow';
-  owner: typeof SYSTEM_WORKFLOW_OWNER;
-  productizationIssue: typeof SYSTEM_WORKFLOW_PRODUCTIZATION_ISSUE;
-  sourceIssue?: number;
-  version: number;
-  visibility: 'organization';
-};
-
-export type SystemWorkflowDuplicateMetadata = {
-  canonicalId: string;
-  currentSystemWorkflowChangeSummary: string;
-  currentSystemWorkflowVersion: number;
-  credentialPolicy: SystemWorkflowCredentialPolicy;
-  duplicatedAt: string;
-  productizationIssue: typeof SYSTEM_WORKFLOW_PRODUCTIZATION_ISSUE;
-  sourceIssue?: number;
-  sourceWorkflowChangeSummary: string;
-  sourceWorkflowId: string;
-  sourceWorkflowVersion: number;
-  upgradeEligible: boolean;
-  upgradePolicy: 'manual';
-  upgradeStatus: SystemWorkflowUpgradeStatus;
-};
-
-export type BuildSystemWorkflowMetadataInput = {
-  canonicalId: string;
-  changeSummary?: string;
-  credentialPolicy?: SystemWorkflowCredentialPolicy;
-  sourceIssue?: number;
-  version?: number;
-};
-
-export function buildSystemWorkflowMetadata(
-  input: BuildSystemWorkflowMetadataInput,
-): SystemWorkflowMetadata {
-  const version = normalizeSystemWorkflowVersion(input.version);
-
-  return {
-    canonicalId: input.canonicalId,
-    changeSummary:
-      input.changeSummary ?? SYSTEM_WORKFLOW_TEMPLATE_CHANGE_SUMMARY,
-    credentialPolicy: input.credentialPolicy ?? 'tenant-connected-account',
-    duplicable: true,
-    immutable: true,
-    kind: 'system-workflow',
-    owner: SYSTEM_WORKFLOW_OWNER,
-    productizationIssue: SYSTEM_WORKFLOW_PRODUCTIZATION_ISSUE,
-    sourceIssue: input.sourceIssue,
-    version,
-    visibility: 'organization',
-  };
-}
-
-export function getMetadataRecord(metadata: unknown): Record<string, unknown> {
-  if (metadata && typeof metadata === 'object' && !Array.isArray(metadata)) {
-    return { ...(metadata as Record<string, unknown>) };
-  }
-
-  return {};
-}
-
-export function getSystemWorkflowMetadata(
-  metadata: unknown,
-): SystemWorkflowMetadata | null {
-  const systemWorkflow =
-    getMetadataRecord(metadata)[SYSTEM_WORKFLOW_METADATA_KEY];
-
-  if (
-    !systemWorkflow ||
-    typeof systemWorkflow !== 'object' ||
-    Array.isArray(systemWorkflow)
-  ) {
-    return null;
-  }
-
-  const record = systemWorkflow as Record<string, unknown>;
-  if (
-    record.kind !== 'system-workflow' ||
-    record.owner !== SYSTEM_WORKFLOW_OWNER ||
-    typeof record.canonicalId !== 'string'
-  ) {
-    return null;
-  }
-
-  return record as SystemWorkflowMetadata;
-}
-
-export function getSystemWorkflowDuplicateMetadata(
-  metadata: unknown,
-): SystemWorkflowDuplicateMetadata | null {
-  const duplicateMetadata =
-    getMetadataRecord(metadata)[SYSTEM_WORKFLOW_DUPLICATE_METADATA_KEY];
-
-  if (
-    !duplicateMetadata ||
-    typeof duplicateMetadata !== 'object' ||
-    Array.isArray(duplicateMetadata)
-  ) {
-    return null;
-  }
-
-  const record = duplicateMetadata as Record<string, unknown>;
-  if (
-    typeof record.canonicalId !== 'string' ||
-    typeof record.sourceWorkflowId !== 'string'
-  ) {
-    return null;
-  }
-
-  return record as SystemWorkflowDuplicateMetadata;
-}
-
-export function isProtectedSystemWorkflowMetadata(metadata: unknown): boolean {
-  const systemWorkflow = getSystemWorkflowMetadata(metadata);
-  return systemWorkflow?.immutable === true;
-}
-
-export function buildSystemWorkflowDuplicateMetadata(
-  metadata: unknown,
-  sourceWorkflowId: string,
-): Record<string, unknown> {
-  const duplicatedMetadata = getMetadataRecord(metadata);
-  const systemWorkflow = getSystemWorkflowMetadata(duplicatedMetadata);
-  delete duplicatedMetadata[SYSTEM_WORKFLOW_METADATA_KEY];
-
-  if (!systemWorkflow) {
-    return duplicatedMetadata;
-  }
-
-  const sourceWorkflowVersion = normalizeSystemWorkflowVersion(
-    systemWorkflow.version,
-  );
-  const sourceWorkflowChangeSummary =
-    systemWorkflow.changeSummary ?? SYSTEM_WORKFLOW_TEMPLATE_CHANGE_SUMMARY;
-
-  return {
-    ...duplicatedMetadata,
-    [SYSTEM_WORKFLOW_DUPLICATE_METADATA_KEY]: {
-      canonicalId: systemWorkflow.canonicalId,
-      currentSystemWorkflowChangeSummary: sourceWorkflowChangeSummary,
-      currentSystemWorkflowVersion: sourceWorkflowVersion,
-      credentialPolicy: systemWorkflow.credentialPolicy,
-      duplicatedAt: new Date().toISOString(),
-      productizationIssue: systemWorkflow.productizationIssue,
-      sourceIssue: systemWorkflow.sourceIssue,
-      sourceWorkflowChangeSummary,
-      sourceWorkflowId,
-      sourceWorkflowVersion,
-      upgradeEligible: false,
-      upgradePolicy: 'manual',
-      upgradeStatus: 'current',
-    },
-  };
-}
-
-export function buildSystemWorkflowUpgradeMetadata(
-  duplicateMetadata: SystemWorkflowDuplicateMetadata,
-  currentSystemWorkflow: SystemWorkflowMetadata,
-): SystemWorkflowDuplicateMetadata {
-  const currentSystemWorkflowVersion = normalizeSystemWorkflowVersion(
-    currentSystemWorkflow.version,
-  );
-  const sourceWorkflowVersion = normalizeSystemWorkflowVersion(
-    duplicateMetadata.sourceWorkflowVersion,
-  );
-  const upgradeEligible = currentSystemWorkflowVersion > sourceWorkflowVersion;
-
-  return {
-    ...duplicateMetadata,
-    currentSystemWorkflowChangeSummary:
-      currentSystemWorkflow.changeSummary ??
-      SYSTEM_WORKFLOW_TEMPLATE_CHANGE_SUMMARY,
-    currentSystemWorkflowVersion,
-    upgradeEligible,
-    upgradeStatus: upgradeEligible ? 'upgrade_available' : 'current',
-  };
-}
-
-function normalizeSystemWorkflowVersion(version: unknown): number {
-  return typeof version === 'number' && Number.isInteger(version) && version > 0
-    ? version
-    : SYSTEM_WORKFLOW_TEMPLATE_VERSION;
-}
+export type {
+  BuildSystemWorkflowMetadataInput,
+  SystemWorkflowCredentialPolicy,
+  SystemWorkflowDuplicateMetadata,
+  SystemWorkflowMetadata,
+  SystemWorkflowUpgradeStatus,
+} from '@genfeedai/interfaces';

--- a/packages/interfaces/package.json
+++ b/packages/interfaces/package.json
@@ -47,6 +47,7 @@
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "deps:update": "bunx npm-check-updates -u && bun install",
     "dev": "tsc --watch",
+    "test": "bun test src",
     "type-check": "tsc --noEmit"
   },
   "sideEffects": false,

--- a/packages/interfaces/src/automation/index.ts
+++ b/packages/interfaces/src/automation/index.ts
@@ -2,5 +2,6 @@ export * from './metadata.interface';
 export * from './setting.interface';
 export * from './setting-option.interface';
 export * from './sort.interface';
+export * from './system-workflow-contract.interface';
 export * from './workflow.interface';
 export * from './workflow-builder.interface';

--- a/packages/interfaces/src/automation/system-workflow-contract.interface.spec.ts
+++ b/packages/interfaces/src/automation/system-workflow-contract.interface.spec.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  buildSystemWorkflowDuplicateMetadata,
+  buildSystemWorkflowMetadata,
+  buildSystemWorkflowUpgradeMetadata,
+  getSystemWorkflowDuplicateMetadata,
+  getSystemWorkflowMetadata,
+  isProtectedSystemWorkflowMetadata,
+  SYSTEM_WORKFLOW_TEMPLATE_CHANGE_SUMMARY,
+  SYSTEM_WORKFLOW_TEMPLATE_VERSION,
+} from './system-workflow-contract.interface';
+
+const canonicalMetadata = buildSystemWorkflowMetadata({
+  canonicalId: 'scheduled-post-publishing',
+  changeSummary: 'Current publishing template.',
+  sourceIssue: 1029,
+  version: 2,
+});
+
+const duplicateMetadata = getSystemWorkflowDuplicateMetadata(
+  buildSystemWorkflowDuplicateMetadata(
+    { systemWorkflow: canonicalMetadata },
+    'workflow-source-1',
+  ),
+);
+
+if (!duplicateMetadata) {
+  throw new Error('Expected builder output to produce duplicate metadata.');
+}
+
+describe('system workflow metadata contract', () => {
+  it('accepts current builder output', () => {
+    expect(
+      getSystemWorkflowMetadata({ systemWorkflow: canonicalMetadata }),
+    ).toEqual(canonicalMetadata);
+    expect(duplicateMetadata).not.toBeNull();
+  });
+
+  it('normalizes canonical metadata stored before template versioning', () => {
+    const metadata = {
+      canonicalId: 'scheduled-post-publishing',
+      credentialPolicy: 'tenant-connected-account',
+      duplicable: true,
+      immutable: true,
+      kind: 'system-workflow',
+      owner: 'genfeed',
+      productizationIssue: 1011,
+      sourceIssue: 1029,
+      visibility: 'organization',
+    };
+
+    expect(getSystemWorkflowMetadata({ systemWorkflow: metadata })).toEqual({
+      ...metadata,
+      changeSummary: SYSTEM_WORKFLOW_TEMPLATE_CHANGE_SUMMARY,
+      version: SYSTEM_WORKFLOW_TEMPLATE_VERSION,
+    });
+    expect(
+      isProtectedSystemWorkflowMetadata({ systemWorkflow: metadata }),
+    ).toBe(true);
+  });
+
+  it('normalizes legacy identity-only canonical metadata', () => {
+    expect(
+      getSystemWorkflowMetadata({
+        systemWorkflow: {
+          canonicalId: 'daily-trends-digest',
+          immutable: true,
+          kind: 'system-workflow',
+          owner: 'genfeed',
+        },
+      }),
+    ).toEqual(
+      buildSystemWorkflowMetadata({
+        canonicalId: 'daily-trends-digest',
+      }),
+    );
+  });
+
+  const invalidCanonicalCases: Array<[string, unknown]> = [
+    ['a non-record value', 'system-workflow'],
+    ['an empty canonicalId', { ...canonicalMetadata, canonicalId: '' }],
+    ['a non-string changeSummary', { ...canonicalMetadata, changeSummary: 2 }],
+    [
+      'an unknown credentialPolicy',
+      { ...canonicalMetadata, credentialPolicy: 'unknown' },
+    ],
+    ['a non-boolean duplicable flag', { ...canonicalMetadata, duplicable: 1 }],
+    ['a mutable marker', { ...canonicalMetadata, immutable: false }],
+    ['an unknown kind', { ...canonicalMetadata, kind: 'workflow' }],
+    ['an unknown owner', { ...canonicalMetadata, owner: 'tenant' }],
+    [
+      'a different productization issue',
+      { ...canonicalMetadata, productizationIssue: 999 },
+    ],
+    ['an invalid source issue', { ...canonicalMetadata, sourceIssue: 0 }],
+    ['an invalid version', { ...canonicalMetadata, version: 0 }],
+    ['an unknown visibility', { ...canonicalMetadata, visibility: 'private' }],
+  ];
+
+  for (const [label, systemWorkflow] of invalidCanonicalCases) {
+    it(`rejects canonical metadata with ${label}`, () => {
+      expect(getSystemWorkflowMetadata({ systemWorkflow })).toBeNull();
+    });
+  }
+
+  it('normalizes duplicate metadata stored before upgrade tracking', () => {
+    const legacyDuplicate = {
+      canonicalId: 'scheduled-post-publishing',
+      credentialPolicy: 'tenant-connected-account',
+      duplicatedAt: '2026-07-01T12:00:00.000Z',
+      productizationIssue: 1011,
+      sourceIssue: 1029,
+      sourceWorkflowId: 'workflow-source-1',
+    };
+
+    expect(
+      getSystemWorkflowDuplicateMetadata({
+        duplicatedFromSystemWorkflow: legacyDuplicate,
+      }),
+    ).toEqual({
+      ...legacyDuplicate,
+      currentSystemWorkflowChangeSummary:
+        SYSTEM_WORKFLOW_TEMPLATE_CHANGE_SUMMARY,
+      currentSystemWorkflowVersion: SYSTEM_WORKFLOW_TEMPLATE_VERSION,
+      sourceWorkflowChangeSummary: SYSTEM_WORKFLOW_TEMPLATE_CHANGE_SUMMARY,
+      sourceWorkflowVersion: SYSTEM_WORKFLOW_TEMPLATE_VERSION,
+      upgradeEligible: false,
+      upgradePolicy: 'manual',
+      upgradeStatus: 'current',
+    });
+  });
+
+  it('normalizes legacy identity-only duplicate metadata', () => {
+    expect(
+      getSystemWorkflowDuplicateMetadata({
+        duplicatedFromSystemWorkflow: {
+          canonicalId: 'daily-trends-digest',
+          sourceWorkflowId: 'workflow-source-1',
+        },
+      }),
+    ).toMatchObject({
+      canonicalId: 'daily-trends-digest',
+      sourceWorkflowId: 'workflow-source-1',
+      sourceWorkflowVersion: SYSTEM_WORKFLOW_TEMPLATE_VERSION,
+      upgradeEligible: false,
+      upgradeStatus: 'current',
+    });
+  });
+
+  const currentDuplicate = duplicateMetadata;
+  const invalidDuplicateCases: Array<[string, unknown]> = [
+    ['a non-record value', 'duplicate'],
+    ['an empty canonicalId', { ...currentDuplicate, canonicalId: '' }],
+    [
+      'a non-string current change summary',
+      { ...currentDuplicate, currentSystemWorkflowChangeSummary: 2 },
+    ],
+    [
+      'an invalid current version',
+      { ...currentDuplicate, currentSystemWorkflowVersion: 0 },
+    ],
+    [
+      'an unknown credential policy',
+      { ...currentDuplicate, credentialPolicy: 'unknown' },
+    ],
+    ['an invalid duplicatedAt', { ...currentDuplicate, duplicatedAt: 2 }],
+    [
+      'a different productization issue',
+      { ...currentDuplicate, productizationIssue: 999 },
+    ],
+    ['an invalid source issue', { ...currentDuplicate, sourceIssue: 0 }],
+    [
+      'a non-string source change summary',
+      { ...currentDuplicate, sourceWorkflowChangeSummary: 2 },
+    ],
+    [
+      'an empty source workflow id',
+      { ...currentDuplicate, sourceWorkflowId: '' },
+    ],
+    [
+      'an invalid source version',
+      { ...currentDuplicate, sourceWorkflowVersion: 0 },
+    ],
+    [
+      'a non-boolean upgrade flag',
+      { ...currentDuplicate, upgradeEligible: 'yes' },
+    ],
+    [
+      'an unknown upgrade policy',
+      { ...currentDuplicate, upgradePolicy: 'automatic' },
+    ],
+    [
+      'an unknown upgrade status',
+      { ...currentDuplicate, upgradeStatus: 'pending' },
+    ],
+  ];
+
+  for (const [label, duplicatedFromSystemWorkflow] of invalidDuplicateCases) {
+    it(`rejects duplicate metadata with ${label}`, () => {
+      expect(
+        getSystemWorkflowDuplicateMetadata({
+          duplicatedFromSystemWorkflow,
+        }),
+      ).toBeNull();
+    });
+  }
+
+  it('rejects upgrade metadata built from different canonical workflows', () => {
+    expect(() =>
+      buildSystemWorkflowUpgradeMetadata(
+        currentDuplicate,
+        buildSystemWorkflowMetadata({
+          canonicalId: 'daily-trends-digest',
+          version: 3,
+        }),
+      ),
+    ).toThrow(
+      'duplicate canonicalId "scheduled-post-publishing" does not match current canonicalId "daily-trends-digest"',
+    );
+  });
+});

--- a/packages/interfaces/src/automation/system-workflow-contract.interface.ts
+++ b/packages/interfaces/src/automation/system-workflow-contract.interface.ts
@@ -1,0 +1,249 @@
+export const SYSTEM_WORKFLOW_METADATA_KEY = 'systemWorkflow';
+export const SYSTEM_WORKFLOW_DUPLICATE_METADATA_KEY =
+  'duplicatedFromSystemWorkflow';
+export const SYSTEM_WORKFLOW_OWNER = 'genfeed';
+export const SYSTEM_WORKFLOW_PRODUCTIZATION_ISSUE = 1011;
+export const SYSTEM_WORKFLOW_TEMPLATE_VERSION = 1;
+export const SYSTEM_WORKFLOW_TEMPLATE_CHANGE_SUMMARY =
+  'Initial system workflow template version.';
+
+export type SystemWorkflowCredentialPolicy =
+  | 'tenant-connected-account'
+  | 'system-policy';
+
+export type SystemWorkflowUpgradeStatus = 'current' | 'upgrade_available';
+
+export type SystemWorkflowMetadata = {
+  canonicalId: string;
+  changeSummary: string;
+  credentialPolicy: SystemWorkflowCredentialPolicy;
+  duplicable: boolean;
+  immutable: boolean;
+  kind: 'system-workflow';
+  owner: typeof SYSTEM_WORKFLOW_OWNER;
+  productizationIssue: typeof SYSTEM_WORKFLOW_PRODUCTIZATION_ISSUE;
+  sourceIssue?: number;
+  version: number;
+  visibility: 'organization';
+};
+
+export type SystemWorkflowDuplicateMetadata = {
+  canonicalId: string;
+  currentSystemWorkflowChangeSummary: string;
+  currentSystemWorkflowVersion: number;
+  credentialPolicy: SystemWorkflowCredentialPolicy;
+  duplicatedAt: string;
+  productizationIssue: typeof SYSTEM_WORKFLOW_PRODUCTIZATION_ISSUE;
+  sourceIssue?: number;
+  sourceWorkflowChangeSummary: string;
+  sourceWorkflowId: string;
+  sourceWorkflowVersion: number;
+  upgradeEligible: boolean;
+  upgradePolicy: 'manual';
+  upgradeStatus: SystemWorkflowUpgradeStatus;
+};
+
+export type BuildSystemWorkflowMetadataInput = {
+  canonicalId: string;
+  changeSummary?: string;
+  credentialPolicy?: SystemWorkflowCredentialPolicy;
+  sourceIssue?: number;
+  version?: number;
+};
+
+export function buildSystemWorkflowMetadata(
+  input: BuildSystemWorkflowMetadataInput,
+): SystemWorkflowMetadata {
+  const version = normalizeSystemWorkflowVersion(input.version);
+
+  return {
+    canonicalId: input.canonicalId,
+    changeSummary:
+      input.changeSummary ?? SYSTEM_WORKFLOW_TEMPLATE_CHANGE_SUMMARY,
+    credentialPolicy: input.credentialPolicy ?? 'tenant-connected-account',
+    duplicable: true,
+    immutable: true,
+    kind: 'system-workflow',
+    owner: SYSTEM_WORKFLOW_OWNER,
+    productizationIssue: SYSTEM_WORKFLOW_PRODUCTIZATION_ISSUE,
+    sourceIssue: input.sourceIssue,
+    version,
+    visibility: 'organization',
+  };
+}
+
+export function getMetadataRecord(metadata: unknown): Record<string, unknown> {
+  if (isRecord(metadata)) {
+    return { ...metadata };
+  }
+
+  return {};
+}
+
+export function getSystemWorkflowMetadata(
+  metadata: unknown,
+): SystemWorkflowMetadata | null {
+  const systemWorkflow =
+    getMetadataRecord(metadata)[SYSTEM_WORKFLOW_METADATA_KEY];
+
+  if (!isRecord(systemWorkflow) || !isSystemWorkflowMetadata(systemWorkflow)) {
+    return null;
+  }
+
+  return systemWorkflow;
+}
+
+export function getSystemWorkflowDuplicateMetadata(
+  metadata: unknown,
+): SystemWorkflowDuplicateMetadata | null {
+  const duplicateMetadata =
+    getMetadataRecord(metadata)[SYSTEM_WORKFLOW_DUPLICATE_METADATA_KEY];
+
+  if (
+    !isRecord(duplicateMetadata) ||
+    !isSystemWorkflowDuplicateMetadata(duplicateMetadata)
+  ) {
+    return null;
+  }
+
+  return duplicateMetadata;
+}
+
+export function isProtectedSystemWorkflowMetadata(metadata: unknown): boolean {
+  return getSystemWorkflowMetadata(metadata)?.immutable === true;
+}
+
+export function buildSystemWorkflowDuplicateMetadata(
+  metadata: unknown,
+  sourceWorkflowId: string,
+): Record<string, unknown> {
+  const duplicatedMetadata = getMetadataRecord(metadata);
+  const systemWorkflow = getSystemWorkflowMetadata(duplicatedMetadata);
+  delete duplicatedMetadata[SYSTEM_WORKFLOW_METADATA_KEY];
+
+  if (!systemWorkflow) {
+    return duplicatedMetadata;
+  }
+
+  const sourceWorkflowVersion = normalizeSystemWorkflowVersion(
+    systemWorkflow.version,
+  );
+  const sourceWorkflowChangeSummary =
+    systemWorkflow.changeSummary ?? SYSTEM_WORKFLOW_TEMPLATE_CHANGE_SUMMARY;
+
+  return {
+    ...duplicatedMetadata,
+    [SYSTEM_WORKFLOW_DUPLICATE_METADATA_KEY]: {
+      canonicalId: systemWorkflow.canonicalId,
+      currentSystemWorkflowChangeSummary: sourceWorkflowChangeSummary,
+      currentSystemWorkflowVersion: sourceWorkflowVersion,
+      credentialPolicy: systemWorkflow.credentialPolicy,
+      duplicatedAt: new Date().toISOString(),
+      productizationIssue: systemWorkflow.productizationIssue,
+      sourceIssue: systemWorkflow.sourceIssue,
+      sourceWorkflowChangeSummary,
+      sourceWorkflowId,
+      sourceWorkflowVersion,
+      upgradeEligible: false,
+      upgradePolicy: 'manual',
+      upgradeStatus: 'current',
+    },
+  };
+}
+
+export function buildSystemWorkflowUpgradeMetadata(
+  duplicateMetadata: SystemWorkflowDuplicateMetadata,
+  currentSystemWorkflow: SystemWorkflowMetadata,
+): SystemWorkflowDuplicateMetadata {
+  const currentSystemWorkflowVersion = normalizeSystemWorkflowVersion(
+    currentSystemWorkflow.version,
+  );
+  const sourceWorkflowVersion = normalizeSystemWorkflowVersion(
+    duplicateMetadata.sourceWorkflowVersion,
+  );
+  const upgradeEligible = currentSystemWorkflowVersion > sourceWorkflowVersion;
+
+  return {
+    ...duplicateMetadata,
+    currentSystemWorkflowChangeSummary:
+      currentSystemWorkflow.changeSummary ??
+      SYSTEM_WORKFLOW_TEMPLATE_CHANGE_SUMMARY,
+    currentSystemWorkflowVersion,
+    upgradeEligible,
+    upgradeStatus: upgradeEligible ? 'upgrade_available' : 'current',
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isSystemWorkflowCredentialPolicy(
+  value: unknown,
+): value is SystemWorkflowCredentialPolicy {
+  return value === 'tenant-connected-account' || value === 'system-policy';
+}
+
+function isSystemWorkflowUpgradeStatus(
+  value: unknown,
+): value is SystemWorkflowUpgradeStatus {
+  return value === 'current' || value === 'upgrade_available';
+}
+
+function isOptionalIssueNumber(value: unknown): value is number | undefined {
+  return (
+    value === undefined ||
+    (typeof value === 'number' && Number.isInteger(value) && value > 0)
+  );
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0;
+}
+
+function isSystemWorkflowMetadata(
+  record: Record<string, unknown>,
+): record is SystemWorkflowMetadata {
+  return (
+    typeof record.canonicalId === 'string' &&
+    record.canonicalId.length > 0 &&
+    typeof record.changeSummary === 'string' &&
+    isSystemWorkflowCredentialPolicy(record.credentialPolicy) &&
+    record.duplicable === true &&
+    record.immutable === true &&
+    record.kind === 'system-workflow' &&
+    record.owner === SYSTEM_WORKFLOW_OWNER &&
+    record.productizationIssue === SYSTEM_WORKFLOW_PRODUCTIZATION_ISSUE &&
+    isOptionalIssueNumber(record.sourceIssue) &&
+    isPositiveInteger(record.version) &&
+    record.visibility === 'organization'
+  );
+}
+
+function isSystemWorkflowDuplicateMetadata(
+  record: Record<string, unknown>,
+): record is SystemWorkflowDuplicateMetadata {
+  return (
+    typeof record.canonicalId === 'string' &&
+    record.canonicalId.length > 0 &&
+    typeof record.currentSystemWorkflowChangeSummary === 'string' &&
+    isPositiveInteger(record.currentSystemWorkflowVersion) &&
+    isSystemWorkflowCredentialPolicy(record.credentialPolicy) &&
+    typeof record.duplicatedAt === 'string' &&
+    record.productizationIssue === SYSTEM_WORKFLOW_PRODUCTIZATION_ISSUE &&
+    isOptionalIssueNumber(record.sourceIssue) &&
+    typeof record.sourceWorkflowChangeSummary === 'string' &&
+    typeof record.sourceWorkflowId === 'string' &&
+    record.sourceWorkflowId.length > 0 &&
+    isPositiveInteger(record.sourceWorkflowVersion) &&
+    typeof record.upgradeEligible === 'boolean' &&
+    record.upgradePolicy === 'manual' &&
+    isSystemWorkflowUpgradeStatus(record.upgradeStatus)
+  );
+}
+
+function normalizeSystemWorkflowVersion(version: unknown): number {
+  return isPositiveInteger(version)
+    ? version
+    : SYSTEM_WORKFLOW_TEMPLATE_VERSION;
+}

--- a/packages/interfaces/src/automation/system-workflow-contract.interface.ts
+++ b/packages/interfaces/src/automation/system-workflow-contract.interface.ts
@@ -83,30 +83,21 @@ export function getMetadataRecord(metadata: unknown): Record<string, unknown> {
 export function getSystemWorkflowMetadata(
   metadata: unknown,
 ): SystemWorkflowMetadata | null {
-  const systemWorkflow =
-    getMetadataRecord(metadata)[SYSTEM_WORKFLOW_METADATA_KEY];
+  const systemWorkflow = isRecord(metadata)
+    ? metadata[SYSTEM_WORKFLOW_METADATA_KEY]
+    : undefined;
 
-  if (!isRecord(systemWorkflow) || !isSystemWorkflowMetadata(systemWorkflow)) {
-    return null;
-  }
-
-  return systemWorkflow;
+  return normalizeSystemWorkflowMetadata(systemWorkflow);
 }
 
 export function getSystemWorkflowDuplicateMetadata(
   metadata: unknown,
 ): SystemWorkflowDuplicateMetadata | null {
-  const duplicateMetadata =
-    getMetadataRecord(metadata)[SYSTEM_WORKFLOW_DUPLICATE_METADATA_KEY];
+  const duplicateMetadata = isRecord(metadata)
+    ? metadata[SYSTEM_WORKFLOW_DUPLICATE_METADATA_KEY]
+    : undefined;
 
-  if (
-    !isRecord(duplicateMetadata) ||
-    !isSystemWorkflowDuplicateMetadata(duplicateMetadata)
-  ) {
-    return null;
-  }
-
-  return duplicateMetadata;
+  return normalizeSystemWorkflowDuplicateMetadata(duplicateMetadata);
 }
 
 export function isProtectedSystemWorkflowMetadata(metadata: unknown): boolean {
@@ -155,6 +146,12 @@ export function buildSystemWorkflowUpgradeMetadata(
   duplicateMetadata: SystemWorkflowDuplicateMetadata,
   currentSystemWorkflow: SystemWorkflowMetadata,
 ): SystemWorkflowDuplicateMetadata {
+  if (duplicateMetadata.canonicalId !== currentSystemWorkflow.canonicalId) {
+    throw new Error(
+      `Cannot build system workflow upgrade metadata: duplicate canonicalId "${duplicateMetadata.canonicalId}" does not match current canonicalId "${currentSystemWorkflow.canonicalId}".`,
+    );
+  }
+
   const currentSystemWorkflowVersion = normalizeSystemWorkflowVersion(
     currentSystemWorkflow.version,
   );
@@ -201,45 +198,116 @@ function isPositiveInteger(value: unknown): value is number {
   return typeof value === 'number' && Number.isInteger(value) && value > 0;
 }
 
-function isSystemWorkflowMetadata(
-  record: Record<string, unknown>,
-): record is SystemWorkflowMetadata {
-  return (
-    typeof record.canonicalId === 'string' &&
-    record.canonicalId.length > 0 &&
-    typeof record.changeSummary === 'string' &&
-    isSystemWorkflowCredentialPolicy(record.credentialPolicy) &&
-    record.duplicable === true &&
-    record.immutable === true &&
-    record.kind === 'system-workflow' &&
-    record.owner === SYSTEM_WORKFLOW_OWNER &&
-    record.productizationIssue === SYSTEM_WORKFLOW_PRODUCTIZATION_ISSUE &&
-    isOptionalIssueNumber(record.sourceIssue) &&
-    isPositiveInteger(record.version) &&
-    record.visibility === 'organization'
-  );
+function normalizeSystemWorkflowMetadata(
+  value: unknown,
+): SystemWorkflowMetadata | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const canonicalId = value.canonicalId;
+  const changeSummary =
+    value.changeSummary ?? SYSTEM_WORKFLOW_TEMPLATE_CHANGE_SUMMARY;
+  const credentialPolicy = value.credentialPolicy ?? 'tenant-connected-account';
+  const duplicable = value.duplicable ?? true;
+  const productizationIssue =
+    value.productizationIssue ?? SYSTEM_WORKFLOW_PRODUCTIZATION_ISSUE;
+  const version = value.version ?? SYSTEM_WORKFLOW_TEMPLATE_VERSION;
+  const visibility = value.visibility ?? 'organization';
+
+  if (
+    typeof canonicalId !== 'string' ||
+    canonicalId.length === 0 ||
+    typeof changeSummary !== 'string' ||
+    !isSystemWorkflowCredentialPolicy(credentialPolicy) ||
+    typeof duplicable !== 'boolean' ||
+    value.immutable !== true ||
+    value.kind !== 'system-workflow' ||
+    value.owner !== SYSTEM_WORKFLOW_OWNER ||
+    productizationIssue !== SYSTEM_WORKFLOW_PRODUCTIZATION_ISSUE ||
+    !isOptionalIssueNumber(value.sourceIssue) ||
+    !isPositiveInteger(version) ||
+    visibility !== 'organization'
+  ) {
+    return null;
+  }
+
+  return {
+    canonicalId,
+    changeSummary,
+    credentialPolicy,
+    duplicable,
+    immutable: true,
+    kind: 'system-workflow',
+    owner: SYSTEM_WORKFLOW_OWNER,
+    productizationIssue: SYSTEM_WORKFLOW_PRODUCTIZATION_ISSUE,
+    sourceIssue: value.sourceIssue,
+    version,
+    visibility: 'organization',
+  };
 }
 
-function isSystemWorkflowDuplicateMetadata(
-  record: Record<string, unknown>,
-): record is SystemWorkflowDuplicateMetadata {
-  return (
-    typeof record.canonicalId === 'string' &&
-    record.canonicalId.length > 0 &&
-    typeof record.currentSystemWorkflowChangeSummary === 'string' &&
-    isPositiveInteger(record.currentSystemWorkflowVersion) &&
-    isSystemWorkflowCredentialPolicy(record.credentialPolicy) &&
-    typeof record.duplicatedAt === 'string' &&
-    record.productizationIssue === SYSTEM_WORKFLOW_PRODUCTIZATION_ISSUE &&
-    isOptionalIssueNumber(record.sourceIssue) &&
-    typeof record.sourceWorkflowChangeSummary === 'string' &&
-    typeof record.sourceWorkflowId === 'string' &&
-    record.sourceWorkflowId.length > 0 &&
-    isPositiveInteger(record.sourceWorkflowVersion) &&
-    typeof record.upgradeEligible === 'boolean' &&
-    record.upgradePolicy === 'manual' &&
-    isSystemWorkflowUpgradeStatus(record.upgradeStatus)
-  );
+function normalizeSystemWorkflowDuplicateMetadata(
+  value: unknown,
+): SystemWorkflowDuplicateMetadata | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  const canonicalId = value.canonicalId;
+  const credentialPolicy = value.credentialPolicy ?? 'tenant-connected-account';
+  const duplicatedAt = value.duplicatedAt ?? '';
+  const productizationIssue =
+    value.productizationIssue ?? SYSTEM_WORKFLOW_PRODUCTIZATION_ISSUE;
+  const sourceWorkflowChangeSummary =
+    value.sourceWorkflowChangeSummary ??
+    SYSTEM_WORKFLOW_TEMPLATE_CHANGE_SUMMARY;
+  const sourceWorkflowId = value.sourceWorkflowId;
+  const sourceWorkflowVersion =
+    value.sourceWorkflowVersion ?? SYSTEM_WORKFLOW_TEMPLATE_VERSION;
+  const currentSystemWorkflowChangeSummary =
+    value.currentSystemWorkflowChangeSummary ?? sourceWorkflowChangeSummary;
+  const currentSystemWorkflowVersion =
+    value.currentSystemWorkflowVersion ?? sourceWorkflowVersion;
+  const upgradeEligible = value.upgradeEligible ?? false;
+  const upgradePolicy = value.upgradePolicy ?? 'manual';
+  const upgradeStatus = value.upgradeStatus ?? 'current';
+
+  if (
+    typeof canonicalId !== 'string' ||
+    canonicalId.length === 0 ||
+    typeof currentSystemWorkflowChangeSummary !== 'string' ||
+    !isPositiveInteger(currentSystemWorkflowVersion) ||
+    !isSystemWorkflowCredentialPolicy(credentialPolicy) ||
+    typeof duplicatedAt !== 'string' ||
+    productizationIssue !== SYSTEM_WORKFLOW_PRODUCTIZATION_ISSUE ||
+    !isOptionalIssueNumber(value.sourceIssue) ||
+    typeof sourceWorkflowChangeSummary !== 'string' ||
+    typeof sourceWorkflowId !== 'string' ||
+    sourceWorkflowId.length === 0 ||
+    !isPositiveInteger(sourceWorkflowVersion) ||
+    typeof upgradeEligible !== 'boolean' ||
+    upgradePolicy !== 'manual' ||
+    !isSystemWorkflowUpgradeStatus(upgradeStatus)
+  ) {
+    return null;
+  }
+
+  return {
+    canonicalId,
+    currentSystemWorkflowChangeSummary,
+    currentSystemWorkflowVersion,
+    credentialPolicy,
+    duplicatedAt,
+    productizationIssue: SYSTEM_WORKFLOW_PRODUCTIZATION_ISSUE,
+    sourceIssue: value.sourceIssue,
+    sourceWorkflowChangeSummary,
+    sourceWorkflowId,
+    sourceWorkflowVersion,
+    upgradeEligible,
+    upgradePolicy: 'manual',
+    upgradeStatus,
+  };
 }
 
 function normalizeSystemWorkflowVersion(version: unknown): number {

--- a/packages/interfaces/src/index.ts
+++ b/packages/interfaces/src/index.ts
@@ -48,6 +48,7 @@ export * from './automation/setting-option.interface';
 export * from './automation/smart-scheduler.interface';
 export * from './automation/sort.interface';
 export * from './automation/subscription-change-preview.interface';
+export * from './automation/system-workflow-contract.interface';
 export * from './automation/task.interface';
 export * from './automation/workflow.interface';
 export * from './automation/workflow-builder.interface';


### PR DESCRIPTION
## Summary
- move canonical system-workflow metadata constants, types, builders, parsers, and protection checks into `@genfeedai/interfaces`
- keep the API compatibility module as a focused re-export while making the app consume the same typed, fail-closed parser
- update workflow library guard fixtures and add malformed canonical/duplicate metadata regression coverage

## Verification
- `bunx biome check <8 changed TypeScript files>` — passed
- `git diff --cached --check` — passed
- serializer/shared-boundary static assertions — passed
- staged path and credential-pattern scans — passed
- Secretlint — blocked locally because the configured rule packages are unavailable in this worktree
- focused tests, typecheck, and builds — deferred to PR CI under the repository local-machine policy

## Residual risk
The shared parser now rejects partial legacy canonical markers instead of treating them as protected system workflows. Current canonical records are produced by the full builder; CI should validate all typed consumers and focused regression suites.

Closes #1895
Parent: #1026