### PR TITLE
test(auth): cover user-create provisioning hooks

### DIFF
--- a/apps/server/api/src/auth/better-auth/better-auth.factory.spec.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.factory.spec.ts
@@ -21,11 +21,14 @@ type PrismaForBetterAuth = ICreateBetterAuthOptions['prisma'];
 function requireUserCreateHooks(
   onUserCreated?: ICreateBetterAuthOptions['onUserCreated'],
 ) {
-  const hooks = buildBetterAuthUserDatabaseHooks(onUserCreated).user?.create;
-  if (!hooks?.before || !hooks.after) {
+  const createHooks =
+    buildBetterAuthUserDatabaseHooks(onUserCreated).user?.create;
+  const before = createHooks?.before;
+  const after = createHooks?.after;
+  if (!before || !after) {
     throw new Error('Better Auth user-create hooks are required');
   }
-  return hooks;
+  return { after, before };
 }
 
 function createPrismaMock() {
@@ -356,13 +359,10 @@ describe('buildBetterAuthUserDatabaseHooks', () => {
   it('generates a URL-safe handle when first-time user creation has none', async () => {
     const hooks = requireUserCreateHooks();
 
-    const result = await hooks.before(
-      {
-        email: 'New.User+Test@example.com',
-        name: 'New User',
-      } as never,
-      null,
-    );
+    const result = await hooks.before({
+      email: 'New.User+Test@example.com',
+      name: 'New User',
+    } as never);
 
     expect(result).toEqual({
       data: expect.objectContaining({
@@ -380,7 +380,7 @@ describe('buildBetterAuthUserDatabaseHooks', () => {
       handle: 'existing-handle',
     };
 
-    await expect(hooks.before(user as never, null)).resolves.toEqual({
+    await expect(hooks.before(user as never)).resolves.toEqual({
       data: user,
     });
   });
@@ -389,13 +389,10 @@ describe('buildBetterAuthUserDatabaseHooks', () => {
     const onUserCreated = vi.fn().mockResolvedValue(undefined);
     const hooks = requireUserCreateHooks(onUserCreated);
 
-    await hooks.after(
-      {
-        email: 'new@example.com',
-        id: 'user_canonical',
-      } as never,
-      null,
-    );
+    await hooks.after({
+      email: 'new@example.com',
+      id: 'user_canonical',
+    } as never);
 
     expect(onUserCreated).toHaveBeenCalledWith({
       email: 'new@example.com',
@@ -409,13 +406,10 @@ describe('buildBetterAuthUserDatabaseHooks', () => {
     const hooks = requireUserCreateHooks(onUserCreated);
 
     await expect(
-      hooks.after(
-        {
-          email: 'new@example.com',
-          id: 'user_canonical',
-        } as never,
-        null,
-      ),
+      hooks.after({
+        email: 'new@example.com',
+        id: 'user_canonical',
+      } as never),
     ).rejects.toBe(provisioningError);
   });
 
@@ -423,7 +417,7 @@ describe('buildBetterAuthUserDatabaseHooks', () => {
     const onUserCreated = vi.fn().mockResolvedValue(undefined);
     const hooks = requireUserCreateHooks(onUserCreated);
 
-    await hooks.after({ id: 'user_without_email' } as never, null);
+    await hooks.after({ id: 'user_without_email' } as never);
 
     expect(onUserCreated).toHaveBeenCalledWith({
       email: null,
@@ -435,13 +429,10 @@ describe('buildBetterAuthUserDatabaseHooks', () => {
     const hooks = requireUserCreateHooks();
 
     await expect(
-      hooks.after(
-        {
-          email: 'new@example.com',
-          id: 'user_without_callback',
-        } as never,
-        null,
-      ),
+      hooks.after({
+        email: 'new@example.com',
+        id: 'user_without_callback',
+      } as never),
     ).resolves.toBeUndefined();
   });
 });

--- a/apps/server/api/src/auth/better-auth/better-auth.factory.spec.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.factory.spec.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   assertSignupMagicLinkCanCreateUser,
   buildBetterAuthOrganizationOptions,
+  buildBetterAuthUserDatabaseHooks,
   buildRateLimitStorage,
   createBetterAuthInstance,
   resolveBetterAuthJwtAccess,
@@ -16,6 +17,16 @@ import type {
 } from './better-auth.types';
 
 type PrismaForBetterAuth = ICreateBetterAuthOptions['prisma'];
+
+function requireUserCreateHooks(
+  onUserCreated?: ICreateBetterAuthOptions['onUserCreated'],
+) {
+  const hooks = buildBetterAuthUserDatabaseHooks(onUserCreated).user?.create;
+  if (!hooks?.before || !hooks.after) {
+    throw new Error('Better Auth user-create hooks are required');
+  }
+  return hooks;
+}
 
 function createPrismaMock() {
   return {
@@ -341,6 +352,70 @@ describe('buildBetterAuthOrganizationOptions', () => {
   });
 });
 
+describe('buildBetterAuthUserDatabaseHooks', () => {
+  it('generates a URL-safe handle when first-time user creation has none', async () => {
+    const hooks = requireUserCreateHooks();
+
+    const result = await hooks.before(
+      {
+        email: 'New.User+Test@example.com',
+        name: 'New User',
+      } as never,
+      null,
+    );
+
+    expect(result).toEqual({
+      data: expect.objectContaining({
+        email: 'New.User+Test@example.com',
+        handle: expect.stringMatching(/^new-user-test-[0-9a-f]{8}$/),
+        name: 'New User',
+      }),
+    });
+  });
+
+  it('preserves an existing handle', async () => {
+    const hooks = requireUserCreateHooks();
+    const user = {
+      email: 'existing@example.com',
+      handle: 'existing-handle',
+    };
+
+    await expect(hooks.before(user as never, null)).resolves.toEqual({
+      data: user,
+    });
+  });
+
+  it('awaits provisioning with the canonical user id and email', async () => {
+    const onUserCreated = vi.fn().mockResolvedValue(undefined);
+    const hooks = requireUserCreateHooks(onUserCreated);
+
+    await hooks.after(
+      {
+        email: 'new@example.com',
+        id: 'user_canonical',
+      } as never,
+      null,
+    );
+
+    expect(onUserCreated).toHaveBeenCalledWith({
+      email: 'new@example.com',
+      userId: 'user_canonical',
+    });
+  });
+
+  it('normalizes a missing provisioning email to null', async () => {
+    const onUserCreated = vi.fn().mockResolvedValue(undefined);
+    const hooks = requireUserCreateHooks(onUserCreated);
+
+    await hooks.after({ id: 'user_without_email' } as never, null);
+
+    expect(onUserCreated).toHaveBeenCalledWith({
+      email: null,
+      userId: 'user_without_email',
+    });
+  });
+});
+
 describe('assertSignupMagicLinkCanCreateUser', () => {
   it('does not query for normal login magic links', async () => {
     const prisma = createPrismaMock();
@@ -476,5 +551,8 @@ describe('createBetterAuthInstance source', () => {
 
     expect(source).toContain('additionalFields');
     expect(source).toMatch(/handle:\s*\{/);
+    expect(source).toContain(
+      'databaseHooks: buildBetterAuthUserDatabaseHooks(onUserCreated)',
+    );
   });
 });

--- a/apps/server/api/src/auth/better-auth/better-auth.factory.spec.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.factory.spec.ts
@@ -385,7 +385,7 @@ describe('buildBetterAuthUserDatabaseHooks', () => {
     });
   });
 
-  it('awaits provisioning with the canonical user id and email', async () => {
+  it('passes the canonical user id and email to provisioning', async () => {
     const onUserCreated = vi.fn().mockResolvedValue(undefined);
     const hooks = requireUserCreateHooks(onUserCreated);
 
@@ -403,6 +403,22 @@ describe('buildBetterAuthUserDatabaseHooks', () => {
     });
   });
 
+  it('awaits provisioning and propagates failures', async () => {
+    const provisioningError = new Error('provisioning failed');
+    const onUserCreated = vi.fn().mockRejectedValue(provisioningError);
+    const hooks = requireUserCreateHooks(onUserCreated);
+
+    await expect(
+      hooks.after(
+        {
+          email: 'new@example.com',
+          id: 'user_canonical',
+        } as never,
+        null,
+      ),
+    ).rejects.toBe(provisioningError);
+  });
+
   it('normalizes a missing provisioning email to null', async () => {
     const onUserCreated = vi.fn().mockResolvedValue(undefined);
     const hooks = requireUserCreateHooks(onUserCreated);
@@ -413,6 +429,20 @@ describe('buildBetterAuthUserDatabaseHooks', () => {
       email: null,
       userId: 'user_without_email',
     });
+  });
+
+  it('does not require a provisioning callback', async () => {
+    const hooks = requireUserCreateHooks();
+
+    await expect(
+      hooks.after(
+        {
+          email: 'new@example.com',
+          id: 'user_without_callback',
+        } as never,
+        null,
+      ),
+    ).resolves.toBeUndefined();
   });
 });
 

--- a/apps/server/api/src/auth/better-auth/better-auth.factory.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.factory.ts
@@ -1,7 +1,12 @@
 import { randomUUID } from 'node:crypto';
 import { dash } from '@better-auth/infra';
 import type { IBetterAuthJwtUserPayloadSource } from '@genfeedai/interfaces';
-import { APIError, betterAuth, type RateLimit } from 'better-auth';
+import {
+  APIError,
+  type BetterAuthOptions,
+  betterAuth,
+  type RateLimit,
+} from 'better-auth';
 import { prismaAdapter } from 'better-auth/adapters/prisma';
 import {
   jwt,
@@ -25,6 +30,8 @@ const RATE_LIMIT_TTL_SECONDS = 86_400;
 const BETTER_AUTH_CREATOR_ROLE = 'admin';
 const BETTER_AUTH_DEFAULT_ORGANIZATION_CATEGORY = 'BUSINESS';
 const SIGN_UP_MAGIC_LINK_INTENT = 'signup';
+
+type BetterAuthDatabaseHooks = NonNullable<BetterAuthOptions['databaseHooks']>;
 
 export const SIGN_UP_MAGIC_LINK_EXISTING_USER_MESSAGE =
   'An account already exists for this email. Sign in instead.';
@@ -300,6 +307,55 @@ function generateHandle(input: {
 }
 
 /**
+ * Build the first-time user hooks as a directly testable auth boundary.
+ *
+ * The before hook supplies the required Genfeed handle that Better Auth does
+ * not own. The after hook awaits resource provisioning so callers do not
+ * observe a newly created user before its canonical organization, brand,
+ * membership, settings, and credits have been initialized.
+ */
+export function buildBetterAuthUserDatabaseHooks(
+  onUserCreated?: ICreateBetterAuthOptions['onUserCreated'],
+): BetterAuthDatabaseHooks {
+  return {
+    user: {
+      create: {
+        before: async (user) => {
+          const typed = user as {
+            handle?: string;
+            email?: string | null;
+            name?: string | null;
+          };
+          if (typed.handle) {
+            return { data: user };
+          }
+          return {
+            data: {
+              ...user,
+              handle: generateHandle({
+                email: typed.email,
+                name: typed.name,
+              }),
+            },
+          };
+        },
+        // Provision org/settings/brand/member/credits for the new user. Awaited
+        // so a brand-new user is fully set up before its first request, and
+        // (idempotently) a no-op for returning preserved users. Replaces the
+        // legacy auth provider `user.created` webhook (epic #735, Phase 4).
+        after: async (user) => {
+          const typed = user as { id: string; email?: string | null };
+          await onUserCreated?.({
+            email: typed.email ?? null,
+            userId: typed.id,
+          });
+        },
+      },
+    },
+  };
+}
+
+/**
  * Resolve the active organization embedded in BA JWTs for DB-less consumers
  * such as the notifications websocket process. Mirrors
  * BetterAuthIdentityResolverService's org precedence without importing Nest
@@ -559,42 +615,7 @@ export function createBetterAuthInstance(options: ICreateBetterAuthOptions) {
         },
       },
     },
-    databaseHooks: {
-      user: {
-        create: {
-          before: async (user) => {
-            const typed = user as {
-              handle?: string;
-              email?: string | null;
-              name?: string | null;
-            };
-            if (typed.handle) {
-              return { data: user };
-            }
-            return {
-              data: {
-                ...user,
-                handle: generateHandle({
-                  email: typed.email,
-                  name: typed.name,
-                }),
-              },
-            };
-          },
-          // Provision org/settings/brand/member/credits for the new user. Awaited
-          // so a brand-new user is fully set up before their first request, and
-          // (idempotently) a no-op for returning preserved users. Replaces the
-          // legacy auth provider `user.created` webhook (epic #735, Phase 4).
-          after: async (user) => {
-            const typed = user as { id: string; email?: string | null };
-            await onUserCreated?.({
-              email: typed.email ?? null,
-              userId: typed.id,
-            });
-          },
-        },
-      },
-    },
+    databaseHooks: buildBetterAuthUserDatabaseHooks(onUserCreated),
     plugins: [
       ...(apiKey ? [dash({ apiKey })] : []),
       magicLink({

--- a/apps/server/api/src/auth/better-auth/better-auth.factory.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.factory.ts
@@ -32,6 +32,15 @@ const BETTER_AUTH_DEFAULT_ORGANIZATION_CATEGORY = 'BUSINESS';
 const SIGN_UP_MAGIC_LINK_INTENT = 'signup';
 
 type BetterAuthDatabaseHooks = NonNullable<BetterAuthOptions['databaseHooks']>;
+type BetterAuthUserBeforePayload = {
+  email?: string | null;
+  handle?: string;
+  name?: string | null;
+};
+type BetterAuthUserAfterPayload = {
+  email?: string | null;
+  id: string;
+};
 
 export const SIGN_UP_MAGIC_LINK_EXISTING_USER_MESSAGE =
   'An account already exists for this email. Sign in instead.';
@@ -321,11 +330,7 @@ export function buildBetterAuthUserDatabaseHooks(
     user: {
       create: {
         before: async (user) => {
-          const typed = user as {
-            handle?: string;
-            email?: string | null;
-            name?: string | null;
-          };
+          const typed = user as BetterAuthUserBeforePayload;
           if (typed.handle) {
             return { data: user };
           }
@@ -344,7 +349,7 @@ export function buildBetterAuthUserDatabaseHooks(
         // (idempotently) a no-op for returning preserved users. Replaces the
         // legacy auth provider `user.created` webhook (epic #735, Phase 4).
         after: async (user) => {
-          const typed = user as { id: string; email?: string | null };
+          const typed = user as BetterAuthUserAfterPayload;
           await onUserCreated?.({
             email: typed.email ?? null,
             userId: typed.id,


### PR DESCRIPTION
Closes #1898
Parent: #1593

## Summary

- extract Better Auth user-create hooks into a typed, directly testable builder
- preserve existing handles and cover generated URL-safe handles for first-time users
- verify awaited provisioning receives canonical `users.id` and nullable email

## Verification

- `bunx --bun @biomejs/biome@2.5.3 check apps/server/api/src/auth/better-auth/better-auth.factory.ts apps/server/api/src/auth/better-auth/better-auth.factory.spec.ts`
- `git diff --check`
- focused static assertions for builder export, production wiring, and four regression cases
- staged path and credential-pattern scan

## Deferred to PR CI

- focused Vitest execution
- API typecheck, builds, and broader suites (local-machine policy)

## Residual risk

Better Auth hook type compatibility and runtime regression coverage remain pending until CI completes.