### PR TITLE
chore(lint): enforce notification noExplicitAny

### DIFF
--- a/apps/server/notifications/src/services/discord/discord-bot.service.spec.ts
+++ b/apps/server/notifications/src/services/discord/discord-bot.service.spec.ts
@@ -43,11 +43,22 @@ vi.mock('discord.js', () => {
 
 import { Client, TextChannel } from 'discord.js';
 
+const createMockDiscordClient = () => ({
+  channels: {
+    fetch: vi.fn(),
+  },
+  destroy: vi.fn().mockResolvedValue(undefined),
+  login: vi.fn().mockResolvedValue('token'),
+  on: vi.fn(),
+  once: vi.fn(),
+  user: { id: 'bot-user-123', tag: 'TestBot#1234' },
+});
+
 describe('DiscordBotService', () => {
   let service: DiscordBotService;
   let mockConfigService: Mocked<ConfigService>;
   let mockLogger: Mocked<LoggerService>;
-  let mockClient: any;
+  let mockClient: ReturnType<typeof createMockDiscordClient>;
 
   beforeEach(async () => {
     mockConfigService = {
@@ -74,16 +85,7 @@ describe('DiscordBotService', () => {
     } as unknown as Mocked<LoggerService>;
 
     // Reset Client mock
-    mockClient = {
-      channels: {
-        fetch: vi.fn(),
-      },
-      destroy: vi.fn().mockResolvedValue(undefined),
-      login: vi.fn().mockResolvedValue('token'),
-      on: vi.fn(),
-      once: vi.fn(),
-      user: { id: 'bot-user-123', tag: 'TestBot#1234' },
-    };
+    mockClient = createMockDiscordClient();
 
     (Client as Mock).mockImplementation(() => mockClient);
 

--- a/biome.json
+++ b/biome.json
@@ -117,6 +117,16 @@
       }
     },
     {
+      "includes": ["apps/server/notifications/**/*.ts"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noExplicitAny": "error"
+          }
+        }
+      }
+    },
+    {
       "includes": [
         "ee/packages/**/*.{controller,service,module,resolver,guard,interceptor,pipe,middleware,filter}.ts"
       ],


### PR DESCRIPTION
## Summary

- replace the notifications Discord client test `any` with an inferred mock factory
- promote Biome `noExplicitAny` from warning to error for `apps/server/notifications/**/*.ts`
- keep the repository-wide backend warning ratchet unchanged outside this runtime

## Verification

- `bunx --bun @biomejs/biome@2.5.3 check biome.json apps/server/notifications --reporter=summary --max-diagnostics=100` — passed (66 files, no errors or warnings; two pre-existing config infos)
- temporary in-scope explicit-`any` fixture — failed closed with two `lint/suspicious/noExplicitAny` errors and exit 1, then removed
- `git diff --check` — passed
- staged secret filename/pattern scan — passed

## Skipped locally

- tests, typecheck, and build: reserved for PR CI by local machine policy
- Secretlint: local CLI could not resolve its configured rule modules; PR CI owns the authoritative check

Closes #1923