### PR TITLE
feat(workflows): reconcile system workflow duplicate upgrades

### DIFF
--- a/apps/server/api/src/collections/workflows/services/workflow-template-seeder-metadata.util.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-template-seeder-metadata.util.ts
@@ -1,0 +1,44 @@
+function isMetadataRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function areWorkflowMetadataValuesEqual(
+  left: unknown,
+  right: unknown,
+): boolean {
+  if (left === right) {
+    return true;
+  }
+
+  if (Array.isArray(left) || Array.isArray(right)) {
+    if (!Array.isArray(left) || !Array.isArray(right)) {
+      return false;
+    }
+
+    return (
+      left.length === right.length &&
+      left.every((item, index) =>
+        areWorkflowMetadataValuesEqual(item, right[index]),
+      )
+    );
+  }
+
+  if (isMetadataRecord(left) || isMetadataRecord(right)) {
+    if (!isMetadataRecord(left) || !isMetadataRecord(right)) {
+      return false;
+    }
+
+    const leftKeys = Object.keys(left);
+    const rightKeys = Object.keys(right);
+    return (
+      leftKeys.length === rightKeys.length &&
+      leftKeys.every(
+        (key) =>
+          Object.hasOwn(right, key) &&
+          areWorkflowMetadataValuesEqual(left[key], right[key]),
+      )
+    );
+  }
+
+  return false;
+}

--- a/apps/server/api/src/collections/workflows/services/workflow-template-seeder.service.spec.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-template-seeder.service.spec.ts
@@ -4,7 +4,10 @@ import {
 } from '@api/collections/workflows/services/system-workflow-provenance.service';
 import { WorkflowTemplateSeederService } from '@api/collections/workflows/services/workflow-template-seeder.service';
 import {
+  buildSystemWorkflowDuplicateMetadata,
   buildSystemWorkflowMetadata,
+  getSystemWorkflowDuplicateMetadata,
+  SYSTEM_WORKFLOW_DUPLICATE_METADATA_KEY,
   SYSTEM_WORKFLOW_TEMPLATE_CHANGE_SUMMARY,
   SYSTEM_WORKFLOW_TEMPLATE_VERSION,
 } from '@api/collections/workflows/system-workflow.contract';
@@ -28,6 +31,7 @@ describe('WorkflowTemplateSeederService seeded livestream bot workflows', () => 
       findFirst: vi.fn(),
       findMany: vi.fn(),
       update: vi.fn(),
+      updateMany: vi.fn(),
     },
   };
   const workflowExecutionQueueService = {
@@ -48,6 +52,7 @@ describe('WorkflowTemplateSeederService seeded livestream bot workflows', () => 
     prisma.workflow.findFirst.mockResolvedValue(null);
     prisma.workflow.findMany.mockResolvedValue([]);
     prisma.workflow.update.mockResolvedValue({});
+    prisma.workflow.updateMany.mockResolvedValue({ count: 0 });
     workflowExecutionQueueService.syncWorkflowScheduler.mockResolvedValue(
       undefined,
     );
@@ -201,6 +206,203 @@ describe('WorkflowTemplateSeederService seeded livestream bot workflows', () => 
       where: { id: 'workflow-1' },
     });
     expect(tx.workflow.create).not.toHaveBeenCalled();
+  });
+
+  it('marks stale system workflow duplicates as upgrade available', async () => {
+    const sourceSystemWorkflow = buildSystemWorkflowMetadata({
+      canonicalId: 'daily-trends-digest',
+      changeSummary: 'Initial daily digest.',
+      version: 1,
+    });
+    const duplicateMetadata = buildSystemWorkflowDuplicateMetadata(
+      { customFlag: true, systemWorkflow: sourceSystemWorkflow },
+      'system-workflow-1',
+    );
+    const currentSystemWorkflow = buildSystemWorkflowMetadata({
+      canonicalId: 'daily-trends-digest',
+      changeSummary: 'Add owner summary delivery.',
+      version: 2,
+    });
+    prisma.workflow.findMany.mockResolvedValue([
+      {
+        id: 'duplicate-1',
+        metadata: duplicateMetadata,
+      },
+    ]);
+
+    await service.reconcileSystemWorkflowDuplicates(
+      'org-1',
+      currentSystemWorkflow,
+    );
+
+    expect(prisma.workflow.findMany).toHaveBeenCalledWith({
+      select: { id: true, metadata: true },
+      where: {
+        isDeleted: false,
+        metadata: {
+          equals: 'daily-trends-digest',
+          path: [
+            SYSTEM_WORKFLOW_DUPLICATE_METADATA_KEY,
+            'canonicalId',
+          ],
+        },
+        organizationId: 'org-1',
+      },
+    });
+    expect(prisma.workflow.updateMany).toHaveBeenCalledWith({
+      data: {
+        metadata: expect.objectContaining({
+          customFlag: true,
+          duplicatedFromSystemWorkflow: expect.objectContaining({
+            canonicalId: 'daily-trends-digest',
+            currentSystemWorkflowChangeSummary:
+              'Add owner summary delivery.',
+            currentSystemWorkflowVersion: 2,
+            sourceWorkflowVersion: 1,
+            upgradeEligible: true,
+            upgradeStatus: 'upgrade_available',
+          }),
+        }),
+      },
+      where: {
+        id: 'duplicate-1',
+        isDeleted: false,
+        metadata: { equals: duplicateMetadata },
+        organizationId: 'org-1',
+      },
+    });
+  });
+
+  it('does not write duplicate metadata that already matches the canonical version', async () => {
+    const currentSystemWorkflow = buildSystemWorkflowMetadata({
+      canonicalId: 'daily-trends-digest',
+      changeSummary: 'Current daily digest.',
+      version: 2,
+    });
+    prisma.workflow.findMany.mockResolvedValue([
+      {
+        id: 'duplicate-1',
+        metadata: buildSystemWorkflowDuplicateMetadata(
+          { systemWorkflow: currentSystemWorkflow },
+          'system-workflow-1',
+        ),
+      },
+    ]);
+
+    await service.reconcileSystemWorkflowDuplicates(
+      'org-1',
+      currentSystemWorkflow,
+    );
+
+    expect(prisma.workflow.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('retries duplicate reconciliation after a metadata compare-and-swap miss', async () => {
+    const currentSystemWorkflow = buildSystemWorkflowMetadata({
+      canonicalId: 'livestream-bot-session-processing',
+      sourceIssue: 793,
+      version: 1,
+    });
+    const duplicateMetadata = buildSystemWorkflowDuplicateMetadata(
+      { systemWorkflow: currentSystemWorkflow },
+      'system-workflow-1',
+    );
+    const duplicateProvenance =
+      getSystemWorkflowDuplicateMetadata(duplicateMetadata);
+
+    if (!duplicateProvenance) {
+      throw new Error('Expected valid duplicate provenance fixture');
+    }
+
+    const staleMetadata = {
+      ...duplicateMetadata,
+      duplicatedFromSystemWorkflow: {
+        ...duplicateProvenance,
+        currentSystemWorkflowChangeSummary: 'Stale projection.',
+        currentSystemWorkflowVersion: 2,
+        upgradeEligible: true,
+        upgradeStatus: 'upgrade_available' as const,
+      },
+    };
+    prisma.workflow.findFirst.mockResolvedValue({
+      id: 'system-workflow-1',
+      metadata: {
+        sourceIssue: 793,
+        sourceTemplateChangeSummary: SYSTEM_WORKFLOW_TEMPLATE_CHANGE_SUMMARY,
+        sourceTemplateId: 'livestream-bot-session-processing',
+        sourceTemplateVersion: SYSTEM_WORKFLOW_TEMPLATE_VERSION,
+        sourceType: 'seeded-template',
+        systemWorkflow: currentSystemWorkflow,
+      },
+    });
+    prisma.workflow.findMany.mockResolvedValue([
+      {
+        id: 'duplicate-1',
+        metadata: staleMetadata,
+      },
+    ]);
+    prisma.workflow.updateMany
+      .mockResolvedValueOnce({ count: 0 })
+      .mockResolvedValueOnce({ count: 1 });
+
+    await service.ensureLivestreamBotWorkflows('user-1', 'org-1');
+    await service.ensureLivestreamBotWorkflows('user-1', 'org-1');
+
+    expect(prisma.workflow.updateMany).toHaveBeenCalledTimes(2);
+    expect(prisma.workflow.updateMany).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        data: {
+          metadata: expect.objectContaining({
+            duplicatedFromSystemWorkflow: expect.objectContaining({
+              currentSystemWorkflowVersion: 1,
+              upgradeEligible: false,
+              upgradeStatus: 'current',
+            }),
+          }),
+        },
+        where: expect.objectContaining({
+          id: 'duplicate-1',
+          metadata: { equals: staleMetadata },
+          organizationId: 'org-1',
+        }),
+      }),
+    );
+  });
+
+  it('skips malformed and foreign system workflow duplicate metadata', async () => {
+    const currentSystemWorkflow = buildSystemWorkflowMetadata({
+      canonicalId: 'daily-trends-digest',
+      changeSummary: 'Current daily digest.',
+      version: 2,
+    });
+    prisma.workflow.findMany.mockResolvedValue([
+      {
+        id: 'malformed-duplicate',
+        metadata: {
+          duplicatedFromSystemWorkflow: {
+            canonicalId: 'daily-trends-digest',
+          },
+        },
+      },
+      {
+        id: 'foreign-duplicate',
+        metadata: buildSystemWorkflowDuplicateMetadata(
+          {
+            systemWorkflow: buildSystemWorkflowMetadata({
+              canonicalId: 'scheduled-post-publishing',
+            }),
+          },
+          'system-workflow-2',
+        ),
+      },
+    ]);
+
+    await service.reconcileSystemWorkflowDuplicates(
+      'org-1',
+      currentSystemWorkflow,
+    );
+
+    expect(prisma.workflow.updateMany).not.toHaveBeenCalled();
   });
 
   it('seeds action-level system workflows for hardcoded product action replacements', async () => {

--- a/apps/server/api/src/collections/workflows/services/workflow-template-seeder.service.spec.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-template-seeder.service.spec.ts
@@ -345,6 +345,14 @@ describe('WorkflowTemplateSeederService seeded livestream bot workflows', () => 
     await service.ensureLivestreamBotWorkflows('user-1', 'org-1');
 
     expect(prisma.workflow.updateMany).toHaveBeenCalledTimes(2);
+    expect(logger.debug).toHaveBeenCalledWith(
+      'System workflow duplicate metadata changed before reconciliation; retrying on a later seed pass',
+      {
+        canonicalId: 'livestream-bot-session-processing',
+        organizationId: 'org-1',
+        workflowId: 'duplicate-1',
+      },
+    );
     expect(prisma.workflow.updateMany).toHaveBeenLastCalledWith(
       expect.objectContaining({
         data: {
@@ -399,6 +407,22 @@ describe('WorkflowTemplateSeederService seeded livestream bot workflows', () => 
     );
 
     expect(prisma.workflow.updateMany).not.toHaveBeenCalled();
+    expect(logger.debug).toHaveBeenCalledWith(
+      'Skipped system workflow duplicate reconciliation for invalid provenance',
+      {
+        canonicalId: 'daily-trends-digest',
+        organizationId: 'org-1',
+        workflowId: 'malformed-duplicate',
+      },
+    );
+    expect(logger.debug).toHaveBeenCalledWith(
+      'Skipped system workflow duplicate reconciliation for invalid provenance',
+      {
+        canonicalId: 'daily-trends-digest',
+        organizationId: 'org-1',
+        workflowId: 'foreign-duplicate',
+      },
+    );
   });
 
   it('seeds action-level system workflows for hardcoded product action replacements', async () => {

--- a/apps/server/api/src/collections/workflows/services/workflow-template-seeder.service.spec.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-template-seeder.service.spec.ts
@@ -241,10 +241,7 @@ describe('WorkflowTemplateSeederService seeded livestream bot workflows', () => 
         isDeleted: false,
         metadata: {
           equals: 'daily-trends-digest',
-          path: [
-            SYSTEM_WORKFLOW_DUPLICATE_METADATA_KEY,
-            'canonicalId',
-          ],
+          path: [SYSTEM_WORKFLOW_DUPLICATE_METADATA_KEY, 'canonicalId'],
         },
         organizationId: 'org-1',
       },
@@ -255,8 +252,7 @@ describe('WorkflowTemplateSeederService seeded livestream bot workflows', () => 
           customFlag: true,
           duplicatedFromSystemWorkflow: expect.objectContaining({
             canonicalId: 'daily-trends-digest',
-            currentSystemWorkflowChangeSummary:
-              'Add owner summary delivery.',
+            currentSystemWorkflowChangeSummary: 'Add owner summary delivery.',
             currentSystemWorkflowVersion: 2,
             sourceWorkflowVersion: 1,
             upgradeEligible: true,

--- a/apps/server/api/src/collections/workflows/services/workflow-template-seeder.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-template-seeder.service.ts
@@ -2,12 +2,16 @@ import { type WorkflowVisualNode } from '@api/collections/workflows/schemas/work
 import { SYSTEM_WORKFLOW_ACTION_DEFINITIONS } from '@api/collections/workflows/services/system-workflow-provenance.service';
 import { WorkflowExecutionQueueService } from '@api/collections/workflows/services/workflow-execution-queue.service';
 import {
+  buildSystemWorkflowUpgradeMetadata,
   buildSystemWorkflowMetadata,
   getMetadataRecord,
+  getSystemWorkflowDuplicateMetadata,
   getSystemWorkflowMetadata,
+  SYSTEM_WORKFLOW_DUPLICATE_METADATA_KEY,
   SYSTEM_WORKFLOW_METADATA_KEY,
   SYSTEM_WORKFLOW_TEMPLATE_CHANGE_SUMMARY,
   SYSTEM_WORKFLOW_TEMPLATE_VERSION,
+  type SystemWorkflowMetadata,
 } from '@api/collections/workflows/system-workflow.contract';
 import { AD_AUTOMATION_WORKFLOW_TEMPLATES } from '@api/collections/workflows/templates/ad-automation-workflows.template';
 import { AGENT_AUTOPILOT_WORKFLOW_TEMPLATES } from '@api/collections/workflows/templates/agent-autopilot-workflows.template';
@@ -190,6 +194,86 @@ export class WorkflowTemplateSeederService {
   }
 
   /**
+   * Refreshes version visibility for editable workflows duplicated from a
+   * canonical system workflow. Only provenance metadata changes; user-owned
+   * workflow content, scheduling, lifecycle, and ownership stay untouched.
+   */
+  async reconcileSystemWorkflowDuplicates(
+    organizationId: string,
+    currentSystemWorkflow: SystemWorkflowMetadata,
+  ): Promise<void> {
+    const duplicates = await this.prisma.workflow.findMany({
+      select: { id: true, metadata: true },
+      where: {
+        isDeleted: false,
+        metadata: {
+          equals: currentSystemWorkflow.canonicalId,
+          path: [
+            SYSTEM_WORKFLOW_DUPLICATE_METADATA_KEY,
+            'canonicalId',
+          ],
+        },
+        organizationId,
+      },
+    });
+
+    for (const duplicate of duplicates) {
+      const metadata = getMetadataRecord(duplicate.metadata);
+      const duplicateMetadata = getSystemWorkflowDuplicateMetadata(metadata);
+
+      if (
+        !duplicateMetadata ||
+        duplicateMetadata.canonicalId !== currentSystemWorkflow.canonicalId
+      ) {
+        continue;
+      }
+
+      const reconciledMetadata = buildSystemWorkflowUpgradeMetadata(
+        duplicateMetadata,
+        currentSystemWorkflow,
+      );
+
+      if (
+        this.areSeededMetadataValuesEqual(
+          duplicateMetadata,
+          reconciledMetadata,
+        )
+      ) {
+        continue;
+      }
+
+      await this.prisma.workflow.updateMany({
+        data: {
+          metadata: {
+            ...metadata,
+            [SYSTEM_WORKFLOW_DUPLICATE_METADATA_KEY]: reconciledMetadata,
+          },
+        } as never,
+        where: {
+          id: duplicate.id,
+          isDeleted: false,
+          metadata: { equals: duplicate.metadata } as never,
+          organizationId,
+        },
+      });
+    }
+  }
+
+  private async reconcileDesiredSystemWorkflowDuplicates(
+    organizationId: string,
+    metadata: unknown,
+  ): Promise<void> {
+    const currentSystemWorkflow = getSystemWorkflowMetadata(metadata);
+
+    if (currentSystemWorkflow) {
+      await this.reconcileSystemWorkflowDuplicates(
+        organizationId,
+        currentSystemWorkflow,
+      );
+    }
+  }
+
+  /**
    * Race-safe idempotent insert keyed on `metadata.sourceTemplateId` within an
    * organization. Fast-path read first; otherwise a SERIALIZABLE re-check +
    * create where both operations use the same `tx` client so Postgres can
@@ -228,6 +312,10 @@ export class WorkflowTemplateSeederService {
           where: { id: preCheck.id },
         });
       }
+      await this.reconcileDesiredSystemWorkflowDuplicates(
+        input.organizationId,
+        input.createData.metadata,
+      );
       return;
     }
 
@@ -267,10 +355,15 @@ export class WorkflowTemplateSeederService {
           `${input.logContext}: serialization conflict - workflow already seeded by concurrent request`,
           input.logMeta,
         );
-        return;
+      } else {
+        throw error;
       }
-      throw error;
     }
+
+    await this.reconcileDesiredSystemWorkflowDuplicates(
+      input.organizationId,
+      input.createData.metadata,
+    );
   }
 
   private buildSeededTemplateCreateData(input: {
@@ -385,6 +478,10 @@ export class WorkflowTemplateSeederService {
           where: { id: preCheck.id },
         });
       }
+      await this.reconcileDesiredSystemWorkflowDuplicates(
+        organizationId,
+        createData.metadata,
+      );
       return;
     }
 
@@ -428,10 +525,15 @@ export class WorkflowTemplateSeederService {
           'ensureDailyTrendsDigestWorkflow: serialization conflict - workflow already seeded by concurrent request',
           { organizationId },
         );
-        return;
+      } else {
+        throw error;
       }
-      throw error;
     }
+
+    await this.reconcileDesiredSystemWorkflowDuplicates(
+      organizationId,
+      createData.metadata,
+    );
   }
 
   private buildDailyTrendsDigestCreateData(

--- a/apps/server/api/src/collections/workflows/services/workflow-template-seeder.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-template-seeder.service.ts
@@ -181,6 +181,14 @@ export class WorkflowTemplateSeederService {
         !duplicateMetadata ||
         duplicateMetadata.canonicalId !== currentSystemWorkflow.canonicalId
       ) {
+        this.logger?.debug(
+          'Skipped system workflow duplicate reconciliation for invalid provenance',
+          {
+            canonicalId: currentSystemWorkflow.canonicalId,
+            organizationId,
+            workflowId: duplicate.id,
+          },
+        );
         continue;
       }
 
@@ -195,7 +203,7 @@ export class WorkflowTemplateSeederService {
         continue;
       }
 
-      await this.prisma.workflow.updateMany({
+      const { count } = await this.prisma.workflow.updateMany({
         data: {
           metadata: {
             ...metadata,
@@ -209,6 +217,17 @@ export class WorkflowTemplateSeederService {
           organizationId,
         },
       });
+
+      if (count === 0) {
+        this.logger?.debug(
+          'System workflow duplicate metadata changed before reconciliation; retrying on a later seed pass',
+          {
+            canonicalId: currentSystemWorkflow.canonicalId,
+            organizationId,
+            workflowId: duplicate.id,
+          },
+        );
+      }
     }
   }
 

--- a/apps/server/api/src/collections/workflows/services/workflow-template-seeder.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-template-seeder.service.ts
@@ -152,11 +152,6 @@ export class WorkflowTemplateSeederService {
       : 0;
   }
 
-  /**
-   * Refreshes version visibility for editable workflows duplicated from a
-   * canonical system workflow. Only provenance metadata changes; user-owned
-   * workflow content, scheduling, lifecycle, and ownership stay untouched.
-   */
   async reconcileSystemWorkflowDuplicates(
     organizationId: string,
     currentSystemWorkflow: SystemWorkflowMetadata,

--- a/apps/server/api/src/collections/workflows/services/workflow-template-seeder.service.ts
+++ b/apps/server/api/src/collections/workflows/services/workflow-template-seeder.service.ts
@@ -1,9 +1,10 @@
 import { type WorkflowVisualNode } from '@api/collections/workflows/schemas/workflow.schema';
 import { SYSTEM_WORKFLOW_ACTION_DEFINITIONS } from '@api/collections/workflows/services/system-workflow-provenance.service';
 import { WorkflowExecutionQueueService } from '@api/collections/workflows/services/workflow-execution-queue.service';
+import { areWorkflowMetadataValuesEqual } from '@api/collections/workflows/services/workflow-template-seeder-metadata.util';
 import {
-  buildSystemWorkflowUpgradeMetadata,
   buildSystemWorkflowMetadata,
+  buildSystemWorkflowUpgradeMetadata,
   getMetadataRecord,
   getSystemWorkflowDuplicateMetadata,
   getSystemWorkflowMetadata,
@@ -135,7 +136,7 @@ export class WorkflowTemplateSeederService {
     }
 
     for (const [key, value] of Object.entries(desiredMetadata)) {
-      if (!this.areSeededMetadataValuesEqual(existingMetadata[key], value)) {
+      if (!areWorkflowMetadataValuesEqual(existingMetadata[key], value)) {
         return repairedMetadata;
       }
     }
@@ -149,48 +150,6 @@ export class WorkflowTemplateSeederService {
       version > 0
       ? version
       : 0;
-  }
-
-  private areSeededMetadataValuesEqual(left: unknown, right: unknown): boolean {
-    if (left === right) {
-      return true;
-    }
-
-    if (Array.isArray(left) || Array.isArray(right)) {
-      if (!Array.isArray(left) || !Array.isArray(right)) {
-        return false;
-      }
-
-      return (
-        left.length === right.length &&
-        left.every((item, index) =>
-          this.areSeededMetadataValuesEqual(item, right[index]),
-        )
-      );
-    }
-
-    if (this.isMetadataRecord(left) || this.isMetadataRecord(right)) {
-      if (!this.isMetadataRecord(left) || !this.isMetadataRecord(right)) {
-        return false;
-      }
-
-      const leftKeys = Object.keys(left);
-      const rightKeys = Object.keys(right);
-      return (
-        leftKeys.length === rightKeys.length &&
-        leftKeys.every(
-          (key) =>
-            Object.hasOwn(right, key) &&
-            this.areSeededMetadataValuesEqual(left[key], right[key]),
-        )
-      );
-    }
-
-    return false;
-  }
-
-  private isMetadataRecord(value: unknown): value is Record<string, unknown> {
-    return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
   }
 
   /**
@@ -208,10 +167,7 @@ export class WorkflowTemplateSeederService {
         isDeleted: false,
         metadata: {
           equals: currentSystemWorkflow.canonicalId,
-          path: [
-            SYSTEM_WORKFLOW_DUPLICATE_METADATA_KEY,
-            'canonicalId',
-          ],
+          path: [SYSTEM_WORKFLOW_DUPLICATE_METADATA_KEY, 'canonicalId'],
         },
         organizationId,
       },
@@ -234,10 +190,7 @@ export class WorkflowTemplateSeederService {
       );
 
       if (
-        this.areSeededMetadataValuesEqual(
-          duplicateMetadata,
-          reconciledMetadata,
-        )
+        areWorkflowMetadataValuesEqual(duplicateMetadata, reconciledMetadata)
       ) {
         continue;
       }


### PR DESCRIPTION
## Summary
- reconcile editable system-workflow duplicate provenance against the current canonical template version during seeding
- preserve user workflow content and metadata with organization/soft-delete guards plus an optimistic metadata compare-and-swap
- retry reconciliation on later seed passes after transient failures or concurrent metadata changes
- cover stale, current, malformed, foreign-canonical, tenant-scope, and CAS-retry behavior

## Verification
- `bunx @biomejs/biome check apps/server/api/src/collections/workflows/services/workflow-template-seeder.service.ts apps/server/api/src/collections/workflows/services/workflow-template-seeder.service.spec.ts apps/server/api/src/collections/workflows/services/workflow-template-seeder-metadata.util.ts` — passed
- scoped Biome formatting, staged diff checks, runtime line-cap assertion, and credential/path scans — passed
- independent implementation review — passed after repairing the reconciliation retry path
- exact-head CI run `29688791601` — passed, including changed API tests, typecheck, build, formatting, lint, guards, OpenAPI drift, and Tests Gate
- exact-head Server Image PR Guard, Codebase Health Check, Link Check, and external security checks — passed

## Residual risk
Fleet Review remains the required exact-head gate before merge. The project item intentionally remains In Progress.

Closes #1908
Parent: #1026
