### PR TITLE
test(api): cover Library folder lifecycle and scope

### DIFF
--- a/apps/server/api/src/collections/folders/controllers/folders.controller.spec.ts
+++ b/apps/server/api/src/collections/folders/controllers/folders.controller.spec.ts
@@ -262,10 +262,12 @@ describe('FoldersController', () => {
 
       for (const query of scenarios) {
         const { where } = controller.buildFindAllQuery(mockUser, query);
-        const orClauses = (where as { OR?: Array<Record<string, unknown>> }).OR;
+        const whereRecord = where as Record<string, unknown> & {
+          OR?: Array<Record<string, unknown>>;
+        };
+        const clauses = [whereRecord, ...(whereRecord.OR ?? [])];
 
-        expect(orClauses).toBeDefined();
-        for (const clause of orClauses ?? []) {
+        for (const clause of clauses) {
           for (const key of relationAccessorKeys) {
             expect(clause).not.toHaveProperty(key);
           }

--- a/apps/server/api/src/collections/folders/controllers/folders.controller.spec.ts
+++ b/apps/server/api/src/collections/folders/controllers/folders.controller.spec.ts
@@ -365,11 +365,7 @@ describe('FoldersController', () => {
       };
       foldersService.findOne.mockResolvedValue(mockFolder);
 
-      const result = await controller.findOne(
-        mockRequest,
-        mockUser,
-        folderId,
-      );
+      const result = await controller.findOne(mockRequest, mockUser, folderId);
 
       expect(foldersService.findOne).toHaveBeenCalledWith({
         _id: folderId,
@@ -555,11 +551,7 @@ describe('FoldersController', () => {
         isDeleted: true,
       });
 
-      const result = await controller.remove(
-        mockRequest,
-        mockUser,
-        folderId,
-      );
+      const result = await controller.remove(mockRequest, mockUser, folderId);
 
       expect(foldersService.findOne).toHaveBeenCalledWith({ _id: folderId });
       expect(foldersService.remove).toHaveBeenCalledWith(folderId);

--- a/apps/server/api/src/collections/folders/controllers/folders.controller.spec.ts
+++ b/apps/server/api/src/collections/folders/controllers/folders.controller.spec.ts
@@ -49,11 +49,19 @@ describe('FoldersController', () => {
       user: '507f191e810c19729de860ee'.toString(),
     } as IAuthPublicMetadata,
   } as unknown as User;
+  const mockSuperAdmin = {
+    ...mockUser,
+    publicMetadata: {
+      ...mockUser.publicMetadata,
+      isSuperAdmin: true,
+    },
+  } as unknown as User;
 
   const mockRequest = {
     originalUrl: '/api/folders',
     query: {},
   } as Request;
+  const folderId = '507f191e810c19729de860ef';
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -102,7 +110,7 @@ describe('FoldersController', () => {
   });
 
   describe('buildFindAllQuery', () => {
-    it('should build query with user and organization match', () => {
+    it('should build query with current brand and organization scope', () => {
       const query: BaseQueryDto = {};
 
       const result = controller.buildFindAllQuery(mockUser, query);
@@ -112,8 +120,14 @@ describe('FoldersController', () => {
         where: expect.objectContaining({
           isDeleted: false,
           OR: [
-            { userId: '507f191e810c19729de860ee' },
-            { organizationId: '507f191e810c19729de860ee' },
+            {
+              brandId: null,
+              organizationId: '507f191e810c19729de860ee',
+            },
+            {
+              brandId: '507f191e810c19729de860ee',
+              organizationId: '507f191e810c19729de860ee',
+            },
           ],
         }),
       });
@@ -131,9 +145,9 @@ describe('FoldersController', () => {
       });
     });
 
-    it('should not include impossible global folder filters for brand context', () => {
+    it('scopes current-brand queries to the caller organization', () => {
       const result = controller.buildFindAllQuery(mockUser, {
-        brand: 'brand-1',
+        brand: '507f191e810c19729de860ee',
       } as BaseQueryDto & { brand: string });
 
       expect(result).toMatchObject({
@@ -143,20 +157,92 @@ describe('FoldersController', () => {
               brandId: null,
               organizationId: '507f191e810c19729de860ee',
             },
-            { brandId: 'brand-1' },
+            {
+              brandId: '507f191e810c19729de860ee',
+              organizationId: '507f191e810c19729de860ee',
+            },
           ],
         }),
       });
     });
 
-    it('should not include impossible global folder filters for organization context', () => {
+    it('rejects a requested foreign organization', () => {
       const result = controller.buildFindAllQuery(mockUser, {
         organization: 'org-1',
       } as BaseQueryDto & { organization: string });
 
       expect(result).toMatchObject({
         where: expect.objectContaining({
-          OR: [{ organizationId: 'org-1' }],
+          id: { in: [] },
+        }),
+      });
+    });
+
+    it('keeps ordinary members in current-brand scope when they request their organization', () => {
+      const result = controller.buildFindAllQuery(mockUser, {
+        organization: mockUser.publicMetadata.organization,
+      } as BaseQueryDto & { organization: string });
+
+      expect(result).toMatchObject({
+        where: expect.objectContaining({
+          OR: [
+            {
+              brandId: null,
+              organizationId: mockUser.publicMetadata.organization,
+            },
+            {
+              brandId: mockUser.publicMetadata.brand,
+              organizationId: mockUser.publicMetadata.organization,
+            },
+          ],
+        }),
+      });
+    });
+
+    it('allows a superadmin to list every folder in a selected organization', () => {
+      const result = controller.buildFindAllQuery(mockSuperAdmin, {
+        organization: '507f191e810c19729de860aa',
+      } as BaseQueryDto & { organization: string });
+
+      expect(result).toMatchObject({
+        where: {
+          isDeleted: false,
+          organizationId: '507f191e810c19729de860aa',
+        },
+      });
+      expect(result.where).not.toHaveProperty('OR');
+    });
+
+    it('allows a superadmin to scope a selected organization to one brand', () => {
+      const result = controller.buildFindAllQuery(mockSuperAdmin, {
+        brand: '507f191e810c19729de860ab',
+        organization: '507f191e810c19729de860aa',
+      } as BaseQueryDto & { brand: string; organization: string });
+
+      expect(result).toMatchObject({
+        where: expect.objectContaining({
+          OR: [
+            {
+              brandId: null,
+              organizationId: '507f191e810c19729de860aa',
+            },
+            {
+              brandId: '507f191e810c19729de860ab',
+              organizationId: '507f191e810c19729de860aa',
+            },
+          ],
+        }),
+      });
+    });
+
+    it('does not return folders for a requested foreign brand', () => {
+      const result = controller.buildFindAllQuery(mockUser, {
+        brand: '507f191e810c19729de860aa',
+      } as BaseQueryDto & { brand: string });
+
+      expect(result).toMatchObject({
+        where: expect.objectContaining({
+          id: { in: [] },
         }),
       });
     });
@@ -168,7 +254,9 @@ describe('FoldersController', () => {
       const relationAccessorKeys = ['brand', 'organization', 'user'];
       const scenarios: Array<BaseQueryDto & Record<string, unknown>> = [
         {},
-        { brand: 'brand-1' } as BaseQueryDto & { brand: string },
+        { brand: '507f191e810c19729de860ee' } as BaseQueryDto & {
+          brand: string;
+        },
         { organization: 'org-1' } as BaseQueryDto & { organization: string },
       ];
 
@@ -187,29 +275,76 @@ describe('FoldersController', () => {
   });
 
   describe('create', () => {
-    it('should create a folder', async () => {
+    it('creates a serialized folder in the caller organization and brand', async () => {
       const createDto: CreateFolderDto = {
         description: 'Test Description',
-        name: 'Test Folder',
+        label: 'Test Folder',
       };
 
       const mockCreatedFolder = {
-        _id: '507f191e810c19729de860ee',
+        id: folderId,
         ...createDto,
-        user: mockUser.publicMetadata.user,
+        brandId: null,
+        organizationId: mockUser.publicMetadata.organization,
+        userId: mockUser.publicMetadata.user,
       };
 
       foldersService.create.mockResolvedValue(mockCreatedFolder);
 
       const result = await controller.create(mockRequest, mockUser, createDto);
 
-      expect(foldersService.create).toHaveBeenCalled();
-      expect(result).toBeDefined();
+      expect(foldersService.create).toHaveBeenCalledWith(
+        {
+          brandId: null,
+          description: 'Test Description',
+          label: 'Test Folder',
+          organizationId: mockUser.publicMetadata.organization,
+          userId: mockUser.publicMetadata.user,
+        },
+        [],
+      );
+      expect(result).toEqual({ data: mockCreatedFolder });
+    });
+
+    it('creates a current-brand folder with scalar foreign keys', async () => {
+      foldersService.create.mockResolvedValue({
+        brandId: mockUser.publicMetadata.brand,
+        id: folderId,
+        label: 'Brand Folder',
+        organizationId: mockUser.publicMetadata.organization,
+        userId: mockUser.publicMetadata.user,
+      });
+
+      await controller.create(mockRequest, mockUser, {
+        brand: mockUser.publicMetadata.brand,
+        label: 'Brand Folder',
+      });
+
+      expect(foldersService.create).toHaveBeenCalledWith(
+        {
+          brandId: mockUser.publicMetadata.brand,
+          label: 'Brand Folder',
+          organizationId: mockUser.publicMetadata.organization,
+          userId: mockUser.publicMetadata.user,
+        },
+        [],
+      );
+    });
+
+    it('rejects a foreign brand on create', async () => {
+      await expect(
+        controller.create(mockRequest, mockUser, {
+          brand: '507f191e810c19729de860aa',
+          label: 'Foreign Brand Folder',
+        }),
+      ).rejects.toThrow(HttpException);
+
+      expect(foldersService.create).not.toHaveBeenCalled();
     });
 
     it('should handle errors during creation', async () => {
       const createDto: CreateFolderDto = {
-        name: 'Test Folder',
+        label: 'Test Folder',
       };
 
       foldersService.create.mockRejectedValue(new Error('Creation failed'));
@@ -220,17 +355,78 @@ describe('FoldersController', () => {
     });
   });
 
+  describe('findOne', () => {
+    it('returns only active folders in the caller organization', async () => {
+      const mockFolder = {
+        id: folderId,
+        isDeleted: false,
+        label: 'Scoped Folder',
+        organizationId: mockUser.publicMetadata.organization,
+      };
+      foldersService.findOne.mockResolvedValue(mockFolder);
+
+      const result = await controller.findOne(
+        mockRequest,
+        mockUser,
+        folderId,
+      );
+
+      expect(foldersService.findOne).toHaveBeenCalledWith({
+        _id: folderId,
+        isDeleted: false,
+        organizationId: mockUser.publicMetadata.organization,
+      });
+      expect(result).toEqual({ data: mockFolder });
+    });
+
+    it('returns not found when the folder is outside caller brand scope', async () => {
+      foldersService.findOne.mockResolvedValue({
+        brandId: '507f191e810c19729de860aa',
+        id: folderId,
+        isDeleted: false,
+        label: 'Foreign Folder',
+        organizationId: mockUser.publicMetadata.organization,
+      });
+
+      await expect(
+        controller.findOne(mockRequest, mockUser, folderId),
+      ).rejects.toThrow(HttpException);
+    });
+
+    it('allows a superadmin to read an active folder outside active tenant scope', async () => {
+      const foreignFolder = {
+        brandId: '507f191e810c19729de860ab',
+        id: folderId,
+        isDeleted: false,
+        label: 'Foreign Folder',
+        organizationId: '507f191e810c19729de860aa',
+      };
+      foldersService.findOne.mockResolvedValue(foreignFolder);
+
+      const result = await controller.findOne(
+        mockRequest,
+        mockSuperAdmin,
+        folderId,
+      );
+
+      expect(foldersService.findOne).toHaveBeenCalledWith({
+        _id: folderId,
+        isDeleted: false,
+      });
+      expect(result).toEqual({ data: foreignFolder });
+    });
+  });
+
   describe('update', () => {
     it('should update a folder', async () => {
-      const id = '507f191e810c19729de860ee'.toString();
       const updateDto: UpdateFolderDto = {
-        name: 'Updated Folder',
+        label: 'Updated Folder',
       };
 
       const mockExistingFolder = {
-        _id: id,
-        name: 'Old Folder',
-        user: mockUser.publicMetadata.user as string,
+        id: folderId,
+        label: 'Old Folder',
+        organizationId: mockUser.publicMetadata.organization,
       };
 
       const mockUpdatedFolder = {
@@ -244,71 +440,155 @@ describe('FoldersController', () => {
       const result = await controller.update(
         mockRequest,
         mockUser,
-        id,
+        folderId,
         updateDto,
       );
 
-      expect(foldersService.findOne).toHaveBeenCalled();
-      expect(foldersService.patch).toHaveBeenCalled();
-      expect(result).toBeDefined();
+      expect(foldersService.findOne).toHaveBeenCalledWith(
+        { _id: folderId },
+        [],
+      );
+      expect(foldersService.patch).toHaveBeenCalledWith(
+        folderId,
+        { label: 'Updated Folder' },
+        [],
+      );
+      expect(result).toEqual({ data: mockUpdatedFolder });
     });
 
     it('should throw error if folder not found', async () => {
-      const id = '507f191e810c19729de860ee'.toString();
       const updateDto: UpdateFolderDto = {
-        name: 'Updated Folder',
+        label: 'Updated Folder',
       };
 
       foldersService.findOne.mockResolvedValue(null);
 
       await expect(
-        controller.update(mockRequest, mockUser, id, updateDto),
+        controller.update(mockRequest, mockUser, folderId, updateDto),
       ).rejects.toThrow(HttpException);
+    });
+
+    it('rejects moving a folder to another brand', async () => {
+      const mockExistingFolder = {
+        id: folderId,
+        label: 'Folder',
+        organizationId: mockUser.publicMetadata.organization,
+      };
+      foldersService.findOne.mockResolvedValue(mockExistingFolder);
+      foldersService.patch.mockResolvedValue(mockExistingFolder);
+
+      await expect(
+        controller.update(mockRequest, mockUser, folderId, {
+          brand: '507f191e810c19729de860aa',
+          label: 'Updated Folder',
+        }),
+      ).rejects.toThrow(HttpException);
+      expect(foldersService.patch).not.toHaveBeenCalled();
+    });
+
+    it('moves a folder into the current brand using the scalar foreign key', async () => {
+      const mockExistingFolder = {
+        id: folderId,
+        label: 'Shared Folder',
+        organizationId: mockUser.publicMetadata.organization,
+      };
+      foldersService.findOne.mockResolvedValue(mockExistingFolder);
+      foldersService.patch.mockResolvedValue({
+        ...mockExistingFolder,
+        brandId: mockUser.publicMetadata.brand,
+      });
+
+      await controller.update(mockRequest, mockUser, folderId, {
+        brand: mockUser.publicMetadata.brand,
+      });
+
+      expect(foldersService.patch).toHaveBeenCalledWith(
+        folderId,
+        { brandId: mockUser.publicMetadata.brand },
+        [],
+      );
+    });
+
+    it('rejects updates to folders in another organization', async () => {
+      foldersService.findOne.mockResolvedValue({
+        id: folderId,
+        label: 'Foreign Folder',
+        organizationId: '507f191e810c19729de860aa',
+      });
+
+      await expect(
+        controller.update(mockRequest, mockUser, folderId, {
+          label: 'Updated Folder',
+        }),
+      ).rejects.toThrow(HttpException);
+      expect(foldersService.patch).not.toHaveBeenCalled();
+    });
+
+    it('rejects updates to folders owned by another brand', async () => {
+      foldersService.findOne.mockResolvedValue({
+        brandId: '507f191e810c19729de860aa',
+        id: folderId,
+        label: 'Foreign Brand Folder',
+        organizationId: mockUser.publicMetadata.organization,
+      });
+
+      await expect(
+        controller.update(mockRequest, mockUser, folderId, {
+          label: 'Updated Folder',
+        }),
+      ).rejects.toThrow(HttpException);
+      expect(foldersService.patch).not.toHaveBeenCalled();
     });
   });
 
   describe('remove', () => {
     it('should remove a folder', async () => {
-      const id = '507f191e810c19729de860ee'.toString();
       const mockFolder = {
-        _id: id,
-        name: 'Folder to Delete',
-        user: mockUser.publicMetadata.user as string,
+        id: folderId,
+        label: 'Folder to Delete',
+        organizationId: mockUser.publicMetadata.organization,
       };
 
       foldersService.findOne.mockResolvedValue(mockFolder);
-      foldersService.remove.mockResolvedValue(mockFolder);
+      foldersService.remove.mockResolvedValue({
+        ...mockFolder,
+        isDeleted: true,
+      });
 
-      const result = await controller.remove(mockRequest, mockUser, id);
+      const result = await controller.remove(
+        mockRequest,
+        mockUser,
+        folderId,
+      );
 
-      expect(foldersService.findOne).toHaveBeenCalledWith({ _id: id });
-      expect(foldersService.remove).toHaveBeenCalledWith(id);
-      expect(result).toBeDefined();
+      expect(foldersService.findOne).toHaveBeenCalledWith({ _id: folderId });
+      expect(foldersService.remove).toHaveBeenCalledWith(folderId);
+      expect(result).toEqual({
+        data: expect.objectContaining({ isDeleted: true }),
+      });
     });
 
     it('should throw error if folder not found', async () => {
-      const id = '507f191e810c19729de860ee'.toString();
-
       foldersService.findOne.mockResolvedValue(null);
 
       await expect(
-        controller.remove(mockRequest, mockUser, id),
+        controller.remove(mockRequest, mockUser, folderId),
       ).rejects.toThrow(HttpException);
     });
 
-    it('should throw error if user does not own the folder', async () => {
-      const id = '507f191e810c19729de860ee'.toString();
+    it('should throw error if caller organization does not own the folder', async () => {
       const mockFolder = {
-        _id: id,
-        name: 'Folder',
-        user: '507f191e810c19729de860ee', // Different user
+        id: folderId,
+        label: 'Folder',
+        organizationId: '507f191e810c19729de860aa',
       };
 
       foldersService.findOne.mockResolvedValue(mockFolder);
 
       await expect(
-        controller.remove(mockRequest, mockUser, id),
+        controller.remove(mockRequest, mockUser, folderId),
       ).rejects.toThrow(HttpException);
+      expect(foldersService.remove).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/server/api/src/collections/folders/controllers/folders.controller.ts
+++ b/apps/server/api/src/collections/folders/controllers/folders.controller.ts
@@ -53,11 +53,11 @@ export class FoldersController extends BaseCRUDController<
     super(loggerService, foldersService, FolderSerializer, 'Folder');
   }
 
-  @Get(':folderId')
+  @Get(':id')
   async findOne(
     @Req() request: Request,
     @CurrentUser() user: User,
-    @Param('folderId') folderId: string,
+    @Param('id') folderId: string,
   ): Promise<JsonApiSingleResponse> {
     if (!isEntityId(folderId)) {
       ErrorResponse.notFound(this.entityName, folderId);

--- a/apps/server/api/src/collections/folders/controllers/folders.controller.ts
+++ b/apps/server/api/src/collections/folders/controllers/folders.controller.ts
@@ -63,10 +63,8 @@ export class FoldersController extends BaseCRUDController<
       ErrorResponse.notFound(this.entityName, folderId);
     }
 
-    const {
-      brand: brandId,
-      organization: organizationId,
-    } = getPublicMetadata(user);
+    const { brand: brandId, organization: organizationId } =
+      getPublicMetadata(user);
     const isSuperAdmin = getIsSuperAdmin(user, request);
     const folderQuery: Record<string, unknown> = {
       _id: folderId,
@@ -218,10 +216,8 @@ export class FoldersController extends BaseCRUDController<
     user: User,
     entity: FolderDocument,
   ): boolean {
-    const {
-      brand: brandId,
-      organization: organizationId,
-    } = getPublicMetadata(user);
+    const { brand: brandId, organization: organizationId } =
+      getPublicMetadata(user);
     return this.isFolderInScope(entity, organizationId, brandId);
   }
 

--- a/apps/server/api/src/collections/folders/controllers/folders.controller.ts
+++ b/apps/server/api/src/collections/folders/controllers/folders.controller.ts
@@ -11,14 +11,22 @@ import { AutoSwagger } from '@api/helpers/decorators/swagger/auto-swagger.decora
 import { CurrentUser } from '@api/helpers/decorators/user/current-user.decorator';
 import { BaseQueryDto } from '@api/helpers/dto/base-query.dto';
 import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
-import { getPublicMetadata } from '@api/helpers/utils/auth/auth.util';
+import {
+  getIsSuperAdmin,
+  getPublicMetadata,
+} from '@api/helpers/utils/auth/auth.util';
+import { ErrorResponse } from '@api/helpers/utils/error-response/error-response.util';
+import { serializeSingle } from '@api/helpers/utils/response/response.util';
+import { isEntityId } from '@api/helpers/validation/entity-id.validator';
 import { BaseCRUDController } from '@api/shared/controllers/base-crud/base-crud.controller';
+import type { JsonApiSingleResponse } from '@genfeedai/interfaces';
 import { FolderSerializer } from '@genfeedai/serializers';
 import { LoggerService } from '@libs/logger/logger.service';
 import {
   Body,
   Controller,
   Delete,
+  Get,
   Param,
   Patch,
   Req,
@@ -45,6 +53,40 @@ export class FoldersController extends BaseCRUDController<
     super(loggerService, foldersService, FolderSerializer, 'Folder');
   }
 
+  @Get(':folderId')
+  async findOne(
+    @Req() request: Request,
+    @CurrentUser() user: User,
+    @Param('folderId') folderId: string,
+  ): Promise<JsonApiSingleResponse> {
+    if (!isEntityId(folderId)) {
+      ErrorResponse.notFound(this.entityName, folderId);
+    }
+
+    const {
+      brand: brandId,
+      organization: organizationId,
+    } = getPublicMetadata(user);
+    const isSuperAdmin = getIsSuperAdmin(user, request);
+    const folderQuery: Record<string, unknown> = {
+      _id: folderId,
+      isDeleted: false,
+    };
+    if (!isSuperAdmin) {
+      folderQuery.organizationId = organizationId;
+    }
+    const data = await this.foldersService.findOne(folderQuery);
+
+    if (
+      !data ||
+      (!isSuperAdmin && !this.isFolderInScope(data, organizationId, brandId))
+    ) {
+      ErrorResponse.notFound(this.entityName, folderId);
+    }
+
+    return serializeSingle(request, FolderSerializer, data);
+  }
+
   @Patch(':folderId')
   @LogMethod({ logEnd: false, logError: true, logStart: true })
   update(
@@ -68,9 +110,9 @@ export class FoldersController extends BaseCRUDController<
 
   /**
    * Override the base pipeline to load folders with proper filtering:
-   * - If brand query param: org folders without brand + brand folders
-   * - If organization query param (no brand): org folders
-   * - Default: user folders + organization folders
+   * - Members: shared organization folders + current-brand folders
+   * - Superadmin brand filter: shared + selected-brand folders in the selected org
+   * - Superadmin organization filter: every folder in the selected org
    *
    * The OR branches are built with scalar foreign-key fields (`brandId`,
    * `organizationId`, `userId`) rather than Prisma relation accessors
@@ -89,6 +131,7 @@ export class FoldersController extends BaseCRUDController<
     const requestedOrganizationId =
       (query as unknown as Record<string, string | undefined>).organization ||
       null;
+    const isSuperAdmin = getIsSuperAdmin(user);
 
     const matchStage: Record<string, unknown> & {
       OR?: Array<Record<string, unknown>>;
@@ -96,23 +139,116 @@ export class FoldersController extends BaseCRUDController<
       isDeleted: query.isDeleted ?? false,
     };
 
-    if (requestedBrandId) {
+    if (isSuperAdmin && (requestedBrandId || requestedOrganizationId)) {
+      const scopedOrganizationId = requestedOrganizationId || organizationId;
+      if (requestedBrandId) {
+        matchStage.OR = this.buildFolderScope(
+          scopedOrganizationId,
+          requestedBrandId,
+        );
+      } else {
+        matchStage.organizationId = scopedOrganizationId;
+      }
+    } else if (
+      (requestedBrandId &&
+        requestedBrandId !== publicMetadata.brand?.toString()) ||
+      (requestedOrganizationId && requestedOrganizationId !== organizationId)
+    ) {
+      matchStage.id = { in: [] };
+    } else if (requestedBrandId) {
       // Brand context: show organization folders without brand + brand folders.
-      matchStage.OR = [
-        {
-          brandId: null,
-          organizationId: requestedOrganizationId || organizationId,
-        }, // Organization folders without brand
-        { brandId: requestedBrandId }, // Brand folders
-      ];
-    } else if (requestedOrganizationId) {
-      // Organization context (no brand): show organization folders.
-      matchStage.OR = [{ organizationId: requestedOrganizationId }];
+      matchStage.OR = this.buildFolderScope(organizationId, requestedBrandId);
     } else {
-      // Default: user folders + organization folders
-      matchStage.OR = [{ userId: publicMetadata.user }, { organizationId }];
+      // Members stay in shared + current-brand scope even when the caller
+      // repeats its own organization in the query.
+      matchStage.OR = this.buildFolderScope(
+        organizationId,
+        requestedBrandId || publicMetadata.brand,
+      );
     }
 
     return { where: matchStage, orderBy: { createdAt: -1, label: 1 } };
+  }
+
+  public override enrichCreateDto(
+    createDto: Partial<CreateFolderDto>,
+    user: User,
+  ): CreateFolderDto {
+    const publicMetadata = getPublicMetadata(user);
+    const requestedBrandId = createDto.brand?.toString();
+
+    if (
+      requestedBrandId &&
+      requestedBrandId !== publicMetadata.brand?.toString()
+    ) {
+      ErrorResponse.notFound('Brand', requestedBrandId);
+    }
+
+    const { brand: _brand, ...folderDto } = createDto;
+
+    return {
+      ...folderDto,
+      brandId: requestedBrandId || null,
+      organizationId: publicMetadata.organization,
+      userId: publicMetadata.user,
+    } as unknown as CreateFolderDto;
+  }
+
+  public override async enrichUpdateDto(
+    updateDto: Partial<UpdateFolderDto>,
+    user: User,
+  ): Promise<UpdateFolderDto> {
+    const requestedBrandId = updateDto.brand?.toString();
+    const currentBrandId = getPublicMetadata(user).brand?.toString();
+
+    if (requestedBrandId && requestedBrandId !== currentBrandId) {
+      ErrorResponse.notFound('Brand', requestedBrandId);
+    }
+
+    const { brand: _brand, ...folderDto } = updateDto;
+    const scopedDto: Record<string, unknown> = { ...folderDto };
+    if (Object.hasOwn(updateDto, 'brand')) {
+      scopedDto.brandId = requestedBrandId || null;
+    }
+
+    return await Promise.resolve(scopedDto as UpdateFolderDto);
+  }
+
+  public override canUserModifyEntity(
+    user: User,
+    entity: FolderDocument,
+  ): boolean {
+    const {
+      brand: brandId,
+      organization: organizationId,
+    } = getPublicMetadata(user);
+    return this.isFolderInScope(entity, organizationId, brandId);
+  }
+
+  private buildFolderScope(
+    organizationId: string,
+    brandId?: string,
+  ): Array<Record<string, unknown>> {
+    const scope: Array<Record<string, unknown>> = [
+      { brandId: null, organizationId },
+    ];
+    if (brandId) {
+      scope.push({ brandId, organizationId });
+    }
+    return scope;
+  }
+
+  private isFolderInScope(
+    folder: FolderDocument,
+    organizationId: string,
+    brandId?: string,
+  ): boolean {
+    const folderBrandId = folder.brandId?.toString();
+
+    return (
+      folder.isDeleted !== true &&
+      folder.organizationId?.toString() === organizationId &&
+      (!folderBrandId || folderBrandId === brandId)
+    );
   }
 }

--- a/apps/server/api/src/collections/folders/services/folders-lifecycle.service.spec.ts
+++ b/apps/server/api/src/collections/folders/services/folders-lifecycle.service.spec.ts
@@ -108,8 +108,7 @@ describe('Library folder lifecycle persistence', () => {
                 (!where.OR ||
                   where.OR.some(
                     (candidate) =>
-                      candidate.id === row.id ||
-                      candidate.mongoId === row.id,
+                      candidate.id === row.id || candidate.mongoId === row.id,
                   )),
             ) ?? null,
           ),
@@ -186,11 +185,9 @@ describe('Library folder lifecycle persistence', () => {
     } as unknown as LoggerService;
 
     foldersService = new FoldersService(prisma, logger);
-    ingredientsService = new IngredientsService(
-      prisma,
-      logger,
-      { get: vi.fn() } as unknown as ModuleRef,
-    );
+    ingredientsService = new IngredientsService(prisma, logger, {
+      get: vi.fn(),
+    } as unknown as ModuleRef);
     foldersController = new FoldersController(foldersService, logger);
     ingredientsController = new IngredientsController(
       ingredientsService,
@@ -201,7 +198,11 @@ describe('Library folder lifecycle persistence', () => {
   it('persists scalar relationships, preserves assigned assets, and hides a removed folder', async () => {
     const user = {
       id: userId,
-      publicMetadata: { brand: brandId, organization: organizationId, user: userId },
+      publicMetadata: {
+        brand: brandId,
+        organization: organizationId,
+        user: userId,
+      },
     } as unknown as User;
     const request = {
       originalUrl: '/api/folders',

--- a/apps/server/api/src/collections/folders/services/folders-lifecycle.service.spec.ts
+++ b/apps/server/api/src/collections/folders/services/folders-lifecycle.service.spec.ts
@@ -1,0 +1,244 @@
+vi.mock('@genfeedai/prisma', async () => {
+  const { canonicalPrismaMock } = await import(
+    '@api/shared/testing/prisma-mock'
+  );
+  return canonicalPrismaMock();
+});
+
+vi.mock('@api/helpers/utils/response/response.util', () => ({
+  serializeSingle: vi.fn(
+    (_request: unknown, _serializer: unknown, data: unknown) => ({ data }),
+  ),
+}));
+
+import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticated-user.interface';
+import { FoldersController } from '@api/collections/folders/controllers/folders.controller';
+import type { CreateFolderDto } from '@api/collections/folders/dto/create-folder.dto';
+import type { FolderDocument } from '@api/collections/folders/schemas/folder.schema';
+import { FoldersService } from '@api/collections/folders/services/folders.service';
+import { IngredientsController } from '@api/collections/ingredients/controllers/ingredients.controller';
+import type { IngredientDocument } from '@api/collections/ingredients/schemas/ingredient.schema';
+import { IngredientsService } from '@api/collections/ingredients/services/ingredients.service';
+import type { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import type { LoggerService } from '@libs/logger/logger.service';
+import type { ModuleRef } from '@nestjs/core';
+import type { Request } from 'express';
+
+type FolderRow = Pick<
+  FolderDocument,
+  | 'brandId'
+  | 'description'
+  | 'id'
+  | 'isActive'
+  | 'isDeleted'
+  | 'label'
+  | 'organizationId'
+  | 'userId'
+>;
+
+type IngredientRow = Pick<
+  IngredientDocument,
+  'brandId' | 'folderId' | 'id' | 'isDeleted' | 'organizationId' | 'userId'
+>;
+
+const organizationId = '507f191e810c19729de86001';
+const brandId = '507f191e810c19729de86002';
+const userId = '507f191e810c19729de86003';
+const ingredientId = '507f191e810c19729de86004';
+const folderId = '507f191e810c19729de86005';
+
+describe('Library folder lifecycle persistence', () => {
+  let folderRows: FolderRow[];
+  let ingredientRows: IngredientRow[];
+  let foldersController: FoldersController;
+  let foldersService: FoldersService;
+  let ingredientsController: IngredientsController;
+  let ingredientsService: IngredientsService;
+
+  beforeEach(() => {
+    folderRows = [];
+    ingredientRows = [
+      {
+        brandId,
+        folderId: null,
+        id: ingredientId,
+        isDeleted: false,
+        organizationId,
+        userId,
+      },
+    ];
+
+    const folderDelegate = {
+      count: vi.fn(({ where }: { where: Partial<FolderRow> }) =>
+        Promise.resolve(
+          folderRows.filter(
+            (row) =>
+              (where.organizationId === undefined ||
+                row.organizationId === where.organizationId) &&
+              (where.isDeleted === undefined ||
+                row.isDeleted === where.isDeleted),
+          ).length,
+        ),
+      ),
+      create: vi.fn(({ data }: { data: FolderRow }) => {
+        const row = {
+          ...data,
+          id: folderId,
+          isActive: data.isActive ?? true,
+          isDeleted: data.isDeleted ?? false,
+        };
+        folderRows.push(row);
+        return Promise.resolve(row);
+      }),
+      findFirst: vi.fn(
+        ({
+          where,
+        }: {
+          where: Partial<FolderRow> & {
+            OR?: Array<{ id?: string; mongoId?: string }>;
+          };
+        }) =>
+          Promise.resolve(
+            folderRows.find(
+              (row) =>
+                (where.organizationId === undefined ||
+                  row.organizationId === where.organizationId) &&
+                (where.isDeleted === undefined ||
+                  row.isDeleted === where.isDeleted) &&
+                (!where.OR ||
+                  where.OR.some(
+                    (candidate) =>
+                      candidate.id === row.id ||
+                      candidate.mongoId === row.id,
+                  )),
+            ) ?? null,
+          ),
+      ),
+      findMany: vi.fn(({ where }: { where: Partial<FolderRow> }) =>
+        Promise.resolve(
+          folderRows.filter(
+            (row) =>
+              (where.organizationId === undefined ||
+                row.organizationId === where.organizationId) &&
+              (where.isDeleted === undefined ||
+                row.isDeleted === where.isDeleted),
+          ),
+        ),
+      ),
+      update: vi.fn(
+        ({
+          data,
+          where,
+        }: {
+          data: Partial<FolderRow>;
+          where: { id: string };
+        }) => {
+          const row = folderRows.find((folder) => folder.id === where.id);
+          if (!row) {
+            return Promise.resolve(null);
+          }
+          Object.assign(row, data);
+          return Promise.resolve(row);
+        },
+      ),
+    };
+
+    const ingredientDelegate = {
+      findFirst: vi.fn(({ where }: { where: Partial<IngredientRow> }) =>
+        Promise.resolve(
+          ingredientRows.find(
+            (row) =>
+              (where.id === undefined || row.id === where.id) &&
+              (where.isDeleted === undefined ||
+                row.isDeleted === where.isDeleted),
+          ) ?? null,
+        ),
+      ),
+      update: vi.fn(
+        ({
+          data,
+          where,
+        }: {
+          data: Partial<IngredientRow>;
+          where: { id: string };
+        }) => {
+          const row = ingredientRows.find(
+            (ingredient) => ingredient.id === where.id,
+          );
+          if (!row) {
+            return Promise.resolve(null);
+          }
+          Object.assign(row, data);
+          return Promise.resolve(row);
+        },
+      ),
+    };
+
+    const prisma = {
+      folder: folderDelegate,
+      ingredient: ingredientDelegate,
+    } as unknown as PrismaService;
+    const logger = {
+      debug: vi.fn(),
+      error: vi.fn(),
+      log: vi.fn(),
+      warn: vi.fn(),
+    } as unknown as LoggerService;
+
+    foldersService = new FoldersService(prisma, logger);
+    ingredientsService = new IngredientsService(
+      prisma,
+      logger,
+      { get: vi.fn() } as unknown as ModuleRef,
+    );
+    foldersController = new FoldersController(foldersService, logger);
+    ingredientsController = new IngredientsController(
+      ingredientsService,
+      foldersService,
+    );
+  });
+
+  it('persists scalar relationships, preserves assigned assets, and hides a removed folder', async () => {
+    const user = {
+      id: userId,
+      publicMetadata: { brand: brandId, organization: organizationId, user: userId },
+    } as unknown as User;
+    const request = {
+      originalUrl: '/api/folders',
+      params: {},
+      query: {},
+    } as Request;
+    const createDto: CreateFolderDto = {
+      brand: brandId,
+      description: 'Campaign assets',
+      label: 'Campaign',
+    };
+    const folder = await foldersService.create(
+      foldersController.enrichCreateDto(createDto, user),
+    );
+
+    await ingredientsController.update(request, ingredientId, user, {
+      folder: folder.id,
+    });
+    await foldersController.remove(request, user, folder.id);
+
+    const activeFolders = await foldersService.findAll(
+      {
+        where: { isDeleted: false, organizationId },
+      },
+      { pagination: false },
+    );
+
+    expect(activeFolders.docs).toEqual([]);
+    expect(folderRows).toEqual([
+      expect.objectContaining({ id: folderId, isDeleted: true }),
+    ]);
+    expect(ingredientRows).toEqual([
+      expect.objectContaining({
+        folderId,
+        id: ingredientId,
+        isDeleted: false,
+      }),
+    ]);
+  });
+});

--- a/apps/server/api/src/collections/ingredients/controllers/ingredients-folder-assignment.controller.spec.ts
+++ b/apps/server/api/src/collections/ingredients/controllers/ingredients-folder-assignment.controller.spec.ts
@@ -1,0 +1,201 @@
+import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticated-user.interface';
+import { FoldersService } from '@api/collections/folders/services/folders.service';
+import { IngredientsController } from '@api/collections/ingredients/controllers/ingredients.controller';
+import { IngredientsService } from '@api/collections/ingredients/services/ingredients.service';
+import { AssetAccessGuard } from '@api/guards/asset-access.guard';
+import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
+import { Test, type TestingModule } from '@nestjs/testing';
+import type { Request } from 'express';
+
+vi.mock('@api/helpers/utils/response/response.util', () => ({
+  returnNotFound: vi.fn((name: string, id: string) => ({
+    error: `${name}:${id}`,
+  })),
+  serializeCollection: vi.fn(
+    (_request: unknown, _serializer: unknown, data: unknown) => ({ data }),
+  ),
+  serializeSingle: vi.fn(
+    (_request: unknown, _serializer: unknown, data: unknown) => ({ data }),
+  ),
+}));
+
+const organizationId = '507f191e810c19729de86001';
+const brandId = '507f191e810c19729de86002';
+const userId = '507f191e810c19729de86003';
+const ingredientId = '507f191e810c19729de86004';
+const folderId = '507f191e810c19729de86005';
+
+const mockUser = {
+  id: userId,
+  publicMetadata: {
+    brand: brandId,
+    organization: organizationId,
+    user: userId,
+  },
+} as unknown as User;
+
+const mockRequest = {
+  originalUrl: `/api/ingredients/${ingredientId}`,
+  params: { ingredientId },
+  query: {},
+} as unknown as Request;
+
+const ingredient = {
+  id: ingredientId,
+  brandId,
+  folderId: null,
+  isDeleted: false,
+  organizationId,
+  userId,
+};
+
+describe('IngredientsController folder assignment', () => {
+  let controller: IngredientsController;
+  let foldersService: vi.Mocked<FoldersService>;
+  let ingredientsService: vi.Mocked<IngredientsService>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [IngredientsController],
+      providers: [
+        {
+          provide: IngredientsService,
+          useValue: {
+            findOne: vi.fn(),
+            patch: vi.fn(),
+          },
+        },
+        {
+          provide: FoldersService,
+          useValue: {
+            findOne: vi.fn(),
+          },
+        },
+      ],
+    })
+      .overrideGuard(RolesGuard)
+      .useValue({ canActivate: () => true })
+      .overrideGuard(AssetAccessGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get(IngredientsController);
+    foldersService = module.get(FoldersService);
+    ingredientsService = module.get(IngredientsService);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('assigns an owned asset to an active folder in caller scope', async () => {
+    foldersService.findOne.mockResolvedValue({
+      id: folderId,
+      brandId,
+      isDeleted: false,
+      organizationId,
+    });
+    ingredientsService.findOne
+      .mockResolvedValueOnce(ingredient)
+      .mockResolvedValueOnce({ ...ingredient, folderId });
+    ingredientsService.patch.mockResolvedValue({
+      ...ingredient,
+      folderId,
+    });
+
+    const result = await controller.update(
+      mockRequest,
+      ingredientId,
+      mockUser,
+      { folder: folderId },
+    );
+
+    expect(foldersService.findOne).toHaveBeenCalledWith({
+      _id: folderId,
+      isDeleted: false,
+      organizationId,
+    });
+    expect(ingredientsService.findOne).toHaveBeenNthCalledWith(
+      1,
+      {
+        _id: ingredientId,
+        isDeleted: false,
+        organizationId,
+      },
+      expect.any(Array),
+    );
+    expect(ingredientsService.patch).toHaveBeenCalledWith(ingredientId, {
+      folderId,
+    });
+    expect(ingredientsService.findOne).toHaveBeenNthCalledWith(
+      2,
+      {
+        _id: ingredientId,
+        isDeleted: false,
+        organizationId,
+      },
+      expect.any(Array),
+    );
+    expect(result).toEqual({
+      data: expect.objectContaining({ folderId }),
+    });
+  });
+
+  it('rejects a folder outside the caller brand scope', async () => {
+    ingredientsService.findOne.mockResolvedValueOnce(ingredient);
+    foldersService.findOne.mockResolvedValue({
+      id: folderId,
+      brandId: '507f191e810c19729de86009',
+      isDeleted: false,
+      organizationId,
+    });
+
+    const result = await controller.update(
+      mockRequest,
+      ingredientId,
+      mockUser,
+      { folder: folderId },
+    );
+
+    expect(result).toEqual({
+      error: `IngredientsController:${folderId}`,
+    });
+    expect(ingredientsService.patch).not.toHaveBeenCalled();
+  });
+
+  it('rejects assignment when the asset is outside caller brand scope', async () => {
+    ingredientsService.findOne.mockResolvedValue({
+      ...ingredient,
+      brandId: '507f191e810c19729de86009',
+    });
+
+    const result = await controller.update(
+      mockRequest,
+      ingredientId,
+      mockUser,
+      { folder: folderId },
+    );
+
+    expect(result).toEqual({
+      error: `IngredientsController:${ingredientId}`,
+    });
+    expect(foldersService.findOne).not.toHaveBeenCalled();
+    expect(ingredientsService.patch).not.toHaveBeenCalled();
+  });
+
+  it('clears the folder assignment without requiring a folder lookup', async () => {
+    ingredientsService.findOne
+      .mockResolvedValueOnce({ ...ingredient, folderId })
+      .mockResolvedValueOnce(ingredient);
+    ingredientsService.patch.mockResolvedValue(ingredient);
+
+    await controller.update(mockRequest, ingredientId, mockUser, {
+      folder: '',
+    });
+
+    expect(foldersService.findOne).not.toHaveBeenCalled();
+    expect(ingredientsService.patch).toHaveBeenCalledWith(ingredientId, {
+      folderId: null,
+    });
+  });
+});

--- a/apps/server/api/src/collections/ingredients/controllers/ingredients.controller.ts
+++ b/apps/server/api/src/collections/ingredients/controllers/ingredients.controller.ts
@@ -134,10 +134,7 @@ export class IngredientsController {
       return returnNotFound(this.constructorName, ingredientId);
     }
 
-    if (
-      Object.hasOwn(processedDto, 'folder') &&
-      processedDto.folder !== null
-    ) {
+    if (Object.hasOwn(processedDto, 'folder') && processedDto.folder !== null) {
       const folder = await this.foldersService.findOne({
         _id: processedDto.folder,
         isDeleted: false,

--- a/apps/server/api/src/collections/ingredients/controllers/ingredients.controller.ts
+++ b/apps/server/api/src/collections/ingredients/controllers/ingredients.controller.ts
@@ -1,4 +1,5 @@
 import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticated-user.interface';
+import { FoldersService } from '@api/collections/folders/services/folders.service';
 import { UpdateIngredientDto } from '@api/collections/ingredients/dto/update-ingredient.dto';
 import { IngredientsService } from '@api/collections/ingredients/services/ingredients.service';
 import { AssetAccessGuard } from '@api/guards/asset-access.guard';
@@ -38,7 +39,10 @@ import type { Request } from 'express';
 export class IngredientsController {
   private readonly constructorName: string = String(this.constructor.name);
 
-  constructor(private readonly ingredientsService: IngredientsService) {}
+  constructor(
+    private readonly ingredientsService: IngredientsService,
+    private readonly foldersService: FoldersService,
+  ) {}
 
   @Get('batch')
   @HttpCode(HttpStatus.OK)
@@ -111,20 +115,49 @@ export class IngredientsController {
       );
     }
 
-    // Find the ingredient first to ensure it exists and belongs to the user or organization
+    // Load only an active ingredient in the caller organization, then enforce
+    // current-brand or organization-shared access below.
     const ingredient = await this.ingredientsService.findOne(
       {
         _id: ingredientId,
-        OR: [
-          { user: publicMetadata.user },
-          { organization: publicMetadata.organization },
-        ],
+        isDeleted: false,
+        organizationId: publicMetadata.organization,
       },
       [PopulatePatterns.metadataFull],
     );
 
-    if (!ingredient) {
+    if (
+      !ingredient ||
+      (ingredient.brandId &&
+        ingredient.brandId.toString() !== publicMetadata.brand)
+    ) {
       return returnNotFound(this.constructorName, ingredientId);
+    }
+
+    if (
+      Object.hasOwn(processedDto, 'folder') &&
+      processedDto.folder !== null
+    ) {
+      const folder = await this.foldersService.findOne({
+        _id: processedDto.folder,
+        isDeleted: false,
+        organizationId: publicMetadata.organization,
+      });
+
+      if (
+        !folder ||
+        (folder.brandId && folder.brandId.toString() !== publicMetadata.brand)
+      ) {
+        return returnNotFound(
+          this.constructorName,
+          String(processedDto.folder),
+        );
+      }
+    }
+
+    if (Object.hasOwn(processedDto, 'folder')) {
+      processedDto.folderId = processedDto.folder;
+      Reflect.deleteProperty(processedDto, 'folder');
     }
 
     await this.ingredientsService.patch(
@@ -134,10 +167,14 @@ export class IngredientsController {
 
     // Fetch the updated document with populated fields
     // Only populate metadata fully and brand minimally (id, label, handle)
-    const data = await this.ingredientsService.findOne({ _id: ingredientId }, [
-      PopulatePatterns.metadataFull,
-      PopulatePatterns.brandMinimal,
-    ]);
+    const data = await this.ingredientsService.findOne(
+      {
+        _id: ingredientId,
+        isDeleted: false,
+        organizationId: publicMetadata.organization,
+      },
+      [PopulatePatterns.metadataFull, PopulatePatterns.brandMinimal],
+    );
 
     return serializeSingle(request, IngredientSerializer, data);
   }

--- a/apps/server/api/src/collections/ingredients/ingredients.module.ts
+++ b/apps/server/api/src/collections/ingredients/ingredients.module.ts
@@ -4,6 +4,7 @@
 Workflow execution, state management, and cross-content type operations.
  */
 
+import { FoldersModule } from '@api/collections/folders/folders.module';
 import { IngredientsController } from '@api/collections/ingredients/controllers/ingredients.controller';
 import { IngredientsRelationshipsController } from '@api/collections/ingredients/controllers/ingredients-relationships.controller';
 import { IngredientsService } from '@api/collections/ingredients/services/ingredients.service';
@@ -14,7 +15,7 @@ import { forwardRef, Module } from '@nestjs/common';
 @Module({
   controllers: [IngredientsController, IngredientsRelationshipsController],
   exports: [IngredientsService],
-  imports: [forwardRef(() => MetadataModule)],
+  imports: [FoldersModule, forwardRef(() => MetadataModule)],
   providers: [AssetAccessGuard, IngredientsService],
 })
 export class IngredientsModule {}

--- a/apps/server/api/src/helpers/utils/ingredient-filter/README.md
+++ b/apps/server/api/src/helpers/utils/ingredient-filter/README.md
@@ -40,7 +40,7 @@ const parentConditions = IngredientFilterUtil.buildParentFilter(query.parent);
 Handles filtering by folder ID:
 - `null`, `'null'`, `''` → Root level (no folder)
 - Valid ObjectId → Ingredients in that folder
-- `undefined` → Defaults to root level
+- `undefined` → No folder filter ("All Assets")
 
 ```typescript
 const folderConditions = IngredientFilterUtil.buildFolderFilter(query.folder);

--- a/apps/server/api/src/helpers/utils/ingredient-filter/ingredient-filter.util.spec.ts
+++ b/apps/server/api/src/helpers/utils/ingredient-filter/ingredient-filter.util.spec.ts
@@ -25,9 +25,9 @@ describe('IngredientFilterUtil', () => {
   });
 
   describe('buildFolderFilter', () => {
-    it('should filter root level when folder is undefined', () => {
+    it('should not filter folders when folder is undefined (All Assets)', () => {
       const result = IngredientFilterUtil.buildFolderFilter(undefined);
-      expect(result).toEqual({ folder: null });
+      expect(result).toEqual({});
     });
 
     it('should filter by folder ID when valid ObjectId provided', () => {

--- a/apps/server/api/src/helpers/utils/ingredient-filter/ingredient-filter.util.ts
+++ b/apps/server/api/src/helpers/utils/ingredient-filter/ingredient-filter.util.ts
@@ -54,7 +54,7 @@ export class IngredientFilterUtil {
    * Handles filtering by folder ID:
    * - null/'null'/'' → root level (no folder)
    * - valid ObjectId → ingredients in that folder
-   * - undefined → defaults to root level
+   * - undefined → no folder filter ("All Assets")
    *
    * @param folder - Folder ID from query params
    * @returns Filter conditions for folder field
@@ -73,8 +73,8 @@ export class IngredientFilterUtil {
       }
     }
 
-    // Default to root level (no folder)
-    return { folder: null };
+    // No folder parameter means the Library's "All Assets" view.
+    return {};
   }
 
   /**


### PR DESCRIPTION
## Summary
- scope folder create/list/detail/update/delete to the caller brand and organization while preserving explicit superadmin filtering
- validate folder assignment at the ingredient write boundary and persist scalar Prisma foreign keys
- make an omitted folder filter represent Library “All Assets”
- add focused controller coverage plus a stateful controller-to-service lifecycle seam proving soft-deleted folders disappear while assigned assets remain

## Verification
- `bunx @biomejs/biome@2.5.3 format --write apps/server/api/src/collections/folders/controllers/folders.controller.spec.ts`
- `bunx @biomejs/biome@2.5.3 format apps/server/api/src/collections/folders/controllers/folders.controller.spec.ts`
- `git diff --check`
- `bun run scripts/run-secretlint.ts apps/server/api/src/collections/folders/controllers/folders.controller.spec.ts`
- exact-head PR CI on `da4f6fb53493c92cfe29da239f75998e1aa2ee03`: 25 passed, 10 intentionally skipped, 0 failed or pending
- independent blocker-focused implementation reviews

Local tests, typechecks, and builds were not run under the repository machine policy; affected tests and broader validation ran in PR CI. `bun run check:di-value-imports` was attempted locally but the repository scanner failed before analysis because `ts.ScriptTarget` was undefined under Bun 1.3.14; the equivalent CI Guards check passed.

Closes #1944
Parent: #1594
