### PR TITLE
feat(calendar): expose scheduler release read model

### DIFF
--- a/apps/server/api/openapi/openapi.json
+++ b/apps/server/api/openapi/openapi.json
@@ -8551,6 +8551,19 @@
         },
         "type": "object"
       },
+      "ReleaseStatus": {
+        "enum": [
+          "draft",
+          "scheduled",
+          "paused",
+          "cancelled",
+          "publishing",
+          "published",
+          "failed",
+          "partially-published"
+        ],
+        "type": "string"
+      },
       "ReplyBotType": {
         "enum": [
           "reply_guy",
@@ -38560,6 +38573,61 @@
       }
     },
     "/post-groups": {
+      "get": {
+        "operationId": "PostGroupsController.findAll",
+        "parameters": [
+          {
+            "description": "Inclusive release window start in ISO 8601 format",
+            "in": "query",
+            "name": "startDate",
+            "required": true,
+            "schema": {
+              "example": "2026-07-20T00:00:00.000Z",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Inclusive release window end in ISO 8601 format",
+            "in": "query",
+            "name": "endDate",
+            "required": true,
+            "schema": {
+              "example": "2026-07-27T00:00:00.000Z",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter release groups by brand ID",
+            "in": "query",
+            "name": "brandId",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by release status using repeated query keys (for example, ?status=scheduled&status=failed).",
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "items": {
+                "$ref": "#/components/schemas/ReleaseStatus"
+              },
+              "type": "array"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "summary": "findAll",
+        "tags": [
+          "PostGroups"
+        ]
+      },
       "post": {
         "operationId": "PostGroupsController.create",
         "parameters": [

--- a/apps/server/api/src/collections/post-groups/controllers/post-groups.controller.spec.ts
+++ b/apps/server/api/src/collections/post-groups/controllers/post-groups.controller.spec.ts
@@ -6,11 +6,13 @@ vi.mock('@api/helpers/utils/auth/auth.util', () => ({
 }));
 
 vi.mock('@api/helpers/utils/response/response.util', () => ({
+  serializeCollection: vi.fn((_req, _serializer, data) => data.docs),
   serializeSingle: vi.fn((_req, _serializer, data) => data),
 }));
 
 import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticated-user.interface';
 import { PostGroupsController } from '@api/collections/post-groups/controllers/post-groups.controller';
+import type { PostGroupsQueryDto } from '@api/collections/post-groups/dto/post-groups-query.dto';
 import { PostGroupsService } from '@api/collections/post-groups/services/post-groups.service';
 import { ReleaseStatus } from '@genfeedai/enums';
 import { Test, TestingModule } from '@nestjs/testing';
@@ -22,6 +24,7 @@ describe('PostGroupsController', () => {
     cancel: ReturnType<typeof vi.fn>;
     create: ReturnType<typeof vi.fn>;
     getOne: ReturnType<typeof vi.fn>;
+    list: ReturnType<typeof vi.fn>;
     pause: ReturnType<typeof vi.fn>;
     publishNow: ReturnType<typeof vi.fn>;
     resume: ReturnType<typeof vi.fn>;
@@ -42,6 +45,7 @@ describe('PostGroupsController', () => {
             cancel: vi.fn().mockResolvedValue({ id: 'group-1' }),
             create: vi.fn().mockResolvedValue({ id: 'group-1' }),
             getOne: vi.fn().mockResolvedValue({ id: 'group-1' }),
+            list: vi.fn().mockResolvedValue([{ id: 'group-1' }]),
             pause: vi.fn().mockResolvedValue({ id: 'group-1' }),
             publishNow: vi.fn().mockResolvedValue({ id: 'group-1' }),
             resume: vi.fn().mockResolvedValue({ id: 'group-1' }),
@@ -77,6 +81,18 @@ describe('PostGroupsController', () => {
       body,
       'same-request',
     );
+  });
+
+  it('lists release groups through the organization-scoped service boundary', async () => {
+    const query = {
+      endDate: '2026-07-27T00:00:00.000Z',
+      startDate: '2026-07-20T00:00:00.000Z',
+    } as PostGroupsQueryDto;
+
+    await expect(controller.findAll(req, user, query)).resolves.toEqual([
+      { id: 'group-1' },
+    ]);
+    expect(service.list).toHaveBeenCalledWith('org-1', query);
   });
 
   it('routes target updates through the service', async () => {

--- a/apps/server/api/src/collections/post-groups/controllers/post-groups.controller.ts
+++ b/apps/server/api/src/collections/post-groups/controllers/post-groups.controller.ts
@@ -1,10 +1,14 @@
 import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticated-user.interface';
+import { PostGroupsQueryDto } from '@api/collections/post-groups/dto/post-groups-query.dto';
 import { PostGroupsService } from '@api/collections/post-groups/services/post-groups.service';
 import { LogMethod } from '@api/helpers/decorators/log/log-method.decorator';
 import { AutoSwagger } from '@api/helpers/decorators/swagger/auto-swagger.decorator';
 import { CurrentUser } from '@api/helpers/decorators/user/current-user.decorator';
 import { getPublicMetadata } from '@api/helpers/utils/auth/auth.util';
-import { serializeSingle } from '@api/helpers/utils/response/response.util';
+import {
+  serializeCollection,
+  serializeSingle,
+} from '@api/helpers/utils/response/response.util';
 import { ReleaseGroupSerializer } from '@genfeedai/serializers';
 import {
   Body,
@@ -14,6 +18,7 @@ import {
   Param,
   Patch,
   Post,
+  Query,
   Req,
 } from '@nestjs/common';
 import { ApiTags } from '@nestjs/swagger';
@@ -24,6 +29,18 @@ import type { Request } from 'express';
 @Controller('post-groups')
 export class PostGroupsController {
   constructor(private readonly postGroupsService: PostGroupsService) {}
+
+  @Get()
+  @LogMethod({ logEnd: false, logError: true, logStart: true })
+  async findAll(
+    @Req() req: Request,
+    @CurrentUser() user: User,
+    @Query() query: PostGroupsQueryDto,
+  ) {
+    const { organization } = getPublicMetadata(user);
+    const docs = await this.postGroupsService.list(organization, query);
+    return serializeCollection(req, ReleaseGroupSerializer, { docs });
+  }
 
   @Post()
   @LogMethod({ logEnd: false, logError: true, logStart: true })

--- a/apps/server/api/src/collections/post-groups/dto/post-groups-query.dto.spec.ts
+++ b/apps/server/api/src/collections/post-groups/dto/post-groups-query.dto.spec.ts
@@ -1,0 +1,78 @@
+import { PostGroupsQueryDto } from '@api/collections/post-groups/dto/post-groups-query.dto';
+import { ReleaseStatus } from '@genfeedai/enums';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+
+describe('PostGroupsQueryDto', () => {
+  it('accepts a bounded ISO window and normalizes one status to an array', async () => {
+    const query = plainToInstance(PostGroupsQueryDto, {
+      endDate: '2026-07-27T00:00:00.000Z',
+      startDate: '2026-07-20T00:00:00.000Z',
+      status: ReleaseStatus.SCHEDULED,
+    });
+
+    await expect(validate(query)).resolves.toEqual([]);
+    expect(query.status).toEqual([ReleaseStatus.SCHEDULED]);
+  });
+
+  it('preserves repeated valid status filters', async () => {
+    const query = plainToInstance(PostGroupsQueryDto, {
+      endDate: '2026-07-27T00:00:00.000Z',
+      startDate: '2026-07-20T00:00:00.000Z',
+      status: [ReleaseStatus.SCHEDULED, ReleaseStatus.FAILED],
+    });
+
+    await expect(validate(query)).resolves.toEqual([]);
+    expect(query.status).toEqual([
+      ReleaseStatus.SCHEDULED,
+      ReleaseStatus.FAILED,
+    ]);
+  });
+
+  it.each([
+    {
+      endDate: undefined,
+      name: 'a missing end date',
+      startDate: '2026-07-20T00:00:00.000Z',
+    },
+    {
+      endDate: '2026-07-19T00:00:00.000Z',
+      name: 'an inverted range',
+      startDate: '2026-07-20T00:00:00.000Z',
+    },
+    {
+      endDate: '2027-07-22T00:00:00.000Z',
+      name: 'a range longer than 366 days',
+      startDate: '2026-07-20T00:00:00.000Z',
+    },
+  ])('rejects $name', async ({ endDate, startDate }) => {
+    const query = plainToInstance(PostGroupsQueryDto, {
+      endDate,
+      startDate,
+    });
+
+    await expect(validate(query)).resolves.not.toEqual([]);
+  });
+
+  it.each([
+    {
+      name: 'a malformed start date',
+      value: {
+        endDate: '2026-07-27T00:00:00.000Z',
+        startDate: 'not-a-date',
+      },
+    },
+    {
+      name: 'an unknown release status',
+      value: {
+        endDate: '2026-07-27T00:00:00.000Z',
+        startDate: '2026-07-20T00:00:00.000Z',
+        status: 'unknown',
+      },
+    },
+  ])('rejects $name', async ({ value }) => {
+    const query = plainToInstance(PostGroupsQueryDto, value);
+
+    await expect(validate(query)).resolves.not.toEqual([]);
+  });
+});

--- a/apps/server/api/src/collections/post-groups/dto/post-groups-query.dto.ts
+++ b/apps/server/api/src/collections/post-groups/dto/post-groups-query.dto.ts
@@ -1,0 +1,83 @@
+import { IsEntityId } from '@api/helpers/validation/entity-id.validator';
+import { ReleaseStatus } from '@genfeedai/enums';
+import { ApiProperty } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import {
+  IsArray,
+  IsDateString,
+  IsEnum,
+  IsOptional,
+  Validate,
+  type ValidationArguments,
+  ValidatorConstraint,
+  type ValidatorConstraintInterface,
+} from 'class-validator';
+
+const MAX_RELEASE_WINDOW_MS = 366 * 24 * 60 * 60 * 1000;
+
+@ValidatorConstraint({ async: false, name: 'releaseWindow' })
+export class ReleaseWindowConstraint implements ValidatorConstraintInterface {
+  validate(endDate: unknown, args: ValidationArguments): boolean {
+    const query = args.object as PostGroupsQueryDto;
+    if (typeof query.startDate !== 'string' || typeof endDate !== 'string') {
+      return true;
+    }
+
+    const startTime = Date.parse(query.startDate);
+    const endTime = Date.parse(endDate);
+    if (!Number.isFinite(startTime) || !Number.isFinite(endTime)) {
+      return true;
+    }
+
+    const duration = endTime - startTime;
+    return duration >= 0 && duration <= MAX_RELEASE_WINDOW_MS;
+  }
+
+  defaultMessage(): string {
+    return 'endDate must be on or after startDate and no more than 366 days later';
+  }
+}
+
+export class PostGroupsQueryDto {
+  @ApiProperty({
+    description: 'Inclusive release window start in ISO 8601 format',
+    example: '2026-07-20T00:00:00.000Z',
+  })
+  @IsDateString()
+  startDate!: string;
+
+  @ApiProperty({
+    description: 'Inclusive release window end in ISO 8601 format',
+    example: '2026-07-27T00:00:00.000Z',
+  })
+  @IsDateString()
+  @Validate(ReleaseWindowConstraint)
+  endDate!: string;
+
+  @ApiProperty({
+    description: 'Filter release groups by brand ID',
+    required: false,
+  })
+  @IsOptional()
+  @IsEntityId()
+  brandId?: string;
+
+  @ApiProperty({
+    description:
+      'Filter by release status using repeated query keys (for example, ?status=scheduled&status=failed).',
+    enum: ReleaseStatus,
+    enumName: 'ReleaseStatus',
+    isArray: true,
+    required: false,
+  })
+  @Transform(({ value }) => {
+    if (!value) {
+      return undefined;
+    }
+    return Array.isArray(value) ? value : [value];
+  })
+  @IsOptional()
+  @IsArray()
+  @IsEnum(ReleaseStatus, { each: true })
+  status?: ReleaseStatus[];
+}

--- a/apps/server/api/src/collections/post-groups/services/post-group-persistence.service.spec.ts
+++ b/apps/server/api/src/collections/post-groups/services/post-group-persistence.service.spec.ts
@@ -24,9 +24,11 @@ describe('PostGroupPersistenceService', () => {
       create: ReturnType<typeof vi.fn>;
       findFirst: ReturnType<typeof vi.fn>;
       findMany: ReturnType<typeof vi.fn>;
+      groupBy: ReturnType<typeof vi.fn>;
     };
     postGroup: {
       findFirst: ReturnType<typeof vi.fn>;
+      findMany: ReturnType<typeof vi.fn>;
       update: ReturnType<typeof vi.fn>;
     };
   };
@@ -40,9 +42,11 @@ describe('PostGroupPersistenceService', () => {
         create: vi.fn().mockResolvedValue(undefined),
         findFirst: vi.fn(),
         findMany: vi.fn().mockResolvedValue([]),
+        groupBy: vi.fn().mockResolvedValue([]),
       },
       postGroup: {
         findFirst: vi.fn(),
+        findMany: vi.fn().mockResolvedValue([]),
         update: vi.fn(),
       },
     };
@@ -125,6 +129,126 @@ describe('PostGroupPersistenceService', () => {
         },
       ]),
     ).rejects.toThrow(BadRequestException);
+  });
+
+  it('lists active organization releases that intersect the window and hydrates targets in one query', async () => {
+    const targetGroup = makeGroup({
+      id: 'group-target',
+      scheduledAt: null,
+    });
+    prisma.post.groupBy.mockResolvedValue([{ groupId: 'group-target' }]);
+    prisma.post.findMany.mockResolvedValue([
+      makeTarget({
+        groupId: 'group-target',
+        id: 'target-1',
+        targetExecutionState: TargetExecutionState.FAILED,
+      }),
+    ]);
+    prisma.postGroup.findMany.mockResolvedValue([targetGroup]);
+
+    const result = await service.listReleaseGroups({
+      brandId: 'brand-1',
+      endDate: new Date('2026-07-27T00:00:00.000Z'),
+      organizationId: 'org-1',
+      startDate: new Date('2026-07-20T00:00:00.000Z'),
+      statuses: [ReleaseStatus.SCHEDULED, ReleaseStatus.FAILED],
+    });
+
+    expect(prisma.post.groupBy).toHaveBeenCalledWith({
+      by: ['groupId'],
+      where: {
+        brandId: 'brand-1',
+        groupId: { not: null },
+        isDeleted: false,
+        organizationId: 'org-1',
+        parentId: null,
+        scheduledDate: {
+          gte: new Date('2026-07-20T00:00:00.000Z'),
+          lte: new Date('2026-07-27T00:00:00.000Z'),
+        },
+      },
+    });
+    expect(prisma.postGroup.findMany).toHaveBeenCalledWith({
+      orderBy: { id: 'asc' },
+      where: {
+        brandId: 'brand-1',
+        isDeleted: false,
+        organizationId: 'org-1',
+        OR: [
+          {
+            scheduledAt: {
+              gte: new Date('2026-07-20T00:00:00.000Z'),
+              lte: new Date('2026-07-27T00:00:00.000Z'),
+            },
+          },
+          { id: { in: ['group-target'] } },
+        ],
+        status: {
+          in: [ReleaseStatus.SCHEDULED, ReleaseStatus.FAILED],
+        },
+      },
+    });
+    expect(prisma.post.findMany).toHaveBeenCalledWith({
+      orderBy: [
+        { groupId: 'asc' },
+        { order: 'asc' },
+        { createdAt: 'asc' },
+        { id: 'asc' },
+      ],
+      where: {
+        groupId: { in: ['group-target'] },
+        isDeleted: false,
+        organizationId: 'org-1',
+        parentId: null,
+      },
+    });
+    expect(result).toEqual([
+      expect.objectContaining({
+        id: 'group-target',
+        targetSummary: {
+          [TargetExecutionState.FAILED]: 1,
+          total: 1,
+        },
+        targets: [expect.objectContaining({ id: 'target-1' })],
+      }),
+    ]);
+  });
+
+  it('sorts releases by earliest effective schedule and uses the id as a stable tie-breaker', async () => {
+    prisma.post.groupBy.mockResolvedValue([]);
+    prisma.post.findMany.mockResolvedValue([
+      makeTarget({
+        groupId: 'group-target',
+        id: 'target-early',
+        scheduledDate: new Date('2026-07-20T09:00:00.000Z'),
+      }),
+    ]);
+    prisma.postGroup.findMany.mockResolvedValue([
+      makeGroup({
+        id: 'group-b',
+        scheduledAt: new Date('2026-07-20T10:00:00.000Z'),
+      }),
+      makeGroup({
+        id: 'group-target',
+        scheduledAt: new Date('2026-07-20T12:00:00.000Z'),
+      }),
+      makeGroup({
+        id: 'group-a',
+        scheduledAt: new Date('2026-07-20T10:00:00.000Z'),
+      }),
+    ]);
+
+    const result = await service.listReleaseGroups({
+      endDate: new Date('2026-07-27T00:00:00.000Z'),
+      organizationId: 'org-1',
+      startDate: new Date('2026-07-20T00:00:00.000Z'),
+    });
+
+    expect(result.map((release) => release.id)).toEqual([
+      'group-target',
+      'group-a',
+      'group-b',
+    ]);
   });
 
   it('creates only platform-compatible thread and comment child posts', async () => {

--- a/apps/server/api/src/collections/post-groups/services/post-group-persistence.service.ts
+++ b/apps/server/api/src/collections/post-groups/services/post-group-persistence.service.ts
@@ -1,6 +1,7 @@
 import type {
   CreateAttachmentPostsParams,
   CreatePostGroupParams,
+  ReleaseGroupListQuery,
   SchedulerCredential,
   SchedulerPostGroup,
   SchedulerPostTarget,
@@ -189,6 +190,97 @@ export class PostGroupPersistenceService {
     return this.contractService.toReleaseGroup(group, targets);
   }
 
+  async listReleaseGroups(
+    query: ReleaseGroupListQuery,
+  ): Promise<IReleaseGroup[]> {
+    const targetRows = await this.prisma.post.groupBy({
+      by: ['groupId'],
+      where: {
+        ...(query.brandId ? { brandId: query.brandId } : {}),
+        groupId: { not: null },
+        isDeleted: false,
+        organizationId: query.organizationId,
+        parentId: null,
+        scheduledDate: {
+          gte: query.startDate,
+          lte: query.endDate,
+        },
+      },
+    });
+    const targetGroupIds = [
+      ...new Set(
+        targetRows.flatMap((target) =>
+          target.groupId ? [target.groupId] : [],
+        ),
+      ),
+    ];
+
+    const scheduleFilters: Prisma.PostGroupWhereInput[] = [
+      {
+        scheduledAt: {
+          gte: query.startDate,
+          lte: query.endDate,
+        },
+      },
+    ];
+    if (targetGroupIds.length > 0) {
+      scheduleFilters.push({ id: { in: targetGroupIds } });
+    }
+
+    const groups = (await this.prisma.postGroup.findMany({
+      orderBy: { id: 'asc' },
+      where: {
+        ...(query.brandId ? { brandId: query.brandId } : {}),
+        isDeleted: false,
+        organizationId: query.organizationId,
+        OR: scheduleFilters,
+        ...(query.statuses?.length ? { status: { in: query.statuses } } : {}),
+      },
+    })) as SchedulerPostGroup[];
+
+    if (groups.length === 0) {
+      return [];
+    }
+
+    const groupIds = groups.map((group) => group.id);
+    const targets = (await this.prisma.post.findMany({
+      orderBy: [
+        { groupId: 'asc' },
+        { order: 'asc' },
+        { createdAt: 'asc' },
+        { id: 'asc' },
+      ],
+      where: {
+        groupId: { in: groupIds },
+        isDeleted: false,
+        organizationId: query.organizationId,
+        parentId: null,
+      },
+    })) as SchedulerPostTarget[];
+    const targetsByGroup = new Map<string, SchedulerPostTarget[]>();
+    for (const target of targets) {
+      if (!target.groupId) {
+        continue;
+      }
+      const currentTargets = targetsByGroup.get(target.groupId) ?? [];
+      currentTargets.push(target);
+      targetsByGroup.set(target.groupId, currentTargets);
+    }
+
+    return groups
+      .map((group) =>
+        this.contractService.toReleaseGroup(
+          group,
+          targetsByGroup.get(group.id) ?? [],
+        ),
+      )
+      .sort((left, right) => {
+        const scheduleOrder =
+          this.getEarliestSchedule(left) - this.getEarliestSchedule(right);
+        return scheduleOrder || left.id.localeCompare(right.id);
+      });
+  }
+
   async resolveCredentials(
     tx: Pick<SchedulerTx, 'credential'>,
     organizationId: string,
@@ -369,6 +461,18 @@ export class PostGroupPersistenceService {
         parentId: null,
       },
     })) as SchedulerPostTarget[];
+  }
+
+  private getEarliestSchedule(release: IReleaseGroup): number {
+    const schedules = [
+      release.scheduledAt,
+      ...(release.targets ?? []).map((target) => target.scheduledAt),
+    ]
+      .filter((scheduledAt): scheduledAt is string => Boolean(scheduledAt))
+      .map((scheduledAt) => Date.parse(scheduledAt))
+      .filter(Number.isFinite);
+
+    return schedules.length > 0 ? Math.min(...schedules) : Number.MAX_VALUE;
   }
 
   async recalculateAndHydrate(

--- a/apps/server/api/src/collections/post-groups/services/post-group.types.ts
+++ b/apps/server/api/src/collections/post-groups/services/post-group.types.ts
@@ -76,6 +76,14 @@ export type SchedulerPostTarget = {
   workflowExecutionId: string | null;
 };
 
+export type ReleaseGroupListQuery = {
+  brandId?: string;
+  endDate: Date;
+  organizationId: string;
+  startDate: Date;
+  statuses?: ReleaseStatus[];
+};
+
 export type CreateAttachmentPostsParams = {
   brandId: string;
   group: SchedulerPostGroup;

--- a/apps/server/api/src/collections/post-groups/services/post-groups.service.spec.ts
+++ b/apps/server/api/src/collections/post-groups/services/post-groups.service.spec.ts
@@ -93,12 +93,14 @@ describe('PostGroupsService', () => {
       create: ReturnType<typeof vi.fn>;
       findFirst: ReturnType<typeof vi.fn>;
       findMany: ReturnType<typeof vi.fn>;
+      groupBy: ReturnType<typeof vi.fn>;
       update: ReturnType<typeof vi.fn>;
       updateMany: ReturnType<typeof vi.fn>;
     };
     postGroup: {
       create: ReturnType<typeof vi.fn>;
       findFirst: ReturnType<typeof vi.fn>;
+      findMany: ReturnType<typeof vi.fn>;
       update: ReturnType<typeof vi.fn>;
     };
     publishApproval: {
@@ -137,6 +139,7 @@ describe('PostGroupsService', () => {
           ),
         findFirst: vi.fn(),
         findMany: vi.fn().mockResolvedValue([]),
+        groupBy: vi.fn().mockResolvedValue([]),
         update: vi.fn(),
         updateMany: vi.fn().mockResolvedValue({ count: 1 }),
       },
@@ -147,6 +150,7 @@ describe('PostGroupsService', () => {
             Promise.resolve(makeGroup({ ...data, id: 'group-1' })),
           ),
         findFirst: vi.fn().mockResolvedValue(null),
+        findMany: vi.fn().mockResolvedValue([]),
         update: vi
           .fn()
           .mockImplementation(({ data }) =>
@@ -208,6 +212,39 @@ describe('PostGroupsService', () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.clearAllMocks();
+  });
+
+  it('parses the validated calendar window before delegating to persistence', async () => {
+    await expect(
+      service.list('org-1', {
+        brandId: 'brand-1',
+        endDate: '2026-07-27T00:00:00.000Z',
+        startDate: '2026-07-20T00:00:00.000Z',
+        status: [ReleaseStatus.SCHEDULED],
+      }),
+    ).resolves.toEqual([]);
+
+    expect(prisma.post.groupBy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          brandId: 'brand-1',
+          organizationId: 'org-1',
+          scheduledDate: {
+            gte: new Date('2026-07-20T00:00:00.000Z'),
+            lte: new Date('2026-07-27T00:00:00.000Z'),
+          },
+        }),
+      }),
+    );
+    expect(prisma.postGroup.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          brandId: 'brand-1',
+          organizationId: 'org-1',
+          status: { in: [ReleaseStatus.SCHEDULED] },
+        }),
+      }),
+    );
   });
 
   it('creates a scheduled post group and channel target idempotently from the shared contract', async () => {

--- a/apps/server/api/src/collections/post-groups/services/post-groups.service.ts
+++ b/apps/server/api/src/collections/post-groups/services/post-groups.service.ts
@@ -1,3 +1,4 @@
+import type { PostGroupsQueryDto } from '@api/collections/post-groups/dto/post-groups-query.dto';
 import type {
   ManualRetryResolution,
   ResolveManualRetryParams,
@@ -108,6 +109,19 @@ export class PostGroupsService {
       group.id,
     );
     return this.contractService.toReleaseGroup(group, targets);
+  }
+
+  list(
+    organizationId: string,
+    query: PostGroupsQueryDto,
+  ): Promise<IReleaseGroup[]> {
+    return this.persistenceService.listReleaseGroups({
+      ...(query.brandId ? { brandId: query.brandId } : {}),
+      endDate: new Date(query.endDate),
+      organizationId,
+      startDate: new Date(query.startDate),
+      ...(query.status?.length ? { statuses: query.status } : {}),
+    });
   }
 
   async scheduleTarget(


### PR DESCRIPTION
## Summary

- add authenticated `GET /post-groups` for bounded calendar/list windows
- filter release groups by organization, brand, inclusive schedule range, and release status
- batch-hydrate canonical release targets and summaries with deterministic effective-schedule ordering
- validate required/inverted/oversized date ranges and repeated status filters

## Verification

Exact head: `28ac2310eb910e5b344b124f094480543684e5a3`

- CI Tests Gate, build, typecheck, changed API tests, OpenAPI drift, lint, format, guards, package/server/extension/web tests, Gitleaks, and Secretlint: passed
- Server Image PR Guard: passed
- Fallow PR Audit and CodeRabbit: passed
- `bunx --bun @biomejs/biome@2.5.3 check <9 changed source/test files>`
- `bun run scripts/check-request-context-usage.ts` from `apps/server/api`
- `git diff --cached --check`
- staged sensitive filename and credential-pattern scan
- supplementary Fable review: approved; database-side target grouping and DTO test gaps addressed

## Skipped locally

- Unit tests, typecheck, build, and broad suites were delegated to PR CI under the repository's MacBook resource policy; all corresponding exact-head CI gates passed.

## Residual risk

- The endpoint intentionally returns the complete bounded window rather than paginating it; the maximum window is 366 days. Fleet Review remains required on this exact head before merge.

Closes #1937
