### PR TITLE
refactor(agent-runs): split run operations controller

### DIFF
--- a/apps/server/api/src/collections/agent-runs/agent-runs.module.ts
+++ b/apps/server/api/src/collections/agent-runs/agent-runs.module.ts
@@ -4,8 +4,10 @@
  * Replaces embedded runHistory on AgentStrategy with org-scoped run documents.
  */
 import { AgentRunsController } from '@api/collections/agent-runs/controllers/agent-runs.controller';
+import { AgentRunsOperationsController } from '@api/collections/agent-runs/controllers/agent-runs-operations.controller';
 import { ThreadRunsController } from '@api/collections/agent-runs/controllers/thread-runs.controller';
 import { AgentRunsService } from '@api/collections/agent-runs/services/agent-runs.service';
+import { AgentRunsOperationsService } from '@api/collections/agent-runs/services/agent-runs-operations.service';
 import { QueuesModule } from '@api/queues/core/queues.module';
 import { AgentThreadingModule } from '@api/services/agent-threading/agent-threading.module';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
@@ -17,7 +19,11 @@ import { LoggerService } from '@libs/logger/logger.service';
 import { forwardRef, Module } from '@nestjs/common';
 
 @Module({
-  controllers: [AgentRunsController, ThreadRunsController],
+  controllers: [
+    AgentRunsController,
+    AgentRunsOperationsController,
+    ThreadRunsController,
+  ],
   exports: [AgentRunsService],
   imports: [
     forwardRef(() => AgentThreadingModule),
@@ -25,6 +31,7 @@ import { forwardRef, Module } from '@nestjs/common';
   ],
   providers: [
     AgentArtifactReferenceService,
+    AgentRunsOperationsService,
     AgentRunsService,
     { provide: SERVER_TOKENS.logger, useExisting: LoggerService },
     { provide: SERVER_TOKENS.prisma, useExisting: PrismaService },

--- a/apps/server/api/src/collections/agent-runs/controllers/agent-runs-operations.controller.spec.ts
+++ b/apps/server/api/src/collections/agent-runs/controllers/agent-runs-operations.controller.spec.ts
@@ -1,0 +1,91 @@
+vi.mock('@api/helpers/utils/response/response.util', () => ({
+  serializeSingle: vi.fn((_req, _serializer, data) => ({ data })),
+}));
+
+import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticated-user.interface';
+import { AgentRunsOperationsController } from '@api/collections/agent-runs/controllers/agent-runs-operations.controller';
+import { AgentRunsOperationsService } from '@api/collections/agent-runs/services/agent-runs-operations.service';
+import { RequestMethod } from '@nestjs/common';
+import { METHOD_METADATA, PATH_METADATA } from '@nestjs/common/constants';
+import type { Request } from 'express';
+
+describe('AgentRunsOperationsController', () => {
+  const mockUser: User = {
+    id: 'user_123',
+    publicMetadata: {
+      brand: '507f1f77bcf86cd799439013',
+      organization: '507f1f77bcf86cd799439012',
+      user: '507f1f77bcf86cd799439014',
+    },
+  };
+  const mockRequest = { originalUrl: '/api/runs', query: {} } as Request;
+  const operationsService = {
+    cancelRun: vi.fn(),
+    retryRun: vi.fn(),
+  };
+  const controller = new AgentRunsOperationsController(
+    operationsService as unknown as AgentRunsOperationsService,
+  );
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    [
+      'cancelRun',
+      AgentRunsOperationsController.prototype.cancelRun,
+      ':id/cancellations',
+      'AgentRunsController.cancelRun',
+    ],
+    [
+      'retryRun',
+      AgentRunsOperationsController.prototype.retryRun,
+      ':id/retries',
+      'AgentRunsController.retryRun',
+    ],
+  ])('preserves route and operation metadata for %s', (_name, handler, path, operationId) => {
+    expect(Reflect.getMetadata(PATH_METADATA, handler)).toBe(path);
+    expect(Reflect.getMetadata(METHOD_METADATA, handler)).toBe(
+      RequestMethod.POST,
+    );
+    expect(Reflect.getMetadata('swagger/apiOperation', handler)).toMatchObject({
+      operationId,
+    });
+  });
+
+  it('delegates cancellation with authenticated scope', async () => {
+    const run = { id: 'run1', status: 'cancelled' };
+    operationsService.cancelRun.mockResolvedValue(run);
+
+    await expect(
+      controller.cancelRun(mockRequest, 'run1', mockUser),
+    ).resolves.toEqual({ data: run });
+    expect(operationsService.cancelRun).toHaveBeenCalledWith('run1', {
+      brandId: '507f1f77bcf86cd799439013',
+      organizationId: '507f1f77bcf86cd799439012',
+      userId: '507f1f77bcf86cd799439014',
+    });
+  });
+
+  it('allows organization-scoped callers to select a brand', async () => {
+    const organizationUser: User = {
+      ...mockUser,
+      publicMetadata: { ...mockUser.publicMetadata, brand: undefined },
+    };
+    operationsService.retryRun.mockResolvedValue({ id: 'run1' });
+
+    await controller.retryRun(
+      mockRequest,
+      'run1',
+      organizationUser,
+      'selected-brand',
+    );
+
+    expect(operationsService.retryRun).toHaveBeenCalledWith('run1', {
+      brandId: 'selected-brand',
+      organizationId: '507f1f77bcf86cd799439012',
+      userId: '507f1f77bcf86cd799439014',
+    });
+  });
+});

--- a/apps/server/api/src/collections/agent-runs/controllers/agent-runs-operations.controller.ts
+++ b/apps/server/api/src/collections/agent-runs/controllers/agent-runs-operations.controller.ts
@@ -1,0 +1,93 @@
+import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticated-user.interface';
+import {
+  type AgentRunOperationScope,
+  AgentRunsOperationsService,
+} from '@api/collections/agent-runs/services/agent-runs-operations.service';
+import { AutoSwagger } from '@api/helpers/decorators/swagger/auto-swagger.decorator';
+import { CurrentUser } from '@api/helpers/decorators/user/current-user.decorator';
+import { getPublicMetadata } from '@api/helpers/utils/auth/auth.util';
+import { serializeSingle } from '@api/helpers/utils/response/response.util';
+import {
+  AgentRunSerializer,
+  sanitizeAgentRunForSerialization,
+} from '@genfeedai/serializers';
+import {
+  Controller,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Post,
+  Query,
+  Req,
+} from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import type { Request } from 'express';
+
+@ApiTags('Agent Runs')
+@AutoSwagger()
+@Controller('runs')
+export class AgentRunsOperationsController {
+  constructor(private readonly operationsService: AgentRunsOperationsService) {}
+
+  @Post(':id/cancellations')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    operationId: 'AgentRunsController.cancelRun',
+    summary: 'Cancel a running agent',
+  })
+  @ApiResponse({ description: 'Run cancelled', status: 200 })
+  async cancelRun(
+    @Req() request: Request,
+    @Param('id') id: string,
+    @CurrentUser() user: User,
+    @Query('brand') requestedBrandId?: string,
+  ) {
+    const run = await this.operationsService.cancelRun(
+      id,
+      this.buildScope(user, requestedBrandId),
+    );
+
+    return serializeSingle(
+      request,
+      AgentRunSerializer,
+      sanitizeAgentRunForSerialization(run),
+    );
+  }
+
+  @Post(':id/retries')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    operationId: 'AgentRunsController.retryRun',
+    summary: 'Retry a failed or cancelled agent run',
+  })
+  @ApiResponse({ description: 'Run requeued', status: 200 })
+  async retryRun(
+    @Req() request: Request,
+    @Param('id') id: string,
+    @CurrentUser() user: User,
+    @Query('brand') requestedBrandId?: string,
+  ) {
+    const run = await this.operationsService.retryRun(
+      id,
+      this.buildScope(user, requestedBrandId),
+    );
+
+    return serializeSingle(
+      request,
+      AgentRunSerializer,
+      sanitizeAgentRunForSerialization(run),
+    );
+  }
+
+  private buildScope(
+    user: User,
+    requestedBrandId?: string,
+  ): AgentRunOperationScope {
+    const publicMetadata = getPublicMetadata(user);
+    return {
+      brandId: publicMetadata.brand ?? requestedBrandId,
+      organizationId: publicMetadata.organization,
+      userId: publicMetadata.user,
+    };
+  }
+}

--- a/apps/server/api/src/collections/agent-runs/controllers/agent-runs.controller.spec.ts
+++ b/apps/server/api/src/collections/agent-runs/controllers/agent-runs.controller.spec.ts
@@ -15,11 +15,7 @@ import type {
 import type { CreateAgentRunDto } from '@api/collections/agent-runs/dto/create-agent-run.dto';
 import type { AgentRunDocument } from '@api/collections/agent-runs/schemas/agent-run.schema';
 import { AgentRunsService } from '@api/collections/agent-runs/services/agent-runs.service';
-import { NotFoundException } from '@api/helpers/exceptions/http/not-found.exception';
-import { AgentRunQueueService } from '@api/queues/agent-run/agent-run-queue.service';
-import { AgentThreadEngineService } from '@api/services/agent-threading/services/agent-thread-engine.service';
 import { LoggerService } from '@libs/logger/logger.service';
-import { ServiceUnavailableException } from '@nestjs/common';
 import { Test, type TestingModule } from '@nestjs/testing';
 import type { Request } from 'express';
 
@@ -41,24 +37,13 @@ describe('AgentRunsController', () => {
     controller.buildFindAllQuery(mockUser, query as AgentRunsQueryDto);
 
   const mockServiceMethods = {
-    cancel: vi.fn(),
     create: vi.fn(),
     findAll: vi.fn(),
     findOne: vi.fn(),
     getActiveRuns: vi.fn(),
     getStats: vi.fn(),
     patch: vi.fn(),
-    prepareRetry: vi.fn(),
     remove: vi.fn(),
-    rollbackRetry: vi.fn(),
-  };
-
-  const mockQueueService = {
-    queueRun: vi.fn(),
-  };
-
-  const mockThreadEngineService = {
-    appendEvent: vi.fn(),
   };
 
   beforeEach(async () => {
@@ -66,15 +51,6 @@ describe('AgentRunsController', () => {
       controllers: [AgentRunsController],
       providers: [
         { provide: AgentRunsService, useValue: mockServiceMethods },
-        { provide: AgentRunQueueService, useValue: mockQueueService },
-        {
-          provide: AgentThreadEngineService,
-          useValue: mockThreadEngineService,
-        },
-        {
-          provide: AgentThreadEngineService,
-          useValue: mockThreadEngineService,
-        },
         {
           provide: LoggerService,
           useValue: {
@@ -450,223 +426,6 @@ describe('AgentRunsController', () => {
         '507f1f77bcf86cd799439013',
       );
       expect(result).toEqual(mockStats);
-    });
-  });
-
-  describe('cancelRun', () => {
-    it('should cancel an agent run', async () => {
-      const mockRun = { _id: 'run1', status: 'cancelled' };
-      mockServiceMethods.cancel.mockResolvedValue(mockRun);
-
-      await controller.cancelRun(mockRequest, 'run1', mockUser);
-
-      expect(mockServiceMethods.cancel).toHaveBeenCalledWith(
-        'run1',
-        '507f1f77bcf86cd799439012',
-        '507f1f77bcf86cd799439013',
-      );
-      expect(mockThreadEngineService.appendEvent).not.toHaveBeenCalled();
-    });
-
-    it('should append a run.cancelled thread event from the scalar threadId FK', async () => {
-      const mockRun = {
-        _id: 'run1',
-        status: 'cancelled',
-        thread: undefined,
-        threadId: 'thread1',
-      };
-      mockServiceMethods.cancel.mockResolvedValue(mockRun);
-      mockThreadEngineService.appendEvent.mockResolvedValue({});
-
-      await controller.cancelRun(mockRequest, 'run1', mockUser);
-
-      expect(mockThreadEngineService.appendEvent).toHaveBeenCalledWith({
-        commandId: 'run-cancelled:run1',
-        organizationId: '507f1f77bcf86cd799439012',
-        payload: {
-          detail: 'The active run was cancelled by the user.',
-          label: 'Run cancelled',
-          status: 'cancelled',
-        },
-        runId: 'run1',
-        threadId: 'thread1',
-        type: 'run.cancelled',
-        userId: '507f1f77bcf86cd799439014',
-      });
-    });
-
-    it('should fall back to the populated thread id when threadId is absent', async () => {
-      const mockRun = {
-        _id: 'run1',
-        status: 'cancelled',
-        thread: { id: 'legacy-thread1' },
-        threadId: null,
-      };
-      mockServiceMethods.cancel.mockResolvedValue(mockRun);
-      mockThreadEngineService.appendEvent.mockResolvedValue({});
-
-      await controller.cancelRun(mockRequest, 'run1', mockUser);
-
-      expect(mockThreadEngineService.appendEvent).toHaveBeenCalledWith(
-        expect.objectContaining({
-          runId: 'run1',
-          threadId: 'legacy-thread1',
-          type: 'run.cancelled',
-        }),
-      );
-    });
-
-    it('should throw NotFoundException when run not found', async () => {
-      mockServiceMethods.cancel.mockResolvedValue(null);
-
-      await expect(
-        controller.cancelRun(mockRequest, 'nonexistent', mockUser),
-      ).rejects.toThrow(NotFoundException);
-      expect(mockThreadEngineService.appendEvent).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('retryRun', () => {
-    const preparation = {
-      jobData: {
-        organizationId: '507f1f77bcf86cd799439012',
-        runId: 'run1',
-        userId: 'user_run_owner',
-      },
-      previousStatus: 'FAILED',
-      rollback: {
-        claimedAt: new Date('2026-07-10T00:00:00.000Z'),
-        state: { error: 'original failure', status: 'FAILED' },
-      },
-      run: { id: 'run1', retryCount: 1, status: 'PENDING' },
-    };
-
-    it('should reset the run, requeue it, and scope by auth metadata', async () => {
-      mockServiceMethods.prepareRetry.mockResolvedValue(preparation);
-      mockQueueService.queueRun.mockResolvedValue('agent-run-run1');
-
-      const result = await controller.retryRun(mockRequest, 'run1', mockUser);
-
-      expect(mockServiceMethods.prepareRetry).toHaveBeenCalledWith(
-        'run1',
-        '507f1f77bcf86cd799439012',
-        {
-          brandId: '507f1f77bcf86cd799439013',
-          retriedBy: '507f1f77bcf86cd799439014',
-        },
-      );
-      expect(mockQueueService.queueRun).toHaveBeenCalledWith(
-        preparation.jobData,
-      );
-      expect(result).toEqual({ data: preparation.run });
-    });
-
-    it('should throw NotFoundException when run not found', async () => {
-      mockServiceMethods.prepareRetry.mockResolvedValue(null);
-
-      await expect(
-        controller.retryRun(mockRequest, 'nonexistent', mockUser),
-      ).rejects.toThrow(NotFoundException);
-      expect(mockQueueService.queueRun).not.toHaveBeenCalled();
-    });
-
-    it('should restore the prior run state when enqueueing fails', async () => {
-      mockServiceMethods.prepareRetry.mockResolvedValue(preparation);
-      mockQueueService.queueRun.mockRejectedValue(new Error('redis down'));
-      mockServiceMethods.rollbackRetry.mockResolvedValue(true);
-
-      await expect(
-        controller.retryRun(mockRequest, 'run1', mockUser),
-      ).rejects.toThrow('redis down');
-      expect(mockServiceMethods.rollbackRetry).toHaveBeenCalledWith(
-        'run1',
-        '507f1f77bcf86cd799439012',
-        preparation.rollback,
-        '507f1f77bcf86cd799439013',
-      );
-    });
-
-    it('should preserve the enqueue error when rollback also fails', async () => {
-      mockServiceMethods.prepareRetry.mockResolvedValue(preparation);
-      mockQueueService.queueRun.mockRejectedValue(new Error('redis down'));
-      mockServiceMethods.rollbackRetry.mockRejectedValue(
-        new Error('database unavailable'),
-      );
-
-      await expect(
-        controller.retryRun(mockRequest, 'run1', mockUser),
-      ).rejects.toThrow('redis down');
-    });
-
-    it('should append a run.retried thread event when the run has a thread', async () => {
-      mockServiceMethods.prepareRetry.mockResolvedValue({
-        ...preparation,
-        run: { ...preparation.run, threadId: 'thread1' },
-      });
-      mockQueueService.queueRun.mockResolvedValue('agent-run-run1');
-      mockThreadEngineService.appendEvent.mockResolvedValue({});
-
-      await controller.retryRun(mockRequest, 'run1', mockUser);
-
-      expect(mockThreadEngineService.appendEvent).toHaveBeenCalledWith({
-        commandId: 'run-retried:run1:1',
-        organizationId: '507f1f77bcf86cd799439012',
-        payload: {
-          detail: 'The run was requeued for retry by the user.',
-          label: 'Run retried',
-          status: 'pending',
-        },
-        runId: 'run1',
-        threadId: 'thread1',
-        type: 'run.retried',
-        userId: '507f1f77bcf86cd799439014',
-      });
-    });
-
-    it('should not fail the retry when the thread event append fails', async () => {
-      mockServiceMethods.prepareRetry.mockResolvedValue({
-        ...preparation,
-        run: { ...preparation.run, threadId: 'thread1' },
-      });
-      mockQueueService.queueRun.mockResolvedValue('agent-run-run1');
-      mockThreadEngineService.appendEvent.mockRejectedValue(
-        new Error('thread not found'),
-      );
-
-      const result = await controller.retryRun(mockRequest, 'run1', mockUser);
-
-      expect(result).toEqual({
-        data: { ...preparation.run, threadId: 'thread1' },
-      });
-    });
-
-    it('should throw ServiceUnavailableException when the queue is not wired', async () => {
-      const module: TestingModule = await Test.createTestingModule({
-        controllers: [AgentRunsController],
-        providers: [
-          { provide: AgentRunsService, useValue: mockServiceMethods },
-          {
-            provide: LoggerService,
-            useValue: {
-              debug: vi.fn(),
-              error: vi.fn(),
-              log: vi.fn(),
-              warn: vi.fn(),
-            },
-          },
-        ],
-      })
-        .overrideGuard(BetterAuthGuard)
-        .useValue({ canActivate: () => true })
-        .compile();
-
-      const queuelessController =
-        module.get<AgentRunsController>(AgentRunsController);
-
-      await expect(
-        queuelessController.retryRun(mockRequest, 'run1', mockUser),
-      ).rejects.toThrow(ServiceUnavailableException);
-      expect(mockServiceMethods.prepareRetry).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/server/api/src/collections/agent-runs/controllers/agent-runs.controller.ts
+++ b/apps/server/api/src/collections/agent-runs/controllers/agent-runs.controller.ts
@@ -18,8 +18,6 @@ import {
   serializeSingle,
 } from '@api/helpers/utils/response/response.util';
 import { handleQuerySort } from '@api/helpers/utils/sort/sort.util';
-import { AgentRunQueueService } from '@api/queues/agent-run/agent-run-queue.service';
-import { AgentThreadEngineService } from '@api/services/agent-threading/services/agent-thread-engine.service';
 import { BaseCRUDController } from '@api/shared/controllers/base-crud/base-crud.controller';
 import { AgentExecutionStatus } from '@genfeedai/enums';
 import type { JsonApiSingleResponse } from '@genfeedai/interfaces';
@@ -35,12 +33,9 @@ import {
   Get,
   HttpCode,
   HttpStatus,
-  Optional,
   Param,
-  Post,
   Query,
   Req,
-  ServiceUnavailableException,
 } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import type { Request } from 'express';
@@ -57,10 +52,6 @@ export class AgentRunsController extends BaseCRUDController<
   constructor(
     public readonly agentRunsService: AgentRunsService,
     public readonly loggerService: LoggerService,
-    @Optional()
-    private readonly agentThreadEngineService?: AgentThreadEngineService,
-    @Optional()
-    private readonly agentRunQueueService?: AgentRunQueueService,
   ) {
     super(loggerService, agentRunsService, AgentRunSerializer, 'AgentRun', [
       'organization',
@@ -375,147 +366,5 @@ export class AgentRunsController extends BaseCRUDController<
     }
 
     return content;
-  }
-
-  @Post(':id/cancellations')
-  @HttpCode(HttpStatus.OK)
-  @ApiOperation({ summary: 'Cancel a running agent' })
-  @ApiResponse({ description: 'Run cancelled', status: 200 })
-  async cancelRun(
-    @Req() request: Request,
-    @Param('id') id: string,
-    @CurrentUser() user: User,
-    @Query('brand') requestedBrandId?: string,
-  ) {
-    const publicMetadata = getPublicMetadata(user);
-    const brandId = publicMetadata.brand ?? requestedBrandId;
-    const run = await this.agentRunsService.cancel(
-      id,
-      publicMetadata.organization,
-      brandId,
-    );
-
-    if (!run) {
-      throw new NotFoundException('Agent run');
-    }
-
-    const threadId =
-      run.threadId?.toString() ??
-      (run.thread as unknown as { id?: string })?.id?.toString() ??
-      run.thread?.toString();
-
-    if (threadId) {
-      await this.agentThreadEngineService?.appendEvent({
-        commandId: `run-cancelled:${id}`,
-        organizationId: publicMetadata.organization,
-        payload: {
-          detail: 'The active run was cancelled by the user.',
-          label: 'Run cancelled',
-          status: 'cancelled',
-        },
-        runId: id,
-        threadId: threadId,
-        type: 'run.cancelled',
-        userId: publicMetadata.user,
-      });
-    }
-
-    return serializeSingle(
-      request,
-      AgentRunSerializer,
-      sanitizeAgentRunForSerialization(run),
-    );
-  }
-
-  @Post(':id/retries')
-  @HttpCode(HttpStatus.OK)
-  @ApiOperation({ summary: 'Retry a failed or cancelled agent run' })
-  @ApiResponse({ description: 'Run requeued', status: 200 })
-  async retryRun(
-    @Req() request: Request,
-    @Param('id') id: string,
-    @CurrentUser() user: User,
-    @Query('brand') requestedBrandId?: string,
-  ) {
-    if (!this.agentRunQueueService) {
-      throw new ServiceUnavailableException('Agent run queue is unavailable');
-    }
-
-    const publicMetadata = getPublicMetadata(user);
-    const brandId = publicMetadata.brand ?? requestedBrandId;
-    const preparation = await this.agentRunsService.prepareRetry(
-      id,
-      publicMetadata.organization,
-      {
-        brandId,
-        retriedBy: publicMetadata.user,
-      },
-    );
-
-    if (!preparation) {
-      throw new NotFoundException('Agent run');
-    }
-
-    const { jobData, rollback, run } = preparation;
-
-    try {
-      await this.agentRunQueueService.queueRun(jobData);
-    } catch (error) {
-      try {
-        const restored = await this.agentRunsService.rollbackRetry(
-          id,
-          publicMetadata.organization,
-          rollback,
-          brandId,
-        );
-        if (!restored) {
-          this.loggerService.warn('Agent run retry rollback was not applied', {
-            runId: id,
-          });
-        }
-      } catch (rollbackError) {
-        this.loggerService.warn('Failed to roll back agent run retry', {
-          error: (rollbackError as Error)?.message,
-          runId: id,
-        });
-      }
-      throw error;
-    }
-
-    const threadId =
-      run.threadId?.toString() ??
-      (run.thread as unknown as { id?: string })?.id?.toString() ??
-      run.thread?.toString();
-
-    if (threadId) {
-      try {
-        await this.agentThreadEngineService?.appendEvent({
-          commandId: `run-retried:${id}:${run.retryCount ?? 0}`,
-          organizationId: publicMetadata.organization,
-          payload: {
-            detail: 'The run was requeued for retry by the user.',
-            label: 'Run retried',
-            status: 'pending',
-          },
-          runId: id,
-          threadId,
-          type: 'run.retried',
-          userId: publicMetadata.user,
-        });
-      } catch (error) {
-        // The retry already succeeded; thread provenance is best-effort.
-        this.loggerService.warn('Failed to append run.retried thread event', {
-          error: (error as Error)?.message,
-          runId: id,
-          threadId,
-        });
-      }
-    }
-
-    return serializeSingle(
-      request,
-      AgentRunSerializer,
-      sanitizeAgentRunForSerialization(run),
-    );
   }
 }

--- a/apps/server/api/src/collections/agent-runs/services/agent-runs-operations.service.spec.ts
+++ b/apps/server/api/src/collections/agent-runs/services/agent-runs-operations.service.spec.ts
@@ -103,6 +103,24 @@ describe('AgentRunsOperationsService', () => {
       );
     });
 
+    it('does not fail when appending the thread event fails', async () => {
+      const run = {
+        id: 'run1',
+        status: 'cancelled',
+        threadId: 'thread1',
+      };
+      agentRunsService.cancel.mockResolvedValue(run);
+      threadEngineService.appendEvent.mockRejectedValue(
+        new Error('thread not found'),
+      );
+
+      await expect(service.cancelRun('run1', scope)).resolves.toBe(run);
+      expect(loggerService.warn).toHaveBeenCalledWith(
+        'Failed to append run.cancelled thread event',
+        expect.objectContaining({ runId: 'run1', threadId: 'thread1' }),
+      );
+    });
+
     it('throws when the run is missing', async () => {
       agentRunsService.cancel.mockResolvedValue(null);
 

--- a/apps/server/api/src/collections/agent-runs/services/agent-runs-operations.service.spec.ts
+++ b/apps/server/api/src/collections/agent-runs/services/agent-runs-operations.service.spec.ts
@@ -1,0 +1,235 @@
+import { AgentRunsService } from '@api/collections/agent-runs/services/agent-runs.service';
+import {
+  type AgentRunOperationScope,
+  AgentRunsOperationsService,
+} from '@api/collections/agent-runs/services/agent-runs-operations.service';
+import { NotFoundException } from '@api/helpers/exceptions/http/not-found.exception';
+import { AgentRunQueueService } from '@api/queues/agent-run/agent-run-queue.service';
+import { AgentThreadEngineService } from '@api/services/agent-threading/services/agent-thread-engine.service';
+import { LoggerService } from '@libs/logger/logger.service';
+import { ServiceUnavailableException } from '@nestjs/common';
+
+describe('AgentRunsOperationsService', () => {
+  const scope: AgentRunOperationScope = {
+    brandId: '507f1f77bcf86cd799439013',
+    organizationId: '507f1f77bcf86cd799439012',
+    userId: '507f1f77bcf86cd799439014',
+  };
+  const agentRunsService = {
+    cancel: vi.fn(),
+    prepareRetry: vi.fn(),
+    rollbackRetry: vi.fn(),
+  };
+  const queueService = { queueRun: vi.fn() };
+  const threadEngineService = { appendEvent: vi.fn() };
+  const loggerService = {
+    debug: vi.fn(),
+    error: vi.fn(),
+    log: vi.fn(),
+    warn: vi.fn(),
+  };
+  let service: AgentRunsOperationsService;
+
+  beforeEach(() => {
+    service = new AgentRunsOperationsService(
+      agentRunsService as unknown as AgentRunsService,
+      loggerService as unknown as LoggerService,
+      threadEngineService as unknown as AgentThreadEngineService,
+      queueService as unknown as AgentRunQueueService,
+    );
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('cancelRun', () => {
+    it('cancels an agent run with the supplied scope', async () => {
+      const run = { id: 'run1', status: 'cancelled' };
+      agentRunsService.cancel.mockResolvedValue(run);
+
+      await expect(service.cancelRun('run1', scope)).resolves.toBe(run);
+      expect(agentRunsService.cancel).toHaveBeenCalledWith(
+        'run1',
+        scope.organizationId,
+        scope.brandId,
+      );
+      expect(threadEngineService.appendEvent).not.toHaveBeenCalled();
+    });
+
+    it('appends a run.cancelled event from the scalar thread id', async () => {
+      agentRunsService.cancel.mockResolvedValue({
+        id: 'run1',
+        status: 'cancelled',
+        thread: undefined,
+        threadId: 'thread1',
+      });
+      threadEngineService.appendEvent.mockResolvedValue({});
+
+      await service.cancelRun('run1', scope);
+
+      expect(threadEngineService.appendEvent).toHaveBeenCalledWith({
+        commandId: 'run-cancelled:run1',
+        organizationId: scope.organizationId,
+        payload: {
+          detail: 'The active run was cancelled by the user.',
+          label: 'Run cancelled',
+          status: 'cancelled',
+        },
+        runId: 'run1',
+        threadId: 'thread1',
+        type: 'run.cancelled',
+        userId: scope.userId,
+      });
+    });
+
+    it('falls back to the populated thread id', async () => {
+      agentRunsService.cancel.mockResolvedValue({
+        id: 'run1',
+        status: 'cancelled',
+        thread: { id: 'legacy-thread1' },
+        threadId: null,
+      });
+      threadEngineService.appendEvent.mockResolvedValue({});
+
+      await service.cancelRun('run1', scope);
+
+      expect(threadEngineService.appendEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          runId: 'run1',
+          threadId: 'legacy-thread1',
+          type: 'run.cancelled',
+        }),
+      );
+    });
+
+    it('throws when the run is missing', async () => {
+      agentRunsService.cancel.mockResolvedValue(null);
+
+      await expect(service.cancelRun('missing', scope)).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(threadEngineService.appendEvent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('retryRun', () => {
+    const preparation = {
+      jobData: {
+        organizationId: scope.organizationId,
+        runId: 'run1',
+        userId: 'user_run_owner',
+      },
+      previousStatus: 'FAILED',
+      rollback: {
+        claimedAt: new Date('2026-07-10T00:00:00.000Z'),
+        state: { error: 'original failure', status: 'FAILED' },
+      },
+      run: { id: 'run1', retryCount: 1, status: 'PENDING' },
+    };
+
+    it('resets and requeues the run with the supplied scope', async () => {
+      agentRunsService.prepareRetry.mockResolvedValue(preparation);
+      queueService.queueRun.mockResolvedValue('agent-run-run1');
+
+      await expect(service.retryRun('run1', scope)).resolves.toBe(
+        preparation.run,
+      );
+      expect(agentRunsService.prepareRetry).toHaveBeenCalledWith(
+        'run1',
+        scope.organizationId,
+        { brandId: scope.brandId, retriedBy: scope.userId },
+      );
+      expect(queueService.queueRun).toHaveBeenCalledWith(preparation.jobData);
+    });
+
+    it('throws when the run is missing', async () => {
+      agentRunsService.prepareRetry.mockResolvedValue(null);
+
+      await expect(service.retryRun('missing', scope)).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(queueService.queueRun).not.toHaveBeenCalled();
+    });
+
+    it('restores the prior state when enqueueing fails', async () => {
+      agentRunsService.prepareRetry.mockResolvedValue(preparation);
+      queueService.queueRun.mockRejectedValue(new Error('redis down'));
+      agentRunsService.rollbackRetry.mockResolvedValue(true);
+
+      await expect(service.retryRun('run1', scope)).rejects.toThrow(
+        'redis down',
+      );
+      expect(agentRunsService.rollbackRetry).toHaveBeenCalledWith(
+        'run1',
+        scope.organizationId,
+        preparation.rollback,
+        scope.brandId,
+      );
+    });
+
+    it('preserves the enqueue error when rollback also fails', async () => {
+      agentRunsService.prepareRetry.mockResolvedValue(preparation);
+      queueService.queueRun.mockRejectedValue(new Error('redis down'));
+      agentRunsService.rollbackRetry.mockRejectedValue(
+        new Error('database unavailable'),
+      );
+
+      await expect(service.retryRun('run1', scope)).rejects.toThrow(
+        'redis down',
+      );
+    });
+
+    it('appends a run.retried event when the run has a thread', async () => {
+      agentRunsService.prepareRetry.mockResolvedValue({
+        ...preparation,
+        run: { ...preparation.run, threadId: 'thread1' },
+      });
+      queueService.queueRun.mockResolvedValue('agent-run-run1');
+      threadEngineService.appendEvent.mockResolvedValue({});
+
+      await service.retryRun('run1', scope);
+
+      expect(threadEngineService.appendEvent).toHaveBeenCalledWith({
+        commandId: 'run-retried:run1:1',
+        organizationId: scope.organizationId,
+        payload: {
+          detail: 'The run was requeued for retry by the user.',
+          label: 'Run retried',
+          status: 'pending',
+        },
+        runId: 'run1',
+        threadId: 'thread1',
+        type: 'run.retried',
+        userId: scope.userId,
+      });
+    });
+
+    it('does not fail when appending the thread event fails', async () => {
+      const run = { ...preparation.run, threadId: 'thread1' };
+      agentRunsService.prepareRetry.mockResolvedValue({ ...preparation, run });
+      queueService.queueRun.mockResolvedValue('agent-run-run1');
+      threadEngineService.appendEvent.mockRejectedValue(
+        new Error('thread not found'),
+      );
+
+      await expect(service.retryRun('run1', scope)).resolves.toBe(run);
+      expect(loggerService.warn).toHaveBeenCalledWith(
+        'Failed to append run.retried thread event',
+        expect.objectContaining({ runId: 'run1', threadId: 'thread1' }),
+      );
+    });
+
+    it('throws when the queue is not wired', async () => {
+      const queuelessService = new AgentRunsOperationsService(
+        agentRunsService as unknown as AgentRunsService,
+        loggerService as unknown as LoggerService,
+      );
+
+      await expect(queuelessService.retryRun('run1', scope)).rejects.toThrow(
+        ServiceUnavailableException,
+      );
+      expect(agentRunsService.prepareRetry).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/server/api/src/collections/agent-runs/services/agent-runs-operations.service.ts
+++ b/apps/server/api/src/collections/agent-runs/services/agent-runs-operations.service.ts
@@ -144,9 +144,7 @@ export class AgentRunsOperationsService {
     return run;
   }
 
-  private resolveThreadId(
-    run: Pick<AgentRunDocument, 'thread' | 'threadId'>,
-  ): string | undefined {
+  private resolveThreadId(run: AgentRunDocument): string | undefined {
     const populatedThread = run.thread as
       | LegacyPopulatedThreadReference
       | undefined;

--- a/apps/server/api/src/collections/agent-runs/services/agent-runs-operations.service.ts
+++ b/apps/server/api/src/collections/agent-runs/services/agent-runs-operations.service.ts
@@ -1,3 +1,4 @@
+import type { AgentRunDocument } from '@api/collections/agent-runs/schemas/agent-run.schema';
 import { AgentRunsService } from '@api/collections/agent-runs/services/agent-runs.service';
 import { NotFoundException } from '@api/helpers/exceptions/http/not-found.exception';
 import { AgentRunQueueService } from '@api/queues/agent-run/agent-run-queue.service';
@@ -14,6 +15,10 @@ export interface AgentRunOperationScope {
   organizationId: string;
   userId: string;
 }
+
+type LegacyPopulatedThreadReference = {
+  id?: unknown;
+};
 
 @Injectable()
 export class AgentRunsOperationsService {
@@ -37,24 +42,30 @@ export class AgentRunsOperationsService {
       throw new NotFoundException('Agent run');
     }
 
-    const threadId =
-      run.threadId?.toString() ??
-      (run.thread as unknown as { id?: string })?.id?.toString() ??
-      run.thread?.toString();
+    const threadId = this.resolveThreadId(run);
     if (threadId) {
-      await this.agentThreadEngineService?.appendEvent({
-        commandId: `run-cancelled:${id}`,
-        organizationId: scope.organizationId,
-        payload: {
-          detail: 'The active run was cancelled by the user.',
-          label: 'Run cancelled',
-          status: 'cancelled',
-        },
-        runId: id,
-        threadId,
-        type: 'run.cancelled',
-        userId: scope.userId,
-      });
+      try {
+        await this.agentThreadEngineService?.appendEvent({
+          commandId: `run-cancelled:${id}`,
+          organizationId: scope.organizationId,
+          payload: {
+            detail: 'The active run was cancelled by the user.',
+            label: 'Run cancelled',
+            status: 'cancelled',
+          },
+          runId: id,
+          threadId,
+          type: 'run.cancelled',
+          userId: scope.userId,
+        });
+      } catch (error) {
+        // The cancellation already succeeded; thread provenance is best-effort.
+        this.loggerService.warn('Failed to append run.cancelled thread event', {
+          error: (error as Error)?.message,
+          runId: id,
+          threadId,
+        });
+      }
     }
 
     return run;
@@ -84,13 +95,13 @@ export class AgentRunsOperationsService {
       await this.agentRunQueueService.queueRun(jobData);
     } catch (error) {
       try {
-        const restored = await this.agentRunsService.rollbackRetry(
+        const isRestored = await this.agentRunsService.rollbackRetry(
           id,
           scope.organizationId,
           rollback,
           scope.brandId,
         );
-        if (!restored) {
+        if (!isRestored) {
           this.loggerService.warn('Agent run retry rollback was not applied', {
             runId: id,
           });
@@ -104,10 +115,7 @@ export class AgentRunsOperationsService {
       throw error;
     }
 
-    const threadId =
-      run.threadId?.toString() ??
-      (run.thread as unknown as { id?: string })?.id?.toString() ??
-      run.thread?.toString();
+    const threadId = this.resolveThreadId(run);
     if (threadId) {
       try {
         await this.agentThreadEngineService?.appendEvent({
@@ -134,5 +142,18 @@ export class AgentRunsOperationsService {
     }
 
     return run;
+  }
+
+  private resolveThreadId(
+    run: Pick<AgentRunDocument, 'thread' | 'threadId'>,
+  ): string | undefined {
+    const populatedThread = run.thread as
+      | LegacyPopulatedThreadReference
+      | undefined;
+    return (
+      run.threadId?.toString() ??
+      populatedThread?.id?.toString() ??
+      populatedThread?.toString()
+    );
   }
 }

--- a/apps/server/api/src/collections/agent-runs/services/agent-runs-operations.service.ts
+++ b/apps/server/api/src/collections/agent-runs/services/agent-runs-operations.service.ts
@@ -1,0 +1,138 @@
+import { AgentRunsService } from '@api/collections/agent-runs/services/agent-runs.service';
+import { NotFoundException } from '@api/helpers/exceptions/http/not-found.exception';
+import { AgentRunQueueService } from '@api/queues/agent-run/agent-run-queue.service';
+import { AgentThreadEngineService } from '@api/services/agent-threading/services/agent-thread-engine.service';
+import { LoggerService } from '@libs/logger/logger.service';
+import {
+  Injectable,
+  Optional,
+  ServiceUnavailableException,
+} from '@nestjs/common';
+
+export interface AgentRunOperationScope {
+  brandId?: string;
+  organizationId: string;
+  userId: string;
+}
+
+@Injectable()
+export class AgentRunsOperationsService {
+  constructor(
+    private readonly agentRunsService: AgentRunsService,
+    private readonly loggerService: LoggerService,
+    @Optional()
+    private readonly agentThreadEngineService?: AgentThreadEngineService,
+    @Optional()
+    private readonly agentRunQueueService?: AgentRunQueueService,
+  ) {}
+
+  async cancelRun(id: string, scope: AgentRunOperationScope) {
+    const run = await this.agentRunsService.cancel(
+      id,
+      scope.organizationId,
+      scope.brandId,
+    );
+
+    if (!run) {
+      throw new NotFoundException('Agent run');
+    }
+
+    const threadId =
+      run.threadId?.toString() ??
+      (run.thread as unknown as { id?: string })?.id?.toString() ??
+      run.thread?.toString();
+    if (threadId) {
+      await this.agentThreadEngineService?.appendEvent({
+        commandId: `run-cancelled:${id}`,
+        organizationId: scope.organizationId,
+        payload: {
+          detail: 'The active run was cancelled by the user.',
+          label: 'Run cancelled',
+          status: 'cancelled',
+        },
+        runId: id,
+        threadId,
+        type: 'run.cancelled',
+        userId: scope.userId,
+      });
+    }
+
+    return run;
+  }
+
+  async retryRun(id: string, scope: AgentRunOperationScope) {
+    if (!this.agentRunQueueService) {
+      throw new ServiceUnavailableException('Agent run queue is unavailable');
+    }
+
+    const preparation = await this.agentRunsService.prepareRetry(
+      id,
+      scope.organizationId,
+      {
+        brandId: scope.brandId,
+        retriedBy: scope.userId,
+      },
+    );
+
+    if (!preparation) {
+      throw new NotFoundException('Agent run');
+    }
+
+    const { jobData, rollback, run } = preparation;
+
+    try {
+      await this.agentRunQueueService.queueRun(jobData);
+    } catch (error) {
+      try {
+        const restored = await this.agentRunsService.rollbackRetry(
+          id,
+          scope.organizationId,
+          rollback,
+          scope.brandId,
+        );
+        if (!restored) {
+          this.loggerService.warn('Agent run retry rollback was not applied', {
+            runId: id,
+          });
+        }
+      } catch (rollbackError) {
+        this.loggerService.warn('Failed to roll back agent run retry', {
+          error: (rollbackError as Error)?.message,
+          runId: id,
+        });
+      }
+      throw error;
+    }
+
+    const threadId =
+      run.threadId?.toString() ??
+      (run.thread as unknown as { id?: string })?.id?.toString() ??
+      run.thread?.toString();
+    if (threadId) {
+      try {
+        await this.agentThreadEngineService?.appendEvent({
+          commandId: `run-retried:${id}:${run.retryCount ?? 0}`,
+          organizationId: scope.organizationId,
+          payload: {
+            detail: 'The run was requeued for retry by the user.',
+            label: 'Run retried',
+            status: 'pending',
+          },
+          runId: id,
+          threadId,
+          type: 'run.retried',
+          userId: scope.userId,
+        });
+      } catch (error) {
+        // The retry already succeeded; thread provenance is best-effort.
+        this.loggerService.warn('Failed to append run.retried thread event', {
+          error: (error as Error)?.message,
+          runId: id,
+          threadId,
+        });
+      }
+    }
+
+    return run;
+  }
+}


### PR DESCRIPTION
## Summary

- split cancellation and retry routes into a dedicated AgentRunsOperationsController
- move queue rollback and thread-event orchestration into AgentRunsOperationsService
- preserve public routes, HTTP responses, tenant/brand scope, serializers, errors, and OpenAPI operation IDs
- keep both production controllers below the 500-line threshold

## Verification

- bunx @biomejs/biome@2.5.3 check on all seven changed files
- git diff --cached --check
- static route inventory: each cancellation/retry route is registered once
- module wiring and public operation ID assertions
- staged path and credential-pattern scans
- committed diff and clean-worktree checks

## Skipped locally

Per repository machine policy, focused unit tests, typecheck, OpenAPI regeneration, builds, and broad suites are deferred to PR CI.

Closes #1902
Refs #1744