### PR TITLE
feat(review): show reviewer attribution in history

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/review/components/ReviewGrid.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/review/components/ReviewGrid.test.tsx
@@ -329,7 +329,18 @@ describe('ReviewGrid', () => {
                 decision: 'approved',
                 feedback: 'Ship this one.',
                 reviewedAt: '2026-03-09T12:00:00.000Z',
+                reviewer: {
+                  avatar: 'https://cdn.example.com/ada.png',
+                  displayName: 'Ada Lovelace',
+                  handle: 'ada',
+                  id: 'user-1',
+                },
                 reviewerId: 'user-1',
+              },
+              {
+                decision: 'request_changes',
+                feedback: 'Legacy feedback.',
+                reviewedAt: '2026-03-08T12:00:00.000Z',
               },
             ],
             reviewFeedback: 'Final approved notes',
@@ -366,6 +377,9 @@ describe('ReviewGrid', () => {
     ).toBeVisible();
     expect(screen.getByText('Review history')).toBeVisible();
     expect(screen.getByText('Ship this one.')).toBeVisible();
+    expect(screen.getByText('Ada Lovelace')).toBeVisible();
+    expect(screen.getByText('@ada')).toBeVisible();
+    expect(screen.getByText('Reviewer unavailable')).toBeVisible();
     expect(screen.getByText('Saved reviewer notes')).toBeVisible();
     expect(screen.getAllByText('Final approved notes')).toHaveLength(2);
     expect(

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/review/components/ReviewHistoryPanel.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/review/components/ReviewHistoryPanel.tsx
@@ -3,12 +3,24 @@
 import type { IBatchItem } from '@genfeedai/interfaces';
 import { formatDateInTimezone } from '@helpers/formatting/timezone/timezone.helper';
 import InsetSurface from '@ui/display/inset-surface/InsetSurface';
+import { Avatar, AvatarFallback, AvatarImage } from '@ui/primitives/avatar';
 
 type ReviewEvent = NonNullable<IBatchItem['reviewEvents']>[number];
 
 interface ReviewHistoryPanelProps {
   browserTimezone: string;
   reviewEvents: ReviewEvent[];
+}
+
+function getReviewerInitials(displayName: string): string {
+  const initials = displayName
+    .trim()
+    .split(/\s+/)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase())
+    .join('');
+
+  return initials || '?';
 }
 
 export default function ReviewHistoryPanel({
@@ -47,6 +59,38 @@ export default function ReviewHistoryPanel({
                 {event.feedback}
               </p>
             )}
+            <div className="mt-3 flex items-center gap-2">
+              <Avatar className="size-7 bg-background shadow-border">
+                {event.reviewer?.avatar ? (
+                  <AvatarImage
+                    alt={`${event.reviewer.displayName} profile picture`}
+                    className="object-cover"
+                    src={event.reviewer.avatar}
+                  />
+                ) : null}
+                <AvatarFallback className="text-[10px] font-semibold text-foreground/70">
+                  {event.reviewer
+                    ? getReviewerInitials(event.reviewer.displayName)
+                    : '?'}
+                </AvatarFallback>
+              </Avatar>
+              {event.reviewer ? (
+                <p className="min-w-0 text-xs text-foreground/55">
+                  <span className="font-medium text-foreground/75">
+                    {event.reviewer.displayName}
+                  </span>
+                  {event.reviewer.handle ? (
+                    <span className="ml-1">
+                      @{event.reviewer.handle.replace(/^@/, '')}
+                    </span>
+                  ) : null}
+                </p>
+              ) : (
+                <p className="text-xs text-foreground/45">
+                  Reviewer unavailable
+                </p>
+              )}
+            </div>
           </InsetSurface>
         ))}
       </div>

--- a/apps/server/api/src/services/batch-generation/batch-generation-review.service.ts
+++ b/apps/server/api/src/services/batch-generation/batch-generation-review.service.ts
@@ -224,14 +224,12 @@ export class BatchGenerationReviewService {
           item.reviewFeedback = undefined;
           item.versionPinId = versionPinId;
           item.reviewedAt = reviewedAt;
-          item.reviewEvents = [
-            ...(item.reviewEvents ?? []),
-            {
-              decision: 'approved',
-              reviewedAt,
-              ...(versionPinId ? { versionPinId } : {}),
-            },
-          ];
+          this.appendApprovedReviewEvent(
+            item,
+            reviewedAt,
+            createdByUserId,
+            versionPinId,
+          );
           if (item.postId && item.scheduledDate) {
             postIdsToSchedule.push(item.postId);
           }
@@ -298,6 +296,23 @@ export class BatchGenerationReviewService {
     return this.summaryService.toBatchSummary(updatedBatch);
   }
 
+  private appendApprovedReviewEvent(
+    item: BatchItemFull,
+    reviewedAt: string,
+    reviewerId: string,
+    versionPinId?: string,
+  ): void {
+    item.reviewEvents = [
+      ...(item.reviewEvents ?? []),
+      {
+        decision: 'approved',
+        reviewedAt,
+        reviewerId,
+        ...(versionPinId ? { versionPinId } : {}),
+      },
+    ];
+  }
+
   private getSelectedPostIds(
     batchItems: BatchItemFull[],
     itemIdSet: Set<string>,
@@ -344,7 +359,12 @@ export class BatchGenerationReviewService {
         item.reviewedAt = reviewedAt;
         item.reviewEvents = [
           ...(item.reviewEvents ?? []),
-          { decision: 'rejected', feedback, reviewedAt },
+          {
+            decision: 'rejected',
+            feedback,
+            reviewedAt,
+            ...(actorUserId ? { reviewerId: actorUserId } : {}),
+          },
         ];
         if (item.postId) {
           postIdsToReject.push(item.postId);
@@ -431,7 +451,12 @@ export class BatchGenerationReviewService {
         item.reviewedAt = reviewedAt;
         item.reviewEvents = [
           ...(item.reviewEvents ?? []),
-          { decision: 'request_changes', feedback, reviewedAt },
+          {
+            decision: 'request_changes',
+            feedback,
+            reviewedAt,
+            ...(actorUserId ? { reviewerId: actorUserId } : {}),
+          },
         ];
         if (item.postId) {
           postIdsToKeepAsDraft.push(item.postId);

--- a/apps/server/api/src/services/batch-generation/batch-generation-summary.service.ts
+++ b/apps/server/api/src/services/batch-generation/batch-generation-summary.service.ts
@@ -1,12 +1,17 @@
 import { PublishApprovalsService } from '@api/collections/publish-approvals/services/publish-approvals.service';
 import {
   type BatchConfig,
+  type BatchItemFull,
   type BatchWithConfig,
   cloneBatchItems,
 } from '@api/services/batch-generation/batch-generation.types';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { BatchItemStatus, BatchStatus } from '@genfeedai/enums';
-import type { IBatchSummary } from '@genfeedai/interfaces';
+import type {
+  IBatchReviewEvent,
+  IBatchReviewEventReviewer,
+  IBatchSummary,
+} from '@genfeedai/interfaces';
 import { Injectable } from '@nestjs/common';
 
 type PostAnalyticsSummary = {
@@ -29,6 +34,19 @@ type LinkedPostAnalytics = {
   totalViews: number;
 };
 
+interface ReviewerMemberRecord {
+  organizationId: string;
+  user: {
+    avatar: string | null;
+    firstName: string | null;
+    handle: string;
+    id: string;
+    isDeleted: boolean;
+    lastName: string | null;
+    name: string | null;
+  };
+}
+
 @Injectable()
 export class BatchGenerationSummaryService {
   constructor(
@@ -45,16 +63,9 @@ export class BatchGenerationSummaryService {
     const batchItemsById = new Map(
       batches.map((batch) => [batch.id, cloneBatchItems(batch.items)]),
     );
-    const postIds = [
-      ...new Set(
-        [...batchItemsById.values()]
-          .flat()
-          .flatMap((item) => (item.postId ? [item.postId] : [])),
-      ),
-    ];
-    const organizationIds = [
-      ...new Set(batches.map((batch) => batch.organizationId)),
-    ];
+    const postIds = this.collectPostIds(batchItemsById);
+    const organizationIds = this.collectOrganizationIds(batches);
+    const reviewerIds = this.collectReviewerIds(batchItemsById);
 
     const linkedPosts =
       postIds.length > 0
@@ -102,18 +113,17 @@ export class BatchGenerationSummaryService {
             },
           })
         : [];
-
     const analyticsMap = this.buildAnalyticsMap(linkedAnalytics);
     const linkedPostMap = new Map(linkedPosts.map((post) => [post.id, post]));
+    const reviewerMap = await this.loadReviewerMap(
+      organizationIds,
+      reviewerIds,
+    );
 
     return batches.map((batch) => {
       const batchConfig = (batch.config ?? {}) as BatchConfig;
       const batchItems = batchItemsById.get(batch.id) ?? [];
-      const pendingCount = batchItems.filter(
-        (item) =>
-          item.status === BatchItemStatus.PENDING ||
-          item.status === BatchItemStatus.GENERATING,
-      ).length;
+      const pendingCount = this.countPendingItems(batchItems);
 
       return {
         brandId: batch.brandId ?? '',
@@ -169,12 +179,11 @@ export class BatchGenerationSummaryService {
             postUrl: linkedPost?.url ?? undefined,
             prompt: item.prompt,
             reviewDecision: item.reviewDecision,
-            reviewEvents: (item.reviewEvents ?? []).map((event) => ({
-              decision: event.decision,
-              feedback: event.feedback,
-              reviewedAt: event.reviewedAt,
-              versionPinId: event.versionPinId,
-            })),
+            reviewEvents: this.toReviewEvents(
+              item,
+              batch.organizationId,
+              reviewerMap,
+            ),
             reviewedAt: item.reviewedAt,
             reviewFeedback: item.reviewFeedback,
             publishApproval:
@@ -199,6 +208,104 @@ export class BatchGenerationSummaryService {
         totalCount: batchConfig.totalCount ?? batchItems.length,
       };
     });
+  }
+
+  private collectOrganizationIds(batches: BatchWithConfig[]): string[] {
+    return [...new Set(batches.map((batch) => batch.organizationId))];
+  }
+
+  private collectPostIds(
+    batchItemsById: Map<string, BatchItemFull[]>,
+  ): string[] {
+    return [
+      ...new Set(
+        [...batchItemsById.values()]
+          .flat()
+          .flatMap((item) => (item.postId ? [item.postId] : [])),
+      ),
+    ];
+  }
+
+  private countPendingItems(batchItems: BatchItemFull[]): number {
+    return batchItems.filter(
+      (item) =>
+        item.status === BatchItemStatus.PENDING ||
+        item.status === BatchItemStatus.GENERATING,
+    ).length;
+  }
+
+  private collectReviewerIds(
+    batchItemsById: Map<string, BatchItemFull[]>,
+  ): string[] {
+    return [
+      ...new Set(
+        [...batchItemsById.values()]
+          .flat()
+          .flatMap((item) =>
+            (item.reviewEvents ?? []).flatMap((event) =>
+              event.reviewerId ? [event.reviewerId] : [],
+            ),
+          ),
+      ),
+    ];
+  }
+
+  private async loadReviewerMap(
+    organizationIds: string[],
+    reviewerIds: string[],
+  ): Promise<Map<string, IBatchReviewEventReviewer>> {
+    if (reviewerIds.length === 0) {
+      return new Map();
+    }
+
+    const reviewerMembers = (await this.prisma.member.findMany({
+      select: {
+        organizationId: true,
+        user: {
+          select: {
+            avatar: true,
+            firstName: true,
+            handle: true,
+            id: true,
+            isDeleted: true,
+            lastName: true,
+            name: true,
+          },
+        },
+      },
+      where: {
+        isActive: true,
+        isDeleted: false,
+        organizationId: { in: organizationIds },
+        userId: { in: reviewerIds },
+      },
+    })) as unknown as ReviewerMemberRecord[];
+
+    return new Map(
+      reviewerMembers
+        .filter((member) => !member.user.isDeleted)
+        .map((member) => [
+          this.reviewerKey(member.organizationId, member.user.id),
+          this.toReviewEventReviewer(member),
+        ]),
+    );
+  }
+
+  private toReviewEvents(
+    item: BatchItemFull,
+    organizationId: string,
+    reviewerMap: Map<string, IBatchReviewEventReviewer>,
+  ): IBatchReviewEvent[] {
+    return (item.reviewEvents ?? []).map((event) => ({
+      decision: event.decision,
+      feedback: event.feedback,
+      reviewedAt: event.reviewedAt,
+      reviewer: event.reviewerId
+        ? reviewerMap.get(this.reviewerKey(organizationId, event.reviewerId))
+        : undefined,
+      reviewerId: event.reviewerId,
+      versionPinId: event.versionPinId,
+    }));
   }
 
   private buildAnalyticsMap(
@@ -234,5 +341,29 @@ export class BatchGenerationSummaryService {
       }
     }
     return analyticsMap;
+  }
+
+  private reviewerKey(organizationId: string, userId: string): string {
+    return `${organizationId}:${userId}`;
+  }
+
+  private toReviewEventReviewer(
+    member: ReviewerMemberRecord,
+  ): IBatchReviewEventReviewer {
+    const fullName = [member.user.firstName, member.user.lastName]
+      .filter(Boolean)
+      .join(' ')
+      .trim();
+
+    return {
+      ...(member.user.avatar ? { avatar: member.user.avatar } : {}),
+      displayName:
+        member.user.name ||
+        fullName ||
+        member.user.handle ||
+        `Team member ${member.user.id.slice(0, 8)}`,
+      handle: member.user.handle,
+      id: member.user.id,
+    };
   }
 }

--- a/apps/server/api/src/services/batch-generation/batch-generation.controller.spec.ts
+++ b/apps/server/api/src/services/batch-generation/batch-generation.controller.spec.ts
@@ -229,5 +229,28 @@ describe('BatchGenerationController', () => {
         'test-object-id',
       );
     });
+
+    it('passes the canonical user id when rejecting items', async () => {
+      service.rejectItems.mockResolvedValue({ id: 'batch-1' } as never);
+
+      await controller.itemAction(
+        mockReq,
+        'batch-1',
+        {
+          action: 'reject',
+          feedback: 'Not aligned with the brief.',
+          itemIds: ['item-1'],
+        } as never,
+        {} as never,
+      );
+
+      expect(service.rejectItems).toHaveBeenCalledWith(
+        'batch-1',
+        ['item-1'],
+        'test-object-id',
+        'Not aligned with the brief.',
+        'test-object-id',
+      );
+    });
   });
 });

--- a/apps/server/api/src/services/batch-generation/batch-generation.service.spec.ts
+++ b/apps/server/api/src/services/batch-generation/batch-generation.service.spec.ts
@@ -28,10 +28,14 @@ describe('BatchGenerationService approval version pins', () => {
     findMany: ReturnType<typeof vi.fn>;
     updateMany: ReturnType<typeof vi.fn>;
   };
+  let memberDelegate: {
+    findMany: ReturnType<typeof vi.fn>;
+  };
   let service: BatchGenerationService;
   let prisma: {
     $transaction: ReturnType<typeof vi.fn>;
     batch: typeof batchDelegate;
+    member: typeof memberDelegate;
     post: typeof postDelegate;
     postAnalytics: { findMany: ReturnType<typeof vi.fn> };
   };
@@ -75,6 +79,9 @@ describe('BatchGenerationService approval version pins', () => {
       findMany: vi.fn().mockResolvedValue([]),
       updateMany: vi.fn().mockResolvedValue({ count: 1 }),
     };
+    memberDelegate = {
+      findMany: vi.fn().mockResolvedValue([]),
+    };
     artifactReferenceService = {
       createOrReuseVersionPin: vi.fn().mockResolvedValue({ id: 'pin-1' }),
     };
@@ -90,6 +97,7 @@ describe('BatchGenerationService approval version pins', () => {
         callback({ batch: batchDelegate, post: postDelegate }),
       ),
       batch: batchDelegate,
+      member: memberDelegate,
       post: postDelegate,
       postAnalytics: { findMany: vi.fn().mockResolvedValue([]) },
     };
@@ -183,6 +191,7 @@ describe('BatchGenerationService approval version pins', () => {
         reviewEvents: [
           expect.objectContaining({
             decision: 'approved',
+            reviewerId: 'canonical-user-1',
             versionPinId: 'pin-1',
           }),
         ],
@@ -195,6 +204,90 @@ describe('BatchGenerationService approval version pins', () => {
     expect(
       publishApprovalsService.createForCurrentPost.mock.invocationCallOrder[0],
     ).toBeLessThan(postDelegate.updateMany.mock.invocationCallOrder[0] ?? 0);
+  });
+
+  it('attributes request-changes decisions to the canonical reviewer', async () => {
+    batchDelegate.findFirst.mockResolvedValue(
+      createBatchRecord([
+        {
+          _id: 'item-1',
+          format: ContentFormat.IMAGE,
+          status: BatchItemStatus.COMPLETED,
+        },
+      ]),
+    );
+
+    await service.requestChanges(
+      'batch-1',
+      ['item-1'],
+      'org-1',
+      'Use a clearer opening line.',
+      'canonical-user-1',
+    );
+
+    expect(batchDelegate.updateMany).toHaveBeenCalledWith({
+      data: {
+        items: [
+          expect.objectContaining({
+            reviewDecision: 'request_changes',
+            reviewEvents: [
+              expect.objectContaining({
+                decision: 'request_changes',
+                feedback: 'Use a clearer opening line.',
+                reviewerId: 'canonical-user-1',
+              }),
+            ],
+          }),
+        ],
+      },
+      where: {
+        id: 'batch-1',
+        isDeleted: false,
+        organizationId: 'org-1',
+      },
+    });
+  });
+
+  it('attributes reject decisions to the canonical reviewer', async () => {
+    batchDelegate.findFirst.mockResolvedValue(
+      createBatchRecord([
+        {
+          _id: 'item-1',
+          format: ContentFormat.IMAGE,
+          status: BatchItemStatus.COMPLETED,
+        },
+      ]),
+    );
+
+    await service.rejectItems(
+      'batch-1',
+      ['item-1'],
+      'org-1',
+      'This misses the brief.',
+      'canonical-user-1',
+    );
+
+    expect(batchDelegate.updateMany).toHaveBeenCalledWith({
+      data: {
+        items: [
+          expect.objectContaining({
+            reviewDecision: 'rejected',
+            reviewEvents: [
+              expect.objectContaining({
+                decision: 'rejected',
+                feedback: 'This misses the brief.',
+                reviewerId: 'canonical-user-1',
+              }),
+            ],
+          }),
+        ],
+      },
+      where: {
+        id: 'batch-1',
+        isDeleted: false,
+        organizationId: 'org-1',
+      },
+    });
   });
 
   it('fails before approval mutations when pin creation fails', async () => {
@@ -373,5 +466,114 @@ describe('BatchGenerationService approval version pins', () => {
         select: expect.objectContaining({ reviewVersionPinId: true }),
       }),
     );
+  });
+
+  it('hydrates reviewer identity only through an active organization membership', async () => {
+    batchDelegate.findFirst.mockResolvedValue(
+      createBatchRecord([
+        {
+          _id: 'item-1',
+          format: ContentFormat.IMAGE,
+          reviewEvents: [
+            {
+              decision: 'approved',
+              reviewedAt: '2026-07-20T08:00:00.000Z',
+              reviewerId: 'reviewer-1',
+            },
+            {
+              decision: 'request_changes',
+              reviewedAt: '2026-07-20T08:01:00.000Z',
+              reviewerId: 'cross-org-reviewer',
+            },
+            {
+              decision: 'rejected',
+              reviewedAt: '2026-07-20T08:02:00.000Z',
+              reviewerId: 'deleted-reviewer',
+            },
+            {
+              decision: 'approved',
+              reviewedAt: '2026-07-20T08:03:00.000Z',
+            },
+          ],
+          status: BatchItemStatus.COMPLETED,
+        },
+      ]),
+    );
+    memberDelegate.findMany.mockResolvedValue([
+      {
+        organizationId: 'org-1',
+        user: {
+          avatar: 'https://cdn.example.com/reviewer.png',
+          firstName: 'Ada',
+          handle: 'ada',
+          id: 'reviewer-1',
+          isDeleted: false,
+          lastName: 'Lovelace',
+          name: null,
+        },
+      },
+      {
+        organizationId: 'org-2',
+        user: {
+          avatar: null,
+          firstName: 'Other',
+          handle: 'other',
+          id: 'cross-org-reviewer',
+          isDeleted: false,
+          lastName: 'Tenant',
+          name: null,
+        },
+      },
+      {
+        organizationId: 'org-1',
+        user: {
+          avatar: null,
+          firstName: 'Deleted',
+          handle: 'deleted',
+          id: 'deleted-reviewer',
+          isDeleted: true,
+          lastName: 'Reviewer',
+          name: null,
+        },
+      },
+    ]);
+
+    const result = await service.getBatch('batch-1', 'org-1');
+
+    expect(memberDelegate.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          isActive: true,
+          isDeleted: false,
+          organizationId: { in: ['org-1'] },
+          userId: {
+            in: ['reviewer-1', 'cross-org-reviewer', 'deleted-reviewer'],
+          },
+        },
+      }),
+    );
+    expect(result.items[0]?.reviewEvents).toEqual([
+      expect.objectContaining({
+        reviewer: {
+          avatar: 'https://cdn.example.com/reviewer.png',
+          displayName: 'Ada Lovelace',
+          handle: 'ada',
+          id: 'reviewer-1',
+        },
+        reviewerId: 'reviewer-1',
+      }),
+      expect.objectContaining({
+        reviewer: undefined,
+        reviewerId: 'cross-org-reviewer',
+      }),
+      expect.objectContaining({
+        reviewer: undefined,
+        reviewerId: 'deleted-reviewer',
+      }),
+      expect.objectContaining({
+        reviewer: undefined,
+        reviewerId: undefined,
+      }),
+    ]);
   });
 });

--- a/apps/server/api/src/services/batch-generation/batch-generation.types.ts
+++ b/apps/server/api/src/services/batch-generation/batch-generation.types.ts
@@ -24,6 +24,7 @@ export interface BatchItemFull extends BatchItem {
     decision: 'approved' | 'rejected' | 'request_changes';
     feedback?: string;
     reviewedAt: string;
+    reviewerId?: string;
     versionPinId?: string;
   }>;
   gateOverallScore?: number;

--- a/packages/interfaces/src/batch/batch.interface.ts
+++ b/packages/interfaces/src/batch/batch.interface.ts
@@ -64,12 +64,7 @@ export interface IBatchItem {
   reviewDecision?: 'approved' | 'rejected' | 'request_changes';
   reviewFeedback?: string;
   reviewedAt?: string;
-  reviewEvents?: Array<{
-    decision: 'approved' | 'rejected' | 'request_changes';
-    feedback?: string;
-    reviewedAt: string;
-    versionPinId?: string;
-  }>;
+  reviewEvents?: IBatchReviewEvent[];
   versionPinId?: string;
   publishApproval?: IPublishApproval;
   sourceActionId?: string;
@@ -93,6 +88,22 @@ export interface IBatchItem {
   postAvgEngagementRate?: number;
   postUrl?: string;
   createdAt: string;
+}
+
+export interface IBatchReviewEventReviewer {
+  avatar?: string;
+  displayName: string;
+  handle: string;
+  id: string;
+}
+
+export interface IBatchReviewEvent {
+  decision: 'approved' | 'rejected' | 'request_changes';
+  feedback?: string;
+  reviewedAt: string;
+  reviewer?: IBatchReviewEventReviewer;
+  reviewerId?: string;
+  versionPinId?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- persist the canonical reviewer user ID for approve, reject, and request-changes events
- hydrate public reviewer identity only through active, non-deleted membership in the batch organization
- show reviewer avatar, display name, and handle in review history with a safe legacy/unavailable fallback
- add focused service, controller, and UI coverage for attribution and tenant isolation

## Verification
- bunx biome check (11 changed files)
- bun run design:lint (0 errors; 9 existing unused-token warnings)
- git diff --check
- staged secret scan
- local tests/typecheck/build skipped by repository machine policy; PR CI is the verification gate

Closes #1933