### PR TITLE
refactor(twitter): extract response mapping boundary

### DIFF
--- a/apps/server/api/src/services/integrations/twitter/services/twitter-response.mapper.spec.ts
+++ b/apps/server/api/src/services/integrations/twitter/services/twitter-response.mapper.spec.ts
@@ -1,0 +1,198 @@
+import { CredentialPlatform } from '@genfeedai/enums';
+import { TwitterResponseMapper } from './twitter-response.mapper';
+
+describe('TwitterResponseMapper', () => {
+  const mapper = new TwitterResponseMapper();
+
+  describe('mapSearchResults', () => {
+    it('projects authors and sorts tweets by engagement', () => {
+      const result = mapper.mapSearchResults({
+        data: {
+          data: [
+            {
+              author_id: 'author-low',
+              created_at: '2026-01-01T00:00:00.000Z',
+              id: 'tweet-low',
+              public_metrics: { like_count: 1 },
+              text: 'Low engagement',
+            },
+            {
+              author_id: 'author-high',
+              created_at: '2026-01-02T00:00:00.000Z',
+              id: 'tweet-high',
+              public_metrics: { like_count: 5, retweet_count: 3 },
+              text: 'High engagement',
+            },
+          ],
+        },
+        includes: {
+          users: [
+            { id: 'author-low', name: 'Low', username: 'low' },
+            { id: 'author-high', name: 'High', username: 'high' },
+          ],
+        },
+      });
+
+      expect(result).toEqual([
+        expect.objectContaining({
+          authorName: 'High',
+          authorUsername: 'high',
+          engagement: 8,
+          id: 'tweet-high',
+        }),
+        expect.objectContaining({
+          authorName: 'Low',
+          authorUsername: 'low',
+          engagement: 1,
+          id: 'tweet-low',
+        }),
+      ]);
+    });
+
+    it('returns an empty projection for a partial response', () => {
+      expect(mapper.mapSearchResults({})).toEqual([]);
+    });
+  });
+
+  describe('user projections', () => {
+    it('maps a user and follower count', () => {
+      expect(
+        mapper.mapUser({
+          data: {
+            id: 'user-1',
+            name: 'User One',
+            public_metrics: { followers_count: 42 },
+            username: 'userone',
+          },
+        }),
+      ).toEqual({
+        followersCount: 42,
+        id: 'user-1',
+        name: 'User One',
+        username: 'userone',
+      });
+    });
+
+    it('returns null or an empty list when provider data is absent', () => {
+      expect(mapper.mapUser({})).toBeNull();
+      expect(mapper.mapUsers({})).toEqual([]);
+    });
+  });
+
+  describe('mapTrends', () => {
+    it('projects scope and normalized growth', () => {
+      expect(
+        mapper.mapTrends(
+          [
+            {
+              trends: [
+                {
+                  name: '#launch',
+                  tweet_volume: 250_000,
+                  url: 'https://x.com/search?q=%23launch',
+                },
+              ],
+            },
+          ],
+          'organization-1',
+          'brand-1',
+        ),
+      ).toEqual([
+        {
+          brandId: 'brand-1',
+          growthRate: 25,
+          mentions: 250_000,
+          organizationId: 'organization-1',
+          platform: CredentialPlatform.TWITTER,
+          topic: '#launch',
+          url: 'https://x.com/search?q=%23launch',
+        },
+      ]);
+    });
+  });
+
+  describe('analytics projections', () => {
+    it('projects video views, impressions, and engagement rate', () => {
+      const result = mapper.mapAnalytics({
+        data: [
+          {
+            organic_metrics: { impression_count: 1_000 },
+            public_metrics: {
+              like_count: 50,
+              quote_count: 5,
+              reply_count: 10,
+              retweet_count: 10,
+            },
+          },
+        ],
+        includes: {
+          media: [
+            {
+              public_metrics: { view_count: 5_000 },
+              type: 'video',
+            },
+          ],
+        },
+      });
+
+      expect(result).toEqual({
+        bookmarks: 0,
+        comments: 10,
+        engagementRate: 7.5,
+        impressions: 1_000,
+        likes: 50,
+        mediaType: 'video',
+        quotes: 5,
+        retweets: 10,
+        views: 5_000,
+      });
+    });
+
+    it('returns the existing zero-value contract for a partial response', () => {
+      expect(mapper.mapAnalytics({})).toEqual({
+        bookmarks: 0,
+        comments: 0,
+        engagementRate: undefined,
+        impressions: undefined,
+        likes: 0,
+        mediaType: 'text',
+        quotes: 0,
+        retweets: 0,
+        views: 0,
+      });
+    });
+
+    it('correlates batch media by key and ignores malformed rows without IDs', () => {
+      const result = mapper.mapAnalyticsBatch({
+        data: [
+          {
+            attachments: { media_keys: ['media-1'] },
+            id: 'tweet-1',
+            public_metrics: { like_count: 2 },
+          },
+          {
+            public_metrics: { like_count: 99 },
+          },
+        ],
+        includes: {
+          media: [
+            {
+              media_key: 'media-1',
+              public_metrics: { view_count: 900 },
+              type: 'video',
+            },
+          ],
+        },
+      });
+
+      expect(result.size).toBe(1);
+      expect(result.get('tweet-1')).toEqual(
+        expect.objectContaining({
+          likes: 2,
+          mediaType: 'video',
+          views: 900,
+        }),
+      );
+    });
+  });
+});

--- a/apps/server/api/src/services/integrations/twitter/services/twitter-response.mapper.ts
+++ b/apps/server/api/src/services/integrations/twitter/services/twitter-response.mapper.ts
@@ -1,0 +1,296 @@
+import { CredentialPlatform } from '@genfeedai/enums';
+import type { ITwitterSearchResult } from '@genfeedai/interfaces';
+import { Injectable } from '@nestjs/common';
+
+export interface TwitterTrendItem {
+  name: string;
+  tweet_volume: number | null;
+  url: string;
+}
+
+export interface TwitterTrendResponse {
+  trends?: TwitterTrendItem[];
+}
+
+export interface TwitterTrendResult {
+  brandId?: string;
+  growthRate: number;
+  mentions: number;
+  organizationId?: string;
+  platform: CredentialPlatform;
+  topic: string;
+  url: string;
+}
+
+export interface TwitterUserSummary {
+  id: string;
+  username: string;
+  name?: string;
+  public_metrics?: {
+    followers_count?: number;
+  };
+}
+
+export interface TwitterUserResponse {
+  data?: TwitterUserSummary;
+}
+
+export interface TwitterUsersResponse {
+  data?: TwitterUserSummary[];
+}
+
+export interface TwitterMappedUser {
+  followersCount?: number;
+  id: string;
+  name?: string;
+  username: string;
+}
+
+interface TwitterSearchAuthor {
+  id: string;
+  name: string;
+  username: string;
+}
+
+interface TwitterSearchTweet {
+  author_id?: string;
+  created_at?: string;
+  id: string;
+  public_metrics?: {
+    like_count?: number;
+    quote_count?: number;
+    reply_count?: number;
+    retweet_count?: number;
+  };
+  text: string;
+}
+
+export interface TwitterSearchResponse {
+  data?: {
+    data?: TwitterSearchTweet[];
+  };
+  includes?: {
+    users?: TwitterSearchAuthor[];
+  };
+}
+
+interface TwitterMetrics {
+  bookmark_count?: number;
+  impression_count?: number;
+  like_count?: number;
+  quote_count?: number;
+  reply_count?: number;
+  retweet_count?: number;
+  view_count?: number;
+}
+
+export interface TwitterMediaItem {
+  media_key?: string;
+  public_metrics?: {
+    view_count?: number;
+  };
+  type: string;
+}
+
+interface TwitterAnalyticsTweet {
+  attachments?: {
+    media_keys?: string[];
+  };
+  id?: string;
+  non_public_metrics?: TwitterMetrics;
+  organic_metrics?: TwitterMetrics;
+  public_metrics?: TwitterMetrics;
+}
+
+export interface TwitterAnalyticsResponse {
+  data?: TwitterAnalyticsTweet[];
+  includes?: {
+    media?: TwitterMediaItem[];
+  };
+}
+
+export interface TwitterAnalyticsResult {
+  bookmarks?: number;
+  comments: number;
+  engagementRate?: number;
+  impressions?: number;
+  likes: number;
+  mediaType?: 'text' | 'image' | 'video' | 'mixed';
+  quotes?: number;
+  retweets?: number;
+  views: number;
+}
+
+@Injectable()
+export class TwitterResponseMapper {
+  mapSearchResults(result: TwitterSearchResponse): ITwitterSearchResult[] {
+    const authors = new Map(
+      (result.includes?.users ?? []).map((user) => [
+        user.id,
+        { name: user.name, username: user.username },
+      ]),
+    );
+
+    return (result.data?.data ?? [])
+      .map((tweet) => {
+        const author = authors.get(tweet.author_id ?? '');
+        const metrics = tweet.public_metrics ?? {};
+        const likes = metrics.like_count ?? 0;
+        const retweets = metrics.retweet_count ?? 0;
+
+        return {
+          authorName: author?.name ?? 'Unknown',
+          authorUsername: author?.username ?? 'unknown',
+          createdAt: tweet.created_at ?? new Date().toISOString(),
+          engagement: likes + retweets,
+          id: tweet.id,
+          likes,
+          quotes: metrics.quote_count ?? 0,
+          replies: metrics.reply_count ?? 0,
+          retweets,
+          text: tweet.text,
+        };
+      })
+      .sort((left, right) => right.engagement - left.engagement);
+  }
+
+  mapUser(result: TwitterUserResponse): TwitterMappedUser | null {
+    return result.data ? this.mapUserSummary(result.data) : null;
+  }
+
+  mapUsers(result: TwitterUsersResponse): TwitterMappedUser[] {
+    return (result.data ?? []).map((user) => this.mapUserSummary(user));
+  }
+
+  mapTrends(
+    result: TwitterTrendResponse[] | null | undefined,
+    organizationId?: string,
+    brandId?: string,
+  ): TwitterTrendResult[] {
+    return (result?.[0]?.trends ?? []).slice(0, 10).map((trend) => {
+      const mentions = trend.tweet_volume || 0;
+
+      return {
+        brandId,
+        growthRate: this.calculateGrowthRate(mentions),
+        mentions,
+        organizationId,
+        platform: CredentialPlatform.TWITTER,
+        topic: trend.name,
+        url: trend.url,
+      };
+    });
+  }
+
+  mapAnalytics(result: TwitterAnalyticsResponse): TwitterAnalyticsResult {
+    return this.mapTweetAnalytics(
+      result.data?.[0],
+      result.includes?.media ?? [],
+    );
+  }
+
+  mapAnalyticsBatch(
+    result: TwitterAnalyticsResponse,
+  ): Map<string, TwitterAnalyticsResult> {
+    const mediaByKey = new Map<string, TwitterMediaItem>();
+    for (const media of result.includes?.media ?? []) {
+      if (media.media_key) {
+        mediaByKey.set(media.media_key, media);
+      }
+    }
+
+    const analyticsByTweet = new Map<string, TwitterAnalyticsResult>();
+    for (const tweet of result.data ?? []) {
+      if (!tweet.id) {
+        continue;
+      }
+
+      const media = (tweet.attachments?.media_keys ?? []).flatMap((key) => {
+        const item = mediaByKey.get(key);
+        return item ? [item] : [];
+      });
+
+      analyticsByTweet.set(tweet.id, this.mapTweetAnalytics(tweet, media));
+    }
+
+    return analyticsByTweet;
+  }
+
+  private calculateGrowthRate(tweetVolume: number): number {
+    if (tweetVolume === 0) {
+      return 0;
+    }
+
+    return Math.round(Math.min((tweetVolume / 1_000_000) * 100, 100));
+  }
+
+  private mapTweetAnalytics(
+    tweet: TwitterAnalyticsTweet | undefined,
+    media: TwitterMediaItem[],
+  ): TwitterAnalyticsResult {
+    const metrics = tweet?.public_metrics ?? {};
+    const nonPublicMetrics = tweet?.non_public_metrics ?? {};
+    const organicMetrics = tweet?.organic_metrics ?? {};
+    const mediaType = this.resolveMediaType(media);
+    const impressions =
+      nonPublicMetrics.impression_count || organicMetrics.impression_count || 0;
+    const totalEngagements =
+      (metrics.like_count || 0) +
+      (metrics.retweet_count || 0) +
+      (metrics.reply_count || 0) +
+      (metrics.quote_count || 0);
+    const engagementRate =
+      impressions > 0 ? (totalEngagements / impressions) * 100 : 0;
+
+    let views = metrics.view_count || 0;
+    if (mediaType === 'video') {
+      const video = media.find((item) => item.type === 'video');
+      if (video?.public_metrics?.view_count) {
+        views = video.public_metrics.view_count;
+      }
+    }
+
+    return {
+      bookmarks: metrics.bookmark_count || 0,
+      comments: metrics.reply_count || 0,
+      engagementRate:
+        engagementRate > 0 ? Number(engagementRate.toFixed(2)) : undefined,
+      impressions: impressions || undefined,
+      likes: metrics.like_count || 0,
+      mediaType,
+      quotes: metrics.quote_count || 0,
+      retweets: metrics.retweet_count || 0,
+      views: views || impressions || 0,
+    };
+  }
+
+  private mapUserSummary(user: TwitterUserSummary): TwitterMappedUser {
+    return {
+      followersCount: user.public_metrics?.followers_count,
+      id: user.id,
+      name: user.name,
+      username: user.username,
+    };
+  }
+
+  private resolveMediaType(
+    media: TwitterMediaItem[],
+  ): TwitterAnalyticsResult['mediaType'] {
+    if (media.length === 0) {
+      return 'text';
+    }
+
+    const mediaTypes = new Set(media.map((item) => item.type));
+    if (mediaTypes.size > 1) {
+      return 'mixed';
+    }
+    if (mediaTypes.has('video') || mediaTypes.has('animated_gif')) {
+      return 'video';
+    }
+    if (mediaTypes.has('photo')) {
+      return 'image';
+    }
+
+    return 'text';
+  }
+}

--- a/apps/server/api/src/services/integrations/twitter/services/twitter.coverage.spec.ts
+++ b/apps/server/api/src/services/integrations/twitter/services/twitter.coverage.spec.ts
@@ -81,6 +81,7 @@ import { ActivitiesService } from '@api/collections/activities/services/activiti
 import { CredentialsService } from '@api/collections/credentials/services/credentials.service';
 import { mockModel } from '@api/helpers/mocks/model.mock';
 import { TwitterService } from '@api/services/integrations/twitter/services/twitter.service';
+import { TwitterResponseMapper } from '@api/services/integrations/twitter/services/twitter-response.mapper';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { ConfigService } from '@libs/config/config.service';
 import { LoggerService } from '@libs/logger/logger.service';
@@ -143,6 +144,7 @@ describe('TwitterService (coverage)', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         TwitterService,
+        TwitterResponseMapper,
         { provide: ActivitiesService, useValue: activitiesService },
         { provide: ConfigService, useValue: { get: vi.fn(() => 'cfg-val') } },
         { provide: CredentialsService, useValue: credentialsService },

--- a/apps/server/api/src/services/integrations/twitter/services/twitter.service.spec.ts
+++ b/apps/server/api/src/services/integrations/twitter/services/twitter.service.spec.ts
@@ -16,11 +16,10 @@ vi.mock('@libs/utils/encryption/encryption.util', () => ({
 import { ActivitiesService } from '@api/collections/activities/services/activities.service';
 import { CredentialsService } from '@api/collections/credentials/services/credentials.service';
 import { AnalyticsService } from '@api/endpoints/analytics/analytics.service';
-import { Analytic } from '@api/endpoints/analytics/schemas/analytic.schema';
 import { mockModel } from '@api/helpers/mocks/model.mock';
 import { TwitterService } from '@api/services/integrations/twitter/services/twitter.service';
+import { TwitterResponseMapper } from '@api/services/integrations/twitter/services/twitter-response.mapper';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
-import { type Activity } from '@genfeedai/prisma';
 import { ConfigService } from '@libs/config/config.service';
 import { LoggerService } from '@libs/logger/logger.service';
 import { HttpService } from '@nestjs/axios';
@@ -33,6 +32,7 @@ describe('TwitterService', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         TwitterService,
+        TwitterResponseMapper,
         { provide: ActivitiesService, useValue: {} },
         { provide: ConfigService, useValue: { get: vi.fn() } },
         {

--- a/apps/server/api/src/services/integrations/twitter/services/twitter.service.ts
+++ b/apps/server/api/src/services/integrations/twitter/services/twitter.service.ts
@@ -19,28 +19,16 @@ import { HttpService } from '@nestjs/axios';
 import { Injectable } from '@nestjs/common';
 import { firstValueFrom } from 'rxjs';
 import { TwitterApi } from 'twitter-api-v2';
-
-interface TwitterTrendItem {
-  name: string;
-  tweet_volume: number | null;
-  url: string;
-}
-
-interface TwitterMediaItem {
-  type: string;
-  media_key?: string;
-  public_metrics?: { view_count?: number };
-}
-
-interface TwitterTrendResult {
-  brandId?: string;
-  growthRate: number;
-  mentions: number;
-  organizationId?: string;
-  platform: CredentialPlatform;
-  topic: string;
-  url: string;
-}
+import {
+  type TwitterAnalyticsResponse,
+  type TwitterAnalyticsResult,
+  TwitterResponseMapper,
+  type TwitterSearchResponse,
+  type TwitterTrendResponse,
+  type TwitterTrendResult,
+  type TwitterUserResponse,
+  type TwitterUsersResponse,
+} from './twitter-response.mapper';
 
 interface TwitterApiErrorShape {
   code?: number;
@@ -53,23 +41,6 @@ interface TwitterApiErrorShape {
   rateLimitWaitMs?: number;
 }
 
-interface TwitterUserSummary {
-  id: string;
-  username: string;
-  name?: string;
-  public_metrics?: {
-    followers_count?: number;
-  };
-}
-
-interface TwitterUserResponse {
-  data?: TwitterUserSummary;
-}
-
-interface TwitterUsersResponse {
-  data?: TwitterUserSummary[];
-}
-
 interface TweetMediaOptions {
   media: {
     media_ids:
@@ -79,18 +50,6 @@ interface TweetMediaOptions {
       | [string, string, string, string];
   };
   quote_tweet_id?: string;
-}
-
-interface TwitterAnalyticsResult {
-  views: number;
-  likes: number;
-  comments: number;
-  retweets?: number;
-  bookmarks?: number;
-  quotes?: number;
-  impressions?: number;
-  engagementRate?: number;
-  mediaType?: 'text' | 'image' | 'video' | 'mixed';
 }
 
 function requireString(
@@ -117,6 +76,7 @@ export class TwitterService {
     private readonly activitiesService: ActivitiesService,
     private readonly credentialsService: CredentialsService,
     private readonly httpService: HttpService,
+    private readonly responseMapper: TwitterResponseMapper,
   ) {
     this.twitterClient = new TwitterApi(
       // @ts-expect-error TS2769
@@ -235,44 +195,9 @@ export class TwitterService {
         'user.fields': 'username,name',
       });
 
-      const authorMap = new Map<string, { username: string; name: string }>();
-      if (result.includes?.users) {
-        for (const user of result.includes.users) {
-          authorMap.set(user.id, {
-            name: user.name,
-            username: user.username,
-          });
-        }
-      }
-
-      const tweets: ITwitterSearchResult[] = [];
-      if (result.data?.data) {
-        for (const tweet of result.data.data) {
-          const author = authorMap.get(tweet.author_id ?? '');
-          const metrics = tweet.public_metrics ?? {
-            like_count: 0,
-            quote_count: 0,
-            reply_count: 0,
-            retweet_count: 0,
-          };
-
-          tweets.push({
-            authorName: author?.name ?? 'Unknown',
-            authorUsername: author?.username ?? 'unknown',
-            createdAt: tweet.created_at ?? new Date().toISOString(),
-            engagement:
-              (metrics.like_count ?? 0) + (metrics.retweet_count ?? 0),
-            id: tweet.id,
-            likes: metrics.like_count ?? 0,
-            quotes: metrics.quote_count ?? 0,
-            replies: metrics.reply_count ?? 0,
-            retweets: metrics.retweet_count ?? 0,
-            text: tweet.text,
-          });
-        }
-      }
-
-      tweets.sort((a, b) => b.engagement - a.engagement);
+      const tweets = this.responseMapper.mapSearchResults(
+        result as unknown as TwitterSearchResponse,
+      );
 
       this.loggerService.log(
         `${url} found ${tweets.length} tweets for query "${query}"`,
@@ -302,17 +227,7 @@ export class TwitterService {
         { 'user.fields': 'public_metrics' },
       )) as TwitterUserResponse;
 
-      const user = result.data;
-      if (!user) {
-        return null;
-      }
-
-      return {
-        followersCount: user.public_metrics?.followers_count,
-        id: user.id,
-        name: user.name,
-        username: user.username,
-      };
+      return this.responseMapper.mapUser(result);
     } catch (error: unknown) {
       this.loggerService.error(`${caller} failed`, error);
       throw error;
@@ -345,7 +260,7 @@ export class TwitterService {
         },
       )) as TwitterUsersResponse;
 
-      return this.mapUsersWithFollowerCount(result);
+      return this.responseMapper.mapUsers(result);
     } catch (error: unknown) {
       this.loggerService.error(`${caller} failed`, error);
       throw error;
@@ -378,7 +293,7 @@ export class TwitterService {
         },
       )) as TwitterUsersResponse;
 
-      return this.mapUsersWithFollowerCount(result);
+      return this.responseMapper.mapUsers(result);
     } catch (error: unknown) {
       this.loggerService.error(`${caller} failed`, error);
       throw error;
@@ -411,7 +326,7 @@ export class TwitterService {
         },
       )) as TwitterUsersResponse;
 
-      return this.mapUsersWithFollowerCount(result);
+      return this.responseMapper.mapUsers(result);
     } catch (error: unknown) {
       this.loggerService.error(`${caller} failed`, error);
       throw error;
@@ -430,16 +345,10 @@ export class TwitterService {
       // NOTE: This endpoint requires Twitter API Pro tier access
       const res = await this.twitterClient.v1.trendsByPlace(woeid);
 
-      return (
-        res?.[0]?.trends?.slice(0, 10).map((trend: TwitterTrendItem) => ({
-          brandId,
-          growthRate: this.calculateGrowthRate(trend.tweet_volume || 0),
-          mentions: trend.tweet_volume || 0,
-          organizationId,
-          platform: CredentialPlatform.TWITTER,
-          topic: trend.name,
-          url: trend.url,
-        })) || []
+      return this.responseMapper.mapTrends(
+        res as unknown as TwitterTrendResponse[],
+        organizationId,
+        brandId,
       );
     } catch (error: unknown) {
       const errorObject = error as TwitterApiErrorShape;
@@ -471,35 +380,6 @@ export class TwitterService {
       // Return empty array - no fake data
       return [];
     }
-  }
-
-  /**
-   * Calculate growth rate based on tweet volume
-   * Higher volume = higher growth rate
-   */
-  private calculateGrowthRate(tweetVolume: number): number {
-    if (tweetVolume === 0) {
-      return 0;
-    }
-
-    // Normalize to 0-100 scale
-    // Assuming max volume is 1M tweets
-    const normalized = Math.min((tweetVolume / 1000000) * 100, 100);
-    return Math.round(normalized);
-  }
-
-  private mapUsersWithFollowerCount(result: TwitterUsersResponse): Array<{
-    id: string;
-    username: string;
-    name?: string;
-    followersCount?: number;
-  }> {
-    return (result.data ?? []).map((user) => ({
-      followersCount: user.public_metrics?.followers_count,
-      id: user.id,
-      name: user.name,
-      username: user.username,
-    }));
   }
 
   /**
@@ -681,17 +561,7 @@ export class TwitterService {
     tweetId: string,
     accessToken?: string,
     accessTokenSecret?: string,
-  ): Promise<{
-    views: number;
-    likes: number;
-    comments: number;
-    retweets?: number;
-    bookmarks?: number;
-    quotes?: number;
-    impressions?: number;
-    engagementRate?: number;
-    mediaType?: 'text' | 'image' | 'video' | 'mixed';
-  }> {
+  ): Promise<TwitterAnalyticsResult> {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
 
     try {
@@ -718,64 +588,9 @@ export class TwitterService {
         'tweet.fields': `${fields},attachments`,
       });
 
-      const tweet = res?.data?.[0];
-      const metrics = tweet?.public_metrics || {};
-      const nonPublicMetrics = tweet?.non_public_metrics || {};
-      const organicMetrics = tweet?.organic_metrics || {};
-
-      // Determine media type from attachments
-      let mediaType: 'text' | 'image' | 'video' | 'mixed' = 'text';
-      const media = res?.includes?.media || [];
-
-      if (media.length > 0) {
-        const mediaTypes = new Set(media.map((m: TwitterMediaItem) => m.type));
-        if (mediaTypes.size > 1) {
-          mediaType = 'mixed';
-        } else if (mediaTypes.has('video') || mediaTypes.has('animated_gif')) {
-          mediaType = 'video';
-        } else if (mediaTypes.has('photo')) {
-          mediaType = 'image';
-        }
-      }
-
-      // Calculate engagement rate if we have impression data
-      const impressions =
-        nonPublicMetrics.impression_count ||
-        organicMetrics.impression_count ||
-        0;
-
-      const totalEngagements =
-        (metrics.like_count || 0) +
-        (metrics.retweet_count || 0) +
-        (metrics.reply_count || 0) +
-        (metrics.quote_count || 0);
-
-      const engagementRate =
-        impressions > 0 ? (totalEngagements / impressions) * 100 : 0;
-
-      // For video tweets, try to get video-specific metrics
-      let videoViews = metrics.view_count || 0;
-      if (mediaType === 'video' && media.length > 0) {
-        const videoMedia = media.find(
-          (m: TwitterMediaItem) => m.type === 'video',
-        );
-        if (videoMedia?.public_metrics?.view_count) {
-          videoViews = videoMedia.public_metrics.view_count;
-        }
-      }
-
-      return {
-        bookmarks: metrics.bookmark_count || 0,
-        comments: metrics.reply_count || 0,
-        engagementRate:
-          engagementRate > 0 ? Number(engagementRate.toFixed(2)) : undefined,
-        impressions: impressions || undefined,
-        likes: metrics.like_count || 0,
-        mediaType,
-        quotes: metrics.quote_count || 0,
-        retweets: metrics.retweet_count || 0,
-        views: videoViews || impressions || 0,
-      };
+      return this.responseMapper.mapAnalytics(
+        res as unknown as TwitterAnalyticsResponse,
+      );
     } catch (error: unknown) {
       // Handle rate limit (429) errors first - don't log as error
       const errorObject = error as TwitterApiErrorShape;
@@ -823,22 +638,7 @@ export class TwitterService {
     tweetIds: string[],
     accessToken?: string,
     accessTokenSecret?: string,
-  ): Promise<
-    Map<
-      string,
-      {
-        views: number;
-        likes: number;
-        comments: number;
-        retweets?: number;
-        bookmarks?: number;
-        quotes?: number;
-        impressions?: number;
-        engagementRate?: number;
-        mediaType?: 'text' | 'image' | 'video' | 'mixed';
-      }
-    >
-  > {
+  ): Promise<Map<string, TwitterAnalyticsResult>> {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
 
     if (tweetIds.length === 0) {
@@ -875,92 +675,9 @@ export class TwitterService {
 
       this.loggerService.log('Twitter API  client.v2.get tweets', res);
 
-      const tweets = res?.data || [];
-      const media = res?.includes?.media || [];
-
-      // Create a map for quick media lookup by key
-      const mediaByKey = new Map<string, TwitterMediaItem>();
-      media.forEach((m: TwitterMediaItem) => {
-        // @ts-expect-error TS2345
-        mediaByKey.set(m.media_key, m);
-      });
-
-      // Process each tweet and build result map
-      const results = new Map<string, TwitterAnalyticsResult>();
-
-      for (const tweet of tweets) {
-        const metrics = tweet?.public_metrics || {};
-        const nonPublicMetrics = tweet?.non_public_metrics || {};
-        const organicMetrics = tweet?.organic_metrics || {};
-
-        // Determine media type from attachments
-        let mediaType: 'text' | 'image' | 'video' | 'mixed' = 'text';
-        const tweetMedia: TwitterMediaItem[] = [];
-
-        if (tweet.attachments?.media_keys) {
-          for (const key of tweet.attachments.media_keys) {
-            const m = mediaByKey.get(key);
-            if (m) {
-              tweetMedia.push(m);
-            }
-          }
-        }
-
-        if (tweetMedia.length > 0) {
-          const mediaTypes = new Set(
-            tweetMedia.map((m: TwitterMediaItem) => m.type),
-          );
-          if (mediaTypes.size > 1) {
-            mediaType = 'mixed';
-          } else if (
-            mediaTypes.has('video') ||
-            mediaTypes.has('animated_gif')
-          ) {
-            mediaType = 'video';
-          } else if (mediaTypes.has('photo')) {
-            mediaType = 'image';
-          }
-        }
-
-        // Calculate engagement rate if we have impression data
-        const impressions =
-          nonPublicMetrics.impression_count ||
-          organicMetrics.impression_count ||
-          0;
-
-        const totalEngagements =
-          (metrics.like_count || 0) +
-          (metrics.retweet_count || 0) +
-          (metrics.reply_count || 0) +
-          (metrics.quote_count || 0);
-
-        const engagementRate =
-          impressions > 0 ? (totalEngagements / impressions) * 100 : 0;
-
-        // For video tweets, try to get video-specific metrics
-        let videoViews = metrics.view_count || 0;
-        if (mediaType === 'video' && tweetMedia.length > 0) {
-          const videoMedia = tweetMedia.find(
-            (m: TwitterMediaItem) => m.type === 'video',
-          );
-          if (videoMedia?.public_metrics?.view_count) {
-            videoViews = videoMedia.public_metrics.view_count;
-          }
-        }
-
-        results.set(tweet.id, {
-          bookmarks: metrics.bookmark_count || 0,
-          comments: metrics.reply_count || 0,
-          engagementRate:
-            engagementRate > 0 ? Number(engagementRate.toFixed(2)) : undefined,
-          impressions: impressions || undefined,
-          likes: metrics.like_count || 0,
-          mediaType,
-          quotes: metrics.quote_count || 0,
-          retweets: metrics.retweet_count || 0,
-          views: videoViews || impressions || 0,
-        });
-      }
+      const results = this.responseMapper.mapAnalyticsBatch(
+        res as unknown as TwitterAnalyticsResponse,
+      );
 
       this.loggerService.log(
         `${url} success - fetched analytics for ${results.size} tweets`,

--- a/apps/server/api/src/services/integrations/twitter/twitter.module.ts
+++ b/apps/server/api/src/services/integrations/twitter/twitter.module.ts
@@ -3,11 +3,13 @@ import { BrandsModule } from '@api/collections/brands/brands.module';
 import { CredentialsCoreModule } from '@api/collections/credentials/credentials-core.module';
 import { TwitterController } from '@api/services/integrations/twitter/controllers/twitter.controller';
 import { TwitterService } from '@api/services/integrations/twitter/services/twitter.service';
+import { TwitterResponseMapper } from '@api/services/integrations/twitter/services/twitter-response.mapper';
 import { createServiceModule } from '@api/shared/service-module.factory';
 import { HttpModule } from '@nestjs/axios';
 import { forwardRef, Module } from '@nestjs/common';
 
 const BaseModule = createServiceModule(TwitterService, {
+  additionalProviders: [TwitterResponseMapper],
   additionalImports: [
     forwardRef(() => HttpModule),
     forwardRef(() => BrandsModule),


### PR DESCRIPTION
## Summary

- extract Twitter/X search, user, trend, and analytics response projection into a typed `TwitterResponseMapper`
- keep provider calls, credentials, organization scope, rate-limit handling, logging, and public service methods unchanged
- reduce `TwitterService` from 1,005 to 722 lines and add focused mapper coverage for success, partial, and malformed provider rows

## Verification

- `bunx @biomejs/biome@2.5.3 check <six touched files>` — passed
- `bun run scripts/architecture/check-runtime-complexity.ts --base d0b39d8a074ad2263eb251cfd1a47d02285be669` — passed (0 violations)
- staged `secretlint` scan — passed
- `git diff --cached --check` and line/delegation assertions — passed
- structured Fable adversarial review — approved with no blocking findings
- `bun run check:di-value-imports` — unavailable because the repository TypeScript runtime exposes no `ts.ScriptTarget`; imports were manually verified as runtime value imports
- local tests, typecheck, and build were not run per local-machine policy; PR CI is authoritative

## Residual risk

- third-party Twitter SDK responses cross the mapper boundary through explicit structural casts; response semantics are covered by existing service coverage plus the new mapper spec

Parent: #1742
Closes #1921
