### PR TITLE
chore(extension): remove remaining unused dependencies

### DIFF
--- a/apps/extensions/browser/app/package.json
+++ b/apps/extensions/browser/app/package.json
@@ -13,11 +13,9 @@
     "@plasmohq/storage": "1.15.0",
     "@sentry/browser": "10.64.0",
     "axios": "1.18.1",
-    "lucide-react": "1.23.0",
     "plasmo": "0.90.5",
     "react": "19.2.7",
     "react-dom": "19.2.7",
-    "tailwind-merge": "3.6.0",
     "zustand": "5.0.14"
   },
   "description": "Genfeed.ai - Generate (good) AI content for your business",

--- a/bun.lock
+++ b/bun.lock
@@ -286,11 +286,9 @@
         "@plasmohq/storage": "1.15.0",
         "@sentry/browser": "10.64.0",
         "axios": "1.18.1",
-        "lucide-react": "1.23.0",
         "plasmo": "0.90.5",
         "react": "19.2.7",
         "react-dom": "19.2.7",
-        "tailwind-merge": "3.6.0",
         "zustand": "5.0.14",
       },
       "devDependencies": {


### PR DESCRIPTION
Closes #1912

## Summary
- remove the final two Fallow-confirmed unused dependencies from the browser extension workspace
- keep root and shared-workspace dependency declarations unchanged
- keep the root lockfile workspace entry aligned with the extension manifest

## Verification
- `bunx biome check apps/extensions/browser/app/package.json`
- exact extension import search for `lucide-react` and `tailwind-merge`
- manifest/lock parity and non-extension declaration assertions
- `git diff --check` and exact two-file/four-deletion scope check
- no added lines, so the commit introduces no credential-bearing content

## Skipped locally
- extension tests, typecheck, build, and broad Fallow checks are delegated to pull-request CI under the local-machine policy

## Residual risk
- limited to package-resolution assumptions; PR CI covers extension tests, typecheck, build, and Codebase Health on the exact head