### PR TITLE
fix(ci): classify daily deploy child runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,7 +291,7 @@ jobs:
       - name: Package Release Scripts
         run: bunx vitest run --config scripts/package-release/vitest.config.ts
       - name: CI Workflow Contract
-        run: node --test scripts/ci/tests-gate.test.mjs
+        run: node --test scripts/ci/tests-gate.test.mjs scripts/ci/daily-deploy-orchestration.test.mjs
       # Fail the build if the committed Prisma model metadata (enum-field-map)
       # has drifted from schema.prisma — soft-delete filtering + enum
       # normalization under the Prisma 7 driver adapter depend on it, and it

--- a/.github/workflows/daily-production-deploy.yml
+++ b/.github/workflows/daily-production-deploy.yml
@@ -213,7 +213,11 @@ jobs:
 
             try {
               if (process.env.SHOULD_CONTINUE !== 'true') {
-                skip(process.env.PRECHECK_SKIPPED_REASON || 'Daily production deploy precheck skipped.');
+                skip(
+                  process.env.PRECHECK_SKIPPED_REASON ||
+                    'Daily production deploy precheck skipped.',
+                  'clean no-op',
+                );
                 return;
               }
 
@@ -493,7 +497,7 @@ jobs:
                 owner,
                 repo,
                 run_id: run.id,
-                filter: 'all',
+                filter: 'latest',
                 per_page: 100,
               },
             );

--- a/.github/workflows/daily-production-deploy.yml
+++ b/.github/workflows/daily-production-deploy.yml
@@ -356,6 +356,8 @@ jobs:
     steps:
       - name: Checkout workflow helpers
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Dispatch and watch Deploy ECS (production)
         id: deploy

--- a/.github/workflows/daily-production-deploy.yml
+++ b/.github/workflows/daily-production-deploy.yml
@@ -45,8 +45,10 @@ jobs:
     outputs:
       should_deploy: ${{ steps.preflight.outputs.should_deploy }}
       issue_needed: ${{ steps.preflight.outputs.issue_needed }}
+      outcome: ${{ steps.preflight.outputs.outcome }}
       skipped_reason: ${{ steps.preflight.outputs.skipped_reason }}
       failure_reason: ${{ steps.preflight.outputs.failure_reason }}
+      failure_stage: ${{ steps.preflight.outputs.failure_stage }}
       master_sha: ${{ steps.preflight.outputs.master_sha }}
       ci_run_url: ${{ steps.preflight.outputs.ci_run_url }}
       gate_run_url: ${{ steps.preflight.outputs.gate_run_url }}
@@ -102,8 +104,10 @@ jobs:
             const result = {
               should_deploy: 'false',
               issue_needed: 'false',
+              outcome: 'blocked',
               skipped_reason: '',
               failure_reason: '',
+              failure_stage: '',
               master_sha: masterSha,
               ci_run_url: '',
               gate_run_url: '',
@@ -118,14 +122,17 @@ jobs:
               }
             }
 
-            function skip(reason) {
+            function skip(reason, outcome = 'blocked') {
+              result.outcome = outcome;
               result.skipped_reason = reason;
               setOutputs();
             }
 
             function block(reason) {
+              result.outcome = 'blocked';
               result.issue_needed = 'true';
               result.failure_reason = reason;
+              result.failure_stage = 'preflight';
               setOutputs();
             }
 
@@ -247,7 +254,10 @@ jobs:
               if (successfulDeployRun) {
                 result.deploy_marker_url = successfulDeployRun.html_url;
                 result.deployed_sha = masterSha;
-                skip(`Current master SHA is already deployed by Deploy ECS (production): ${successfulDeployRun.html_url}`);
+                skip(
+                  `Current master SHA is already deployed by Deploy ECS (production): ${successfulDeployRun.html_url}`,
+                  'clean no-op',
+                );
                 return;
               }
 
@@ -257,7 +267,10 @@ jobs:
                 const releaseSha = await resolveTagSha(release.data.tag_name);
                 if (releaseSha === masterSha) {
                   result.deployed_sha = masterSha;
-                  skip(`Current master SHA is already represented by latest GitHub release ${release.data.tag_name}: ${release.data.html_url}`);
+                  skip(
+                    `Current master SHA is already represented by latest GitHub release ${release.data.tag_name}: ${release.data.html_url}`,
+                    'clean no-op',
+                  );
                   return;
                 }
               } catch (error) {
@@ -271,7 +284,10 @@ jobs:
                 result.deploy_marker_url = result.deploy_marker_url || `GitHub deployment ${deployment.id}`;
                 if (deployment.sha === masterSha) {
                   result.deployed_sha = masterSha;
-                  skip(`Current master SHA is already represented by successful production deployment ${deployment.id}.`);
+                  skip(
+                    `Current master SHA is already represented by successful production deployment ${deployment.id}.`,
+                    'clean no-op',
+                  );
                   return;
                 }
               }
@@ -307,6 +323,7 @@ jobs:
               }
 
               result.should_deploy = 'true';
+              result.outcome = '';
               setOutputs();
             } catch (error) {
               block(`Daily deploy preflight failed unexpectedly: ${error.message}`);
@@ -324,10 +341,18 @@ jobs:
       contents: read
     outputs:
       issue_needed: ${{ steps.deploy.outputs.issue_needed }}
+      outcome: ${{ steps.deploy.outputs.outcome }}
       failure_reason: ${{ steps.deploy.outputs.failure_reason }}
+      failure_stage: ${{ steps.deploy.outputs.failure_stage }}
+      failure_job_name: ${{ steps.deploy.outputs.failure_job_name }}
+      failure_job_url: ${{ steps.deploy.outputs.failure_job_url }}
+      failure_step_name: ${{ steps.deploy.outputs.failure_step_name }}
       deploy_run_url: ${{ steps.deploy.outputs.deploy_run_url }}
       deployed_sha: ${{ steps.deploy.outputs.deployed_sha }}
     steps:
+      - name: Checkout workflow helpers
+        uses: actions/checkout@v5
+
       - name: Dispatch and watch Deploy ECS (production)
         id: deploy
         uses: actions/github-script@v8
@@ -335,17 +360,39 @@ jobs:
           MASTER_SHA: ${{ needs.preflight.outputs.master_sha }}
         with:
           script: |
+            const path = require('node:path');
+            const { pathToFileURL } = require('node:url');
+            const helpers = await import(
+              pathToFileURL(
+                path.join(
+                  process.env.GITHUB_WORKSPACE,
+                  'scripts/ci/daily-deploy-orchestration.mjs',
+                ),
+              ).href,
+            );
+            const {
+              classifyDeployRunFailure,
+              createDeployRunTitle,
+              formatDeployFailure,
+              matchesCorrelatedDeployRun,
+            } = helpers;
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const masterSha = process.env.MASTER_SHA;
             const workflowId = process.env.DEPLOY_WORKFLOW;
-            const startedAt = new Date(Date.now() - 15000);
+            const correlationId = `${context.runId}-${process.env.GITHUB_RUN_ATTEMPT || '1'}`;
+            const expectedRunTitle = createDeployRunTitle(correlationId);
             const deadline = Date.now() + 170 * 60 * 1000;
             const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
             const result = {
               issue_needed: 'false',
+              outcome: '',
               failure_reason: '',
+              failure_stage: '',
+              failure_job_name: '',
+              failure_job_url: '',
+              failure_step_name: '',
               deploy_run_url: '',
               deployed_sha: '',
             };
@@ -356,9 +403,14 @@ jobs:
               }
             }
 
-            function fail(reason) {
+            function fail(reason, classification = {}) {
               result.issue_needed = 'true';
+              result.outcome = 'failed';
               result.failure_reason = reason;
+              result.failure_stage = classification.stage || 'unknown';
+              result.failure_job_name = classification.jobName || '';
+              result.failure_job_url = classification.jobUrl || '';
+              result.failure_step_name = classification.stepName || '';
               setOutputs();
               core.setFailed(reason);
             }
@@ -374,8 +426,12 @@ jobs:
                   per_page: 20,
                 });
                 const match = runs.data.workflow_runs
-                  .filter((run) => run.head_sha === masterSha)
-                  .filter((run) => new Date(run.created_at) >= startedAt)
+                  .filter((run) =>
+                    matchesCorrelatedDeployRun(run, {
+                      correlationId,
+                      masterSha,
+                    }),
+                  )
                   .sort((a, b) => new Date(b.created_at) - new Date(a.created_at))[0];
                 if (match) {
                   return match;
@@ -391,11 +447,16 @@ jobs:
               repo,
               workflow_id: workflowId,
               ref: 'master',
+              inputs: {
+                orchestrator_run_id: correlationId,
+              },
             });
 
             const run = await findDispatchedRun();
             if (!run) {
-              fail(`Deploy ECS (production) dispatch did not produce a discoverable run for ${masterSha}.`);
+              fail(
+                `Deploy ECS (production) dispatch did not produce correlated run ${expectedRunTitle} for ${masterSha}.`,
+              );
               return;
             }
 
@@ -420,12 +481,30 @@ jobs:
             }
 
             if (current.conclusion === 'success') {
+              result.outcome = 'deployed';
               result.deployed_sha = masterSha;
               setOutputs();
               return;
             }
 
-            fail(`Deploy ECS (production) concluded ${current.conclusion}: ${current.html_url}`);
+            const jobs = await github.paginate(
+              github.rest.actions.listJobsForWorkflowRun,
+              {
+                owner,
+                repo,
+                run_id: run.id,
+                filter: 'all',
+                per_page: 100,
+              },
+            );
+            const classification = classifyDeployRunFailure(jobs);
+            fail(
+              `Deploy ECS (production) ${formatDeployFailure(
+                classification,
+                current.conclusion,
+              )}`,
+              classification,
+            );
 
   report-failure:
     name: Report blocking failure
@@ -444,7 +523,12 @@ jobs:
         uses: actions/github-script@v8
         env:
           MASTER_SHA: ${{ needs.preflight.outputs.master_sha || needs.dispatch-deploy.outputs.deployed_sha || 'unknown' }}
+          OUTCOME: ${{ needs.dispatch-deploy.outputs.outcome || needs.preflight.outputs.outcome || 'failed' }}
           FAILURE_REASON: ${{ needs.dispatch-deploy.outputs.failure_reason || needs.preflight.outputs.failure_reason || 'Daily deploy workflow failed before it could record a reason.' }}
+          FAILURE_STAGE: ${{ needs.dispatch-deploy.outputs.failure_stage || needs.preflight.outputs.failure_stage || 'unknown' }}
+          FAILURE_JOB_NAME: ${{ needs.dispatch-deploy.outputs.failure_job_name }}
+          FAILURE_JOB_URL: ${{ needs.dispatch-deploy.outputs.failure_job_url }}
+          FAILURE_STEP_NAME: ${{ needs.dispatch-deploy.outputs.failure_step_name }}
           CI_RUN_URL: ${{ needs.preflight.outputs.ci_run_url }}
           GATE_RUN_URL: ${{ needs.preflight.outputs.gate_run_url }}
           DEPLOY_RUN_URL: ${{ needs.dispatch-deploy.outputs.deploy_run_url }}
@@ -454,17 +538,27 @@ jobs:
             const date = new Date().toISOString().slice(0, 10);
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const masterSha = process.env.MASTER_SHA || 'unknown';
+            const outcome = process.env.OUTCOME || 'failed';
             const deployRunUrl = process.env.DEPLOY_RUN_URL || 'not dispatched';
             const gateRunUrl = process.env.GATE_RUN_URL || 'not available';
             const ciRunUrl = process.env.CI_RUN_URL || 'not available';
             const failureReason = process.env.FAILURE_REASON || 'Unknown failure.';
+            const failureStage = process.env.FAILURE_STAGE || 'unknown';
+            const failureJobName = process.env.FAILURE_JOB_NAME || 'not available';
+            const failureJobUrl = process.env.FAILURE_JOB_URL || 'not available';
+            const failureStepName = process.env.FAILURE_STEP_NAME || 'not available';
             const title = 'Daily production deploy blocked';
             const body = [
               `**Daily production deploy attempt blocked or failed** on \`${date}\`.`,
               ``,
               `- Attempt run: ${runUrl}`,
               `- Master SHA: \`${masterSha}\``,
+              `- Outcome: \`${outcome}\``,
               `- Reason: ${failureReason}`,
+              `- Failure stage: \`${failureStage}\``,
+              `- Failure job: ${failureJobName}`,
+              `- Failure step: ${failureStepName}`,
+              `- Failure job URL: ${failureJobUrl}`,
               `- CI run: ${ciRunUrl}`,
               `- Full-suite gate: ${gateRunUrl}`,
               `- Deploy run: ${deployRunUrl}`,
@@ -541,10 +635,15 @@ jobs:
           PREFLIGHT_ISSUE_NEEDED: ${{ needs.preflight.outputs.issue_needed }}
           DEPLOY_ISSUE_NEEDED: ${{ needs.dispatch-deploy.outputs.issue_needed }}
           SHOULD_DEPLOY: ${{ needs.preflight.outputs.should_deploy }}
+          OUTCOME: ${{ needs.dispatch-deploy.outputs.outcome || needs.preflight.outputs.outcome || 'failed' }}
           MASTER_SHA: ${{ needs.preflight.outputs.master_sha }}
           DEPLOYED_SHA: ${{ needs.dispatch-deploy.outputs.deployed_sha || needs.preflight.outputs.deployed_sha }}
           SKIPPED_REASON: ${{ needs.preflight.outputs.skipped_reason }}
           FAILURE_REASON: ${{ needs.dispatch-deploy.outputs.failure_reason || needs.preflight.outputs.failure_reason }}
+          FAILURE_STAGE: ${{ needs.dispatch-deploy.outputs.failure_stage || needs.preflight.outputs.failure_stage }}
+          FAILURE_JOB_NAME: ${{ needs.dispatch-deploy.outputs.failure_job_name }}
+          FAILURE_JOB_URL: ${{ needs.dispatch-deploy.outputs.failure_job_url }}
+          FAILURE_STEP_NAME: ${{ needs.dispatch-deploy.outputs.failure_step_name }}
           CI_RUN_URL: ${{ needs.preflight.outputs.ci_run_url }}
           GATE_RUN_URL: ${{ needs.preflight.outputs.gate_run_url }}
           DEPLOY_MARKER_URL: ${{ needs.preflight.outputs.deploy_marker_url }}
@@ -557,6 +656,10 @@ jobs:
           deployed_sha="${DEPLOYED_SHA:-not deployed}"
           skipped_reason="${SKIPPED_REASON:-none}"
           failure_reason="${FAILURE_REASON:-none}"
+          failure_stage="${FAILURE_STAGE:-none}"
+          failure_job_name="${FAILURE_JOB_NAME:-not available}"
+          failure_job_url="${FAILURE_JOB_URL:-not available}"
+          failure_step_name="${FAILURE_STEP_NAME:-not available}"
           gate_run_url="${GATE_RUN_URL:-not available}"
           deploy_run_url="${DEPLOY_RUN_URL:-not dispatched}"
           issue_url="${ISSUE_URL:-none}"
@@ -568,10 +671,15 @@ jobs:
           {
             echo "## Daily production deploy"
             echo ""
+            echo "- Outcome: \`${OUTCOME:-failed}\`"
             echo "- Master SHA: \`${MASTER_SHA:-unknown}\`"
             echo "- Deployed SHA: \`${deployed_sha}\`"
             echo "- Skipped reason: ${skipped_reason}"
             echo "- Failure reason: ${failure_reason}"
+            echo "- Failure stage: \`${failure_stage}\`"
+            echo "- Failure job: ${failure_job_name}"
+            echo "- Failure step: ${failure_step_name}"
+            echo "- Failure job URL: ${failure_job_url}"
             echo "- CI run URL: ${CI_RUN_URL:-not available}"
             echo "- Gate run URL: ${gate_run_url}"
             echo "- Deploy run URL: ${deploy_run_url}"

--- a/.github/workflows/deploy-ecs.yml
+++ b/.github/workflows/deploy-ecs.yml
@@ -9,10 +9,15 @@
 # difference between the two is this file's `qa-before-deploy` gate, which the
 # fastlane path deliberately skips.
 name: Deploy ECS (production)
+run-name: ${{ inputs.orchestrator_run_id != '' && format('Deploy ECS (production) · daily:{0}', inputs.orchestrator_run_id) || 'Deploy ECS (production)' }}
 
 on:
   workflow_dispatch:
     inputs:
+      orchestrator_run_id:
+        description: "optional unique correlation id for an orchestrating workflow"
+        required: false
+        default: ""
       image_tag:
         description: "server image tag to deploy (default: current SHA)"
         required: false

--- a/scripts/ci/daily-deploy-orchestration.mjs
+++ b/scripts/ci/daily-deploy-orchestration.mjs
@@ -1,0 +1,155 @@
+const DEPLOY_RUN_TITLE = 'Deploy ECS (production)';
+
+const FAILURE_CONCLUSIONS = new Set([
+  'action_required',
+  'cancelled',
+  'failure',
+  'startup_failure',
+  'timed_out',
+]);
+
+const STAGE_ORDER = new Map([
+  ['full-suite-gate', 0],
+  ['image-availability', 1],
+  ['migration-deploy', 2],
+  ['vercel', 3],
+  ['post-deploy-smoke', 4],
+  ['nested-cancellation', 5],
+  ['unknown', 6],
+]);
+
+const STAGE_LABELS = {
+  'full-suite-gate': 'full-suite/CI gate',
+  'image-availability': 'image availability',
+  'migration-deploy': 'migration/deploy',
+  'nested-cancellation': 'nested workflow cancellation',
+  'post-deploy-smoke': 'post-deploy smoke',
+  unknown: 'unknown deploy stage',
+  vercel: 'Vercel deploy',
+};
+
+const IMAGE_STEP_PATTERN =
+  /(?:resolve available server image|copy server:.*ghcr.*ecr|login to ecr.*ghcr)/iu;
+const MIGRATION_DEPLOY_STEP_PATTERN =
+  /(?:resolve image tag|configure aws credentials|tofu|task definition|snapshot rds|migration|backfill|boot smoke|services stable|roll services|credential-encryption)/iu;
+
+function normalize(value) {
+  return typeof value === 'string' ? value.trim() : String(value ?? '').trim();
+}
+
+function failedStep(job) {
+  return (job.steps ?? []).find((step) =>
+    FAILURE_CONCLUSIONS.has(step.conclusion),
+  );
+}
+
+function classifyJob(job) {
+  const step = failedStep(job);
+  const jobName = normalize(job.name);
+  const stepName = normalize(step?.name);
+  const evidence = `${jobName}\n${stepName}`;
+
+  if (/cancel doomed run/iu.test(jobName)) {
+    return 'nested-cancellation';
+  }
+  if (/qa before deploy/iu.test(jobName)) {
+    return 'full-suite-gate';
+  }
+  if (IMAGE_STEP_PATTERN.test(evidence)) {
+    return 'image-availability';
+  }
+  if (/deploy vercel frontends/iu.test(jobName)) {
+    return 'vercel';
+  }
+  if (/post-deploy smoke/iu.test(jobName)) {
+    return 'post-deploy-smoke';
+  }
+  if (
+    /deploy ecs/iu.test(jobName) ||
+    MIGRATION_DEPLOY_STEP_PATTERN.test(evidence)
+  ) {
+    return 'migration-deploy';
+  }
+  if (job.conclusion === 'cancelled') {
+    return 'nested-cancellation';
+  }
+  return 'unknown';
+}
+
+function conclusionOrder(conclusion) {
+  return conclusion === 'cancelled' ? 1 : 0;
+}
+
+function timestamp(value) {
+  const parsed = Date.parse(value ?? '');
+  return Number.isNaN(parsed) ? Number.MAX_SAFE_INTEGER : parsed;
+}
+
+export function createDeployRunTitle(correlationId) {
+  const normalizedCorrelationId = normalize(correlationId);
+  return normalizedCorrelationId
+    ? `${DEPLOY_RUN_TITLE} · daily:${normalizedCorrelationId}`
+    : DEPLOY_RUN_TITLE;
+}
+
+export function matchesCorrelatedDeployRun(run, { correlationId, masterSha }) {
+  return (
+    run?.event === 'workflow_dispatch' &&
+    run?.head_sha === masterSha &&
+    run?.display_title === createDeployRunTitle(correlationId)
+  );
+}
+
+export function classifyDeployRunFailure(jobs) {
+  const candidates = (jobs ?? [])
+    .filter((job) => FAILURE_CONCLUSIONS.has(job.conclusion))
+    .map((job) => ({
+      job,
+      stage: classifyJob(job),
+      step: failedStep(job),
+    }))
+    .sort(
+      (left, right) =>
+        conclusionOrder(left.job.conclusion) -
+          conclusionOrder(right.job.conclusion) ||
+        (STAGE_ORDER.get(left.stage) ?? STAGE_ORDER.get('unknown')) -
+          (STAGE_ORDER.get(right.stage) ?? STAGE_ORDER.get('unknown')) ||
+        timestamp(left.job.completed_at) - timestamp(right.job.completed_at) ||
+        Number(left.job.id ?? Number.MAX_SAFE_INTEGER) -
+          Number(right.job.id ?? Number.MAX_SAFE_INTEGER),
+    );
+
+  const selected = candidates[0];
+  if (!selected) {
+    return {
+      jobConclusion: '',
+      jobName: '',
+      jobUrl: '',
+      stage: 'unknown',
+      stepName: '',
+    };
+  }
+
+  return {
+    jobConclusion: normalize(selected.job.conclusion),
+    jobName: normalize(selected.job.name),
+    jobUrl: normalize(selected.job.html_url),
+    stage: selected.stage,
+    stepName: normalize(selected.step?.name),
+  };
+}
+
+export function formatDeployFailure(classification, conclusion) {
+  const stageLabel = STAGE_LABELS[classification.stage] ?? STAGE_LABELS.unknown;
+  const evidence = [classification.jobName, classification.stepName]
+    .filter(Boolean)
+    .join(' / ');
+  const url = classification.jobUrl ? `: ${classification.jobUrl}` : '';
+
+  const jobConclusion = classification.jobConclusion || 'failed';
+  const childConclusion = normalize(conclusion) || 'unknown';
+
+  return `${stageLabel} ${jobConclusion}${
+    evidence ? ` at ${evidence}` : ''
+  }${url}; child run concluded ${childConclusion}`;
+}

--- a/scripts/ci/daily-deploy-orchestration.test.mjs
+++ b/scripts/ci/daily-deploy-orchestration.test.mjs
@@ -168,6 +168,10 @@ test('keeps the daily and deploy workflow correlation contract wired', () => {
   );
   assert.match(deployWorkflow, /^ {6}orchestrator_run_id:/m);
   assert.match(dailyWorkflow, /daily-deploy-orchestration\.mjs/);
+  assert.match(
+    dailyWorkflow,
+    /name: Checkout workflow helpers[\s\S]*?persist-credentials: false/,
+  );
   assert.match(dailyWorkflow, /matchesCorrelatedDeployRun/);
   assert.match(dailyWorkflow, /orchestrator_run_id: correlationId/);
   assert.match(dailyWorkflow, /listJobsForWorkflowRun/);

--- a/scripts/ci/daily-deploy-orchestration.test.mjs
+++ b/scripts/ci/daily-deploy-orchestration.test.mjs
@@ -162,11 +162,20 @@ test('keeps the daily and deploy workflow correlation contract wired', () => {
   );
 
   assert.match(deployWorkflow, /^run-name: .*orchestrator_run_id/m);
+  assert.match(
+    deployWorkflow,
+    /format\('Deploy ECS \(production\) · daily:\{0\}', inputs\.orchestrator_run_id\)/,
+  );
   assert.match(deployWorkflow, /^ {6}orchestrator_run_id:/m);
   assert.match(dailyWorkflow, /daily-deploy-orchestration\.mjs/);
   assert.match(dailyWorkflow, /matchesCorrelatedDeployRun/);
   assert.match(dailyWorkflow, /orchestrator_run_id: correlationId/);
   assert.match(dailyWorkflow, /listJobsForWorkflowRun/);
+  assert.match(dailyWorkflow, /filter: 'latest'/);
+  assert.match(
+    dailyWorkflow,
+    /skip\(\s*process\.env\.PRECHECK_SKIPPED_REASON \|\|\s*'Daily production deploy precheck skipped\.',\s*'clean no-op',\s*\)/,
+  );
   assert.match(dailyWorkflow, /failure_stage/);
   assert.match(dailyWorkflow, /OUTCOME: .*'failed'/);
   assert.match(dailyWorkflow, /echo "- Outcome:/);

--- a/scripts/ci/daily-deploy-orchestration.test.mjs
+++ b/scripts/ci/daily-deploy-orchestration.test.mjs
@@ -168,5 +168,6 @@ test('keeps the daily and deploy workflow correlation contract wired', () => {
   assert.match(dailyWorkflow, /orchestrator_run_id: correlationId/);
   assert.match(dailyWorkflow, /listJobsForWorkflowRun/);
   assert.match(dailyWorkflow, /failure_stage/);
-  assert.match(dailyWorkflow, /- Outcome: `\$\{outcome\}`/);
+  assert.match(dailyWorkflow, /OUTCOME: .*'failed'/);
+  assert.match(dailyWorkflow, /echo "- Outcome:/);
 });

--- a/scripts/ci/daily-deploy-orchestration.test.mjs
+++ b/scripts/ci/daily-deploy-orchestration.test.mjs
@@ -1,0 +1,172 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  classifyDeployRunFailure,
+  createDeployRunTitle,
+  formatDeployFailure,
+  matchesCorrelatedDeployRun,
+} from './daily-deploy-orchestration.mjs';
+
+const MASTER_SHA = '018f97c16dca71292860159f0c92bdd684c5740c';
+const CORRELATION_ID = '29672457857-1';
+
+function job(overrides = {}) {
+  return {
+    completed_at: '2026-07-19T04:00:00Z',
+    conclusion: 'failure',
+    html_url: 'https://github.com/genfeedai/genfeed.ai/actions/runs/1/job/1',
+    id: 1,
+    name: 'Unknown job',
+    steps: [],
+    ...overrides,
+  };
+}
+
+test('matches only the exact correlated workflow-dispatch run and master SHA', () => {
+  const run = {
+    display_title: createDeployRunTitle(CORRELATION_ID),
+    event: 'workflow_dispatch',
+    head_sha: MASTER_SHA,
+  };
+
+  assert.equal(
+    matchesCorrelatedDeployRun(run, {
+      correlationId: CORRELATION_ID,
+      masterSha: MASTER_SHA,
+    }),
+    true,
+  );
+  assert.equal(
+    matchesCorrelatedDeployRun(run, {
+      correlationId: 'unrelated-run',
+      masterSha: MASTER_SHA,
+    }),
+    false,
+  );
+  assert.equal(
+    matchesCorrelatedDeployRun(run, {
+      correlationId: CORRELATION_ID,
+      masterSha: 'different-sha',
+    }),
+    false,
+  );
+  assert.equal(
+    matchesCorrelatedDeployRun(
+      { ...run, event: 'push' },
+      { correlationId: CORRELATION_ID, masterSha: MASTER_SHA },
+    ),
+    false,
+  );
+});
+
+test('classifies the observed masked API shard failure before fail-fast cancellation', () => {
+  const classification = classifyDeployRunFailure([
+    job({
+      completed_at: '2026-07-19T03:59:54Z',
+      html_url:
+        'https://github.com/genfeedai/genfeed.ai/actions/runs/29672468247/job/88153881344',
+      id: 88153881344,
+      name: 'QA before deploy / CI Gate / Test API (Shard 1/4)',
+      steps: [
+        {
+          conclusion: 'failure',
+          name: 'Run API test shard',
+        },
+      ],
+    }),
+    job({
+      completed_at: '2026-07-19T04:01:05Z',
+      conclusion: 'cancelled',
+      id: 88154323791,
+      name: 'QA before deploy / Cancel doomed run',
+    }),
+  ]);
+
+  assert.deepEqual(classification, {
+    jobConclusion: 'failure',
+    jobName: 'QA before deploy / CI Gate / Test API (Shard 1/4)',
+    jobUrl:
+      'https://github.com/genfeedai/genfeed.ai/actions/runs/29672468247/job/88153881344',
+    stage: 'full-suite-gate',
+    stepName: 'Run API test shard',
+  });
+  assert.match(
+    formatDeployFailure(classification, 'cancelled'),
+    /full-suite\/CI gate failure at .*Run API test shard.*child run concluded cancelled/,
+  );
+});
+
+test('classifies image, deploy, Vercel, smoke, cancellation, and unknown stages', () => {
+  const cases = [
+    [
+      job({
+        name: 'Deploy / Deploy ECS',
+        steps: [
+          { conclusion: 'failure', name: 'Resolve available server image' },
+        ],
+      }),
+      'image-availability',
+    ],
+    [
+      job({
+        name: 'Deploy / Deploy ECS',
+        steps: [{ conclusion: 'failure', name: 'Run DB migrations' }],
+      }),
+      'migration-deploy',
+    ],
+    [job({ name: 'Deploy / Deploy Vercel frontends' }), 'vercel'],
+    [job({ name: 'Deploy / Post-deploy smoke' }), 'post-deploy-smoke'],
+    [
+      job({
+        conclusion: 'cancelled',
+        name: 'QA before deploy / Cancel doomed run',
+      }),
+      'nested-cancellation',
+    ],
+    [job(), 'unknown'],
+  ];
+
+  for (const [fixture, expectedStage] of cases) {
+    assert.equal(classifyDeployRunFailure([fixture]).stage, expectedStage);
+  }
+});
+
+test('fails closed when terminal child job evidence is unavailable', () => {
+  assert.deepEqual(classifyDeployRunFailure([]), {
+    jobConclusion: '',
+    jobName: '',
+    jobUrl: '',
+    stage: 'unknown',
+    stepName: '',
+  });
+});
+
+test('keeps the daily and deploy workflow correlation contract wired', () => {
+  const dailyWorkflow = readFileSync(
+    fileURLToPath(
+      new URL(
+        '../../.github/workflows/daily-production-deploy.yml',
+        import.meta.url,
+      ),
+    ),
+    'utf8',
+  );
+  const deployWorkflow = readFileSync(
+    fileURLToPath(
+      new URL('../../.github/workflows/deploy-ecs.yml', import.meta.url),
+    ),
+    'utf8',
+  );
+
+  assert.match(deployWorkflow, /^run-name: .*orchestrator_run_id/m);
+  assert.match(deployWorkflow, /^ {6}orchestrator_run_id:/m);
+  assert.match(dailyWorkflow, /daily-deploy-orchestration\.mjs/);
+  assert.match(dailyWorkflow, /matchesCorrelatedDeployRun/);
+  assert.match(dailyWorkflow, /orchestrator_run_id: correlationId/);
+  assert.match(dailyWorkflow, /listJobsForWorkflowRun/);
+  assert.match(dailyWorkflow, /failure_stage/);
+  assert.match(dailyWorkflow, /- Outcome: `\$\{outcome\}`/);
+});


### PR DESCRIPTION
## Summary

- correlate each daily production deploy with an exact child run using the daily run ID and attempt
- classify terminal child failures from job and step evidence instead of reporting only a generic cancellation
- emit explicit deployed, clean no-op, blocked, or failed outcomes with SHA and child evidence
- preserve the existing master-only normal deploy path, QA gates, migration/snapshot gates, concurrency locks, and post-deploy smoke

## Verification

Passed locally:

- `bunx @biomejs/biome@2.5.3 check scripts/ci/daily-deploy-orchestration.mjs scripts/ci/daily-deploy-orchestration.test.mjs`
- `node --check scripts/ci/daily-deploy-orchestration.mjs`
- `node --check scripts/ci/daily-deploy-orchestration.test.mjs`
- `actionlint .github/workflows/daily-production-deploy.yml .github/workflows/deploy-ecs.yml .github/workflows/ci.yml`
- `git diff --cached --check`
- staged path and credential-pattern scans

Deferred to pull-request CI under the local-machine policy:

- `node --test scripts/ci/tests-gate.test.mjs scripts/ci/daily-deploy-orchestration.test.mjs`
- workflow contract validation, typecheck, broader tests, and build

## Residual risk

GitHub run-title propagation and job pagination receive their first live proof in Actions. Fleet Review remains the required exact-head gate before merge. Parent #1813 stays open for the seven-consecutive-scheduled-outcomes observation window.

Closes #1906