### PR TITLE
ci: execute nightly unit workspace matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,7 +273,7 @@ jobs:
       - name: Architecture Guard Fixtures
         run: |
           bunx vitest run --config scripts/architecture/vitest.config.ts check-runtime-complexity.test.ts check-deterministic-locale.test.ts
-          bunx vitest run --config scripts/ci/vitest.config.ts nightly-test-workspace-inventory.test.ts
+          bunx vitest run --config scripts/ci/vitest.config.ts nightly-test-workspace-inventory.test.ts nightly-unit-matrix.test.ts
       - name: DI Value Imports
         run: bun run check:di-value-imports
       - name: Desktop Schema Drift

--- a/.github/workflows/nightly-unit-matrix.yml
+++ b/.github/workflows/nightly-unit-matrix.yml
@@ -1,0 +1,230 @@
+name: Nightly Unit Matrix
+
+on:
+  schedule:
+    # Daily at 00:37 UTC. The offset avoids GitHub's top-of-hour schedule queue.
+    - cron: '37 0 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: nightly-unit-matrix-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  actions: read
+  contents: read
+
+env:
+  CI: true
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  TZ: UTC
+
+jobs:
+  plan:
+    name: Plan Nightly Unit Matrix
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      entry_count: ${{ steps.plan.outputs.entry_count }}
+      matrix: ${{ steps.plan.outputs.matrix }}
+      sha: ${{ steps.plan.outputs.sha }}
+    steps:
+      - name: Checkout immutable workflow SHA
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Setup Bun environment
+        uses: ./.github/actions/setup-bun-env
+        with:
+          bun-version: '1.3.14'
+          cache-turbo: 'false'
+
+      - name: Build inventory-derived matrix
+        id: plan
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          checkout_sha="$(git rev-parse HEAD)"
+          if [ "$checkout_sha" != "$GITHUB_SHA" ]; then
+            echo "::error::Checkout SHA $checkout_sha does not match workflow SHA $GITHUB_SHA"
+            exit 1
+          fi
+
+          bun run scripts/ci/nightly-unit-matrix.ts plan \
+            --sha "$checkout_sha" \
+            --output nightly-unit-matrix-plan.json
+
+          {
+            echo "sha=$checkout_sha"
+            echo "entry_count=$(jq '.entries | length' nightly-unit-matrix-plan.json)"
+            echo "matrix=$(jq -c '{include:.entries}' nightly-unit-matrix-plan.json)"
+          } >> "$GITHUB_OUTPUT"
+
+          bun run scripts/ci/nightly-test-workspace-inventory.ts \
+            | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload immutable matrix plan
+        uses: actions/upload-artifact@v7
+        with:
+          name: nightly-unit-matrix-plan-${{ steps.plan.outputs.sha }}
+          path: nightly-unit-matrix-plan.json
+          if-no-files-found: error
+          retention-days: 30
+
+  unit:
+    name: Unit / ${{ matrix.executionId }}
+    needs: plan
+    if: needs.plan.outputs.entry_count != '0'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      max-parallel: 12
+      matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
+    steps:
+      - name: Checkout immutable matrix SHA
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.plan.outputs.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Setup Bun environment
+        uses: ./.github/actions/setup-bun-env
+        with:
+          bun-version: '1.3.14'
+
+      - name: Run workspace suite
+        shell: bash
+        env:
+          BETTER_AUTH_SECRET: test-better-auth-secret
+          NODE_ENV: test
+          SHARD: ${{ matrix.shard }}
+          SHARD_COUNT: ${{ matrix.shardCount }}
+          WORKSPACE_NAME: ${{ matrix.name }}
+        run: |
+          set -euo pipefail
+
+          if [ "$SHARD_COUNT" -gt 1 ]; then
+            bunx turbo run test \
+              --filter="$WORKSPACE_NAME" \
+              -- \
+              --shard="$SHARD/$SHARD_COUNT"
+          else
+            bunx turbo run test --filter="$WORKSPACE_NAME"
+          fi
+
+  aggregate:
+    name: Nightly Unit Matrix Aggregate
+    needs: [plan, unit]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Checkout immutable matrix SHA
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.plan.outputs.sha || github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Setup Bun environment
+        uses: ./.github/actions/setup-bun-env
+        with:
+          bun-version: '1.3.14'
+          cache-turbo: 'false'
+
+      - name: Download immutable matrix plan
+        if: needs.plan.result == 'success'
+        uses: actions/download-artifact@v8
+        with:
+          name: nightly-unit-matrix-plan-${{ needs.plan.outputs.sha }}
+
+      - name: Read current-run job evidence
+        if: needs.plan.result == 'success'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('node:fs');
+            const jobs = await github.paginate(
+              github.rest.actions.listJobsForWorkflowRun,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: context.runId,
+                filter: 'latest',
+                per_page: 100,
+              },
+            );
+            fs.writeFileSync(
+              'nightly-unit-matrix-jobs.json',
+              `${JSON.stringify(
+                jobs.map(({ conclusion, html_url, name }) => ({
+                  conclusion,
+                  html_url,
+                  name,
+                })),
+                null,
+                2,
+              )}\n`,
+            );
+
+      - name: Aggregate workspace results
+        id: aggregate
+        if: needs.plan.result == 'success'
+        continue-on-error: true
+        run: |
+          bun run scripts/ci/nightly-unit-matrix.ts aggregate \
+            --plan nightly-unit-matrix-plan.json \
+            --jobs nightly-unit-matrix-jobs.json \
+            --output nightly-unit-matrix-summary.json \
+            --markdown nightly-unit-matrix-summary.md
+
+      - name: Publish nightly summary
+        if: always()
+        shell: bash
+        env:
+          PLAN_RESULT: ${{ needs.plan.result }}
+        run: |
+          if [ -f nightly-unit-matrix-summary.md ]; then
+            cat nightly-unit-matrix-summary.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "# Nightly Unit Matrix"
+              echo
+              echo "- Contract: FAIL"
+              echo "- Planning result: \`$PLAN_RESULT\`"
+              echo "- No aggregate summary was produced."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload aggregate evidence
+        if: always() && hashFiles('nightly-unit-matrix-summary.json') != ''
+        uses: actions/upload-artifact@v7
+        with:
+          name: nightly-unit-matrix-summary-${{ needs.plan.outputs.sha || github.sha }}
+          path: |
+            nightly-unit-matrix-jobs.json
+            nightly-unit-matrix-summary.json
+            nightly-unit-matrix-summary.md
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Enforce stable aggregate
+        if: always()
+        shell: bash
+        env:
+          AGGREGATE_OUTCOME: ${{ steps.aggregate.outcome }}
+          PLAN_RESULT: ${{ needs.plan.result }}
+        run: |
+          if [ "$PLAN_RESULT" != "success" ] || [ "$AGGREGATE_OUTCOME" != "success" ]; then
+            echo "::error::Nightly unit matrix contract failed"
+            exit 1
+          fi

--- a/scripts/ci/nightly-test-workspace-inventory.test.ts
+++ b/scripts/ci/nightly-test-workspace-inventory.test.ts
@@ -35,6 +35,7 @@ describe('nightly test workspace inventory', () => {
     );
     writeWorkspace('apps/docs', '@genfeedai/docs');
     writeWorkspace('apps/app', '@genfeedai/app');
+    writeWorkspace('packages/no-tests', '@genfeedai/no-tests', null);
 
     const result = buildNightlyTestWorkspaceInventory({
       rootDir: testDir,
@@ -60,6 +61,23 @@ describe('nightly test workspace inventory', () => {
       package: 1,
       'server-service': 1,
     });
+    expect(result.summary.excludedByClass).toEqual({
+      api: 0,
+      app: 0,
+      client: 0,
+      extension: 0,
+      package: 0,
+      'server-service': 0,
+    });
+    expect(result.summary.discoveredByClass).toEqual({
+      api: 1,
+      app: 1,
+      client: 1,
+      extension: 1,
+      package: 2,
+      'server-service': 1,
+    });
+    expect(result.summary.discoveredWorkspaces).toBe(7);
     expect(result.workspaces[0]).toMatchObject({
       command: 'bun run --cwd apps/app test',
       manifestCommand: 'vitest run',
@@ -142,7 +160,13 @@ describe('nightly test workspace inventory', () => {
 
     expect(result.violations).toEqual([]);
     expect(result.workspaces).toEqual([]);
-    expect(result.excluded).toEqual(exclusions);
+    expect(result.excluded).toEqual([
+      {
+        ...exclusions[0],
+        workspaceClass: 'package',
+      },
+    ]);
+    expect(result.summary.excludedByClass.package).toBe(1);
   });
 
   it('fails when an exclusion no longer matches a test-capable workspace', () => {

--- a/scripts/ci/nightly-test-workspace-inventory.ts
+++ b/scripts/ci/nightly-test-workspace-inventory.ts
@@ -27,6 +27,10 @@ export type NightlyTestExclusion = {
   trackingIssue: number;
 };
 
+export type NightlyTestExcludedWorkspace = NightlyTestExclusion & {
+  workspaceClass: NightlyTestWorkspaceClass;
+};
+
 export type NightlyTestInventoryViolation = {
   kind:
     | 'duplicate-exclusion'
@@ -43,10 +47,12 @@ export type NightlyTestInventoryViolation = {
 };
 
 export type NightlyTestInventoryResult = {
-  excluded: NightlyTestExclusion[];
+  excluded: NightlyTestExcludedWorkspace[];
   summary: {
     byClass: Record<NightlyTestWorkspaceClass, number>;
+    discoveredByClass: Record<NightlyTestWorkspaceClass, number>;
     discoveredWorkspaces: number;
+    excludedByClass: Record<NightlyTestWorkspaceClass, number>;
     excludedWorkspaces: number;
     executableWorkspaces: number;
     testCapableWorkspaces: number;
@@ -228,7 +234,9 @@ function validateExclusion(
 }
 
 function createClassCounts(
-  workspaces: readonly NightlyTestWorkspace[],
+  workspaces: readonly {
+    workspaceClass: NightlyTestWorkspaceClass;
+  }[],
 ): Record<NightlyTestWorkspaceClass, number> {
   const counts = Object.fromEntries(
     WORKSPACE_CLASSES.map((workspaceClass) => [workspaceClass, 0]),
@@ -264,9 +272,12 @@ export function buildNightlyTestWorkspaceInventory(
   const workspaceMatches = discoverWorkspaceMatches(rootDir, workspacePatterns);
   const violations: NightlyTestInventoryViolation[] = [];
   const exclusionsByPath = new Map<string, NightlyTestExclusion>();
+  const discoveredWorkspaces: {
+    workspaceClass: NightlyTestWorkspaceClass;
+  }[] = [];
   const testCapablePaths = new Set<string>();
   const workspaceNames = new Map<string, string>();
-  const excluded: NightlyTestExclusion[] = [];
+  const excluded: NightlyTestExcludedWorkspace[] = [];
   const workspaces: NightlyTestWorkspace[] = [];
 
   for (const exclusion of exclusions) {
@@ -299,6 +310,11 @@ export function buildNightlyTestWorkspaceInventory(
         message: `Workspace is matched by multiple root patterns: ${matchingPatterns.join(', ')}.`,
         path: workspacePath,
       });
+    }
+
+    const workspaceClass = classifyWorkspace(workspacePath);
+    if (workspaceClass) {
+      discoveredWorkspaces.push({ workspaceClass });
     }
 
     const manifest = readJsonFile<WorkspacePackageManifest>(
@@ -349,19 +365,21 @@ export function buildNightlyTestWorkspaceInventory(
       workspaceNames.set(manifest.name, workspacePath);
     }
 
-    const exclusion = exclusionsByPath.get(workspacePath);
-    if (exclusion) {
-      excluded.push(exclusion);
-      continue;
-    }
-
-    const workspaceClass = classifyWorkspace(workspacePath);
     if (!workspaceClass) {
       violations.push({
         kind: 'missing-workspace-classification',
         message:
           'Test-capable workspace is missing a nightly inventory classification.',
         path: workspacePath,
+      });
+      continue;
+    }
+
+    const exclusion = exclusionsByPath.get(workspacePath);
+    if (exclusion) {
+      excluded.push({
+        ...exclusion,
+        workspaceClass,
       });
       continue;
     }
@@ -393,7 +411,9 @@ export function buildNightlyTestWorkspaceInventory(
     excluded,
     summary: {
       byClass: createClassCounts(workspaces),
+      discoveredByClass: createClassCounts(discoveredWorkspaces),
       discoveredWorkspaces: workspaceMatches.size,
+      excludedByClass: createClassCounts(excluded),
       excludedWorkspaces: excluded.length,
       executableWorkspaces: workspaces.length,
       testCapableWorkspaces: testCapablePaths.size,
@@ -414,7 +434,7 @@ export function formatNightlyTestWorkspaceInventory(
     `- Excluded workspaces: ${result.summary.excludedWorkspaces}`,
     ...WORKSPACE_CLASSES.map(
       (workspaceClass) =>
-        `- ${workspaceClass}: ${result.summary.byClass[workspaceClass]}`,
+        `- ${workspaceClass}: ${result.summary.byClass[workspaceClass]} executable, ${result.summary.excludedByClass[workspaceClass]} excluded`,
     ),
   ];
 

--- a/scripts/ci/nightly-unit-matrix.test.ts
+++ b/scripts/ci/nightly-unit-matrix.test.ts
@@ -108,20 +108,17 @@ describe('nightly unit matrix', () => {
     ['failure', 'failed'],
     ['cancelled', 'blocked'],
     ['skipped', 'skipped'],
-  ] as const)(
-    'fails closed when one execution concludes %s',
-    (conclusion, expectedOutcome) => {
-      const plan = buildNightlyUnitMatrixPlan(inventory(), SHA);
-      const jobs = jobsForPlan(plan);
-      jobs[0] = { ...jobs[0], conclusion };
+  ] as const)('fails closed when one execution concludes %s', (conclusion, expectedOutcome) => {
+    const plan = buildNightlyUnitMatrixPlan(inventory(), SHA);
+    const jobs = jobsForPlan(plan);
+    jobs[0] = { ...jobs[0], conclusion };
 
-      const summary = aggregateNightlyUnitMatrix(plan, jobs);
+    const summary = aggregateNightlyUnitMatrix(plan, jobs);
 
-      expect(summary.passed).toBe(false);
-      expect(summary.workspaces[0].outcome).toBe(expectedOutcome);
-      expect(formatNightlyUnitMatrixSummary(summary)).toContain('`apps/app`');
-    },
-  );
+    expect(summary.passed).toBe(false);
+    expect(summary.workspaces[0].outcome).toBe(expectedOutcome);
+    expect(formatNightlyUnitMatrixSummary(summary)).toContain('`apps/app`');
+  });
 
   it('fails closed on missing and duplicate current-run job evidence', () => {
     const plan = buildNightlyUnitMatrixPlan(inventory(), SHA);

--- a/scripts/ci/nightly-unit-matrix.test.ts
+++ b/scripts/ci/nightly-unit-matrix.test.ts
@@ -1,0 +1,244 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  aggregateNightlyUnitMatrix,
+  buildNightlyUnitMatrixPlan,
+  formatNightlyUnitMatrixSummary,
+  type NightlyUnitMatrixJob,
+} from './nightly-unit-matrix';
+import type {
+  NightlyTestInventoryResult,
+  NightlyTestWorkspace,
+} from './nightly-test-workspace-inventory';
+
+const SHA = '0123456789abcdef0123456789abcdef01234567';
+
+describe('nightly unit matrix', () => {
+  it('plans every standard workspace once and app/API workspaces in four shards', () => {
+    const plan = buildNightlyUnitMatrixPlan(inventory(), SHA);
+
+    expect(plan.entries).toHaveLength(10);
+    expect(
+      plan.entries
+        .filter((entry) => entry.path === 'apps/app')
+        .map((entry) => entry.shard),
+    ).toEqual([1, 2, 3, 4]);
+    expect(
+      plan.entries
+        .filter((entry) => entry.path === 'apps/server/api')
+        .map((entry) => entry.shard),
+    ).toEqual([1, 2, 3, 4]);
+    expect(
+      plan.entries.find((entry) => entry.path === 'packages/helpers'),
+    ).toMatchObject({
+      executionId: 'package--packages-helpers',
+      shard: 1,
+      shardCount: 1,
+    });
+  });
+
+  it('rejects an invalid immutable SHA and inventory violations', () => {
+    expect(() => buildNightlyUnitMatrixPlan(inventory(), 'master')).toThrow(
+      /full 40-character SHA/,
+    );
+    expect(() =>
+      buildNightlyUnitMatrixPlan(
+        {
+          ...inventory(),
+          violations: [
+            {
+              kind: 'invalid-command',
+              message: 'invalid',
+              path: 'packages/helpers',
+            },
+          ],
+        },
+        SHA,
+      ),
+    ).toThrow(/1 violation/);
+    expect(() =>
+      buildNightlyUnitMatrixPlan(
+        {
+          ...inventory(),
+          summary: {
+            ...inventory().summary,
+            byClass: {
+              api: 0,
+              app: 0,
+              client: 0,
+              extension: 0,
+              package: 0,
+              'server-service': 0,
+            },
+            executableWorkspaces: 0,
+          },
+          workspaces: [],
+        },
+        SHA,
+      ),
+    ).toThrow(/at least one executable workspace/);
+  });
+
+  it('aggregates a complete green matrix by workspace class', () => {
+    const plan = buildNightlyUnitMatrixPlan(inventory(), SHA);
+    const summary = aggregateNightlyUnitMatrix(plan, jobsForPlan(plan));
+
+    expect(summary.passed).toBe(true);
+    expect(summary.violations).toEqual([]);
+    expect(summary.byClass.app).toMatchObject({
+      blocked: 0,
+      executable: 1,
+      executed: 1,
+      passed: 1,
+    });
+    expect(summary.byClass.package).toMatchObject({
+      discovered: 2,
+      excluded: 1,
+      executable: 1,
+      executed: 1,
+      passed: 1,
+    });
+    expect(formatNightlyUnitMatrixSummary(summary)).toContain(
+      '| package | 2 | 1 | 1 | 1 | 0 | 0 | 0 | 1 |',
+    );
+  });
+
+  it.each([
+    ['failure', 'failed'],
+    ['cancelled', 'blocked'],
+    ['skipped', 'skipped'],
+  ] as const)(
+    'fails closed when one execution concludes %s',
+    (conclusion, expectedOutcome) => {
+      const plan = buildNightlyUnitMatrixPlan(inventory(), SHA);
+      const jobs = jobsForPlan(plan);
+      jobs[0] = { ...jobs[0], conclusion };
+
+      const summary = aggregateNightlyUnitMatrix(plan, jobs);
+
+      expect(summary.passed).toBe(false);
+      expect(summary.workspaces[0].outcome).toBe(expectedOutcome);
+      expect(formatNightlyUnitMatrixSummary(summary)).toContain(
+        '`apps/app`',
+      );
+    },
+  );
+
+  it('fails closed on missing and duplicate current-run job evidence', () => {
+    const plan = buildNightlyUnitMatrixPlan(inventory(), SHA);
+    const completeJobs = jobsForPlan(plan);
+    const missingSummary = aggregateNightlyUnitMatrix(
+      plan,
+      completeJobs.slice(1),
+    );
+    const duplicateSummary = aggregateNightlyUnitMatrix(plan, [
+      ...completeJobs,
+      completeJobs[0],
+    ]);
+
+    expect(missingSummary.passed).toBe(false);
+    expect(missingSummary.violations[0]).toMatch(/Missing job evidence/);
+    expect(duplicateSummary.passed).toBe(false);
+    expect(duplicateSummary.violations[0]).toMatch(/Duplicate job evidence/);
+  });
+
+  it('keeps the scheduled workflow isolated and fail-closed', () => {
+    const workflowPath = fileURLToPath(
+      new URL('../../.github/workflows/nightly-unit-matrix.yml', import.meta.url),
+    );
+    const workflow = readFileSync(workflowPath, 'utf8');
+
+    expect(workflow).toMatch(/^name: Nightly Unit Matrix$/m);
+    expect(workflow).toMatch(/^  schedule:\n {4}- cron:/m);
+    expect(workflow).toMatch(/^  workflow_dispatch:$/m);
+    expect(workflow).toMatch(
+      /^  group: nightly-unit-matrix-\$\{\{ github\.ref \}\}$/m,
+    );
+    expect(workflow).toMatch(/^  cancel-in-progress: false$/m);
+    expect(workflow).toMatch(/ref: \$\{\{ needs\.plan\.outputs\.sha \}\}/);
+    expect(workflow).toMatch(
+      /matrix: \$\{\{ fromJSON\(needs\.plan\.outputs\.matrix\) \}\}/,
+    );
+    expect(workflow).toMatch(/^ {6}max-parallel: 12$/m);
+    expect(workflow).toMatch(/^ {4}name: Nightly Unit Matrix Aggregate$/m);
+    expect(workflow).toMatch(/^ {4}if: \$\{\{ always\(\) \}\}$/m);
+    expect(workflow).not.toMatch(
+      /uses: .*?(deploy|e2e|full-suite|coverage).*?\.ya?ml/,
+    );
+  });
+});
+
+function workspace(
+  path: string,
+  workspaceClass: NightlyTestWorkspace['workspaceClass'],
+): NightlyTestWorkspace {
+  return {
+    command: `bun run --cwd ${path} test`,
+    manifestCommand: 'vitest run',
+    name: `@genfeedai/${path.split('/').at(-1)}`,
+    path,
+    workspaceClass,
+  };
+}
+
+function inventory(): NightlyTestInventoryResult {
+  return {
+    excluded: [
+      {
+        owner: '@genfeedai/ci',
+        path: 'packages/excluded',
+        reason: 'Tracked until the suite becomes hermetic.',
+        reviewDate: '2026-08-20',
+        trackingIssue: 1931,
+        workspaceClass: 'package',
+      },
+    ],
+    summary: {
+      byClass: {
+        api: 1,
+        app: 1,
+        client: 0,
+        extension: 0,
+        package: 1,
+        'server-service': 0,
+      },
+      discoveredByClass: {
+        api: 1,
+        app: 1,
+        client: 0,
+        extension: 0,
+        package: 2,
+        'server-service': 0,
+      },
+      discoveredWorkspaces: 4,
+      excludedByClass: {
+        api: 0,
+        app: 0,
+        client: 0,
+        extension: 0,
+        package: 1,
+        'server-service': 0,
+      },
+      excludedWorkspaces: 1,
+      executableWorkspaces: 3,
+      testCapableWorkspaces: 4,
+    },
+    violations: [],
+    workspaces: [
+      workspace('apps/app', 'app'),
+      workspace('apps/server/api', 'api'),
+      workspace('packages/helpers', 'package'),
+    ],
+  };
+}
+
+function jobsForPlan(
+  plan: ReturnType<typeof buildNightlyUnitMatrixPlan>,
+): NightlyUnitMatrixJob[] {
+  return plan.entries.map((entry) => ({
+    conclusion: 'success',
+    html_url: `https://github.com/genfeedai/genfeed.ai/actions/jobs/${entry.executionId}`,
+    name: `Unit / ${entry.executionId}`,
+  }));
+}

--- a/scripts/ci/nightly-unit-matrix.test.ts
+++ b/scripts/ci/nightly-unit-matrix.test.ts
@@ -18,7 +18,7 @@ describe('nightly unit matrix', () => {
   it('plans every standard workspace once and app/API workspaces in four shards', () => {
     const plan = buildNightlyUnitMatrixPlan(inventory(), SHA);
 
-    expect(plan.entries).toHaveLength(10);
+    expect(plan.entries).toHaveLength(9);
     expect(
       plan.entries
         .filter((entry) => entry.path === 'apps/app')
@@ -151,7 +151,7 @@ describe('nightly unit matrix', () => {
     const workflow = readFileSync(workflowPath, 'utf8');
 
     expect(workflow).toMatch(/^name: Nightly Unit Matrix$/m);
-    expect(workflow).toMatch(/^  schedule:\n {4}- cron:/m);
+    expect(workflow).toMatch(/^  schedule:\n(?: {4}#.*\n)* {4}- cron:/m);
     expect(workflow).toMatch(/^  workflow_dispatch:$/m);
     expect(workflow).toMatch(
       /^  group: nightly-unit-matrix-\$\{\{ github\.ref \}\}$/m,

--- a/scripts/ci/nightly-unit-matrix.test.ts
+++ b/scripts/ci/nightly-unit-matrix.test.ts
@@ -119,9 +119,7 @@ describe('nightly unit matrix', () => {
 
       expect(summary.passed).toBe(false);
       expect(summary.workspaces[0].outcome).toBe(expectedOutcome);
-      expect(formatNightlyUnitMatrixSummary(summary)).toContain(
-        '`apps/app`',
-      );
+      expect(formatNightlyUnitMatrixSummary(summary)).toContain('`apps/app`');
     },
   );
 
@@ -145,7 +143,10 @@ describe('nightly unit matrix', () => {
 
   it('keeps the scheduled workflow isolated and fail-closed', () => {
     const workflowPath = fileURLToPath(
-      new URL('../../.github/workflows/nightly-unit-matrix.yml', import.meta.url),
+      new URL(
+        '../../.github/workflows/nightly-unit-matrix.yml',
+        import.meta.url,
+      ),
     );
     const workflow = readFileSync(workflowPath, 'utf8');
 

--- a/scripts/ci/nightly-unit-matrix.ts
+++ b/scripts/ci/nightly-unit-matrix.ts
@@ -85,8 +85,7 @@ function createExecutionId(
   const normalizedPath = workspacePath
     .replaceAll(/[^a-zA-Z0-9]+/g, '-')
     .replaceAll(/^-|-$/g, '');
-  const shardSuffix =
-    shardCount > 1 ? `--${shard}-of-${shardCount}` : '';
+  const shardSuffix = shardCount > 1 ? `--${shard}-of-${shardCount}` : '';
 
   return `${workspaceClass}--${normalizedPath}${shardSuffix}`;
 }
@@ -117,7 +116,9 @@ export function buildNightlyUnitMatrixPlan(
   }
 
   if (!Number.isInteger(shardCount) || shardCount < 1) {
-    throw new Error('Nightly unit matrix shard count must be a positive integer.');
+    throw new Error(
+      'Nightly unit matrix shard count must be a positive integer.',
+    );
   }
 
   const entries: NightlyUnitMatrixEntry[] = [];
@@ -348,9 +349,7 @@ export function formatNightlyUnitMatrixSummary(
               .map((jobUrl, index) => `[job ${index + 1}](${jobUrl})`)
               .join(', ')
           : 'no terminal job evidence';
-      lines.push(
-        `- \`${workspace.path}\`: ${workspace.outcome} (${jobLinks})`,
-      );
+      lines.push(`- \`${workspace.path}\`: ${workspace.outcome} (${jobLinks})`);
     }
   }
 

--- a/scripts/ci/nightly-unit-matrix.ts
+++ b/scripts/ci/nightly-unit-matrix.ts
@@ -1,0 +1,424 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
+import {
+  buildNightlyTestWorkspaceInventory,
+  type NightlyTestInventoryResult,
+  type NightlyTestWorkspaceClass,
+} from './nightly-test-workspace-inventory';
+
+const WORKSPACE_CLASSES: NightlyTestWorkspaceClass[] = [
+  'api',
+  'app',
+  'client',
+  'extension',
+  'package',
+  'server-service',
+];
+
+const SHARDED_WORKSPACE_CLASSES = new Set<NightlyTestWorkspaceClass>([
+  'api',
+  'app',
+]);
+
+export type NightlyUnitMatrixEntry = {
+  command: string;
+  executionId: string;
+  name: string;
+  path: string;
+  shard: number;
+  shardCount: number;
+  workspaceClass: NightlyTestWorkspaceClass;
+};
+
+export type NightlyUnitMatrixPlan = {
+  entries: NightlyUnitMatrixEntry[];
+  excluded: NightlyTestInventoryResult['excluded'];
+  inventorySummary: NightlyTestInventoryResult['summary'];
+  sha: string;
+};
+
+export type NightlyUnitMatrixJob = {
+  conclusion: string | null;
+  html_url?: string;
+  name: string;
+};
+
+export type NightlyUnitWorkspaceOutcome =
+  | 'blocked'
+  | 'failed'
+  | 'passed'
+  | 'skipped';
+
+export type NightlyUnitWorkspaceResult = {
+  jobUrls: string[];
+  outcome: NightlyUnitWorkspaceOutcome;
+  path: string;
+  workspaceClass: NightlyTestWorkspaceClass;
+};
+
+type NightlyUnitClassCounts = {
+  blocked: number;
+  discovered: number;
+  excluded: number;
+  executable: number;
+  executed: number;
+  failed: number;
+  passed: number;
+  skipped: number;
+};
+
+export type NightlyUnitMatrixSummary = {
+  byClass: Record<NightlyTestWorkspaceClass, NightlyUnitClassCounts>;
+  inventory: NightlyUnitMatrixPlan['inventorySummary'];
+  passed: boolean;
+  sha: string;
+  violations: string[];
+  workspaces: NightlyUnitWorkspaceResult[];
+};
+
+function createExecutionId(
+  workspaceClass: NightlyTestWorkspaceClass,
+  workspacePath: string,
+  shard: number,
+  shardCount: number,
+): string {
+  const normalizedPath = workspacePath
+    .replaceAll(/[^a-zA-Z0-9]+/g, '-')
+    .replaceAll(/^-|-$/g, '');
+  const shardSuffix =
+    shardCount > 1 ? `--${shard}-of-${shardCount}` : '';
+
+  return `${workspaceClass}--${normalizedPath}${shardSuffix}`;
+}
+
+function validateSha(sha: string): void {
+  if (!/^[a-f0-9]{40}$/.test(sha)) {
+    throw new Error('Nightly unit matrix SHA must be a full 40-character SHA.');
+  }
+}
+
+export function buildNightlyUnitMatrixPlan(
+  inventory: NightlyTestInventoryResult,
+  sha: string,
+  shardCount = 4,
+): NightlyUnitMatrixPlan {
+  validateSha(sha);
+
+  if (inventory.violations.length > 0) {
+    throw new Error(
+      `Nightly workspace inventory has ${inventory.violations.length} violation(s).`,
+    );
+  }
+
+  if (inventory.summary.executableWorkspaces === 0) {
+    throw new Error(
+      'Nightly workspace inventory must contain at least one executable workspace.',
+    );
+  }
+
+  if (!Number.isInteger(shardCount) || shardCount < 1) {
+    throw new Error('Nightly unit matrix shard count must be a positive integer.');
+  }
+
+  const entries: NightlyUnitMatrixEntry[] = [];
+  const executionIds = new Set<string>();
+
+  for (const workspace of inventory.workspaces) {
+    const workspaceShardCount = SHARDED_WORKSPACE_CLASSES.has(
+      workspace.workspaceClass,
+    )
+      ? shardCount
+      : 1;
+
+    for (let shard = 1; shard <= workspaceShardCount; shard += 1) {
+      const executionId = createExecutionId(
+        workspace.workspaceClass,
+        workspace.path,
+        shard,
+        workspaceShardCount,
+      );
+
+      if (executionIds.has(executionId)) {
+        throw new Error(`Duplicate nightly execution ID: ${executionId}`);
+      }
+
+      executionIds.add(executionId);
+      entries.push({
+        command: workspace.command,
+        executionId,
+        name: workspace.name,
+        path: workspace.path,
+        shard,
+        shardCount: workspaceShardCount,
+        workspaceClass: workspace.workspaceClass,
+      });
+    }
+  }
+
+  return {
+    entries,
+    excluded: inventory.excluded,
+    inventorySummary: inventory.summary,
+    sha,
+  };
+}
+
+function createClassCounts(
+  plan: NightlyUnitMatrixPlan,
+): Record<NightlyTestWorkspaceClass, NightlyUnitClassCounts> {
+  return Object.fromEntries(
+    WORKSPACE_CLASSES.map((workspaceClass) => [
+      workspaceClass,
+      {
+        blocked: 0,
+        discovered: plan.inventorySummary.discoveredByClass[workspaceClass],
+        excluded: plan.inventorySummary.excludedByClass[workspaceClass],
+        executable: plan.inventorySummary.byClass[workspaceClass],
+        executed: 0,
+        failed: 0,
+        passed: 0,
+        skipped: 0,
+      },
+    ]),
+  ) as Record<NightlyTestWorkspaceClass, NightlyUnitClassCounts>;
+}
+
+function classifyConclusion(
+  conclusion: string | null,
+): NightlyUnitWorkspaceOutcome {
+  if (conclusion === 'success') {
+    return 'passed';
+  }
+
+  if (
+    conclusion === 'failure' ||
+    conclusion === 'timed_out' ||
+    conclusion === 'action_required' ||
+    conclusion === 'startup_failure'
+  ) {
+    return 'failed';
+  }
+
+  if (conclusion === 'skipped') {
+    return 'skipped';
+  }
+
+  return 'blocked';
+}
+
+function resolveWorkspaceOutcome(
+  outcomes: NightlyUnitWorkspaceOutcome[],
+): NightlyUnitWorkspaceOutcome {
+  if (outcomes.includes('failed')) {
+    return 'failed';
+  }
+
+  if (outcomes.includes('blocked')) {
+    return 'blocked';
+  }
+
+  if (outcomes.includes('skipped')) {
+    return 'skipped';
+  }
+
+  return 'passed';
+}
+
+export function aggregateNightlyUnitMatrix(
+  plan: NightlyUnitMatrixPlan,
+  jobs: readonly NightlyUnitMatrixJob[],
+): NightlyUnitMatrixSummary {
+  const expectedEntriesByWorkspace = new Map<
+    string,
+    NightlyUnitMatrixEntry[]
+  >();
+  const jobsByName = new Map<string, NightlyUnitMatrixJob[]>();
+  const violations: string[] = [];
+
+  for (const entry of plan.entries) {
+    const entries = expectedEntriesByWorkspace.get(entry.path) ?? [];
+    entries.push(entry);
+    expectedEntriesByWorkspace.set(entry.path, entries);
+  }
+
+  for (const job of jobs) {
+    const matchingJobs = jobsByName.get(job.name) ?? [];
+    matchingJobs.push(job);
+    jobsByName.set(job.name, matchingJobs);
+  }
+
+  const workspaces: NightlyUnitWorkspaceResult[] = [];
+  const byClass = createClassCounts(plan);
+
+  for (const [workspacePath, entries] of [
+    ...expectedEntriesByWorkspace.entries(),
+  ].sort(([left], [right]) => left.localeCompare(right))) {
+    const outcomes: NightlyUnitWorkspaceOutcome[] = [];
+    const jobUrls: string[] = [];
+
+    for (const entry of entries) {
+      const expectedJobName = `Unit / ${entry.executionId}`;
+      const matchingJobs = jobsByName.get(expectedJobName) ?? [];
+
+      if (matchingJobs.length === 0) {
+        violations.push(`Missing job evidence for ${expectedJobName}.`);
+        outcomes.push('blocked');
+        continue;
+      }
+
+      if (matchingJobs.length > 1) {
+        violations.push(`Duplicate job evidence for ${expectedJobName}.`);
+        outcomes.push('blocked');
+        continue;
+      }
+
+      const [job] = matchingJobs;
+      outcomes.push(classifyConclusion(job.conclusion));
+      if (job.html_url) {
+        jobUrls.push(job.html_url);
+      }
+    }
+
+    const workspaceClass = entries[0].workspaceClass;
+    const outcome = resolveWorkspaceOutcome(outcomes);
+    const classCounts = byClass[workspaceClass];
+
+    classCounts[outcome] += 1;
+    if (outcome === 'passed' || outcome === 'failed') {
+      classCounts.executed += 1;
+    }
+
+    workspaces.push({
+      jobUrls,
+      outcome,
+      path: workspacePath,
+      workspaceClass,
+    });
+  }
+
+  return {
+    byClass,
+    inventory: plan.inventorySummary,
+    passed:
+      violations.length === 0 &&
+      workspaces.every((workspace) => workspace.outcome === 'passed'),
+    sha: plan.sha,
+    violations,
+    workspaces,
+  };
+}
+
+export function formatNightlyUnitMatrixSummary(
+  summary: NightlyUnitMatrixSummary,
+): string {
+  const lines = [
+    '# Nightly Unit Matrix',
+    '',
+    `- SHA: \`${summary.sha}\``,
+    `- Discovered workspaces: ${summary.inventory.discoveredWorkspaces}`,
+    `- Test-capable workspaces: ${summary.inventory.testCapableWorkspaces}`,
+    `- Executable workspaces: ${summary.inventory.executableWorkspaces}`,
+    `- Excluded workspaces: ${summary.inventory.excludedWorkspaces}`,
+    `- Contract: ${summary.passed ? 'PASS' : 'FAIL'}`,
+    '',
+    '| Class | Discovered | Executable | Executed | Passed | Failed | Skipped | Blocked | Excluded |',
+    '| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |',
+    ...WORKSPACE_CLASSES.map((workspaceClass) => {
+      const counts = summary.byClass[workspaceClass];
+      return `| ${workspaceClass} | ${counts.discovered} | ${counts.executable} | ${counts.executed} | ${counts.passed} | ${counts.failed} | ${counts.skipped} | ${counts.blocked} | ${counts.excluded} |`;
+    }),
+  ];
+
+  if (summary.violations.length > 0) {
+    lines.push('', '## Contract violations', '');
+    for (const violation of summary.violations) {
+      lines.push(`- ${violation}`);
+    }
+  }
+
+  const nonPassingWorkspaces = summary.workspaces.filter(
+    (workspace) => workspace.outcome !== 'passed',
+  );
+  if (nonPassingWorkspaces.length > 0) {
+    lines.push('', '## Non-passing workspaces', '');
+    for (const workspace of nonPassingWorkspaces) {
+      const jobLinks =
+        workspace.jobUrls.length > 0
+          ? workspace.jobUrls
+              .map((jobUrl, index) => `[job ${index + 1}](${jobUrl})`)
+              .join(', ')
+          : 'no terminal job evidence';
+      lines.push(
+        `- \`${workspace.path}\`: ${workspace.outcome} (${jobLinks})`,
+      );
+    }
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+function readArgument(name: string): string {
+  const argumentIndex = process.argv.indexOf(name);
+  const value = process.argv[argumentIndex + 1];
+
+  if (argumentIndex === -1 || !value || value.startsWith('--')) {
+    throw new Error(`Missing required argument: ${name}`);
+  }
+
+  return value;
+}
+
+function writeJson(filePath: string, value: unknown): void {
+  writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function runCli(): void {
+  const command = process.argv[2];
+
+  if (command === 'plan') {
+    const outputPath = readArgument('--output');
+    const sha = readArgument('--sha');
+    const plan = buildNightlyUnitMatrixPlan(
+      buildNightlyTestWorkspaceInventory(),
+      sha,
+    );
+    writeJson(outputPath, plan);
+    process.stdout.write(
+      `Planned ${plan.entries.length} nightly executions for ${plan.inventorySummary.executableWorkspaces} workspaces at ${plan.sha}.\n`,
+    );
+    return;
+  }
+
+  if (command === 'aggregate') {
+    const jobs = JSON.parse(
+      readFileSync(readArgument('--jobs'), 'utf8'),
+    ) as NightlyUnitMatrixJob[];
+    const plan = JSON.parse(
+      readFileSync(readArgument('--plan'), 'utf8'),
+    ) as NightlyUnitMatrixPlan;
+    const outputPath = readArgument('--output');
+    const markdownPath = readArgument('--markdown');
+    const summary = aggregateNightlyUnitMatrix(plan, jobs);
+
+    writeJson(outputPath, summary);
+    writeFileSync(
+      markdownPath,
+      formatNightlyUnitMatrixSummary(summary),
+      'utf8',
+    );
+    process.stdout.write(formatNightlyUnitMatrixSummary(summary));
+
+    if (!summary.passed) {
+      process.exitCode = 1;
+    }
+    return;
+  }
+
+  throw new Error(
+    'Usage: nightly-unit-matrix.ts plan|aggregate [required arguments]',
+  );
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runCli();
+}


### PR DESCRIPTION
## Summary

- add a standalone nightly and manually dispatchable unit/integration workflow
- derive 52 execution entries from the canonical 46-workspace inventory, with four-way app/API sharding and a 12-runner cap
- aggregate current-run job evidence fail-closed into per-class JSON and Markdown summaries with retained artifacts
- extend the inventory contract with discovered and excluded counts by workspace class

## Verification

- `bunx @biomejs/biome@2.5.3 format scripts/ci/nightly-test-workspace-inventory.ts scripts/ci/nightly-test-workspace-inventory.test.ts scripts/ci/nightly-unit-matrix.ts scripts/ci/nightly-unit-matrix.test.ts`
- `actionlint .github/workflows/nightly-unit-matrix.yml .github/workflows/ci.yml`
- `git diff --check`
- planner smoke: 52 entries, 46 executable workspaces, 60 discovered workspaces
- exact-head CI: [run 29724882039](https://github.com/genfeedai/genfeed.ai/actions/runs/29724882039) passed all jobs, including focused fixtures, lint, format, typecheck, tests, OpenAPI drift, security scans, build, and Tests Gate
- exact-head Link Check and Codebase Health workflows passed
- independent correctness review: APPROVE after fail-open, secret-boundary, and discovery-accounting fixes
- Fallow audit: no findings

## Residual gates

- Local tests, typecheck, and build were not run under the repository Mac resource policy; exact-head PR CI supplied those checks remotely.
- Fleet Review remains the required exact-head review gate before merge. CodeRabbit did not run because its review quota was temporarily exhausted.
- A live `workflow_dispatch` cannot run until the new workflow exists on the default branch. #1931 remains open for that operational proof.
- Scheduled-failure issue lifecycle remains owned by #1848; three-night observation remains on parent #1847.

Closes #1931
Parent: #1847