### PR TITLE
test(api): cover Library asset lifecycle contracts

### DIFF
--- a/apps/server/api/src/collections/gifs/controllers/gifs.controller.spec.ts
+++ b/apps/server/api/src/collections/gifs/controllers/gifs.controller.spec.ts
@@ -53,6 +53,11 @@ import { GifsService } from '@api/collections/gifs/services/gifs.service';
 import { VotesService } from '@api/collections/votes/services/votes.service';
 import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
 import { CreditsInterceptor } from '@api/helpers/interceptors/credits/credits.interceptor';
+import {
+  serializeCollection,
+  serializeSingle,
+} from '@api/helpers/utils/response/response.util';
+import { IngredientSerializer } from '@genfeedai/serializers';
 import { LoggerService } from '@libs/logger/logger.service';
 import { HttpException, HttpStatus } from '@nestjs/common';
 import { Test, type TestingModule } from '@nestjs/testing';
@@ -82,11 +87,14 @@ describe('GifsController', () => {
     _id: gifId,
     category: 'gif',
     hasVoted: false,
+    id: 'canonical-gif-id',
     metadata: { label: 'Test GIF' },
     scope: 'private',
   };
 
   beforeEach(async () => {
+    vi.clearAllMocks();
+
     gifsService = {
       findAll: vi.fn().mockResolvedValue({
         docs: [mockGif],
@@ -140,6 +148,11 @@ describe('GifsController', () => {
       const result = await controller.findAll(mockRequest, mockUser, query);
       expect(gifsService.findAll).toHaveBeenCalled();
       expect(result).toBeDefined();
+      expect(serializeCollection).toHaveBeenCalledWith(
+        mockRequest,
+        IngredientSerializer,
+        expect.objectContaining({ docs: [mockGif] }),
+      );
     });
 
     it('should support collapsed "latest" queries via sort/limit/pagination params', async () => {
@@ -180,6 +193,29 @@ describe('GifsController', () => {
         orderBy: { createdAt: -1 },
         where: expect.any(Object),
       });
+      expect(findAllQuery.where).toEqual(
+        expect.objectContaining({
+          AND: expect.arrayContaining([
+            expect.objectContaining({
+              OR: expect.arrayContaining([
+                expect.objectContaining({
+                  AND: expect.arrayContaining([
+                    expect.objectContaining({
+                      OR: [
+                        {
+                          organizationId: mockUser.publicMetadata.organization,
+                        },
+                        { organizationId: null },
+                      ],
+                      isDefault: true,
+                    }),
+                  ]),
+                }),
+              ]),
+            }),
+          ]),
+        }),
+      );
     });
   });
 
@@ -187,10 +223,23 @@ describe('GifsController', () => {
     it('should return a single gif', async () => {
       const result = await controller.findOne(mockRequest, gifId, mockUser);
       expect(gifsService.findOne).toHaveBeenCalledWith(
-        { _id: gifId },
+        {
+          _id: gifId,
+          category: 'GIF',
+          isDeleted: false,
+          OR: [
+            { organizationId: mockUser.publicMetadata.organization },
+            { isDefault: true, organizationId: null },
+          ],
+        },
         expect.any(Array),
       );
       expect(result).toEqual(expect.objectContaining({ _id: gifId }));
+      expect(serializeSingle).toHaveBeenCalledWith(
+        mockRequest,
+        IngredientSerializer,
+        expect.objectContaining({ _id: gifId }),
+      );
     });
 
     it('should throw NOT_FOUND when gif does not exist', async () => {
@@ -221,16 +270,29 @@ describe('GifsController', () => {
 
   describe('remove', () => {
     it('should remove a gif and return it', async () => {
-      const result = await controller.remove(mockRequest, gifId);
-      expect(gifsService.remove).toHaveBeenCalledWith(gifId);
+      const result = await controller.remove(mockRequest, gifId, mockUser);
+      expect(gifsService.findOne).toHaveBeenCalledWith({
+        _id: gifId,
+        organizationId: mockUser.publicMetadata.organization,
+        category: 'GIF',
+        isDeleted: false,
+      });
+      expect(gifsService.remove).toHaveBeenCalledWith(mockGif.id);
       expect(result).toEqual(expect.objectContaining({ _id: gifId }));
+      expect(serializeSingle).toHaveBeenCalledWith(
+        mockRequest,
+        IngredientSerializer,
+        mockGif,
+      );
     });
 
-    it('should throw NOT_FOUND when gif to remove does not exist', async () => {
-      gifsService.remove.mockResolvedValueOnce(null);
+    it('should reject gifs outside the caller scope before removal', async () => {
+      gifsService.findOne.mockResolvedValueOnce(null);
       await expect(
-        controller.remove(mockRequest, 'nonexistent'),
+        controller.remove(mockRequest, 'nonexistent', mockUser),
       ).rejects.toThrow(HttpException);
+      expect(gifsService.remove).not.toHaveBeenCalled();
+      expect(serializeSingle).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/server/api/src/collections/gifs/controllers/gifs.controller.ts
+++ b/apps/server/api/src/collections/gifs/controllers/gifs.controller.ts
@@ -8,7 +8,9 @@ import { CurrentUser } from '@api/helpers/decorators/user/current-user.decorator
 import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
 import { CreditsInterceptor } from '@api/helpers/interceptors/credits/credits.interceptor';
 import { getPublicMetadata } from '@api/helpers/utils/auth/auth.util';
+import { CategoryPrismaUtil } from '@api/helpers/utils/category-prisma/category-prisma.util';
 import { CollectionFilterUtil } from '@api/helpers/utils/collection-filter/collection-filter.util';
+import { EntityIdUtil } from '@api/helpers/utils/entity-id/entity-id.util';
 import { IngredientFilterUtil } from '@api/helpers/utils/ingredient-filter/ingredient-filter.util';
 import { customLabels } from '@api/helpers/utils/pagination/pagination.util';
 import { QueryDefaultsUtil } from '@api/helpers/utils/query-defaults/query-defaults.util';
@@ -99,14 +101,11 @@ export class GifsController {
               {
                 AND: [
                   {
-                    OR: [
-                      { user: publicMetadata.user },
-                      {
-                        organization: publicMetadata.organization,
-                      },
-                    ],
+                    organizationId: publicMetadata.organization,
                     brand,
-                    category: IngredientCategory.GIF,
+                    category: CategoryPrismaUtil.toIngredientCategory(
+                      IngredientCategory.GIF,
+                    ),
                     isDeleted,
                     ...(scope !== undefined ? { scope } : {}),
                     status,
@@ -120,9 +119,17 @@ export class GifsController {
               {
                 AND: [
                   {
-                    category: IngredientCategory.GIF,
+                    category: CategoryPrismaUtil.toIngredientCategory(
+                      IngredientCategory.GIF,
+                    ),
                     isDefault: true,
                     isDeleted,
+                    OR: [
+                      {
+                        organizationId: publicMetadata.organization,
+                      },
+                      { organizationId: null },
+                    ],
                     status,
                     // Filter default GIFs by brand when brand is specified
                     ...(isEntityId(query.brand) ? { brand } : {}),
@@ -153,13 +160,26 @@ export class GifsController {
   ): Promise<JsonApiSingleResponse> {
     const publicMetadata = getPublicMetadata(user);
 
-    const data = await this.gifsService.findOne({ _id: gifId }, [
-      PopulatePatterns.metadataFull,
-      PopulatePatterns.promptFull,
-      PopulatePatterns.userMinimal,
-      PopulatePatterns.brandMinimal,
-      PopulatePatterns.organizationMinimal,
-    ]);
+    const data = await this.gifsService.findOne(
+      {
+        _id: gifId,
+        category: CategoryPrismaUtil.toIngredientCategory(
+          IngredientCategory.GIF,
+        ),
+        isDeleted: false,
+        OR: [
+          { organizationId: publicMetadata.organization },
+          { isDefault: true, organizationId: null },
+        ],
+      },
+      [
+        PopulatePatterns.metadataFull,
+        PopulatePatterns.promptFull,
+        PopulatePatterns.userMinimal,
+        PopulatePatterns.brandMinimal,
+        PopulatePatterns.organizationMinimal,
+      ],
+    );
 
     if (!data) {
       return returnNotFound(this.constructorName, gifId);
@@ -181,8 +201,22 @@ export class GifsController {
   async remove(
     @Req() request: Request,
     @Param('gifId') gifId: string,
+    @CurrentUser() user: User,
   ): Promise<JsonApiSingleResponse> {
-    const data = await this.gifsService.remove(gifId);
+    const publicMetadata = getPublicMetadata(user);
+    const gif = await this.gifsService.findOne({
+      _id: gifId,
+      organizationId: publicMetadata.organization,
+      category: CategoryPrismaUtil.toIngredientCategory(IngredientCategory.GIF),
+      isDeleted: false,
+    });
+
+    if (!gif) {
+      return returnNotFound(this.constructorName, gifId);
+    }
+
+    const canonicalGifId = EntityIdUtil.resolveCanonicalId(gif, gifId);
+    const data = await this.gifsService.remove(canonicalGifId);
     return data
       ? serializeSingle(request, IngredientSerializer, data)
       : returnNotFound(this.constructorName, gifId);

--- a/apps/server/api/src/collections/images/controllers/images.controller.spec.ts
+++ b/apps/server/api/src/collections/images/controllers/images.controller.spec.ts
@@ -53,6 +53,11 @@ import type { ImagesQueryDto } from '@api/collections/images/dto/images-query.dt
 import { ImagesService } from '@api/collections/images/services/images.service';
 import { VotesService } from '@api/collections/votes/services/votes.service';
 import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
+import {
+  serializeCollection,
+  serializeSingle,
+} from '@api/helpers/utils/response/response.util';
+import { IngredientSerializer } from '@genfeedai/serializers';
 import { LoggerService } from '@libs/logger/logger.service';
 import { HttpException, HttpStatus } from '@nestjs/common';
 import { Test, type TestingModule } from '@nestjs/testing';
@@ -79,10 +84,13 @@ describe('ImagesController', () => {
   const mockImage = {
     _id: '507f191e810c19729de860ee',
     category: 'image',
+    id: 'canonical-image-id',
     metadata: { label: 'Test image' },
   };
 
   beforeEach(async () => {
+    vi.clearAllMocks();
+
     imagesService = {
       findAll: vi.fn().mockResolvedValue({ docs: [mockImage], totalDocs: 1 }),
       findOne: vi.fn().mockResolvedValue(mockImage),
@@ -156,13 +164,20 @@ describe('ImagesController', () => {
 
       const userBranch = orBranches[0].AND[0];
       expect(userBranch).toMatchObject({
+        organizationId: mockUser.publicMetadata.organization,
         training: { not: false },
         user: mockUser.publicMetadata.user,
       });
       expect(userBranch).not.toHaveProperty('isDefault');
 
       const defaultBranch = orBranches[1].AND[0];
-      expect(defaultBranch).toMatchObject({ isDefault: true });
+      expect(defaultBranch).toMatchObject({
+        OR: [
+          { organizationId: mockUser.publicMetadata.organization },
+          { organizationId: null },
+        ],
+        isDefault: true,
+      });
     });
 
     it('should cap the latest limit at 50', async () => {
@@ -179,6 +194,27 @@ describe('ImagesController', () => {
   });
 
   describe('findAll (standard list)', () => {
+    it('partitions the latest-image cache by active organization and brand', () => {
+      const cacheConfig = Reflect.getMetadata(
+        'cache',
+        ImagesController.prototype.findAll,
+      ) as {
+        keyGenerator: (request: Record<string, unknown>) => string;
+      };
+      const buildKey = (organization: string, brand: string) =>
+        cacheConfig.keyGenerator({
+          query: { latest: 'true', limit: 10 },
+          user: {
+            id: mockUser.id,
+            publicMetadata: { brand, organization },
+          },
+        });
+
+      expect(buildKey('org-a', 'brand-a')).not.toBe(
+        buildKey('org-b', 'brand-b'),
+      );
+    });
+
     it('should build a Prisma AND query for the image list', async () => {
       const query = { limit: 10, page: 1 } as unknown as ImagesQueryDto;
 
@@ -186,9 +222,89 @@ describe('ImagesController', () => {
 
       expect(result).toBeDefined();
       const aggregate = imagesService.findAll.mock.calls[0][0] as {
-        where: { AND?: unknown[] };
+        where: {
+          AND?: Array<{
+            OR?: Array<{
+              AND?: Array<{
+                OR?: Array<Record<string, unknown>>;
+              }>;
+            }>;
+          }>;
+        };
       };
       expect(aggregate.where.AND).toBeDefined();
+      expect(aggregate.where.AND?.[0]?.OR?.[0]?.AND?.[0]).toEqual(
+        expect.objectContaining({
+          organizationId: mockUser.publicMetadata.organization,
+        }),
+      );
+      expect(serializeCollection).toHaveBeenCalledWith(
+        mockRequest,
+        IngredientSerializer,
+        expect.objectContaining({ docs: [mockImage] }),
+      );
+    });
+  });
+
+  describe('findOne', () => {
+    it('tenant-scopes the lookup and serializes the image contract', async () => {
+      await controller.findOne(mockRequest, mockImage._id, mockUser);
+
+      expect(imagesService.findOne).toHaveBeenCalledWith(
+        {
+          _id: mockImage._id,
+          category: 'IMAGE',
+          isDeleted: false,
+          OR: [
+            { organizationId: mockUser.publicMetadata.organization },
+            { isDefault: true, organizationId: null },
+          ],
+        },
+        expect.any(Array),
+      );
+      expect(serializeSingle).toHaveBeenCalledWith(
+        mockRequest,
+        IngredientSerializer,
+        expect.objectContaining({ _id: mockImage._id }),
+      );
+    });
+
+    it('returns not found when the scoped image lookup misses', async () => {
+      imagesService.findOne.mockResolvedValueOnce(null);
+
+      await expect(
+        controller.findOne(mockRequest, mockImage._id, mockUser),
+      ).rejects.toMatchObject({ status: HttpStatus.NOT_FOUND });
+      expect(serializeSingle).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('remove', () => {
+    it('preflights tenant ownership and serializes the soft-deleted image', async () => {
+      await controller.remove(mockRequest, mockImage._id, mockUser);
+
+      expect(imagesService.findOne).toHaveBeenCalledWith({
+        _id: mockImage._id,
+        organizationId: mockUser.publicMetadata.organization,
+        category: 'IMAGE',
+        isDeleted: false,
+      });
+      expect(imagesService.remove).toHaveBeenCalledWith(mockImage.id);
+      expect(serializeSingle).toHaveBeenCalledWith(
+        mockRequest,
+        IngredientSerializer,
+        mockImage,
+      );
+    });
+
+    it('does not delete an image outside the caller scope', async () => {
+      imagesService.findOne.mockResolvedValueOnce(null);
+
+      await expect(
+        controller.remove(mockRequest, mockImage._id, mockUser),
+      ).rejects.toMatchObject({ status: HttpStatus.NOT_FOUND });
+      expect(imagesService.remove).not.toHaveBeenCalled();
+      expect(serializeSingle).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/server/api/src/collections/images/controllers/images.controller.ts
+++ b/apps/server/api/src/collections/images/controllers/images.controller.ts
@@ -8,7 +8,9 @@ import { AutoSwagger } from '@api/helpers/decorators/swagger/auto-swagger.decora
 import { CurrentUser } from '@api/helpers/decorators/user/current-user.decorator';
 import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
 import { getPublicMetadata } from '@api/helpers/utils/auth/auth.util';
+import { CategoryPrismaUtil } from '@api/helpers/utils/category-prisma/category-prisma.util';
 import { CollectionFilterUtil } from '@api/helpers/utils/collection-filter/collection-filter.util';
+import { EntityIdUtil } from '@api/helpers/utils/entity-id/entity-id.util';
 import { IngredientFilterUtil } from '@api/helpers/utils/ingredient-filter/ingredient-filter.util';
 import { customLabels } from '@api/helpers/utils/pagination/pagination.util';
 import { QueryDefaultsUtil } from '@api/helpers/utils/query-defaults/query-defaults.util';
@@ -59,7 +61,7 @@ export class ImagesController {
   @Cache({
     keyGenerator: (req) =>
       req.query.latest === 'true'
-        ? `images:latest:user:${req.user?.id ?? 'anonymous'}:limit:${req.query.limit ?? 10}`
+        ? `images:latest:org:${(req.user?.publicMetadata?.organization as string | undefined) ?? 'global'}:brand:${(req.user?.publicMetadata?.brand as string | undefined) ?? 'global'}:user:${req.user?.id ?? 'anonymous'}:limit:${req.query.limit ?? 10}`
         : '',
     tags: ['images'],
     ttl: 300, // 5 minutes
@@ -92,8 +94,11 @@ export class ImagesController {
                   AND: [
                     {
                       brand: latestBrand,
-                      category: IngredientCategory.IMAGE,
+                      category: CategoryPrismaUtil.toIngredientCategory(
+                        IngredientCategory.IMAGE,
+                      ),
                       isDeleted: latestIsDeleted,
+                      organizationId: publicMetadata.organization,
                       // Exclude training source images by default
                       training: { not: false },
                       user: publicMetadata.user,
@@ -105,9 +110,17 @@ export class ImagesController {
                     {
                       // Filter default images by brand when brand is specified
                       brand: latestBrand,
-                      category: IngredientCategory.IMAGE,
+                      category: CategoryPrismaUtil.toIngredientCategory(
+                        IngredientCategory.IMAGE,
+                      ),
                       isDefault: true,
                       isDeleted: latestIsDeleted,
+                      OR: [
+                        {
+                          organizationId: publicMetadata.organization,
+                        },
+                        { organizationId: null },
+                      ],
                     },
                   ],
                 },
@@ -172,27 +185,10 @@ export class ImagesController {
               {
                 AND: [
                   {
-                    OR: [
-                      // User's own ingredients (when not filtering by isPublic)
-                      ...(query.isPublic === undefined
-                        ? [
-                            { user: publicMetadata.user },
-                            {
-                              organization: publicMetadata.organization,
-                            },
-                          ]
-                        : []),
-                      // Public ingredients in user's organization (when isPublic=true)
-                      ...(query.isPublic === true
-                        ? [
-                            {
-                              isPublic: true,
-                              organization: publicMetadata.organization,
-                            },
-                          ]
-                        : []),
-                    ],
-                    category: IngredientCategory.IMAGE,
+                    organizationId: publicMetadata.organization,
+                    category: CategoryPrismaUtil.toIngredientCategory(
+                      IngredientCategory.IMAGE,
+                    ),
                     isDeleted,
                     ...(query.isPublic === undefined && scope !== undefined
                       ? { scope }
@@ -215,9 +211,17 @@ export class ImagesController {
                     {
                       AND: [
                         {
-                          category: IngredientCategory.IMAGE,
+                          category: CategoryPrismaUtil.toIngredientCategory(
+                            IngredientCategory.IMAGE,
+                          ),
                           isDefault: true,
                           isDeleted,
+                          OR: [
+                            {
+                              organizationId: publicMetadata.organization,
+                            },
+                            { organizationId: null },
+                          ],
                           status,
                           // Filter default images by brand when brand is specified
                           ...(isEntityId(query.brand) ? { brand } : {}),
@@ -256,8 +260,14 @@ export class ImagesController {
     const data = await this.imagesService.findOne(
       {
         _id: imageId,
+        category: CategoryPrismaUtil.toIngredientCategory(
+          IngredientCategory.IMAGE,
+        ),
         isDeleted: false,
-        organization: publicMetadata.organization,
+        OR: [
+          { organizationId: publicMetadata.organization },
+          { isDefault: true, organizationId: null },
+        ],
       },
       [
         PopulatePatterns.metadataFull,
@@ -303,8 +313,24 @@ export class ImagesController {
   async remove(
     @Req() request: Request,
     @Param('imageId') imageId: string,
+    @CurrentUser() user: User,
   ): Promise<JsonApiSingleResponse> {
-    const data = await this.imagesService.remove(imageId);
+    const publicMetadata = getPublicMetadata(user);
+    const image = await this.imagesService.findOne({
+      _id: imageId,
+      organizationId: publicMetadata.organization,
+      category: CategoryPrismaUtil.toIngredientCategory(
+        IngredientCategory.IMAGE,
+      ),
+      isDeleted: false,
+    });
+
+    if (!image) {
+      return returnNotFound(this.constructorName, imageId);
+    }
+
+    const canonicalImageId = EntityIdUtil.resolveCanonicalId(image, imageId);
+    const data = await this.imagesService.remove(canonicalImageId);
     return data
       ? serializeSingle(request, IngredientSerializer, data)
       : returnNotFound(this.constructorName, imageId);

--- a/apps/server/api/src/collections/images/controllers/images.controller.ts
+++ b/apps/server/api/src/collections/images/controllers/images.controller.ts
@@ -76,6 +76,9 @@ export class ImagesController {
     this.loggerService.log(url, { query });
 
     const publicMetadata = getPublicMetadata(user);
+    const imageCategory = CategoryPrismaUtil.toIngredientCategory(
+      IngredientCategory.IMAGE,
+    );
 
     // `latest=true` shorthand — reproduces the exact WHERE clause of the former
     // GET /images/latest route: brand-scoped user images with training sources
@@ -94,9 +97,7 @@ export class ImagesController {
                   AND: [
                     {
                       brand: latestBrand,
-                      category: CategoryPrismaUtil.toIngredientCategory(
-                        IngredientCategory.IMAGE,
-                      ),
+                      category: imageCategory,
                       isDeleted: latestIsDeleted,
                       organizationId: publicMetadata.organization,
                       // Exclude training source images by default
@@ -110,9 +111,7 @@ export class ImagesController {
                     {
                       // Filter default images by brand when brand is specified
                       brand: latestBrand,
-                      category: CategoryPrismaUtil.toIngredientCategory(
-                        IngredientCategory.IMAGE,
-                      ),
+                      category: imageCategory,
                       isDefault: true,
                       isDeleted: latestIsDeleted,
                       OR: [
@@ -186,9 +185,7 @@ export class ImagesController {
                 AND: [
                   {
                     organizationId: publicMetadata.organization,
-                    category: CategoryPrismaUtil.toIngredientCategory(
-                      IngredientCategory.IMAGE,
-                    ),
+                    category: imageCategory,
                     isDeleted,
                     ...(query.isPublic === undefined && scope !== undefined
                       ? { scope }
@@ -211,9 +208,7 @@ export class ImagesController {
                     {
                       AND: [
                         {
-                          category: CategoryPrismaUtil.toIngredientCategory(
-                            IngredientCategory.IMAGE,
-                          ),
+                          category: imageCategory,
                           isDefault: true,
                           isDeleted,
                           OR: [

--- a/apps/server/api/src/collections/musics/controllers/musics.controller.spec.ts
+++ b/apps/server/api/src/collections/musics/controllers/musics.controller.spec.ts
@@ -1,6 +1,22 @@
+vi.mock('@api/helpers/utils/response/response.util', () => ({
+  serializeCollection: vi.fn(
+    (_request: unknown, _serializer: unknown, data: unknown) => data,
+  ),
+  serializeSingle: vi.fn(
+    (_request: unknown, _serializer: unknown, data: unknown) => data,
+  ),
+}));
+
+import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticated-user.interface';
 import { MusicsController } from '@api/collections/musics/controllers/musics.controller';
 import { MusicsService } from '@api/collections/musics/services/musics.service';
+import {
+  serializeCollection,
+  serializeSingle,
+} from '@api/helpers/utils/response/response.util';
+import { MusicSerializer } from '@genfeedai/serializers';
 import { LoggerService } from '@libs/logger/logger.service';
+import type { Request } from 'express';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 function createMockLogger() {
@@ -38,8 +54,23 @@ describe('MusicsController', () => {
   let controller: MusicsController;
   let musicsService: ReturnType<typeof createMockMusicsService>;
   let logger: ReturnType<typeof createMockLogger>;
+  const request = {} as Request;
+  const musicId = '507f191e810c19729de860ea';
+  const organizationId = '507f191e810c19729de860eb';
+  const brandId = '507f191e810c19729de860ec';
+  const userId = '507f191e810c19729de860ed';
+  const music = {
+    brandId,
+    category: 'music',
+    id: 'canonical-music-id',
+    isDeleted: false,
+    mongoId: musicId,
+    organizationId,
+    userId,
+  };
 
   beforeEach(() => {
+    vi.clearAllMocks();
     musicsService = createMockMusicsService();
     logger = createMockLogger();
     controller = new MusicsController(
@@ -70,13 +101,14 @@ describe('MusicsController', () => {
         where: {
           OR: expect.arrayContaining([
             expect.objectContaining({
-              brand: '507f191e810c19729de860ee',
-              category: 'music',
+              brandId: '507f191e810c19729de860ee',
+              category: 'MUSIC',
               isDeleted: false,
-              user: '507f191e810c19729de860ee',
+              organizationId: '507f191e810c19729de860ee',
+              userId: '507f191e810c19729de860ee',
             }),
             expect.objectContaining({
-              category: 'music',
+              category: 'MUSIC',
               isDeleted: false,
             }),
           ]),
@@ -156,8 +188,98 @@ describe('MusicsController', () => {
         inputQuery as never,
       );
 
-      expect(query.where.OR[0]).toMatchObject({ brand: brandId });
-      expect(query.where.OR[1]).toMatchObject({ brand: brandId });
+      expect(query.where.OR[0]).toMatchObject({ brandId });
+      expect(query.where.OR[1]).toMatchObject({ brandId });
+    });
+  });
+
+  describe('asset lifecycle contract', () => {
+    const user = createMockUser({
+      brand: brandId,
+      organization: organizationId,
+      user: userId,
+    }) as User;
+
+    it('lists tenant-owned music and serializes the collection', async () => {
+      const collection = { docs: [music], totalDocs: 1 };
+      musicsService.findAll.mockResolvedValue(collection);
+
+      await controller.findAll(request, user, {} as never);
+
+      expect(musicsService.findAll).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            OR: expect.arrayContaining([
+              expect.objectContaining({
+                brandId,
+                category: 'MUSIC',
+                isDeleted: false,
+                organizationId,
+                userId,
+              }),
+            ]),
+          },
+        }),
+        expect.any(Object),
+      );
+      expect(serializeCollection).toHaveBeenCalledWith(
+        request,
+        MusicSerializer,
+        collection,
+      );
+    });
+
+    it('tenant-scopes a single music lookup and uses the music serializer', async () => {
+      musicsService.findOne.mockResolvedValue(music);
+
+      await controller.findOne(request, user, musicId);
+
+      expect(musicsService.findOne).toHaveBeenCalledWith(
+        {
+          _id: musicId,
+          OR: [{ organizationId }, { isDefault: true, organizationId: null }],
+          category: 'MUSIC',
+          isDeleted: false,
+        },
+        expect.any(Array),
+      );
+      expect(serializeSingle).toHaveBeenCalledWith(
+        request,
+        MusicSerializer,
+        music,
+      );
+    });
+
+    it('soft-deletes only music owned by the canonical caller', async () => {
+      musicsService.findOne.mockResolvedValue(music);
+      musicsService.remove.mockResolvedValue({ ...music, isDeleted: true });
+
+      await controller.remove(request, user, musicId);
+
+      expect(musicsService.findOne).toHaveBeenCalledWith({
+        _id: musicId,
+        OR: [{ organizationId }, { isDefault: true, organizationId: null }],
+        category: 'MUSIC',
+        isDeleted: false,
+      });
+      expect(musicsService.remove).toHaveBeenCalledWith(music.id);
+      expect(serializeSingle).toHaveBeenCalledWith(
+        request,
+        MusicSerializer,
+        expect.objectContaining({ id: music.id, isDeleted: true }),
+      );
+    });
+
+    it('rejects another tenant record before deletion', async () => {
+      musicsService.findOne.mockResolvedValue({
+        ...music,
+        organizationId: '507f191e810c19729de860ff',
+        userId: '507f191e810c19729de860fe',
+      });
+
+      await expect(controller.remove(request, user, musicId)).rejects.toThrow();
+      expect(musicsService.remove).not.toHaveBeenCalled();
+      expect(serializeSingle).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/server/api/src/collections/musics/controllers/musics.controller.ts
+++ b/apps/server/api/src/collections/musics/controllers/musics.controller.ts
@@ -7,6 +7,7 @@ import { MusicsService } from '@api/collections/musics/services/musics.service';
 import { AutoSwagger } from '@api/helpers/decorators/swagger/auto-swagger.decorator';
 import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
 import { getPublicMetadata } from '@api/helpers/utils/auth/auth.util';
+import { CategoryPrismaUtil } from '@api/helpers/utils/category-prisma/category-prisma.util';
 import { CollectionFilterUtil } from '@api/helpers/utils/collection-filter/collection-filter.util';
 import { QueryDefaultsUtil } from '@api/helpers/utils/query-defaults/query-defaults.util';
 import { handleQuerySort } from '@api/helpers/utils/sort/sort.util';
@@ -66,24 +67,67 @@ export class MusicsController extends BaseCRUDController<
       where: {
         OR: [
           {
-            brand,
-            category: IngredientCategory.MUSIC,
+            brandId: brand,
+            category: CategoryPrismaUtil.toIngredientCategory(
+              IngredientCategory.MUSIC,
+            ),
             isDeleted: query.isDeleted ?? false,
+            organizationId: publicMetadata.organization,
             status,
-            user: publicMetadata.user,
+            userId: publicMetadata.user,
           },
           {
-            category: IngredientCategory.MUSIC,
+            OR: [
+              { organizationId: publicMetadata.organization },
+              { organizationId: null },
+            ],
+            category: CategoryPrismaUtil.toIngredientCategory(
+              IngredientCategory.MUSIC,
+            ),
             isDefault,
             isDeleted: query.isDeleted ?? false,
             ...(scope !== undefined ? { scope } : {}),
             status,
             // Filter default musics by brand when brand is specified
-            ...(query.brand && isEntityId(query.brand) ? { brand } : {}),
+            ...(query.brand && isEntityId(query.brand)
+              ? { brandId: brand }
+              : {}),
           },
         ],
       },
       orderBy: query.sort ? handleQuerySort(query.sort) : { createdAt: -1 },
     };
+  }
+
+  public override buildFindOneQuery(
+    user: User,
+    id: string,
+  ): Record<string, unknown> {
+    const publicMetadata = getPublicMetadata(user);
+
+    return {
+      _id: id,
+      OR: [
+        { organizationId: publicMetadata.organization },
+        { isDefault: true, organizationId: null },
+      ],
+      category: CategoryPrismaUtil.toIngredientCategory(
+        IngredientCategory.MUSIC,
+      ),
+      isDeleted: false,
+    };
+  }
+
+  public override canUserModifyEntity(
+    user: User,
+    entity: MusicDocument,
+  ): boolean {
+    const publicMetadata = getPublicMetadata(user);
+    const music = entity as unknown as Record<string, unknown>;
+
+    return (
+      music.organizationId === publicMetadata.organization &&
+      music.userId === publicMetadata.user
+    );
   }
 }

--- a/apps/server/api/src/collections/videos/controllers/videos.controller.spec.ts
+++ b/apps/server/api/src/collections/videos/controllers/videos.controller.spec.ts
@@ -447,6 +447,27 @@ describe('VideosController', () => {
       sort: 'createdAt: -1',
     } as unknown as VideosQueryDto;
 
+    it('partitions the video-list cache by active organization and brand', () => {
+      const cacheConfig = Reflect.getMetadata(
+        'cache',
+        VideosController.prototype.findAll,
+      ) as {
+        keyGenerator: (request: Record<string, unknown>) => string;
+      };
+      const buildKey = (organization: string, brand: string) =>
+        cacheConfig.keyGenerator({
+          query: { latest: 'true', limit: 10 },
+          user: {
+            id: mockUser.id,
+            publicMetadata: { brand, organization },
+          },
+        });
+
+      expect(buildKey('org-a', 'brand-a')).not.toBe(
+        buildKey('org-b', 'brand-b'),
+      );
+    });
+
     it('should short-circuit to the user-scoped latest aggregate', async () => {
       const mockData = { docs: [mockVideo], limit: 10, page: 1, totalDocs: 1 };
       videosService.findAll.mockResolvedValue(
@@ -478,6 +499,7 @@ describe('VideosController', () => {
       // NO organization OR-branch and NO isDefault branch (unlike the list route).
       const branch = aggregate.where.AND[0];
       expect(branch).toMatchObject({
+        organizationId: mockUser.publicMetadata.organization,
         training: { not: false },
         user: mockUser.publicMetadata.user,
       });
@@ -531,6 +553,18 @@ describe('VideosController', () => {
       const result = await controller.findAll(mockRequest, mockUser, baseQuery);
 
       expect(videosService.findAll).toHaveBeenCalled();
+      const aggregate = videosService.findAll.mock.calls[0]?.[0] as {
+        where: {
+          AND: Array<{
+            OR?: Array<Record<string, unknown>>;
+            brand?: unknown;
+          }>;
+        };
+      };
+      expect(aggregate.where.AND[0]).toEqual({
+        organizationId: mockUser.publicMetadata.organization,
+      });
+      expect(aggregate.where.AND[1]?.brand).toBe(mockUser.publicMetadata.brand);
       expect(result).toBeDefined();
       expect(result.data).toBeDefined();
     });
@@ -674,6 +708,25 @@ describe('VideosController', () => {
       );
     });
 
+    it('partitions the video cache by active organization', () => {
+      const cacheConfig = Reflect.getMetadata(
+        'cache',
+        VideosController.prototype.findOne,
+      ) as {
+        keyGenerator: (request: Record<string, unknown>) => string;
+      };
+      const buildKey = (organization: string) =>
+        cacheConfig.keyGenerator({
+          params: { videoId: mockVideoId.toString() },
+          user: {
+            id: mockUser.id,
+            publicMetadata: { organization },
+          },
+        });
+
+      expect(buildKey('org-a')).not.toBe(buildKey('org-b'));
+    });
+
     it('should return a single video', async () => {
       const result = await controller.findOne(
         mockRequest,
@@ -681,8 +734,28 @@ describe('VideosController', () => {
         mockUser,
       );
 
-      expect(videosService.findOne).toHaveBeenCalled();
+      expect(videosService.findAll).toHaveBeenCalledWith(
+        {
+          where: {
+            _id: mockVideoId.toString(),
+            category: 'VIDEO',
+            isDeleted: false,
+            organizationId: mockUser.publicMetadata.organization,
+          },
+        },
+        { pagination: false },
+      );
+      expect(videosService.findOne).toHaveBeenCalledWith(
+        {
+          _id: mockVideoId.toString(),
+          category: 'VIDEO',
+          isDeleted: false,
+          organizationId: mockUser.publicMetadata.organization,
+        },
+        expect.any(Array),
+      );
       expect(result).toBeDefined();
+      expect(result.data).toMatchObject({ type: 'video' });
     });
 
     it('should include vote status', async () => {
@@ -850,12 +923,33 @@ describe('VideosController', () => {
         mockUser,
       );
 
-      expect(videosService.findOne).toHaveBeenCalled();
+      expect(videosService.findOne).toHaveBeenCalledWith({
+        _id: mockVideoId.toString(),
+        organizationId: mockUser.publicMetadata.organization,
+        category: 'VIDEO',
+        isDeleted: false,
+      });
       expect(videosService.remove).toHaveBeenCalledWith(mockVideoId.toString());
       expect(metadataService.remove).toHaveBeenCalledWith(
         mockVideoId.toString(),
       );
       expect(result).toBeDefined();
+    });
+
+    it('resolves a legacy mongoId route to the canonical id before deletion', async () => {
+      const canonicalVideoId = 'canonical-video-id';
+      const legacyVideo = { ...mockVideo, id: canonicalVideoId };
+      videosService.findOne.mockResolvedValue(
+        legacyVideo as unknown as IngredientDocument,
+      );
+      videosService.remove.mockResolvedValue(
+        legacyVideo as unknown as IngredientDocument,
+      );
+
+      await controller.remove(mockRequest, mockVideoId.toString(), mockUser);
+
+      expect(videosService.remove).toHaveBeenCalledWith(canonicalVideoId);
+      expect(metadataService.remove).toHaveBeenCalledWith(canonicalVideoId);
     });
 
     it('should return 404 when video not found', async () => {

--- a/apps/server/api/src/collections/videos/controllers/videos.controller.ts
+++ b/apps/server/api/src/collections/videos/controllers/videos.controller.ts
@@ -26,6 +26,7 @@ import { CreditsInterceptor } from '@api/helpers/interceptors/credits/credits.in
 import { getPublicMetadata } from '@api/helpers/utils/auth/auth.util';
 import { CategoryPrismaUtil } from '@api/helpers/utils/category-prisma/category-prisma.util';
 import { CollectionFilterUtil } from '@api/helpers/utils/collection-filter/collection-filter.util';
+import { EntityIdUtil } from '@api/helpers/utils/entity-id/entity-id.util';
 import { IngredientFilterUtil } from '@api/helpers/utils/ingredient-filter/ingredient-filter.util';
 import { customLabels } from '@api/helpers/utils/pagination/pagination.util';
 import { QueryDefaultsUtil } from '@api/helpers/utils/query-defaults/query-defaults.util';
@@ -99,7 +100,7 @@ export class VideosController {
   @Get()
   @Cache({
     keyGenerator: (req) =>
-      `videos:list:user:${req.user?.id ?? 'anonymous'}:query:${JSON.stringify(req.query)}`,
+      `videos:list:org:${(req.user?.publicMetadata?.organization as string | undefined) ?? 'global'}:brand:${(req.user?.publicMetadata?.brand as string | undefined) ?? 'global'}:user:${req.user?.id ?? 'anonymous'}:query:${JSON.stringify(req.query)}`,
     tags: ['videos'],
     ttl: 300, // 5 minutes
   })
@@ -115,7 +116,8 @@ export class VideosController {
     // GET /videos/latest route: brand-scoped user videos with training sources
     // excluded, ordered by createdAt desc and capped at 50. Unlike the standard
     // list route there is no organization OR-branch and no isDefault branch;
-    // it is user-scoped only and bypasses status/scope/folder/parent/search.
+    // it is scoped to the active organization and user while bypassing
+    // status/scope/folder/parent/search.
     if (query.latest) {
       const latestIsDeleted = QueryDefaultsUtil.getIsDeletedDefault(false);
       const latestBrand = publicMetadata.brand;
@@ -129,6 +131,7 @@ export class VideosController {
                 IngredientCategory.VIDEO,
               ),
               isDeleted: latestIsDeleted,
+              organizationId: publicMetadata.organization,
               // Exclude training source videos by default
               training: { not: false },
               user: publicMetadata.user,
@@ -189,14 +192,7 @@ export class VideosController {
     const aggregate = {
       where: {
         AND: [
-          {
-            OR: [
-              { user: publicMetadata.user },
-              {
-                organization: publicMetadata.organization,
-              },
-            ],
-          },
+          { organizationId: publicMetadata.organization },
           {
             brand,
             category: CategoryPrismaUtil.toIngredientCategory(
@@ -225,7 +221,7 @@ export class VideosController {
   @Get(':videoId')
   @Cache({
     keyGenerator: (req) =>
-      `video:${req.params?.videoId ?? 'unknown'}:user:${req.user?.id ?? 'anonymous'}`,
+      `video:${req.params?.videoId ?? 'unknown'}:org:${(req.user?.publicMetadata?.organization as string | undefined) ?? 'global'}:user:${req.user?.id ?? 'anonymous'}`,
     tags: ['videos'],
     ttl: 900, // 15 minutes
   })
@@ -240,8 +236,11 @@ export class VideosController {
     const pipeline = {
       where: {
         _id: videoId,
+        category: CategoryPrismaUtil.toIngredientCategory(
+          IngredientCategory.VIDEO,
+        ),
         isDeleted: false,
-        organization: publicMetadata.organization,
+        organizationId: publicMetadata.organization,
       },
     };
 
@@ -256,16 +255,26 @@ export class VideosController {
     const data = result.docs[0];
 
     // Populate relationships that aren't in aggregation
-    const populatedData = await this.videosService.findOne({ _id: videoId }, [
-      PopulatePatterns.metadataFull,
-      PopulatePatterns.promptFull,
-      PopulatePatterns.userMinimal,
-      PopulatePatterns.brandMinimal,
-      PopulatePatterns.organizationMinimal,
-      { path: 'captions' },
-      { path: 'votes' },
-      { path: 'posts' },
-    ]);
+    const populatedData = await this.videosService.findOne(
+      {
+        _id: videoId,
+        category: CategoryPrismaUtil.toIngredientCategory(
+          IngredientCategory.VIDEO,
+        ),
+        isDeleted: false,
+        organizationId: publicMetadata.organization,
+      },
+      [
+        PopulatePatterns.metadataFull,
+        PopulatePatterns.promptFull,
+        PopulatePatterns.userMinimal,
+        PopulatePatterns.brandMinimal,
+        PopulatePatterns.organizationMinimal,
+        { path: 'captions' },
+        { path: 'votes' },
+        { path: 'posts' },
+      ],
+    );
 
     if (!populatedData) {
       return returnNotFound(this.constructorName, videoId);
@@ -375,10 +384,10 @@ export class VideosController {
     // Find the video first to ensure it exists and belongs to the user or is part of the same organization
     const video = await this.videosService.findOne({
       _id: videoId,
-      OR: [
-        { user: publicMetadata.user },
-        { organization: publicMetadata.organization },
-      ],
+      organizationId: publicMetadata.organization,
+      category: CategoryPrismaUtil.toIngredientCategory(
+        IngredientCategory.VIDEO,
+      ),
       isDeleted: false,
     });
 
@@ -386,12 +395,12 @@ export class VideosController {
       return returnNotFound(this.constructorName, videoId);
     }
 
-    // Only delete if the user owns the video
-    const data = await this.videosService.remove(videoId);
+    const canonicalVideoId = EntityIdUtil.resolveCanonicalId(video, videoId);
+    const data = await this.videosService.remove(canonicalVideoId);
 
     if (data) {
-      // Send the ingredient ID, then the function will find the metadat and remove it
-      await this.metadataService.remove(videoId);
+      // Send the canonical ingredient ID so legacy mongoId routes delete metadata too.
+      await this.metadataService.remove(canonicalVideoId);
     }
 
     return data

--- a/apps/server/api/src/collections/voices/controllers/voices.controller.spec.ts
+++ b/apps/server/api/src/collections/voices/controllers/voices.controller.spec.ts
@@ -3,6 +3,11 @@ import { VoicesController } from '@api/collections/voices/controllers/voices.con
 import type { VoicesQueryDto } from '@api/collections/voices/dto/voices-query.dto';
 import { VoiceCloneService } from '@api/collections/voices/services/voice-clone.service';
 import { VoiceLibraryService } from '@api/collections/voices/services/voice-library.service';
+import {
+  serializeCollection,
+  serializeSingle,
+} from '@api/helpers/utils/response/response.util';
+import { VoiceCloneSerializer, VoiceSerializer } from '@genfeedai/serializers';
 import { HttpException, HttpStatus } from '@nestjs/common';
 import type { Request } from 'express';
 
@@ -34,6 +39,7 @@ describe('VoicesController', () => {
   let controller: VoicesController;
 
   beforeEach(() => {
+    vi.clearAllMocks();
     cloneService = { deleteClonedVoice: vi.fn() };
     libraryService = { findAll: vi.fn(), findCloned: vi.fn() };
     controller = new VoicesController(
@@ -50,6 +56,11 @@ describe('VoicesController', () => {
       collection,
     );
     expect(libraryService.findAll).toHaveBeenCalledWith(user, query);
+    expect(serializeCollection).toHaveBeenCalledWith(
+      request,
+      VoiceSerializer,
+      collection,
+    );
   });
 
   it('delegates the cloned voice listing', async () => {
@@ -60,6 +71,11 @@ describe('VoicesController', () => {
       controller.findClonedVoices(request, user, query),
     ).resolves.toBe(collection);
     expect(libraryService.findCloned).toHaveBeenCalledWith(user, query);
+    expect(serializeCollection).toHaveBeenCalledWith(
+      request,
+      VoiceCloneSerializer,
+      collection,
+    );
   });
 
   it('rejects an invalid cloned voice id before delegation', async () => {
@@ -76,6 +92,11 @@ describe('VoicesController', () => {
       controller.deleteClonedVoice(request, user, voice.id),
     ).resolves.toBe(voice);
     expect(cloneService.deleteClonedVoice).toHaveBeenCalledWith(user, voice.id);
+    expect(serializeSingle).toHaveBeenCalledWith(
+      request,
+      VoiceCloneSerializer,
+      voice,
+    );
   });
 
   it('returns not found when the cloned voice does not exist', async () => {

--- a/apps/server/api/src/collections/voices/services/voice-clone.service.spec.ts
+++ b/apps/server/api/src/collections/voices/services/voice-clone.service.spec.ts
@@ -185,6 +185,7 @@ describe('VoiceCloneService', () => {
 
     expect(voices.findOne).toHaveBeenCalledWith({
       _id: ingredientId,
+      category: 'VOICE',
       isCloned: true,
       isDeleted: false,
       organizationId,

--- a/apps/server/api/src/collections/voices/services/voice-clone.service.ts
+++ b/apps/server/api/src/collections/voices/services/voice-clone.service.ts
@@ -7,6 +7,7 @@ import type { CloneVoiceDto } from '@api/collections/voices/dto/clone-voice.dto'
 import { VoiceCreditsService } from '@api/collections/voices/services/voice-credits.service';
 import { VoicesService } from '@api/collections/voices/services/voices.service';
 import { getPublicMetadata } from '@api/helpers/utils/auth/auth.util';
+import { CategoryPrismaUtil } from '@api/helpers/utils/category-prisma/category-prisma.util';
 import { ByokService } from '@api/services/byok/byok.service';
 import { FleetService } from '@api/services/integrations/fleet/fleet.service';
 import { NotificationsPublisherService } from '@api/services/notifications/publisher/notifications-publisher.service';
@@ -94,6 +95,9 @@ export class VoiceCloneService {
     const publicMetadata = getPublicMetadata(user);
     const voice = await this.voicesService.findOne({
       _id: id,
+      category: CategoryPrismaUtil.toIngredientCategory(
+        IngredientCategory.VOICE,
+      ),
       isCloned: true,
       isDeleted: false,
       organizationId: publicMetadata.organization,

--- a/apps/server/api/src/collections/voices/services/voice-library.service.spec.ts
+++ b/apps/server/api/src/collections/voices/services/voice-library.service.spec.ts
@@ -2,7 +2,7 @@ import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticat
 import type { VoicesQueryDto } from '@api/collections/voices/dto/voices-query.dto';
 import { VoiceLibraryService } from '@api/collections/voices/services/voice-library.service';
 import { VoicesService } from '@api/collections/voices/services/voices.service';
-import { IngredientCategory, VoiceProvider } from '@genfeedai/enums';
+import { VoiceProvider } from '@genfeedai/enums';
 import { HttpStatus } from '@nestjs/common';
 
 vi.mock('@api/helpers/utils/sort/sort.util', () => ({
@@ -50,7 +50,7 @@ describe('VoiceLibraryService', () => {
           ],
           OR: [{ isCloned: true }, { externalVoiceCatalogId: { not: null } }],
           brandId,
-          category: IngredientCategory.VOICE,
+          category: 'VOICE',
           isDeleted: false,
           isVoiceActive: { not: false },
           organizationId,
@@ -77,6 +77,7 @@ describe('VoiceLibraryService', () => {
     expect(voicesService.findAll).toHaveBeenCalledWith(
       expect.objectContaining({
         where: {
+          category: 'VOICE',
           isCloned: true,
           isDeleted: false,
           organizationId,

--- a/apps/server/api/src/collections/voices/services/voice-library.service.ts
+++ b/apps/server/api/src/collections/voices/services/voice-library.service.ts
@@ -4,6 +4,7 @@ import type { VoicesQueryDto } from '@api/collections/voices/dto/voices-query.dt
 import { VoicesService } from '@api/collections/voices/services/voices.service';
 import { parseVoiceProviders } from '@api/collections/voices/utils/voice-provider.util';
 import { getPublicMetadata } from '@api/helpers/utils/auth/auth.util';
+import { CategoryPrismaUtil } from '@api/helpers/utils/category-prisma/category-prisma.util';
 import { customLabels } from '@api/helpers/utils/pagination/pagination.util';
 import { QueryDefaultsUtil } from '@api/helpers/utils/query-defaults/query-defaults.util';
 import { handleQuerySort } from '@api/helpers/utils/sort/sort.util';
@@ -31,7 +32,9 @@ export class VoiceLibraryService {
       const where: Record<string, unknown> = {
         OR: [{ isCloned: true }, { externalVoiceCatalogId: { not: null } }],
         brandId: publicMetadata.brand,
-        category: IngredientCategory.VOICE,
+        category: CategoryPrismaUtil.toIngredientCategory(
+          IngredientCategory.VOICE,
+        ),
         isDeleted: false,
         organizationId: publicMetadata.organization,
       };
@@ -100,6 +103,9 @@ export class VoiceLibraryService {
         {
           orderBy: { createdAt: -1 as const },
           where: {
+            category: CategoryPrismaUtil.toIngredientCategory(
+              IngredientCategory.VOICE,
+            ),
             isCloned: true,
             isDeleted: false,
             organizationId: publicMetadata.organization,

--- a/apps/server/api/src/helpers/utils/entity-id/entity-id.util.spec.ts
+++ b/apps/server/api/src/helpers/utils/entity-id/entity-id.util.spec.ts
@@ -130,6 +130,26 @@ describe('EntityIdUtil', () => {
     });
   });
 
+  describe('resolveCanonicalId', () => {
+    it('returns the canonical Prisma id from a compatibility lookup result', () => {
+      expect(
+        EntityIdUtil.resolveCanonicalId(
+          { id: 'canonical-cuid', mongoId: '507f1f77bcf86cd799439011' },
+          '507f1f77bcf86cd799439011',
+        ),
+      ).toBe('canonical-cuid');
+    });
+
+    it('falls back to the requested id when the record has no canonical id', () => {
+      expect(
+        EntityIdUtil.resolveCanonicalId(
+          { _id: '507f1f77bcf86cd799439011' },
+          '507f1f77bcf86cd799439011',
+        ),
+      ).toBe('507f1f77bcf86cd799439011');
+    });
+  });
+
   describe('enrichWithUserContext', () => {
     it('should enrich DTO with user and organization', () => {
       const dto = { name: 'Test' };

--- a/apps/server/api/src/helpers/utils/entity-id/entity-id.util.ts
+++ b/apps/server/api/src/helpers/utils/entity-id/entity-id.util.ts
@@ -122,6 +122,21 @@ export class EntityIdUtil {
   }
 
   /**
+   * Resolve the canonical Prisma id from a record found through an `_id`
+   * compatibility lookup, falling back to the requested id for legacy mocks.
+   */
+  static resolveCanonicalId(entity: unknown, fallbackId: string): string {
+    if (typeof entity !== 'object' || entity === null) {
+      return fallbackId;
+    }
+
+    const canonicalId = (entity as Record<string, unknown>).id;
+    return typeof canonicalId === 'string' && canonicalId.length > 0
+      ? canonicalId
+      : fallbackId;
+  }
+
+  /**
    * Normalize an array of values to id strings, filtering out invalid entries.
    */
   static normalizeIds(

--- a/apps/server/api/src/shared/controllers/base-crud/base-crud.controller.spec.ts
+++ b/apps/server/api/src/shared/controllers/base-crud/base-crud.controller.spec.ts
@@ -371,6 +371,7 @@ describe('BaseCRUDController', () => {
       const id = '507f1f77bcf86cd799439019';
       const mockDeletedEntity = {
         _id: id,
+        id: 'canonical-entity-id',
         isDeleted: true,
         name: 'Deleted Entity',
         user: MOCK_USER_ID,
@@ -382,7 +383,7 @@ describe('BaseCRUDController', () => {
       const result = await controller.remove(mockRequest, mockUser, id);
 
       expect(service.findOne).toHaveBeenCalledWith({ _id: id });
-      expect(service.remove).toHaveBeenCalledWith(id);
+      expect(service.remove).toHaveBeenCalledWith(mockDeletedEntity.id);
       expect(result).toEqual({ data: mockDeletedEntity });
     });
 

--- a/apps/server/api/src/shared/controllers/base-crud/base-crud.controller.ts
+++ b/apps/server/api/src/shared/controllers/base-crud/base-crud.controller.ts
@@ -337,10 +337,6 @@ export abstract class BaseCRUDController<
     };
   }
 
-  /**
-   * Build the lookup query used by find and delete operations.
-   * Child controllers can override this to enforce resource-specific scope.
-   */
   public buildFindOneQuery(_user: User, id: string): Record<string, unknown> {
     return { _id: id };
   }

--- a/apps/server/api/src/shared/controllers/base-crud/base-crud.controller.ts
+++ b/apps/server/api/src/shared/controllers/base-crud/base-crud.controller.ts
@@ -182,7 +182,7 @@ export abstract class BaseCRUDController<
   @LogMethod({ logEnd: false, logError: true, logStart: true })
   async findOne(
     @Req() request: Request,
-    @CurrentUser() _user: User,
+    @CurrentUser() user: User,
     @Param('id') id: string,
   ): Promise<JsonApiSingleResponse> {
     if (!isEntityId(id)) {
@@ -190,7 +190,7 @@ export abstract class BaseCRUDController<
     }
 
     const data = await this.service.findOne(
-      { _id: id },
+      this.buildFindOneQuery(user, id),
       this.getPopulateFields(),
     );
 
@@ -288,7 +288,9 @@ export abstract class BaseCRUDController<
     }
 
     // Check ownership before deletion
-    const existing = await this.service.findOne({ _id: id });
+    const existing = await this.service.findOne(
+      this.buildFindOneQuery(user, id),
+    );
     if (!existing) {
       ErrorResponse.notFound(this.entityName, id);
     }
@@ -298,7 +300,8 @@ export abstract class BaseCRUDController<
       ErrorResponse.notFound(this.entityName, id);
     }
 
-    const data = await this.service.remove(id);
+    const canonicalId = EntityIdUtil.resolveCanonicalId(existing, id);
+    const data = await this.service.remove(canonicalId);
 
     if (!data) {
       ErrorResponse.notFound(this.entityName, id);
@@ -332,6 +335,14 @@ export abstract class BaseCRUDController<
       orderBy: handleQuerySort(query.sort),
       where: matchFilter,
     };
+  }
+
+  /**
+   * Build the lookup query used by find and delete operations.
+   * Child controllers can override this to enforce resource-specific scope.
+   */
+  public buildFindOneQuery(_user: User, id: string): Record<string, unknown> {
+    return { _id: id };
   }
 
   public buildFindAllPipeline(


### PR DESCRIPTION
## Summary

- add deterministic list/get/delete contract coverage for image, GIF, video, music, and voice Library assets
- enforce active-organization, brand, category, soft-delete, and cache-key scope at controller/service boundaries
- preserve canonical serializers and resolve legacy Mongo route IDs to canonical Prisma IDs before soft deletion

## Verification

- exact-head PR CI on `6bb7dac03327d38ed5ad8a76b62206d22c181633` — all required checks passed, including changed API tests, typecheck, lint, format, runtime/architecture guards, OpenAPI drift, build, and server-image build
- `bunx @biomejs/biome@2.5.3 check <17 changed files>` — passed with one existing `noStaticOnlyClass` warning on `EntityIdUtil`
- `bun run scripts/run-secretlint.ts <17 changed files>` — passed
- `bun run scripts/check-request-context-usage.ts` from `apps/server/api` — passed
- `git diff --cached --check` — passed
- independent security/correctness review — approved

## Local policy notes

- focused tests, typecheck, and build were not run locally per the repository Mac resource policy; PR CI supplied those checks
- local `check:di-value-imports` and `audit:api:endpoints` could not initialize in this dependency-light worktree because the Bun runtime exposed no `ts.ScriptTarget`; the equivalent PR guards completed successfully

Parent: #1594

Closes #1943