### PR TITLE
refactor(scheduler): extract post-group persistence and mapping

### DIFF
--- a/apps/server/api/src/collections/post-groups/post-groups.module.ts
+++ b/apps/server/api/src/collections/post-groups/post-groups.module.ts
@@ -1,4 +1,6 @@
 import { PostGroupsController } from '@api/collections/post-groups/controllers/post-groups.controller';
+import { PostGroupContractService } from '@api/collections/post-groups/services/post-group-contract.service';
+import { PostGroupPersistenceService } from '@api/collections/post-groups/services/post-group-persistence.service';
 import { PostGroupsService } from '@api/collections/post-groups/services/post-groups.service';
 import { PublishApprovalsModule } from '@api/collections/publish-approvals/publish-approvals.module';
 import { QueuesModule } from '@api/queues/core/queues.module';
@@ -8,6 +10,10 @@ import { forwardRef, Module } from '@nestjs/common';
   controllers: [PostGroupsController],
   exports: [PostGroupsService],
   imports: [forwardRef(() => QueuesModule), PublishApprovalsModule],
-  providers: [PostGroupsService],
+  providers: [
+    PostGroupContractService,
+    PostGroupPersistenceService,
+    PostGroupsService,
+  ],
 })
 export class PostGroupsModule {}

--- a/apps/server/api/src/collections/post-groups/services/post-group-contract.service.spec.ts
+++ b/apps/server/api/src/collections/post-groups/services/post-group-contract.service.spec.ts
@@ -1,0 +1,172 @@
+import type {
+  SchedulerPostGroup,
+  SchedulerPostTarget,
+} from '@api/collections/post-groups/services/post-group.types';
+import { PostGroupContractService } from '@api/collections/post-groups/services/post-group-contract.service';
+import {
+  CredentialPlatform,
+  ReleaseStatus,
+  TargetExecutionState,
+  TargetValidationState,
+} from '@genfeedai/enums';
+import { BadRequestException } from '@nestjs/common';
+
+describe('PostGroupContractService', () => {
+  const service = new PostGroupContractService();
+  const now = new Date('2026-07-19T12:00:00.000Z');
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('parses the shared create contract and lets the header own idempotency', () => {
+    const input = service.parseCreateInput(
+      {
+        baseContent: 'Launch note',
+        idempotencyKey: 'body-key',
+        targets: [
+          {
+            credentialId: 'credential-1',
+            platform: CredentialPlatform.TWITTER,
+          },
+        ],
+        timezone: 'UTC',
+        title: 'Launch',
+      },
+      ' header-key ',
+    );
+
+    expect(input.idempotencyKey).toBe('header-key');
+    expect(service.resolveCreateStatus(input)).toBe(ReleaseStatus.DRAFT);
+  });
+
+  it('maps durable rows into the canonical release contract', () => {
+    const group = makeGroup();
+    const target = makeTarget();
+
+    expect(service.toReleaseGroup(group, [target])).toEqual(
+      expect.objectContaining({
+        attachments: [],
+        id: 'group-1',
+        media: [{ assetId: 'asset-1', kind: 'image' }],
+        status: ReleaseStatus.SCHEDULED,
+        targetSummary: {
+          scheduled: 1,
+          total: 1,
+        },
+        targets: [
+          expect.objectContaining({
+            credentialId: 'credential-1',
+            executionState: TargetExecutionState.SCHEDULED,
+            id: 'target-1',
+            releaseId: 'group-1',
+            settings: { replyPolicy: 'everyone' },
+          }),
+        ],
+      }),
+    );
+  });
+
+  it('preserves validation and strict schedule error categories', () => {
+    expect(() => service.parseFutureScheduleDate('not-a-date')).toThrow(
+      BadRequestException,
+    );
+    expect(() =>
+      service.parseFutureScheduleDate('2026-07-19T11:59:59.000Z'),
+    ).toThrow('must be in the future');
+    expect(() => service.parseCredentialPlatform('unsupported')).toThrow(
+      'not supported',
+    );
+  });
+
+  it('matches only the provenance fields supplied by the caller', () => {
+    const target = makeTarget({
+      agentContextSource: 'explicit',
+      agentContextVersion: 4,
+      agentThreadId: 'thread-1',
+    });
+
+    expect(
+      service.matchesScheduleProvenance(target, {
+        agentContextSource: 'explicit',
+        agentThreadId: 'thread-1',
+      }),
+    ).toBe(true);
+    expect(
+      service.matchesScheduleProvenance(target, {
+        agentContextVersion: 3,
+      }),
+    ).toBe(false);
+  });
+});
+
+function makeGroup(
+  overrides: Partial<SchedulerPostGroup> = {},
+): SchedulerPostGroup {
+  return {
+    attachments: [],
+    baseContent: 'Launch note',
+    brandId: 'brand-1',
+    createdAt: new Date('2026-07-19T10:00:00.000Z'),
+    id: 'group-1',
+    idempotencyKey: 'request-1',
+    isDeleted: false,
+    media: [{ assetId: 'asset-1', kind: 'image' }],
+    organizationId: 'org-1',
+    ownerId: 'user-1',
+    publishedAt: null,
+    recurrence: null,
+    scheduledAt: new Date('2026-07-20T10:00:00.000Z'),
+    status: ReleaseStatus.SCHEDULED,
+    statusTransitions: [],
+    timezone: 'UTC',
+    title: 'Launch',
+    updatedAt: new Date('2026-07-19T10:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function makeTarget(
+  overrides: Partial<SchedulerPostTarget> = {},
+): SchedulerPostTarget {
+  return {
+    agentContextSource: null,
+    agentContextVersion: null,
+    agentRunId: null,
+    agentStrategyId: null,
+    agentThreadId: null,
+    brandId: 'brand-1',
+    createdAt: new Date('2026-07-19T10:00:00.000Z'),
+    credentialId: 'credential-1',
+    externalId: null,
+    externalShortcode: null,
+    groupId: 'group-1',
+    id: 'target-1',
+    isDeleted: false,
+    lastAttemptAt: null,
+    order: 0,
+    platform: CredentialPlatform.TWITTER,
+    publishedAt: null,
+    publishApprovalId: null,
+    retryCount: 0,
+    scheduledDate: new Date('2026-07-20T10:00:00.000Z'),
+    targetAttachments: [],
+    targetError: null,
+    targetExecutionState: TargetExecutionState.SCHEDULED,
+    targetIdempotencyKey: 'target-request-1',
+    targetReadiness: null,
+    targetSettings: { replyPolicy: 'everyone' },
+    targetValidationIssues: [],
+    targetValidationState: TargetValidationState.VALID,
+    timezone: 'UTC',
+    updatedAt: new Date('2026-07-19T10:00:00.000Z'),
+    url: null,
+    workflowExecutionId: null,
+    ...overrides,
+  };
+}

--- a/apps/server/api/src/collections/post-groups/services/post-group-contract.service.ts
+++ b/apps/server/api/src/collections/post-groups/services/post-group-contract.service.ts
@@ -1,0 +1,544 @@
+import type {
+  SchedulerPostGroup,
+  SchedulerPostTarget,
+} from '@api/collections/post-groups/services/post-group.types';
+import {
+  type ChannelTargetValidationResult,
+  validateChannelTargetSettings,
+} from '@api-types/contracts/channel-capabilities.contract';
+import {
+  type ChannelTargetInput,
+  type CreateReleaseGroupInput,
+  createReleaseGroupSchema,
+  type ReleaseAttachmentInput,
+  type ReleaseMediaReferenceInput,
+  type UpdateChannelTargetInput,
+  type UpdateReleaseGroupInput,
+  updateChannelTargetSchema,
+  updateReleaseGroupSchema,
+} from '@api-types/contracts/scheduler.contract';
+import {
+  CredentialPlatform,
+  PostStatus,
+  ReleaseStatus,
+  TargetExecutionState,
+  TargetValidationState,
+} from '@genfeedai/enums';
+import type {
+  IChannelTarget,
+  IReleaseAttachment,
+  IReleaseGroup,
+  IReleaseMediaReference,
+  IReleaseTargetSummary,
+  IScheduleStatusTransition,
+  PostGroupCreateProvenance,
+} from '@genfeedai/interfaces';
+import { Prisma } from '@genfeedai/prisma';
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+} from '@nestjs/common';
+import { type ZodError, z } from 'zod';
+
+type ChannelValidationMedia = NonNullable<
+  Parameters<typeof validateChannelTargetSettings>[0]['media']
+>;
+
+const CREATE_ALLOWED_STATUSES = new Set<string>([
+  ReleaseStatus.DRAFT,
+  ReleaseStatus.SCHEDULED,
+]);
+
+const STRICT_SCHEDULE_DATE_SCHEMA = z.string().datetime({ offset: true });
+
+const SCHEDULABLE_TARGET_STATES = new Set<string>([
+  TargetExecutionState.DRAFT,
+  TargetExecutionState.PAUSED,
+  TargetExecutionState.SCHEDULED,
+]);
+
+@Injectable()
+export class PostGroupContractService {
+  parseCreateInput(
+    body: unknown,
+    headerIdempotencyKey?: string,
+  ): CreateReleaseGroupInput {
+    const idempotencyKey = headerIdempotencyKey?.trim();
+    const payload =
+      idempotencyKey && typeof body === 'object' && body !== null
+        ? { ...body, idempotencyKey }
+        : body;
+    const parsed = createReleaseGroupSchema.safeParse(payload);
+    if (!parsed.success) {
+      throw this.badRequestFromZod(parsed.error);
+    }
+    return parsed.data;
+  }
+
+  parseUpdateInput(body: unknown): UpdateReleaseGroupInput {
+    const parsed = updateReleaseGroupSchema.safeParse(body);
+    if (!parsed.success) {
+      throw this.badRequestFromZod(parsed.error);
+    }
+    return parsed.data;
+  }
+
+  parseTargetInput(body: unknown): UpdateChannelTargetInput {
+    const parsed = updateChannelTargetSchema.safeParse(body);
+    if (!parsed.success) {
+      throw this.badRequestFromZod(parsed.error);
+    }
+    return parsed.data;
+  }
+
+  resolveCreateStatus(input: CreateReleaseGroupInput): ReleaseStatus {
+    const status =
+      input.status ??
+      (input.scheduledDate ||
+      input.targets.some((target) => Boolean(target.scheduledDate))
+        ? ReleaseStatus.SCHEDULED
+        : ReleaseStatus.DRAFT);
+
+    if (!CREATE_ALLOWED_STATUSES.has(status)) {
+      throw new BadRequestException(
+        `Release groups can only be created as ${ReleaseStatus.DRAFT} or ${ReleaseStatus.SCHEDULED}.`,
+      );
+    }
+
+    return status;
+  }
+
+  validateTarget(
+    input: Pick<CreateReleaseGroupInput, 'baseContent' | 'media'>,
+    target: ChannelTargetInput,
+    publishMode: 'draft' | 'publish_now' | 'scheduled',
+  ): ChannelTargetValidationResult {
+    return validateChannelTargetSettings({
+      caption: input.baseContent,
+      credentialId: target.credentialId,
+      media: this.toValidationMedia(input.media),
+      platform: target.platform,
+      publishMode,
+      settings: target.settings ?? {},
+    });
+  }
+
+  invalidTargetException(
+    target: Pick<ChannelTargetInput, 'credentialId' | 'platform'>,
+    validation: ChannelTargetValidationResult,
+  ): BadRequestException {
+    const detail = [...validation.errors, ...validation.warnings]
+      .map((issue) => issue.message)
+      .join('; ');
+    return new BadRequestException({
+      detail:
+        detail ||
+        `Target ${target.credentialId} on ${target.platform} failed validation.`,
+      title: 'Invalid channel target',
+    });
+  }
+
+  assertSchedulableTarget(
+    group: SchedulerPostGroup,
+    target: SchedulerPostTarget,
+  ): asserts group is SchedulerPostGroup & { brandId: string } {
+    if (!SCHEDULABLE_TARGET_STATES.has(target.targetExecutionState)) {
+      throw new ConflictException(
+        `Channel target cannot be scheduled from ${target.targetExecutionState}.`,
+      );
+    }
+    if (!group.brandId) {
+      throw new BadRequestException(
+        'Canonical release target is missing a brand assignment.',
+      );
+    }
+    if (target.brandId !== group.brandId) {
+      throw new BadRequestException(
+        'Channel target brand does not match its canonical release.',
+      );
+    }
+  }
+
+  validateTargetUpdate(
+    existing: SchedulerPostTarget,
+    input: UpdateChannelTargetInput,
+  ): ChannelTargetValidationResult | undefined {
+    const validation =
+      input.settings !== undefined
+        ? validateChannelTargetSettings({
+            credentialId: existing.credentialId,
+            platform: existing.platform,
+            settings: input.settings,
+          })
+        : undefined;
+
+    if (
+      validation &&
+      !validation.valid &&
+      input.executionState !== TargetExecutionState.DRAFT
+    ) {
+      throw this.invalidTargetException(
+        {
+          credentialId: existing.credentialId,
+          platform: existing.platform as CredentialPlatform,
+        },
+        validation,
+      );
+    }
+
+    return validation;
+  }
+
+  toReleaseGroup(
+    group: SchedulerPostGroup,
+    targets: readonly SchedulerPostTarget[],
+  ): IReleaseGroup {
+    return {
+      attachments: this.asReleaseAttachments(group.attachments, group.id),
+      baseContent: group.baseContent,
+      brandId: group.brandId,
+      createdAt: group.createdAt.toISOString(),
+      id: group.id,
+      idempotencyKey: group.idempotencyKey,
+      isDeleted: group.isDeleted,
+      media: this.asMedia(group.media),
+      organizationId: group.organizationId,
+      ownerId: group.ownerId,
+      publishedAt: this.toIso(group.publishedAt),
+      recurrence: this.asRecurrence(group.recurrence),
+      scheduledAt: this.toIso(group.scheduledAt),
+      status: group.status as ReleaseStatus,
+      statusTransitions: this.asTransitions(group.statusTransitions),
+      targetSummary: this.summarizeTargets(targets),
+      targets: targets.map((target) => this.toChannelTarget(target, group.id)),
+      timezone: group.timezone,
+      title: group.title,
+      updatedAt: group.updatedAt.toISOString(),
+    };
+  }
+
+  appendTransition(
+    raw: Prisma.JsonValue,
+    from: string | null,
+    to: string,
+    actorId: string,
+  ): Prisma.InputJsonValue {
+    return this.toJson([
+      ...this.asTransitions(raw),
+      this.buildTransition(from, to, actorId),
+    ]);
+  }
+
+  buildTransition(
+    from: string | null,
+    to: string,
+    actorId: string,
+  ): IScheduleStatusTransition {
+    return {
+      actorId,
+      at: new Date().toISOString(),
+      from,
+      to,
+    };
+  }
+
+  validationIssues(validation: ChannelTargetValidationResult): string[] {
+    return [...validation.errors, ...validation.warnings].map(
+      (issue) => issue.message,
+    );
+  }
+
+  toTargetState(status: string): TargetExecutionState {
+    switch (status) {
+      case ReleaseStatus.DRAFT:
+        return TargetExecutionState.DRAFT;
+      case ReleaseStatus.PAUSED:
+        return TargetExecutionState.PAUSED;
+      case ReleaseStatus.CANCELLED:
+        return TargetExecutionState.CANCELLED;
+      case ReleaseStatus.PUBLISHING:
+        return TargetExecutionState.PUBLISHING;
+      case ReleaseStatus.PUBLISHED:
+        return TargetExecutionState.PUBLISHED;
+      case ReleaseStatus.FAILED:
+        return TargetExecutionState.FAILED;
+      default:
+        return TargetExecutionState.SCHEDULED;
+    }
+  }
+
+  toPostStatus(status: string): string {
+    if (status === ReleaseStatus.DRAFT) {
+      return PostStatus.DRAFT;
+    }
+    if (status === ReleaseStatus.FAILED) {
+      return PostStatus.FAILED;
+    }
+    if (status === ReleaseStatus.PUBLISHED) {
+      return PostStatus.PUBLIC;
+    }
+    return status;
+  }
+
+  parseCredentialPlatform(value: string): CredentialPlatform {
+    const platform = Object.values(CredentialPlatform).find(
+      (candidate) => candidate === value.toLowerCase(),
+    );
+    if (!platform) {
+      throw new BadRequestException(
+        `Channel target platform ${value} is not supported.`,
+      );
+    }
+    return platform;
+  }
+
+  matchesScheduleProvenance(
+    target: SchedulerPostTarget,
+    provenance: PostGroupCreateProvenance | undefined,
+  ): boolean {
+    return (
+      (provenance?.agentContextSource === undefined ||
+        target.agentContextSource === provenance.agentContextSource) &&
+      (provenance?.agentContextVersion === undefined ||
+        target.agentContextVersion === provenance.agentContextVersion) &&
+      (provenance?.agentRunId === undefined ||
+        target.agentRunId === provenance.agentRunId) &&
+      (provenance?.agentStrategyId === undefined ||
+        target.agentStrategyId === provenance.agentStrategyId) &&
+      (provenance?.agentThreadId === undefined ||
+        target.agentThreadId === provenance.agentThreadId)
+    );
+  }
+
+  parseFutureScheduleDate(value: string): Date {
+    if (!STRICT_SCHEDULE_DATE_SCHEMA.safeParse(value).success) {
+      throw new BadRequestException(
+        'scheduledAt must be a valid ISO 8601 date and time with an explicit UTC offset.',
+      );
+    }
+    const date = new Date(value);
+    if (date.getTime() <= Date.now()) {
+      throw new BadRequestException('scheduledAt must be in the future.');
+    }
+    return date;
+  }
+
+  toDate(value: string | undefined | null): Date | null {
+    return value ? new Date(value) : null;
+  }
+
+  toJson(value: unknown): Prisma.InputJsonValue {
+    return value as Prisma.InputJsonValue;
+  }
+
+  toValidationMedia(
+    media:
+      | readonly {
+          assetId: string;
+          kind?: string | null;
+        }[]
+      | undefined,
+  ): ChannelValidationMedia | undefined {
+    if (!media?.length) {
+      return undefined;
+    }
+    return media
+      .filter((item) => this.isValidationMediaKind(item.kind))
+      .map((item) => {
+        const kind = item.kind as ChannelValidationMedia[number]['kind'];
+        return item.assetId ? { id: item.assetId, kind } : { kind };
+      });
+  }
+
+  buildIngredientConnect(
+    media: readonly ReleaseMediaReferenceInput[] | undefined,
+  ): { connect: Array<{ id: string }> } | undefined {
+    if (!media?.length) {
+      return undefined;
+    }
+    return {
+      connect: media.map((item) => ({ id: item.assetId })),
+    };
+  }
+
+  asMedia(value: Prisma.JsonValue): IReleaseMediaReference[] {
+    if (!Array.isArray(value)) {
+      return [];
+    }
+    return value
+      .filter((item) => this.isReleaseMediaReference(item))
+      .map((item) => item as unknown as IReleaseMediaReference);
+  }
+
+  asRecord(value: Prisma.JsonValue): Record<string, unknown> {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      return {};
+    }
+    return value as Record<string, unknown>;
+  }
+
+  private badRequestFromZod(error: ZodError): BadRequestException {
+    return new BadRequestException({
+      detail: error.issues
+        .map((issue) => `${issue.path.join('.') || 'body'}: ${issue.message}`)
+        .join('; '),
+      title: 'Invalid scheduler mutation payload',
+    });
+  }
+
+  private toChannelTarget(
+    target: SchedulerPostTarget,
+    groupId: string,
+  ): IChannelTarget {
+    return {
+      attachments: this.asReleaseAttachments(
+        target.targetAttachments,
+        groupId,
+        target.id,
+      ),
+      createdAt: target.createdAt.toISOString(),
+      credentialId: target.credentialId,
+      error: this.asTargetError(target.targetError),
+      executionState: target.targetExecutionState as TargetExecutionState,
+      externalProviderId: target.externalId,
+      externalShortcode: target.externalShortcode,
+      id: target.id,
+      idempotencyKey: target.targetIdempotencyKey,
+      isDeleted: target.isDeleted,
+      lastAttemptAt: this.toIso(target.lastAttemptAt),
+      order: target.order,
+      platform: target.platform as CredentialPlatform,
+      publishedAt: this.toIso(target.publishedAt),
+      readiness: this.asReadiness(target.targetReadiness),
+      releaseId: groupId,
+      retryCount: target.retryCount,
+      scheduledAt: this.toIso(target.scheduledDate),
+      settings: this.asRecord(target.targetSettings),
+      timezone: target.timezone,
+      updatedAt: target.updatedAt.toISOString(),
+      url: target.url,
+      validationIssues: target.targetValidationIssues,
+      validationState: target.targetValidationState as TargetValidationState,
+      workflowExecutionId: target.workflowExecutionId,
+    };
+  }
+
+  private summarizeTargets(
+    targets: readonly SchedulerPostTarget[],
+  ): IReleaseTargetSummary {
+    const summary: IReleaseTargetSummary = { total: targets.length };
+    for (const target of targets) {
+      const state = target.targetExecutionState as TargetExecutionState;
+      summary[state] = (summary[state] ?? 0) + 1;
+    }
+    return summary;
+  }
+
+  private toIso(value: Date | null): string | null {
+    return value ? value.toISOString() : null;
+  }
+
+  private isValidationMediaKind(
+    kind: string | null | undefined,
+  ): kind is ChannelValidationMedia[number]['kind'] {
+    return (
+      kind === 'carousel' ||
+      kind === 'image' ||
+      kind === 'link' ||
+      kind === 'short_video' ||
+      kind === 'video'
+    );
+  }
+
+  private isReleaseMediaReference(
+    value: unknown,
+  ): value is IReleaseMediaReference {
+    return (
+      typeof value === 'object' &&
+      value !== null &&
+      typeof (value as Record<string, unknown>).assetId === 'string'
+    );
+  }
+
+  private asReleaseAttachments(
+    value: Prisma.JsonValue,
+    releaseId: string,
+    targetId?: string,
+  ): IReleaseAttachment[] {
+    if (!Array.isArray(value)) {
+      return [];
+    }
+
+    return value
+      .filter((item) => this.isReleaseAttachmentInput(item))
+      .map((attachment, index) => ({
+        body: attachment.body,
+        createdAt: '',
+        id: `${releaseId}:${targetId ?? 'release'}:${index}`,
+        isDeleted: false,
+        kind: attachment.kind,
+        order: attachment.order ?? index,
+        platform: attachment.platform ?? null,
+        releaseId,
+        targetId: targetId ?? null,
+        updatedAt: '',
+      }));
+  }
+
+  private isReleaseAttachmentInput(
+    value: unknown,
+  ): value is ReleaseAttachmentInput {
+    return (
+      typeof value === 'object' &&
+      value !== null &&
+      typeof (value as Record<string, unknown>).body === 'string' &&
+      typeof (value as Record<string, unknown>).kind === 'string'
+    );
+  }
+
+  private asTransitions(value: Prisma.JsonValue): IScheduleStatusTransition[] {
+    if (!Array.isArray(value)) {
+      return [];
+    }
+    return value
+      .filter((item) => this.isTransition(item))
+      .map((item) => item as unknown as IScheduleStatusTransition);
+  }
+
+  private isTransition(value: unknown): value is IScheduleStatusTransition {
+    return (
+      typeof value === 'object' &&
+      value !== null &&
+      typeof (value as Record<string, unknown>).to === 'string' &&
+      typeof (value as Record<string, unknown>).at === 'string'
+    );
+  }
+
+  private asRecurrence(
+    value: Prisma.JsonValue | null,
+  ): IReleaseGroup['recurrence'] {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      return null;
+    }
+    return value as unknown as IReleaseGroup['recurrence'];
+  }
+
+  private asReadiness(
+    value: Prisma.JsonValue | null,
+  ): IChannelTarget['readiness'] {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      return null;
+    }
+    return value as unknown as IChannelTarget['readiness'];
+  }
+
+  private asTargetError(
+    value: Prisma.JsonValue | null,
+  ): IChannelTarget['error'] {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      return null;
+    }
+    return value as unknown as IChannelTarget['error'];
+  }
+}

--- a/apps/server/api/src/collections/post-groups/services/post-group-persistence.service.spec.ts
+++ b/apps/server/api/src/collections/post-groups/services/post-group-persistence.service.spec.ts
@@ -1,0 +1,256 @@
+import type {
+  SchedulerPostGroup,
+  SchedulerPostTarget,
+} from '@api/collections/post-groups/services/post-group.types';
+import { PostGroupContractService } from '@api/collections/post-groups/services/post-group-contract.service';
+import { PostGroupPersistenceService } from '@api/collections/post-groups/services/post-group-persistence.service';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import {
+  CredentialPlatform,
+  ReleaseAttachmentKind,
+  ReleaseStatus,
+  TargetExecutionState,
+  TargetValidationState,
+} from '@genfeedai/enums';
+import { BadRequestException } from '@nestjs/common';
+
+describe('PostGroupPersistenceService', () => {
+  let contractService: PostGroupContractService;
+  let service: PostGroupPersistenceService;
+  let prisma: {
+    brand: { findFirst: ReturnType<typeof vi.fn> };
+    credential: { findMany: ReturnType<typeof vi.fn> };
+    post: {
+      create: ReturnType<typeof vi.fn>;
+      findFirst: ReturnType<typeof vi.fn>;
+      findMany: ReturnType<typeof vi.fn>;
+    };
+    postGroup: {
+      findFirst: ReturnType<typeof vi.fn>;
+      update: ReturnType<typeof vi.fn>;
+    };
+  };
+
+  beforeEach(() => {
+    contractService = new PostGroupContractService();
+    prisma = {
+      brand: { findFirst: vi.fn().mockResolvedValue({ id: 'brand-1' }) },
+      credential: { findMany: vi.fn().mockResolvedValue([]) },
+      post: {
+        create: vi.fn().mockResolvedValue(undefined),
+        findFirst: vi.fn(),
+        findMany: vi.fn().mockResolvedValue([]),
+      },
+      postGroup: {
+        findFirst: vi.fn(),
+        update: vi.fn(),
+      },
+    };
+    service = new PostGroupPersistenceService(
+      prisma as unknown as PrismaService,
+      contractService,
+    );
+  });
+
+  it('hydrates an idempotent release through organization-scoped rows', async () => {
+    prisma.postGroup.findFirst.mockResolvedValue(makeGroup());
+    prisma.post.findMany.mockResolvedValue([makeTarget()]);
+
+    await expect(
+      service.findByIdempotencyKey('org-1', 'request-1'),
+    ).resolves.toEqual(
+      expect.objectContaining({
+        id: 'group-1',
+        targets: [expect.objectContaining({ id: 'target-1' })],
+      }),
+    );
+    expect(prisma.postGroup.findFirst).toHaveBeenCalledWith({
+      where: {
+        idempotencyKey: 'request-1',
+        isDeleted: false,
+        organizationId: 'org-1',
+      },
+    });
+    expect(prisma.post.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          groupId: 'group-1',
+          isDeleted: false,
+          organizationId: 'org-1',
+          parentId: null,
+        }),
+      }),
+    );
+  });
+
+  it('enforces credential connection, platform, and brand scope', async () => {
+    prisma.credential.findMany.mockResolvedValue([
+      {
+        brandId: 'brand-1',
+        id: 'credential-1',
+        isConnected: true,
+        organizationId: 'org-1',
+        platform: CredentialPlatform.TWITTER,
+      },
+    ]);
+
+    const credentials = await service.resolveCredentials(
+      prisma as never,
+      'org-1',
+      [
+        {
+          credentialId: 'credential-1',
+          platform: CredentialPlatform.TWITTER,
+        },
+      ],
+    );
+    await expect(
+      service.resolveBrandId(prisma as never, 'org-1', 'brand-1', credentials),
+    ).resolves.toBe('brand-1');
+
+    prisma.credential.findMany.mockResolvedValueOnce([
+      {
+        brandId: 'brand-1',
+        id: 'credential-1',
+        isConnected: false,
+        organizationId: 'org-1',
+        platform: CredentialPlatform.TWITTER,
+      },
+    ]);
+    await expect(
+      service.resolveCredentials(prisma as never, 'org-1', [
+        {
+          credentialId: 'credential-1',
+          platform: CredentialPlatform.TWITTER,
+        },
+      ]),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('creates only platform-compatible thread and comment child posts', async () => {
+    await service.createAttachmentPosts(prisma as never, {
+      brandId: 'brand-1',
+      group: makeGroup(),
+      input: {
+        attachments: [
+          {
+            body: 'Global comment',
+            kind: ReleaseAttachmentKind.COMMENT,
+          },
+          {
+            body: 'LinkedIn thread',
+            kind: ReleaseAttachmentKind.THREAD,
+            platform: CredentialPlatform.LINKEDIN,
+          },
+        ],
+        baseContent: 'Launch note',
+        targets: [
+          {
+            credentialId: 'credential-1',
+            platform: CredentialPlatform.TWITTER,
+          },
+        ],
+        timezone: 'UTC',
+        title: 'Launch',
+      },
+      parent: makeTarget(),
+      target: {
+        attachments: [
+          {
+            body: 'Target thread',
+            kind: ReleaseAttachmentKind.THREAD,
+          },
+        ],
+        credentialId: 'credential-1',
+        platform: CredentialPlatform.TWITTER,
+      },
+      userId: 'user-1',
+    });
+
+    expect(prisma.post.create).toHaveBeenCalledTimes(2);
+    expect(prisma.post.create).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        data: expect.objectContaining({
+          description: 'Global comment',
+          parentId: 'target-1',
+        }),
+      }),
+    );
+    expect(prisma.post.create).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        data: expect.objectContaining({
+          description: 'Target thread',
+          parentId: 'target-1',
+        }),
+      }),
+    );
+  });
+});
+
+function makeGroup(
+  overrides: Partial<SchedulerPostGroup> = {},
+): SchedulerPostGroup {
+  return {
+    attachments: [],
+    baseContent: 'Launch note',
+    brandId: 'brand-1',
+    createdAt: new Date('2026-07-19T10:00:00.000Z'),
+    id: 'group-1',
+    idempotencyKey: 'request-1',
+    isDeleted: false,
+    media: [],
+    organizationId: 'org-1',
+    ownerId: 'user-1',
+    publishedAt: null,
+    recurrence: null,
+    scheduledAt: new Date('2026-07-20T10:00:00.000Z'),
+    status: ReleaseStatus.SCHEDULED,
+    statusTransitions: [],
+    timezone: 'UTC',
+    title: 'Launch',
+    updatedAt: new Date('2026-07-19T10:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+function makeTarget(
+  overrides: Partial<SchedulerPostTarget> = {},
+): SchedulerPostTarget {
+  return {
+    agentContextSource: null,
+    agentContextVersion: null,
+    agentRunId: null,
+    agentStrategyId: null,
+    agentThreadId: null,
+    brandId: 'brand-1',
+    createdAt: new Date('2026-07-19T10:00:00.000Z'),
+    credentialId: 'credential-1',
+    externalId: null,
+    externalShortcode: null,
+    groupId: 'group-1',
+    id: 'target-1',
+    isDeleted: false,
+    lastAttemptAt: null,
+    order: 0,
+    platform: CredentialPlatform.TWITTER,
+    publishedAt: null,
+    publishApprovalId: null,
+    retryCount: 0,
+    scheduledDate: new Date('2026-07-20T10:00:00.000Z'),
+    targetAttachments: [],
+    targetError: null,
+    targetExecutionState: TargetExecutionState.SCHEDULED,
+    targetIdempotencyKey: null,
+    targetReadiness: null,
+    targetSettings: {},
+    targetValidationIssues: [],
+    targetValidationState: TargetValidationState.VALID,
+    timezone: 'UTC',
+    updatedAt: new Date('2026-07-19T10:00:00.000Z'),
+    url: null,
+    workflowExecutionId: null,
+    ...overrides,
+  };
+}

--- a/apps/server/api/src/collections/post-groups/services/post-group-persistence.service.ts
+++ b/apps/server/api/src/collections/post-groups/services/post-group-persistence.service.ts
@@ -1,0 +1,407 @@
+import type {
+  CreateAttachmentPostsParams,
+  CreatePostGroupParams,
+  SchedulerCredential,
+  SchedulerPostGroup,
+  SchedulerPostTarget,
+  SchedulerTx,
+} from '@api/collections/post-groups/services/post-group.types';
+import { PostGroupContractService } from '@api/collections/post-groups/services/post-group-contract.service';
+import { NotFoundException } from '@api/helpers/exceptions/http/not-found.exception';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import {
+  type ChannelTargetInput,
+  deriveReleaseStatusFromTargets,
+} from '@api-types/contracts/scheduler.contract';
+import {
+  ReleaseAttachmentKind,
+  ReleaseStatus,
+  TargetExecutionState,
+} from '@genfeedai/enums';
+import type { IReleaseGroup } from '@genfeedai/interfaces';
+import { Prisma } from '@genfeedai/prisma';
+import { BadRequestException, Injectable } from '@nestjs/common';
+
+@Injectable()
+export class PostGroupPersistenceService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly contractService: PostGroupContractService,
+  ) {}
+
+  async createPostGroup(
+    tx: SchedulerTx,
+    params: CreatePostGroupParams,
+  ): Promise<IReleaseGroup> {
+    const credentials = await this.resolveCredentials(
+      tx,
+      params.organizationId,
+      params.input.targets,
+    );
+    const brandId = await this.resolveBrandId(
+      tx,
+      params.organizationId,
+      params.input.brandId,
+      credentials,
+    );
+    const validations = params.input.targets.map((target) => {
+      const validation = this.contractService.validateTarget(
+        params.input,
+        target,
+        params.status === ReleaseStatus.DRAFT ? 'draft' : 'scheduled',
+      );
+      if (!validation.valid && params.status !== ReleaseStatus.DRAFT) {
+        throw this.contractService.invalidTargetException(target, validation);
+      }
+      return validation;
+    });
+    const transition = this.contractService.buildTransition(
+      null,
+      params.status,
+      params.userId,
+    );
+    const group = (await tx.postGroup.create({
+      data: {
+        attachments: this.contractService.toJson(
+          params.input.attachments ?? [],
+        ),
+        baseContent: params.input.baseContent,
+        brandId,
+        idempotencyKey: params.input.idempotencyKey ?? null,
+        media: this.contractService.toJson(params.input.media ?? []),
+        organizationId: params.organizationId,
+        ownerId: params.userId,
+        recurrence: params.input.recurrence
+          ? this.contractService.toJson(params.input.recurrence)
+          : Prisma.JsonNull,
+        scheduledAt: params.scheduledAt,
+        status: params.status,
+        statusTransitions: this.contractService.toJson([transition]),
+        timezone: params.input.timezone,
+        title: params.input.title,
+      },
+    })) as SchedulerPostGroup;
+
+    const targets: SchedulerPostTarget[] = [];
+    for (const [index, target] of params.input.targets.entries()) {
+      const credential = credentials.get(target.credentialId);
+      if (!credential) {
+        throw new BadRequestException(
+          `Credential ${target.credentialId} is not available for this organization.`,
+        );
+      }
+
+      const validation = validations[index];
+      if (!validation) {
+        throw new BadRequestException(
+          'Missing channel target validation result.',
+        );
+      }
+
+      const created = (await tx.post.create({
+        data: {
+          ...(params.provenance?.agentContextSource && {
+            agentContextSource: params.provenance.agentContextSource,
+          }),
+          ...(params.provenance?.agentContextVersion !== undefined && {
+            agentContextVersion: params.provenance.agentContextVersion,
+          }),
+          ...(params.provenance?.agentRunId && {
+            agentRunId: params.provenance.agentRunId,
+          }),
+          ...(params.provenance?.agentStrategyId && {
+            agentStrategyId: params.provenance.agentStrategyId,
+          }),
+          ...(params.provenance?.agentThreadId && {
+            agentThreadId: params.provenance.agentThreadId,
+          }),
+          brandId,
+          credentialId: target.credentialId,
+          description: params.input.baseContent,
+          groupId: group.id,
+          ingredients: this.contractService.buildIngredientConnect(
+            params.input.media,
+          ),
+          label: params.input.title,
+          order: target.order ?? index,
+          organizationId: params.organizationId,
+          platform: target.platform,
+          ...(params.provenance?.source && {
+            source: params.provenance.source,
+          }),
+          ...(params.provenance?.sourceActionId && {
+            sourceActionId: params.provenance.sourceActionId,
+          }),
+          scheduledDate:
+            this.contractService.toDate(target.scheduledDate) ??
+            group.scheduledAt,
+          status: this.contractService.toPostStatus(params.status),
+          targetAttachments: this.contractService.toJson(
+            target.attachments ?? [],
+          ),
+          targetExecutionState: this.contractService.toTargetState(
+            params.status,
+          ),
+          targetReadiness: validation.readiness
+            ? this.contractService.toJson(validation.readiness)
+            : Prisma.JsonNull,
+          targetSettings: this.contractService.toJson(target.settings ?? {}),
+          targetValidationIssues:
+            this.contractService.validationIssues(validation),
+          targetValidationState: validation.validationState,
+          timezone: target.timezone ?? params.input.timezone,
+          userId: params.userId,
+        },
+      })) as SchedulerPostTarget;
+
+      await this.createAttachmentPosts(tx, {
+        brandId,
+        group,
+        input: params.input,
+        parent: created,
+        target,
+        userId: params.userId,
+      });
+
+      targets.push(created);
+    }
+
+    return this.contractService.toReleaseGroup(group, targets);
+  }
+
+  async findByIdempotencyKey(
+    organizationId: string,
+    idempotencyKey: string,
+  ): Promise<IReleaseGroup | undefined> {
+    const group = (await this.prisma.postGroup.findFirst({
+      where: { idempotencyKey, isDeleted: false, organizationId },
+    })) as SchedulerPostGroup | null;
+
+    if (!group) {
+      return undefined;
+    }
+
+    const targets = await this.getTargets(
+      this.prisma,
+      organizationId,
+      group.id,
+    );
+    return this.contractService.toReleaseGroup(group, targets);
+  }
+
+  async resolveCredentials(
+    tx: Pick<SchedulerTx, 'credential'>,
+    organizationId: string,
+    targets: readonly ChannelTargetInput[],
+  ): Promise<Map<string, SchedulerCredential>> {
+    const ids = [...new Set(targets.map((target) => target.credentialId))];
+    const credentials = (await tx.credential.findMany({
+      select: {
+        brandId: true,
+        id: true,
+        isConnected: true,
+        organizationId: true,
+        platform: true,
+      },
+      where: {
+        id: { in: ids },
+        isDeleted: false,
+        organizationId,
+      },
+    })) as SchedulerCredential[];
+    const byId = new Map(
+      credentials.map((credential) => [credential.id, credential]),
+    );
+
+    for (const target of targets) {
+      const credential = byId.get(target.credentialId);
+      if (!credential) {
+        throw new BadRequestException(
+          `Credential ${target.credentialId} is not connected to this organization.`,
+        );
+      }
+      if (
+        String(credential.platform).toLowerCase() !==
+        String(target.platform).toLowerCase()
+      ) {
+        throw new BadRequestException(
+          `Credential ${target.credentialId} is for ${credential.platform}, not ${target.platform}.`,
+        );
+      }
+      if (!credential.isConnected) {
+        throw new BadRequestException(
+          `Credential ${target.credentialId} is not connected.`,
+        );
+      }
+    }
+
+    return byId;
+  }
+
+  async resolveBrandId(
+    tx: Pick<SchedulerTx, 'brand'>,
+    organizationId: string,
+    requestedBrandId: string | undefined,
+    credentials: ReadonlyMap<string, SchedulerCredential>,
+  ): Promise<string> {
+    const brandId =
+      requestedBrandId ??
+      [...credentials.values()].find((credential) => credential.brandId)
+        ?.brandId ??
+      undefined;
+
+    if (!brandId) {
+      throw new BadRequestException(
+        'brandId is required when scheduler credentials are not brand-scoped.',
+      );
+    }
+
+    const brand = await tx.brand.findFirst({
+      select: { id: true },
+      where: { id: brandId, isDeleted: false, organizationId },
+    });
+
+    if (!brand) {
+      throw new BadRequestException(
+        `Brand ${brandId} is not available for this organization.`,
+      );
+    }
+
+    for (const credential of credentials.values()) {
+      if (credential.brandId && credential.brandId !== brandId) {
+        throw new BadRequestException(
+          `Credential ${credential.id} belongs to a different brand.`,
+        );
+      }
+    }
+
+    return brandId;
+  }
+
+  async createAttachmentPosts(
+    tx: Pick<SchedulerTx, 'post'>,
+    params: CreateAttachmentPostsParams,
+  ): Promise<void> {
+    const attachments = [
+      ...(params.input.attachments ?? []).filter(
+        (attachment) =>
+          !attachment.platform ||
+          attachment.platform === params.target.platform,
+      ),
+      ...(params.target.attachments ?? []),
+    ].filter(
+      (attachment) =>
+        attachment.kind === ReleaseAttachmentKind.COMMENT ||
+        attachment.kind === ReleaseAttachmentKind.THREAD,
+    );
+
+    for (const [index, attachment] of attachments.entries()) {
+      await tx.post.create({
+        data: {
+          brandId: params.brandId,
+          credentialId: params.target.credentialId,
+          description: attachment.body,
+          groupId: params.group.id,
+          label: `${params.group.title} ${attachment.kind}`,
+          order: attachment.order ?? index,
+          organizationId: params.group.organizationId,
+          parentId: params.parent.id,
+          platform: params.target.platform,
+          scheduledDate: params.parent.scheduledDate,
+          status: params.parent.targetExecutionState,
+          targetExecutionState: params.parent.targetExecutionState,
+          timezone: params.parent.timezone,
+          userId: params.userId,
+        },
+      });
+    }
+  }
+
+  async getGroupOrThrow(
+    client: Pick<SchedulerTx, 'postGroup'>,
+    organizationId: string,
+    groupId: string,
+  ): Promise<SchedulerPostGroup> {
+    const group = (await client.postGroup.findFirst({
+      where: { id: groupId, isDeleted: false, organizationId },
+    })) as SchedulerPostGroup | null;
+
+    if (!group) {
+      throw new NotFoundException('PostGroup', groupId);
+    }
+
+    return group;
+  }
+
+  async getTargetOrThrow(
+    client: Pick<SchedulerTx, 'post'>,
+    organizationId: string,
+    groupId: string,
+    targetId: string,
+  ): Promise<SchedulerPostTarget> {
+    const target = (await client.post.findFirst({
+      where: {
+        groupId,
+        id: targetId,
+        isDeleted: false,
+        organizationId,
+      },
+    })) as SchedulerPostTarget | null;
+
+    if (!target) {
+      throw new NotFoundException('ChannelTarget', targetId);
+    }
+
+    return target;
+  }
+
+  async getTargets(
+    client: Pick<SchedulerTx, 'post'>,
+    organizationId: string,
+    groupId: string,
+  ): Promise<SchedulerPostTarget[]> {
+    return (await client.post.findMany({
+      orderBy: [{ order: 'asc' }, { createdAt: 'asc' }],
+      where: {
+        groupId,
+        isDeleted: false,
+        organizationId,
+        parentId: null,
+      },
+    })) as SchedulerPostTarget[];
+  }
+
+  async recalculateAndHydrate(
+    tx: Pick<SchedulerTx, 'post' | 'postGroup'>,
+    organizationId: string,
+    groupId: string,
+    userId: string,
+  ): Promise<IReleaseGroup> {
+    const group = await this.getGroupOrThrow(tx, organizationId, groupId);
+    const targets = await this.getTargets(tx, organizationId, group.id);
+    const status = deriveReleaseStatusFromTargets(
+      targets.map(
+        (target) => target.targetExecutionState as TargetExecutionState,
+      ),
+    );
+    const transitions =
+      status !== group.status
+        ? this.contractService.appendTransition(
+            group.statusTransitions,
+            group.status,
+            status,
+            userId,
+          )
+        : undefined;
+
+    const updated = (await tx.postGroup.update({
+      data: {
+        status,
+        ...(transitions !== undefined && { statusTransitions: transitions }),
+      },
+      where: { id: group.id },
+    })) as SchedulerPostGroup;
+
+    return this.contractService.toReleaseGroup(updated, targets);
+  }
+}

--- a/apps/server/api/src/collections/post-groups/services/post-group.types.ts
+++ b/apps/server/api/src/collections/post-groups/services/post-group.types.ts
@@ -1,0 +1,110 @@
+import type {
+  ChannelTargetInput,
+  CreateReleaseGroupInput,
+  UpdateChannelTargetInput,
+} from '@api-types/contracts/scheduler.contract';
+import type { ReleaseStatus } from '@genfeedai/enums';
+import type {
+  IPublishApproval,
+  PostGroupCreateProvenance,
+} from '@genfeedai/interfaces';
+import type { Prisma } from '@genfeedai/prisma';
+
+export type SchedulerTx = Prisma.TransactionClient;
+
+export type SchedulerCredential = {
+  brandId: string | null;
+  id: string;
+  isConnected: boolean;
+  organizationId: string | null;
+  platform: string;
+};
+
+export type SchedulerPostGroup = {
+  attachments: Prisma.JsonValue;
+  baseContent: string;
+  brandId: string | null;
+  createdAt: Date;
+  id: string;
+  idempotencyKey: string | null;
+  isDeleted: boolean;
+  media: Prisma.JsonValue;
+  organizationId: string;
+  ownerId: string;
+  publishedAt: Date | null;
+  recurrence: Prisma.JsonValue | null;
+  scheduledAt: Date | null;
+  status: string;
+  statusTransitions: Prisma.JsonValue;
+  timezone: string;
+  title: string;
+  updatedAt: Date;
+};
+
+export type SchedulerPostTarget = {
+  agentContextSource: string | null;
+  agentContextVersion: number | null;
+  agentRunId: string | null;
+  agentStrategyId: string | null;
+  agentThreadId: string | null;
+  brandId: string | null;
+  createdAt: Date;
+  credentialId: string;
+  externalId: string | null;
+  externalShortcode: string | null;
+  groupId: string | null;
+  id: string;
+  isDeleted: boolean;
+  lastAttemptAt: Date | null;
+  order: number;
+  platform: string;
+  publishedAt: Date | null;
+  publishApprovalId: string | null;
+  retryCount: number;
+  scheduledDate: Date | null;
+  targetAttachments: Prisma.JsonValue;
+  targetError: Prisma.JsonValue | null;
+  targetExecutionState: string;
+  targetIdempotencyKey: string | null;
+  targetReadiness: Prisma.JsonValue | null;
+  targetSettings: Prisma.JsonValue;
+  targetValidationIssues: string[];
+  targetValidationState: string;
+  timezone: string;
+  updatedAt: Date;
+  url: string | null;
+  workflowExecutionId: string | null;
+};
+
+export type CreateAttachmentPostsParams = {
+  brandId: string;
+  group: SchedulerPostGroup;
+  input: CreateReleaseGroupInput;
+  parent: SchedulerPostTarget;
+  target: ChannelTargetInput;
+  userId: string;
+};
+
+export type CreatePostGroupParams = {
+  input: CreateReleaseGroupInput;
+  organizationId: string;
+  provenance?: PostGroupCreateProvenance;
+  scheduledAt: Date | null;
+  status: ReleaseStatus;
+  userId: string;
+};
+
+export type ResolveManualRetryParams = {
+  existing: SchedulerPostTarget;
+  groupId: string;
+  input: UpdateChannelTargetInput;
+  organizationId: string;
+  targetId: string;
+  tx: SchedulerTx;
+  userId: string;
+};
+
+export type ManualRetryResolution = {
+  isManualRetry: boolean;
+  manualRetryApproval?: IPublishApproval;
+};

--- a/apps/server/api/src/collections/post-groups/services/post-groups.service.spec.ts
+++ b/apps/server/api/src/collections/post-groups/services/post-groups.service.spec.ts
@@ -1,3 +1,5 @@
+import { PostGroupContractService } from '@api/collections/post-groups/services/post-group-contract.service';
+import { PostGroupPersistenceService } from '@api/collections/post-groups/services/post-group-persistence.service';
 import { PostGroupsService } from '@api/collections/post-groups/services/post-groups.service';
 import { PublishApprovalsService } from '@api/collections/publish-approvals/services/publish-approvals.service';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
@@ -173,6 +175,8 @@ describe('PostGroupsService', () => {
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
+        PostGroupContractService,
+        PostGroupPersistenceService,
         PostGroupsService,
         {
           provide: PrismaService,

--- a/apps/server/api/src/collections/post-groups/services/post-groups.service.ts
+++ b/apps/server/api/src/collections/post-groups/services/post-groups.service.ts
@@ -563,12 +563,11 @@ export class PostGroupsService {
       (approval.status === PublishApprovalStatus.APPROVED ||
         approval.status === PublishApprovalStatus.QUEUED ||
         approval.status === PublishApprovalStatus.FAILED) &&
-      approval.provenance.manualRetryCommand;
+      Boolean(approval.provenance.manualRetryCommand);
 
-    return {
-      isManualRetry,
-      ...(isDurableRetry && { manualRetryApproval: approval }),
-    };
+    return isDurableRetry
+      ? { isManualRetry, manualRetryApproval: approval }
+      : { isManualRetry };
   }
 
   cancel(

--- a/apps/server/api/src/collections/post-groups/services/post-groups.service.ts
+++ b/apps/server/api/src/collections/post-groups/services/post-groups.service.ts
@@ -1,139 +1,35 @@
+import type {
+  ManualRetryResolution,
+  ResolveManualRetryParams,
+  SchedulerPostGroup,
+} from '@api/collections/post-groups/services/post-group.types';
+import { PostGroupContractService } from '@api/collections/post-groups/services/post-group-contract.service';
+import { PostGroupPersistenceService } from '@api/collections/post-groups/services/post-group-persistence.service';
 import { PublishApprovalsService } from '@api/collections/publish-approvals/services/publish-approvals.service';
-import { NotFoundException } from '@api/helpers/exceptions/http/not-found.exception';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
-import {
-  type ChannelTargetValidationResult,
-  validateChannelTargetSettings,
-} from '@api-types/contracts/channel-capabilities.contract';
-import {
-  type ChannelTargetInput,
-  type CreateReleaseGroupInput,
-  createReleaseGroupSchema,
-  deriveReleaseStatusFromTargets,
-  type ReleaseAttachmentInput,
-  type ReleaseMediaReferenceInput,
-  type UpdateChannelTargetInput,
-  type UpdateReleaseGroupInput,
-  updateChannelTargetSchema,
-  updateReleaseGroupSchema,
-} from '@api-types/contracts/scheduler.contract';
+import { validateChannelTargetSettings } from '@api-types/contracts/channel-capabilities.contract';
+import type { ChannelTargetInput } from '@api-types/contracts/scheduler.contract';
 import {
   CredentialPlatform,
   PostStatus,
   PublishApprovalStatus,
-  ReleaseAttachmentKind,
   ReleaseStatus,
   TargetExecutionState,
-  TargetValidationState,
 } from '@genfeedai/enums';
 import type {
-  IChannelTarget,
-  IPublishApproval,
-  IReleaseAttachment,
   IReleaseGroup,
-  IReleaseMediaReference,
-  IReleaseTargetSummary,
-  IScheduleStatusTransition,
   PostGroupCreateProvenance,
 } from '@genfeedai/interfaces';
 import { Prisma } from '@genfeedai/prisma';
 import { PostPublishQueueService } from '@genfeedai/server';
 import { LoggerService } from '@libs/logger/logger.service';
-import {
-  BadRequestException,
-  ConflictException,
-  Injectable,
-} from '@nestjs/common';
-import { type ZodError, z } from 'zod';
-
-type SchedulerTx = Prisma.TransactionClient;
-
-type SchedulerCredential = {
-  brandId: string | null;
-  id: string;
-  isConnected: boolean;
-  organizationId: string | null;
-  platform: string;
-};
-
-type SchedulerPostGroup = {
-  attachments: Prisma.JsonValue;
-  baseContent: string;
-  brandId: string | null;
-  createdAt: Date;
-  id: string;
-  idempotencyKey: string | null;
-  isDeleted: boolean;
-  media: Prisma.JsonValue;
-  organizationId: string;
-  ownerId: string;
-  publishedAt: Date | null;
-  recurrence: Prisma.JsonValue | null;
-  scheduledAt: Date | null;
-  status: string;
-  statusTransitions: Prisma.JsonValue;
-  timezone: string;
-  title: string;
-  updatedAt: Date;
-};
-
-type SchedulerPostTarget = {
-  agentContextSource: string | null;
-  agentContextVersion: number | null;
-  agentRunId: string | null;
-  agentStrategyId: string | null;
-  agentThreadId: string | null;
-  brandId: string | null;
-  createdAt: Date;
-  credentialId: string;
-  externalId: string | null;
-  externalShortcode: string | null;
-  groupId: string | null;
-  id: string;
-  isDeleted: boolean;
-  lastAttemptAt: Date | null;
-  order: number;
-  platform: string;
-  publishedAt: Date | null;
-  publishApprovalId: string | null;
-  retryCount: number;
-  scheduledDate: Date | null;
-  targetAttachments: Prisma.JsonValue;
-  targetError: Prisma.JsonValue | null;
-  targetExecutionState: string;
-  targetIdempotencyKey: string | null;
-  targetReadiness: Prisma.JsonValue | null;
-  targetSettings: Prisma.JsonValue;
-  targetValidationIssues: string[];
-  targetValidationState: string;
-  timezone: string;
-  updatedAt: Date;
-  url: string | null;
-  workflowExecutionId: string | null;
-};
-
-type ChannelValidationMedia = NonNullable<
-  Parameters<typeof validateChannelTargetSettings>[0]['media']
->;
-
-const CREATE_ALLOWED_STATUSES = new Set<string>([
-  ReleaseStatus.DRAFT,
-  ReleaseStatus.SCHEDULED,
-]);
-
-const STRICT_SCHEDULE_DATE_SCHEMA = z.string().datetime({ offset: true });
+import { ConflictException, Injectable } from '@nestjs/common';
 
 const GROUP_ACTION_STATES = new Set<string>([
   TargetExecutionState.DRAFT,
   TargetExecutionState.SCHEDULED,
   TargetExecutionState.PAUSED,
   TargetExecutionState.FAILED,
-]);
-
-const SCHEDULABLE_TARGET_STATES = new Set<string>([
-  TargetExecutionState.DRAFT,
-  TargetExecutionState.PAUSED,
-  TargetExecutionState.SCHEDULED,
 ]);
 
 @Injectable()
@@ -143,6 +39,8 @@ export class PostGroupsService {
     private readonly logger: LoggerService,
     private readonly postPublishQueueService: PostPublishQueueService,
     private readonly publishApprovalsService: PublishApprovalsService,
+    private readonly persistenceService: PostGroupPersistenceService,
+    private readonly contractService: PostGroupContractService,
   ) {}
 
   async create(
@@ -152,10 +50,13 @@ export class PostGroupsService {
     headerIdempotencyKey?: string,
     provenance?: PostGroupCreateProvenance,
   ): Promise<IReleaseGroup> {
-    const input = this.parseCreateInput(body, headerIdempotencyKey);
+    const input = this.contractService.parseCreateInput(
+      body,
+      headerIdempotencyKey,
+    );
 
     if (input.idempotencyKey) {
-      const existing = await this.findByIdempotencyKey(
+      const existing = await this.persistenceService.findByIdempotencyKey(
         organizationId,
         input.idempotencyKey,
       );
@@ -167,134 +68,23 @@ export class PostGroupsService {
       }
     }
 
-    const status = this.resolveCreateStatus(input);
-    const scheduledAt = this.toDate(input.scheduledDate);
-
-    const release = await this.prisma.$transaction(async (tx) => {
-      const credentials = await this.resolveCredentials(
-        tx,
+    const status = this.contractService.resolveCreateStatus(input);
+    const scheduledAt = this.contractService.toDate(input.scheduledDate);
+    const release = await this.prisma.$transaction((tx) =>
+      this.persistenceService.createPostGroup(tx, {
+        input,
         organizationId,
-        input.targets,
-      );
-      const brandId = await this.resolveBrandId(
-        tx,
-        organizationId,
-        input.brandId,
-        credentials,
-      );
-      const validations = input.targets.map((target) => {
-        const validation = this.validateTarget(
-          input,
-          target,
-          status === ReleaseStatus.DRAFT ? 'draft' : 'scheduled',
-        );
-        if (!validation.valid && status !== ReleaseStatus.DRAFT) {
-          throw this.invalidTargetException(target, validation);
-        }
-        return validation;
-      });
-      const transition = this.buildTransition(null, status, userId);
-      const group = (await tx.postGroup.create({
-        data: {
-          attachments: this.toJson(input.attachments ?? []),
-          baseContent: input.baseContent,
-          brandId,
-          idempotencyKey: input.idempotencyKey ?? null,
-          media: this.toJson(input.media ?? []),
-          organizationId,
-          ownerId: userId,
-          recurrence: input.recurrence
-            ? this.toJson(input.recurrence)
-            : Prisma.JsonNull,
-          scheduledAt,
-          status,
-          statusTransitions: this.toJson([transition]),
-          timezone: input.timezone,
-          title: input.title,
-        },
-      })) as SchedulerPostGroup;
+        provenance,
+        scheduledAt,
+        status,
+        userId,
+      }),
+    );
 
-      const targets: SchedulerPostTarget[] = [];
-      for (const [index, target] of input.targets.entries()) {
-        const credential = credentials.get(target.credentialId);
-        if (!credential) {
-          throw new BadRequestException(
-            `Credential ${target.credentialId} is not available for this organization.`,
-          );
-        }
-
-        const validation = validations[index];
-        if (!validation) {
-          throw new BadRequestException(
-            'Missing channel target validation result.',
-          );
-        }
-
-        const created = (await tx.post.create({
-          data: {
-            ...(provenance?.agentContextSource && {
-              agentContextSource: provenance.agentContextSource,
-            }),
-            ...(provenance?.agentContextVersion !== undefined && {
-              agentContextVersion: provenance.agentContextVersion,
-            }),
-            ...(provenance?.agentRunId && {
-              agentRunId: provenance.agentRunId,
-            }),
-            ...(provenance?.agentStrategyId && {
-              agentStrategyId: provenance.agentStrategyId,
-            }),
-            ...(provenance?.agentThreadId && {
-              agentThreadId: provenance.agentThreadId,
-            }),
-            brandId,
-            credentialId: target.credentialId,
-            description: input.baseContent,
-            groupId: group.id,
-            ingredients: this.buildIngredientConnect(input.media),
-            label: input.title,
-            order: target.order ?? index,
-            organizationId,
-            platform: target.platform,
-            ...(provenance?.source && { source: provenance.source }),
-            ...(provenance?.sourceActionId && {
-              sourceActionId: provenance.sourceActionId,
-            }),
-            scheduledDate:
-              this.toDate(target.scheduledDate) ?? group.scheduledAt,
-            status: this.toPostStatus(status),
-            targetAttachments: this.toJson(target.attachments ?? []),
-            targetExecutionState: this.toTargetState(status),
-            targetReadiness: validation.readiness
-              ? this.toJson(validation.readiness)
-              : Prisma.JsonNull,
-            targetSettings: this.toJson(target.settings ?? {}),
-            targetValidationIssues: this.validationIssues(validation),
-            targetValidationState: validation.validationState,
-            timezone: target.timezone ?? input.timezone,
-            userId,
-          },
-        })) as SchedulerPostTarget;
-
-        await this.createAttachmentPosts(tx, {
-          brandId,
-          group,
-          input,
-          parent: created,
-          target,
-          userId,
-        });
-
-        targets.push(created);
-      }
-
-      this.logger.debug('Created scheduler post group', {
-        groupId: group.id,
-        organizationId,
-        targetCount: targets.length,
-      });
-
-      return this.toReleaseGroup(group, targets);
+    this.logger.debug('Created scheduler post group', {
+      groupId: release.id,
+      organizationId,
+      targetCount: release.targets?.length ?? 0,
     });
 
     if (release.status === ReleaseStatus.SCHEDULED) {
@@ -307,17 +97,17 @@ export class PostGroupsService {
     organizationId: string,
     groupId: string,
   ): Promise<IReleaseGroup> {
-    const group = await this.getGroupOrThrow(
+    const group = await this.persistenceService.getGroupOrThrow(
       this.prisma,
       organizationId,
       groupId,
     );
-    const targets = await this.getTargets(
+    const targets = await this.persistenceService.getTargets(
       this.prisma,
       organizationId,
       group.id,
     );
-    return this.toReleaseGroup(group, targets);
+    return this.contractService.toReleaseGroup(group, targets);
   }
 
   async scheduleTarget(
@@ -328,62 +118,67 @@ export class PostGroupsService {
     scheduledAt: string,
     provenance?: PostGroupCreateProvenance,
   ): Promise<IReleaseGroup> {
-    const scheduledDate = this.parseFutureScheduleDate(scheduledAt);
+    const scheduledDate =
+      this.contractService.parseFutureScheduleDate(scheduledAt);
 
     return this.prisma.$transaction(async (tx) => {
-      const group = await this.getGroupOrThrow(tx, organizationId, groupId);
-      const target = await this.getTargetOrThrow(
+      const group = await this.persistenceService.getGroupOrThrow(
+        tx,
+        organizationId,
+        groupId,
+      );
+      const target = await this.persistenceService.getTargetOrThrow(
         tx,
         organizationId,
         group.id,
         targetId,
       );
 
-      if (!SCHEDULABLE_TARGET_STATES.has(target.targetExecutionState)) {
-        throw new ConflictException(
-          `Channel target cannot be scheduled from ${target.targetExecutionState}.`,
-        );
-      }
-      if (!group.brandId) {
-        throw new BadRequestException(
-          'Canonical release target is missing a brand assignment.',
-        );
-      }
-      if (target.brandId !== group.brandId) {
-        throw new BadRequestException(
-          'Channel target brand does not match its canonical release.',
-        );
-      }
+      this.contractService.assertSchedulableTarget(group, target);
 
-      const platform = this.parseCredentialPlatform(target.platform);
+      const platform = this.contractService.parseCredentialPlatform(
+        target.platform,
+      );
       const targetInput: ChannelTargetInput = {
         credentialId: target.credentialId,
         platform,
         scheduledDate: scheduledDate.toISOString(),
-        settings: this.asRecord(target.targetSettings),
+        settings: this.contractService.asRecord(target.targetSettings),
         timezone: target.timezone,
       };
-      const credentials = await this.resolveCredentials(tx, organizationId, [
-        targetInput,
-      ]);
-      await this.resolveBrandId(tx, organizationId, group.brandId, credentials);
+      const credentials = await this.persistenceService.resolveCredentials(
+        tx,
+        organizationId,
+        [targetInput],
+      );
+      await this.persistenceService.resolveBrandId(
+        tx,
+        organizationId,
+        group.brandId,
+        credentials,
+      );
 
       const validation = validateChannelTargetSettings({
         caption: group.baseContent,
         credentialId: targetInput.credentialId,
-        media: this.toValidationMedia(this.asMedia(group.media)),
+        media: this.contractService.toValidationMedia(
+          this.contractService.asMedia(group.media),
+        ),
         platform: targetInput.platform,
         publishMode: 'scheduled',
         settings: targetInput.settings ?? {},
       });
       if (!validation.valid) {
-        throw this.invalidTargetException(targetInput, validation);
+        throw this.contractService.invalidTargetException(
+          targetInput,
+          validation,
+        );
       }
 
       const isExactReplay =
         target.targetExecutionState === TargetExecutionState.SCHEDULED &&
         target.scheduledDate?.getTime() === scheduledDate.getTime() &&
-        this.matchesScheduleProvenance(target, provenance);
+        this.contractService.matchesScheduleProvenance(target, provenance);
       if (!isExactReplay) {
         const updated = await tx.post.updateMany({
           data: {
@@ -406,9 +201,10 @@ export class PostGroupsService {
             status: PostStatus.SCHEDULED,
             targetExecutionState: TargetExecutionState.SCHEDULED,
             targetReadiness: validation.readiness
-              ? this.toJson(validation.readiness)
+              ? this.contractService.toJson(validation.readiness)
               : Prisma.JsonNull,
-            targetValidationIssues: this.validationIssues(validation),
+            targetValidationIssues:
+              this.contractService.validationIssues(validation),
             targetValidationState: validation.validationState,
           },
           where: {
@@ -442,7 +238,12 @@ export class PostGroupsService {
         transaction: tx,
       });
 
-      return this.recalculateAndHydrate(tx, organizationId, group.id, userId);
+      return this.persistenceService.recalculateAndHydrate(
+        tx,
+        organizationId,
+        group.id,
+        userId,
+      );
     });
   }
 
@@ -452,14 +253,18 @@ export class PostGroupsService {
     groupId: string,
     body: unknown,
   ): Promise<IReleaseGroup> {
-    const input = this.parseUpdateInput(body);
+    const input = this.contractService.parseUpdateInput(body);
 
     const release = await this.prisma.$transaction(async (tx) => {
-      const existing = await this.getGroupOrThrow(tx, organizationId, groupId);
+      const existing = await this.persistenceService.getGroupOrThrow(
+        tx,
+        organizationId,
+        groupId,
+      );
       const nextStatus = input.status ?? existing.status;
       const transition =
         nextStatus !== existing.status
-          ? this.appendTransition(
+          ? this.contractService.appendTransition(
               existing.statusTransitions,
               existing.status,
               nextStatus,
@@ -470,20 +275,22 @@ export class PostGroupsService {
       const updated = (await tx.postGroup.update({
         data: {
           ...(input.attachments !== undefined && {
-            attachments: this.toJson(input.attachments),
+            attachments: this.contractService.toJson(input.attachments),
           }),
           ...(input.baseContent !== undefined && {
             baseContent: input.baseContent,
           }),
           ...(input.brandId !== undefined && { brandId: input.brandId }),
-          ...(input.media !== undefined && { media: this.toJson(input.media) }),
+          ...(input.media !== undefined && {
+            media: this.contractService.toJson(input.media),
+          }),
           ...(input.recurrence !== undefined && {
             recurrence: input.recurrence
-              ? this.toJson(input.recurrence)
+              ? this.contractService.toJson(input.recurrence)
               : Prisma.JsonNull,
           }),
           ...(input.scheduledDate !== undefined && {
-            scheduledAt: this.toDate(input.scheduledDate),
+            scheduledAt: this.contractService.toDate(input.scheduledDate),
           }),
           ...(input.status !== undefined && { status: input.status }),
           ...(input.timezone !== undefined && { timezone: input.timezone }),
@@ -498,14 +305,18 @@ export class PostGroupsService {
         targetUpdate.description = input.baseContent;
       }
       if (input.scheduledDate !== undefined) {
-        targetUpdate.scheduledDate = this.toDate(input.scheduledDate);
+        targetUpdate.scheduledDate = this.contractService.toDate(
+          input.scheduledDate,
+        );
       }
       if (input.timezone !== undefined) {
         targetUpdate.timezone = input.timezone;
       }
       if (input.status !== undefined) {
-        targetUpdate.status = this.toPostStatus(input.status);
-        targetUpdate.targetExecutionState = this.toTargetState(input.status);
+        targetUpdate.status = this.contractService.toPostStatus(input.status);
+        targetUpdate.targetExecutionState = this.contractService.toTargetState(
+          input.status,
+        );
       }
 
       if (Object.keys(targetUpdate).length > 0) {
@@ -520,8 +331,12 @@ export class PostGroupsService {
         });
       }
 
-      const targets = await this.getTargets(tx, organizationId, existing.id);
-      return this.toReleaseGroup(updated, targets);
+      const targets = await this.persistenceService.getTargets(
+        tx,
+        organizationId,
+        existing.id,
+      );
+      return this.contractService.toReleaseGroup(updated, targets);
     });
     if (
       input.attachments !== undefined ||
@@ -548,101 +363,42 @@ export class PostGroupsService {
     targetId: string,
     body: unknown,
   ): Promise<IReleaseGroup> {
-    const input = this.parseTargetInput(body);
+    const input = this.contractService.parseTargetInput(body);
 
     const result = await this.prisma.$transaction(async (tx) => {
-      const group = await this.getGroupOrThrow(tx, organizationId, groupId);
-      const existing = await this.getTargetOrThrow(
+      const group = await this.persistenceService.getGroupOrThrow(
+        tx,
+        organizationId,
+        groupId,
+      );
+      const existing = await this.persistenceService.getTargetOrThrow(
         tx,
         organizationId,
         group.id,
         targetId,
       );
 
-      const validation =
-        input.settings !== undefined
-          ? validateChannelTargetSettings({
-              credentialId: existing.credentialId,
-              platform: existing.platform,
-              settings: input.settings,
-            })
-          : undefined;
+      const validation = this.contractService.validateTargetUpdate(
+        existing,
+        input,
+      );
 
-      if (
-        validation &&
-        !validation.valid &&
-        input.executionState !== TargetExecutionState.DRAFT
-      ) {
-        throw this.invalidTargetException(
-          {
-            credentialId: existing.credentialId,
-            platform: existing.platform as CredentialPlatform,
-          },
-          validation,
-        );
-      }
-
-      const isManualRetry =
-        existing.targetExecutionState === TargetExecutionState.FAILED &&
-        input.executionState === TargetExecutionState.SCHEDULED;
-      let manualRetryApproval: IPublishApproval | undefined;
-      if (isManualRetry) {
-        const approval =
-          await this.publishApprovalsService.createForCurrentPost({
-            actorUserId: userId,
-            mode: 'scheduled',
-            organizationId,
-            postId: targetId,
-            provenance: {
-              releaseId: groupId,
-              surface: 'post-groups-manual-retry',
-            },
-            transaction: tx,
-          });
-        const provenance = {
-          ...approval.provenance,
-          manualRetryCommand: {
-            releaseId: groupId,
-            requestedByUserId: userId,
-            targetId,
-            version: 1,
-          },
-        };
-        await tx.publishApproval.update({
-          data: { provenance: this.toJson(provenance) },
-          where: { id: approval.id },
+      const { isManualRetry, manualRetryApproval } =
+        await this.resolveManualRetry({
+          existing,
+          groupId,
+          input,
+          organizationId,
+          targetId,
+          tx,
+          userId,
         });
-        manualRetryApproval = { ...approval, provenance };
-      } else if (
-        existing.targetExecutionState === TargetExecutionState.SCHEDULED &&
-        input.executionState === TargetExecutionState.SCHEDULED &&
-        existing.publishApprovalId
-      ) {
-        const row = await tx.publishApproval.findFirst({
-          where: {
-            id: existing.publishApprovalId,
-            organizationId,
-            postId: targetId,
-          },
-        });
-        if (row) {
-          const approval = this.publishApprovalsService.toPublicInterface(row);
-          if (
-            (approval.status === PublishApprovalStatus.APPROVED ||
-              approval.status === PublishApprovalStatus.QUEUED ||
-              approval.status === PublishApprovalStatus.FAILED) &&
-            approval.provenance.manualRetryCommand
-          ) {
-            manualRetryApproval = approval;
-          }
-        }
-      }
 
       await tx.post.update({
         data: {
           ...(input.error !== undefined && {
             targetError: input.error
-              ? this.toJson(input.error)
+              ? this.contractService.toJson(input.error)
               : Prisma.JsonNull,
           }),
           ...(input.executionState !== undefined && {
@@ -664,25 +420,25 @@ export class PostGroupsService {
             targetIdempotencyKey: input.idempotencyKey,
           }),
           ...(input.lastAttemptAt !== undefined && {
-            lastAttemptAt: this.toDate(input.lastAttemptAt),
+            lastAttemptAt: this.contractService.toDate(input.lastAttemptAt),
           }),
           ...(input.order !== undefined && { order: input.order }),
           ...(input.publishedAt !== undefined && {
-            publishedAt: this.toDate(input.publishedAt),
+            publishedAt: this.contractService.toDate(input.publishedAt),
           }),
           ...(input.readiness !== undefined && {
             targetReadiness: input.readiness
-              ? this.toJson(input.readiness)
+              ? this.contractService.toJson(input.readiness)
               : Prisma.JsonNull,
           }),
           ...(input.retryCount !== undefined && {
             retryCount: input.retryCount,
           }),
           ...(input.scheduledDate !== undefined && {
-            scheduledDate: this.toDate(input.scheduledDate),
+            scheduledDate: this.contractService.toDate(input.scheduledDate),
           }),
           ...(input.settings !== undefined && {
-            targetSettings: this.toJson(input.settings),
+            targetSettings: this.contractService.toJson(input.settings),
           }),
           ...(input.timezone !== undefined && { timezone: input.timezone }),
           ...(input.url !== undefined && { url: input.url }),
@@ -693,7 +449,8 @@ export class PostGroupsService {
             targetValidationState: input.validationState,
           }),
           ...(validation && {
-            targetValidationIssues: this.validationIssues(validation),
+            targetValidationIssues:
+              this.contractService.validationIssues(validation),
             targetValidationState: validation.validationState,
           }),
         },
@@ -702,7 +459,7 @@ export class PostGroupsService {
 
       return {
         manualRetryApproval,
-        release: await this.recalculateAndHydrate(
+        release: await this.persistenceService.recalculateAndHydrate(
           tx,
           organizationId,
           group.id,
@@ -742,6 +499,76 @@ export class PostGroupsService {
       });
     }
     return result.release;
+  }
+
+  private async resolveManualRetry(
+    params: ResolveManualRetryParams,
+  ): Promise<ManualRetryResolution> {
+    const isManualRetry =
+      params.existing.targetExecutionState === TargetExecutionState.FAILED &&
+      params.input.executionState === TargetExecutionState.SCHEDULED;
+    if (isManualRetry) {
+      const approval = await this.publishApprovalsService.createForCurrentPost({
+        actorUserId: params.userId,
+        mode: 'scheduled',
+        organizationId: params.organizationId,
+        postId: params.targetId,
+        provenance: {
+          releaseId: params.groupId,
+          surface: 'post-groups-manual-retry',
+        },
+        transaction: params.tx,
+      });
+      const provenance = {
+        ...approval.provenance,
+        manualRetryCommand: {
+          releaseId: params.groupId,
+          requestedByUserId: params.userId,
+          targetId: params.targetId,
+          version: 1,
+        },
+      };
+      await params.tx.publishApproval.update({
+        data: { provenance: this.contractService.toJson(provenance) },
+        where: { id: approval.id },
+      });
+      return {
+        isManualRetry,
+        manualRetryApproval: { ...approval, provenance },
+      };
+    }
+
+    const approvalId = params.existing.publishApprovalId;
+    const canReplay =
+      params.existing.targetExecutionState === TargetExecutionState.SCHEDULED &&
+      params.input.executionState === TargetExecutionState.SCHEDULED &&
+      approvalId;
+    if (!canReplay) {
+      return { isManualRetry };
+    }
+
+    const row = await params.tx.publishApproval.findFirst({
+      where: {
+        id: approvalId,
+        organizationId: params.organizationId,
+        postId: params.targetId,
+      },
+    });
+    if (!row) {
+      return { isManualRetry };
+    }
+
+    const approval = this.publishApprovalsService.toPublicInterface(row);
+    const isDurableRetry =
+      (approval.status === PublishApprovalStatus.APPROVED ||
+        approval.status === PublishApprovalStatus.QUEUED ||
+        approval.status === PublishApprovalStatus.FAILED) &&
+      approval.provenance.manualRetryCommand;
+
+    return {
+      isManualRetry,
+      ...(isDurableRetry && { manualRetryApproval: approval }),
+    };
   }
 
   cancel(
@@ -791,21 +618,31 @@ export class PostGroupsService {
     groupId: string,
   ): Promise<IReleaseGroup> {
     const release = await this.prisma.$transaction(async (tx) => {
-      const group = await this.getGroupOrThrow(tx, organizationId, groupId);
-      const targets = await this.getTargets(tx, organizationId, group.id);
+      const group = await this.persistenceService.getGroupOrThrow(
+        tx,
+        organizationId,
+        groupId,
+      );
+      const targets = await this.persistenceService.getTargets(
+        tx,
+        organizationId,
+        group.id,
+      );
 
       for (const target of targets) {
         const validation = validateChannelTargetSettings({
           caption: group.baseContent,
           credentialId: target.credentialId,
-          media: this.toValidationMedia(this.asMedia(group.media)),
+          media: this.contractService.toValidationMedia(
+            this.contractService.asMedia(group.media),
+          ),
           platform: target.platform,
           publishMode: 'publish_now',
-          settings: this.asRecord(target.targetSettings),
+          settings: this.contractService.asRecord(target.targetSettings),
         });
 
         if (!validation.valid) {
-          throw this.invalidTargetException(
+          throw this.contractService.invalidTargetException(
             {
               credentialId: target.credentialId,
               platform: target.platform as CredentialPlatform,
@@ -829,7 +666,12 @@ export class PostGroupsService {
         },
       });
 
-      return this.recalculateAndHydrate(tx, organizationId, group.id, userId);
+      return this.persistenceService.recalculateAndHydrate(
+        tx,
+        organizationId,
+        group.id,
+        userId,
+      );
     });
 
     await this.approveReleaseTargets(release, userId, 'immediate');
@@ -947,7 +789,11 @@ export class PostGroupsService {
     ) as TargetExecutionState[],
   ): Promise<IReleaseGroup> {
     const release = await this.prisma.$transaction(async (tx) => {
-      const group = await this.getGroupOrThrow(tx, organizationId, groupId);
+      const group = await this.persistenceService.getGroupOrThrow(
+        tx,
+        organizationId,
+        groupId,
+      );
       await tx.post.updateMany({
         data: {
           status: nextState,
@@ -961,7 +807,12 @@ export class PostGroupsService {
         },
       });
 
-      return this.recalculateAndHydrate(tx, organizationId, group.id, userId);
+      return this.persistenceService.recalculateAndHydrate(
+        tx,
+        organizationId,
+        group.id,
+        userId,
+      );
     });
     if (nextState === TargetExecutionState.CANCELLED) {
       await this.invalidateReleaseApprovals(
@@ -988,684 +839,5 @@ export class PostGroupsService {
         ),
       ),
     );
-  }
-
-  private async recalculateAndHydrate(
-    tx: Pick<SchedulerTx, 'post' | 'postGroup'>,
-    organizationId: string,
-    groupId: string,
-    userId: string,
-  ): Promise<IReleaseGroup> {
-    const group = await this.getGroupOrThrow(tx, organizationId, groupId);
-    const targets = await this.getTargets(tx, organizationId, group.id);
-    const status = deriveReleaseStatusFromTargets(
-      targets.map(
-        (target) => target.targetExecutionState as TargetExecutionState,
-      ),
-    );
-    const transitions =
-      status !== group.status
-        ? this.appendTransition(
-            group.statusTransitions,
-            group.status,
-            status,
-            userId,
-          )
-        : undefined;
-
-    const updated = (await tx.postGroup.update({
-      data: {
-        status,
-        ...(transitions !== undefined && { statusTransitions: transitions }),
-      },
-      where: { id: group.id },
-    })) as SchedulerPostGroup;
-
-    return this.toReleaseGroup(updated, targets);
-  }
-
-  private parseCreateInput(
-    body: unknown,
-    headerIdempotencyKey?: string,
-  ): CreateReleaseGroupInput {
-    const idempotencyKey = headerIdempotencyKey?.trim();
-    const payload =
-      idempotencyKey && typeof body === 'object' && body !== null
-        ? { ...body, idempotencyKey }
-        : body;
-    const parsed = createReleaseGroupSchema.safeParse(payload);
-    if (!parsed.success) {
-      throw this.badRequestFromZod(parsed.error);
-    }
-    return parsed.data;
-  }
-
-  private parseUpdateInput(body: unknown): UpdateReleaseGroupInput {
-    const parsed = updateReleaseGroupSchema.safeParse(body);
-    if (!parsed.success) {
-      throw this.badRequestFromZod(parsed.error);
-    }
-    return parsed.data;
-  }
-
-  private parseTargetInput(body: unknown): UpdateChannelTargetInput {
-    const parsed = updateChannelTargetSchema.safeParse(body);
-    if (!parsed.success) {
-      throw this.badRequestFromZod(parsed.error);
-    }
-    return parsed.data;
-  }
-
-  private badRequestFromZod(error: ZodError): BadRequestException {
-    return new BadRequestException({
-      detail: error.issues
-        .map((issue) => `${issue.path.join('.') || 'body'}: ${issue.message}`)
-        .join('; '),
-      title: 'Invalid scheduler mutation payload',
-    });
-  }
-
-  private resolveCreateStatus(input: CreateReleaseGroupInput): ReleaseStatus {
-    const status =
-      input.status ??
-      (input.scheduledDate ||
-      input.targets.some((target) => Boolean(target.scheduledDate))
-        ? ReleaseStatus.SCHEDULED
-        : ReleaseStatus.DRAFT);
-
-    if (!CREATE_ALLOWED_STATUSES.has(status)) {
-      throw new BadRequestException(
-        `Release groups can only be created as ${ReleaseStatus.DRAFT} or ${ReleaseStatus.SCHEDULED}.`,
-      );
-    }
-
-    return status;
-  }
-
-  private async findByIdempotencyKey(
-    organizationId: string,
-    idempotencyKey: string,
-  ): Promise<IReleaseGroup | undefined> {
-    const group = (await this.prisma.postGroup.findFirst({
-      where: { idempotencyKey, isDeleted: false, organizationId },
-    })) as SchedulerPostGroup | null;
-
-    if (!group) {
-      return undefined;
-    }
-
-    const targets = await this.getTargets(
-      this.prisma,
-      organizationId,
-      group.id,
-    );
-    return this.toReleaseGroup(group, targets);
-  }
-
-  private async resolveCredentials(
-    tx: Pick<SchedulerTx, 'credential'>,
-    organizationId: string,
-    targets: readonly ChannelTargetInput[],
-  ): Promise<Map<string, SchedulerCredential>> {
-    const ids = [...new Set(targets.map((target) => target.credentialId))];
-    const credentials = (await tx.credential.findMany({
-      select: {
-        brandId: true,
-        id: true,
-        isConnected: true,
-        organizationId: true,
-        platform: true,
-      },
-      where: {
-        id: { in: ids },
-        isDeleted: false,
-        organizationId,
-      },
-    })) as SchedulerCredential[];
-    const byId = new Map(
-      credentials.map((credential) => [credential.id, credential]),
-    );
-
-    for (const target of targets) {
-      const credential = byId.get(target.credentialId);
-      if (!credential) {
-        throw new BadRequestException(
-          `Credential ${target.credentialId} is not connected to this organization.`,
-        );
-      }
-      if (
-        String(credential.platform).toLowerCase() !==
-        String(target.platform).toLowerCase()
-      ) {
-        throw new BadRequestException(
-          `Credential ${target.credentialId} is for ${credential.platform}, not ${target.platform}.`,
-        );
-      }
-      if (!credential.isConnected) {
-        throw new BadRequestException(
-          `Credential ${target.credentialId} is not connected.`,
-        );
-      }
-    }
-
-    return byId;
-  }
-
-  private async resolveBrandId(
-    tx: Pick<SchedulerTx, 'brand'>,
-    organizationId: string,
-    requestedBrandId: string | undefined,
-    credentials: ReadonlyMap<string, SchedulerCredential>,
-  ): Promise<string> {
-    const brandId =
-      requestedBrandId ??
-      [...credentials.values()].find((credential) => credential.brandId)
-        ?.brandId ??
-      undefined;
-
-    if (!brandId) {
-      throw new BadRequestException(
-        'brandId is required when scheduler credentials are not brand-scoped.',
-      );
-    }
-
-    const brand = await tx.brand.findFirst({
-      select: { id: true },
-      where: { id: brandId, isDeleted: false, organizationId },
-    });
-
-    if (!brand) {
-      throw new BadRequestException(
-        `Brand ${brandId} is not available for this organization.`,
-      );
-    }
-
-    for (const credential of credentials.values()) {
-      if (credential.brandId && credential.brandId !== brandId) {
-        throw new BadRequestException(
-          `Credential ${credential.id} belongs to a different brand.`,
-        );
-      }
-    }
-
-    return brandId;
-  }
-
-  private validateTarget(
-    input: Pick<CreateReleaseGroupInput, 'baseContent' | 'media'>,
-    target: ChannelTargetInput,
-    publishMode: 'draft' | 'publish_now' | 'scheduled',
-  ): ChannelTargetValidationResult {
-    return validateChannelTargetSettings({
-      caption: input.baseContent,
-      credentialId: target.credentialId,
-      media: this.toValidationMedia(input.media),
-      platform: target.platform,
-      publishMode,
-      settings: target.settings ?? {},
-    });
-  }
-
-  private invalidTargetException(
-    target: Pick<ChannelTargetInput, 'credentialId' | 'platform'>,
-    validation: ChannelTargetValidationResult,
-  ): BadRequestException {
-    const detail = [...validation.errors, ...validation.warnings]
-      .map((issue) => issue.message)
-      .join('; ');
-    return new BadRequestException({
-      detail:
-        detail ||
-        `Target ${target.credentialId} on ${target.platform} failed validation.`,
-      title: 'Invalid channel target',
-    });
-  }
-
-  private async createAttachmentPosts(
-    tx: Pick<SchedulerTx, 'post'>,
-    params: {
-      brandId: string;
-      group: SchedulerPostGroup;
-      input: CreateReleaseGroupInput;
-      parent: SchedulerPostTarget;
-      target: ChannelTargetInput;
-      userId: string;
-    },
-  ): Promise<void> {
-    const attachments = [
-      ...(params.input.attachments ?? []).filter(
-        (attachment) =>
-          !attachment.platform ||
-          attachment.platform === params.target.platform,
-      ),
-      ...(params.target.attachments ?? []),
-    ].filter((attachment) => this.isChildPostAttachment(attachment));
-
-    for (const [index, attachment] of attachments.entries()) {
-      await tx.post.create({
-        data: {
-          brandId: params.brandId,
-          credentialId: params.target.credentialId,
-          description: attachment.body,
-          groupId: params.group.id,
-          label: `${params.group.title} ${attachment.kind}`,
-          order: attachment.order ?? index,
-          organizationId: params.group.organizationId,
-          parentId: params.parent.id,
-          platform: params.target.platform,
-          scheduledDate: params.parent.scheduledDate,
-          status: params.parent.targetExecutionState,
-          targetExecutionState: params.parent.targetExecutionState,
-          timezone: params.parent.timezone,
-          userId: params.userId,
-        },
-      });
-    }
-  }
-
-  private isChildPostAttachment(attachment: ReleaseAttachmentInput): boolean {
-    return (
-      attachment.kind === ReleaseAttachmentKind.COMMENT ||
-      attachment.kind === ReleaseAttachmentKind.THREAD
-    );
-  }
-
-  private async getGroupOrThrow(
-    client: Pick<SchedulerTx, 'postGroup'>,
-    organizationId: string,
-    groupId: string,
-  ): Promise<SchedulerPostGroup> {
-    const group = (await client.postGroup.findFirst({
-      where: { id: groupId, isDeleted: false, organizationId },
-    })) as SchedulerPostGroup | null;
-
-    if (!group) {
-      throw new NotFoundException('PostGroup', groupId);
-    }
-
-    return group;
-  }
-
-  private async getTargetOrThrow(
-    client: Pick<SchedulerTx, 'post'>,
-    organizationId: string,
-    groupId: string,
-    targetId: string,
-  ): Promise<SchedulerPostTarget> {
-    const target = (await client.post.findFirst({
-      where: {
-        groupId,
-        id: targetId,
-        isDeleted: false,
-        organizationId,
-      },
-    })) as SchedulerPostTarget | null;
-
-    if (!target) {
-      throw new NotFoundException('ChannelTarget', targetId);
-    }
-
-    return target;
-  }
-
-  private async getTargets(
-    client: Pick<SchedulerTx, 'post'>,
-    organizationId: string,
-    groupId: string,
-  ): Promise<SchedulerPostTarget[]> {
-    return (await client.post.findMany({
-      orderBy: [{ order: 'asc' }, { createdAt: 'asc' }],
-      where: {
-        groupId,
-        isDeleted: false,
-        organizationId,
-        parentId: null,
-      },
-    })) as SchedulerPostTarget[];
-  }
-
-  private toReleaseGroup(
-    group: SchedulerPostGroup,
-    targets: readonly SchedulerPostTarget[],
-  ): IReleaseGroup {
-    return {
-      attachments: this.asReleaseAttachments(group.attachments, group.id),
-      baseContent: group.baseContent,
-      brandId: group.brandId,
-      createdAt: group.createdAt.toISOString(),
-      id: group.id,
-      idempotencyKey: group.idempotencyKey,
-      isDeleted: group.isDeleted,
-      media: this.asMedia(group.media),
-      organizationId: group.organizationId,
-      ownerId: group.ownerId,
-      publishedAt: this.toIso(group.publishedAt),
-      recurrence: this.asRecurrence(group.recurrence),
-      scheduledAt: this.toIso(group.scheduledAt),
-      status: group.status as ReleaseStatus,
-      statusTransitions: this.asTransitions(group.statusTransitions),
-      targetSummary: this.summarizeTargets(targets),
-      targets: targets.map((target) => this.toChannelTarget(target, group.id)),
-      timezone: group.timezone,
-      title: group.title,
-      updatedAt: group.updatedAt.toISOString(),
-    };
-  }
-
-  private toChannelTarget(
-    target: SchedulerPostTarget,
-    groupId: string,
-  ): IChannelTarget {
-    return {
-      attachments: this.asReleaseAttachments(
-        target.targetAttachments,
-        groupId,
-        target.id,
-      ),
-      createdAt: target.createdAt.toISOString(),
-      credentialId: target.credentialId,
-      error: this.asTargetError(target.targetError),
-      executionState: target.targetExecutionState as TargetExecutionState,
-      externalProviderId: target.externalId,
-      externalShortcode: target.externalShortcode,
-      id: target.id,
-      idempotencyKey: target.targetIdempotencyKey,
-      isDeleted: target.isDeleted,
-      lastAttemptAt: this.toIso(target.lastAttemptAt),
-      order: target.order,
-      platform: target.platform as CredentialPlatform,
-      publishedAt: this.toIso(target.publishedAt),
-      readiness: this.asReadiness(target.targetReadiness),
-      releaseId: groupId,
-      retryCount: target.retryCount,
-      scheduledAt: this.toIso(target.scheduledDate),
-      settings: this.asRecord(target.targetSettings),
-      timezone: target.timezone,
-      updatedAt: target.updatedAt.toISOString(),
-      url: target.url,
-      validationIssues: target.targetValidationIssues,
-      validationState: target.targetValidationState as TargetValidationState,
-      workflowExecutionId: target.workflowExecutionId,
-    };
-  }
-
-  private summarizeTargets(
-    targets: readonly SchedulerPostTarget[],
-  ): IReleaseTargetSummary {
-    const summary: IReleaseTargetSummary = { total: targets.length };
-    for (const target of targets) {
-      const state = target.targetExecutionState as TargetExecutionState;
-      summary[state] = (summary[state] ?? 0) + 1;
-    }
-    return summary;
-  }
-
-  private appendTransition(
-    raw: Prisma.JsonValue,
-    from: string | null,
-    to: string,
-    actorId: string,
-  ): Prisma.InputJsonValue {
-    return this.toJson([
-      ...this.asTransitions(raw),
-      this.buildTransition(from, to, actorId),
-    ]);
-  }
-
-  private buildTransition(
-    from: string | null,
-    to: string,
-    actorId: string,
-  ): IScheduleStatusTransition {
-    return {
-      actorId,
-      at: new Date().toISOString(),
-      from,
-      to,
-    };
-  }
-
-  private validationIssues(
-    validation: ChannelTargetValidationResult,
-  ): string[] {
-    return [...validation.errors, ...validation.warnings].map(
-      (issue) => issue.message,
-    );
-  }
-
-  private toTargetState(status: string): TargetExecutionState {
-    switch (status) {
-      case ReleaseStatus.DRAFT:
-        return TargetExecutionState.DRAFT;
-      case ReleaseStatus.PAUSED:
-        return TargetExecutionState.PAUSED;
-      case ReleaseStatus.CANCELLED:
-        return TargetExecutionState.CANCELLED;
-      case ReleaseStatus.PUBLISHING:
-        return TargetExecutionState.PUBLISHING;
-      case ReleaseStatus.PUBLISHED:
-        return TargetExecutionState.PUBLISHED;
-      case ReleaseStatus.FAILED:
-        return TargetExecutionState.FAILED;
-      default:
-        return TargetExecutionState.SCHEDULED;
-    }
-  }
-
-  private toPostStatus(status: string): string {
-    if (status === ReleaseStatus.DRAFT) {
-      return PostStatus.DRAFT;
-    }
-    if (status === ReleaseStatus.FAILED) {
-      return PostStatus.FAILED;
-    }
-    if (status === ReleaseStatus.PUBLISHED) {
-      return PostStatus.PUBLIC;
-    }
-    return status;
-  }
-
-  private parseCredentialPlatform(value: string): CredentialPlatform {
-    const platform = Object.values(CredentialPlatform).find(
-      (candidate) => candidate === value.toLowerCase(),
-    );
-    if (!platform) {
-      throw new BadRequestException(
-        `Channel target platform ${value} is not supported.`,
-      );
-    }
-    return platform;
-  }
-
-  private matchesScheduleProvenance(
-    target: SchedulerPostTarget,
-    provenance: PostGroupCreateProvenance | undefined,
-  ): boolean {
-    return (
-      (provenance?.agentContextSource === undefined ||
-        target.agentContextSource === provenance.agentContextSource) &&
-      (provenance?.agentContextVersion === undefined ||
-        target.agentContextVersion === provenance.agentContextVersion) &&
-      (provenance?.agentRunId === undefined ||
-        target.agentRunId === provenance.agentRunId) &&
-      (provenance?.agentStrategyId === undefined ||
-        target.agentStrategyId === provenance.agentStrategyId) &&
-      (provenance?.agentThreadId === undefined ||
-        target.agentThreadId === provenance.agentThreadId)
-    );
-  }
-
-  private parseFutureScheduleDate(value: string): Date {
-    if (!STRICT_SCHEDULE_DATE_SCHEMA.safeParse(value).success) {
-      throw new BadRequestException(
-        'scheduledAt must be a valid ISO 8601 date and time with an explicit UTC offset.',
-      );
-    }
-    const date = new Date(value);
-    if (date.getTime() <= Date.now()) {
-      throw new BadRequestException('scheduledAt must be in the future.');
-    }
-    return date;
-  }
-
-  private toDate(value: string | undefined | null): Date | null {
-    return value ? new Date(value) : null;
-  }
-
-  private toIso(value: Date | null): string | null {
-    return value ? value.toISOString() : null;
-  }
-
-  private toJson(value: unknown): Prisma.InputJsonValue {
-    return value as Prisma.InputJsonValue;
-  }
-
-  private toValidationMedia(
-    media:
-      | readonly {
-          assetId: string;
-          kind?: string | null;
-        }[]
-      | undefined,
-  ): ChannelValidationMedia | undefined {
-    if (!media?.length) {
-      return undefined;
-    }
-    return media
-      .filter((item) => this.isValidationMediaKind(item.kind))
-      .map((item) => {
-        const kind = item.kind as ChannelValidationMedia[number]['kind'];
-        return item.assetId ? { id: item.assetId, kind } : { kind };
-      });
-  }
-
-  private isValidationMediaKind(
-    kind: string | null | undefined,
-  ): kind is ChannelValidationMedia[number]['kind'] {
-    return (
-      kind === 'carousel' ||
-      kind === 'image' ||
-      kind === 'link' ||
-      kind === 'short_video' ||
-      kind === 'video'
-    );
-  }
-
-  private buildIngredientConnect(
-    media: readonly ReleaseMediaReferenceInput[] | undefined,
-  ): { connect: Array<{ id: string }> } | undefined {
-    if (!media?.length) {
-      return undefined;
-    }
-    return {
-      connect: media.map((item) => ({ id: item.assetId })),
-    };
-  }
-
-  private asMedia(value: Prisma.JsonValue): IReleaseMediaReference[] {
-    if (!Array.isArray(value)) {
-      return [];
-    }
-    return value
-      .filter((item) => this.isReleaseMediaReference(item))
-      .map((item) => item as unknown as IReleaseMediaReference);
-  }
-
-  private isReleaseMediaReference(
-    value: unknown,
-  ): value is IReleaseMediaReference {
-    return (
-      typeof value === 'object' &&
-      value !== null &&
-      typeof (value as Record<string, unknown>).assetId === 'string'
-    );
-  }
-
-  private asReleaseAttachments(
-    value: Prisma.JsonValue,
-    releaseId: string,
-    targetId?: string,
-  ): IReleaseAttachment[] {
-    if (!Array.isArray(value)) {
-      return [];
-    }
-
-    return value
-      .filter(this.isReleaseAttachmentInput)
-      .map((attachment, index) => ({
-        body: attachment.body,
-        createdAt: '',
-        id: `${releaseId}:${targetId ?? 'release'}:${index}`,
-        isDeleted: false,
-        kind: attachment.kind,
-        order: attachment.order ?? index,
-        platform: attachment.platform ?? null,
-        releaseId,
-        targetId: targetId ?? null,
-        updatedAt: '',
-      }));
-  }
-
-  private isReleaseAttachmentInput(
-    value: unknown,
-  ): value is ReleaseAttachmentInput {
-    return (
-      typeof value === 'object' &&
-      value !== null &&
-      typeof (value as Record<string, unknown>).body === 'string' &&
-      typeof (value as Record<string, unknown>).kind === 'string'
-    );
-  }
-
-  private asTransitions(value: Prisma.JsonValue): IScheduleStatusTransition[] {
-    if (!Array.isArray(value)) {
-      return [];
-    }
-    return value
-      .filter((item) => this.isTransition(item))
-      .map((item) => item as unknown as IScheduleStatusTransition);
-  }
-
-  private isTransition(value: unknown): value is IScheduleStatusTransition {
-    return (
-      typeof value === 'object' &&
-      value !== null &&
-      typeof (value as Record<string, unknown>).to === 'string' &&
-      typeof (value as Record<string, unknown>).at === 'string'
-    );
-  }
-
-  private asRecurrence(
-    value: Prisma.JsonValue | null,
-  ): IReleaseGroup['recurrence'] {
-    if (!value || typeof value !== 'object' || Array.isArray(value)) {
-      return null;
-    }
-    return value as unknown as IReleaseGroup['recurrence'];
-  }
-
-  private asRecord(value: Prisma.JsonValue): Record<string, unknown> {
-    if (!value || typeof value !== 'object' || Array.isArray(value)) {
-      return {};
-    }
-    return value as Record<string, unknown>;
-  }
-
-  private asReadiness(
-    value: Prisma.JsonValue | null,
-  ): IChannelTarget['readiness'] {
-    if (!value || typeof value !== 'object' || Array.isArray(value)) {
-      return null;
-    }
-    return value as unknown as IChannelTarget['readiness'];
-  }
-
-  private asTargetError(
-    value: Prisma.JsonValue | null,
-  ): IChannelTarget['error'] {
-    if (!value || typeof value !== 'object' || Array.isArray(value)) {
-      return null;
-    }
-    return value as unknown as IChannelTarget['error'];
   }
 }


### PR DESCRIPTION
Closes #1918
Part of #1739

## Summary
- keep `PostGroupsService` as the stable orchestration facade
- extract scheduler contract parsing, validation, transitions, and response mapping into `PostGroupContractService`
- extract organization-scoped persistence, idempotency, credential/brand resolution, attachment creation, and hydration into `PostGroupPersistenceService`
- add focused contract and persistence specs while preserving existing facade coverage

## Verification
- exact-head CI run `29698794336` — passed lint, format, guards, DI value imports, typecheck, server-service tests, changed API tests, package/extension/web tests, OpenAPI drift, build, and Tests Gate
- `bunx @biomejs/biome@2.5.3 check <8 changed files>` — clean
- `bun run check:multi-tenancy` — 697 files scanned, 0 new violations
- `bun run check:runtime-complexity --base refs/remotes/origin/master` — 0 violations
- `git diff --cached --check` and staged secret pattern scan — clean
- supplementary Fable audit — strict TypeScript narrowing finding fixed before publication

## Skipped / CI
- Local tests, typecheck, and build were intentionally not run under the repository machine-resource policy; GitHub Actions supplied that evidence.
- Local `check:di-value-imports` and TypeScript-AST architecture checks could not run because the isolated worktree lacked a usable TypeScript runtime; the corresponding exact-head CI guards passed.

## Residual risk
- Unified server image build is still running.
- Exact-head Fleet Review remains required before merge.