### PR TITLE
feat(clips): define reference frame contract

### DIFF
--- a/apps/server/api/openapi/openapi.json
+++ b/apps/server/api/openapi/openapi.json
@@ -11165,6 +11165,10 @@
             "description": "Number of ready clips in the project",
             "type": "number"
           },
+          "referenceFrames": {
+            "description": "Versioned source-video reference-frame candidates and selection state",
+            "type": "object"
+          },
           "settings": {
             "allOf": [
               {

--- a/apps/server/api/openapi/openapi.json
+++ b/apps/server/api/openapi/openapi.json
@@ -1886,6 +1886,10 @@
             "description": "The organization ID that owns this resource",
             "type": "string"
           },
+          "referenceFrames": {
+            "description": "Versioned source-video reference-frame candidates and selection state",
+            "type": "object"
+          },
           "settings": {
             "allOf": [
               {

--- a/apps/server/api/src/collections/clip-projects/clip-projects.service.spec.ts
+++ b/apps/server/api/src/collections/clip-projects/clip-projects.service.spec.ts
@@ -13,6 +13,7 @@ vi.mock('@genfeedai/prisma', async () => {
 import { ClipProjectsService } from '@api/collections/clip-projects/clip-projects.service';
 import type { CreateClipProjectDto } from '@api/collections/clip-projects/dto/create-clip-project.dto';
 import type { ClipResultsService } from '@api/collections/clip-results/clip-results.service';
+import { ValidationException } from '@api/helpers/exceptions/http/validation.exception';
 import type { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import type { LoggerService } from '@libs/logger/logger.service';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -114,6 +115,133 @@ describe('ClipProjectsService', () => {
         status: 'pending',
       }),
     });
+  });
+
+  it('normalizes reference-frame state into clip-project config', async () => {
+    prisma.clipProject.create.mockResolvedValue({
+      config: {},
+      id: 'project-1',
+      organizationId: 'org-1',
+      progress: 0,
+      readiness: {},
+      status: 'pending',
+    });
+
+    await service.create({
+      organization: 'org-1',
+      referenceFrames: {
+        candidates: [
+          {
+            diagnostics: [],
+            id: ' frame-1 ',
+            status: 'available',
+            storageKey: 'organizations/org-1/clips/project-1/frame-1.jpg',
+            timestampSeconds: 12.5,
+          },
+        ],
+        diagnostics: [],
+        schemaVersion: 1,
+        selectedCandidateId: null,
+        status: 'ready',
+      },
+      sourceVideoUrl: 'https://youtube.com/watch?v=source',
+    } as CreateClipProjectDto);
+
+    expect(prisma.clipProject.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        config: expect.objectContaining({
+          referenceFrames: expect.objectContaining({
+            candidates: [
+              expect.objectContaining({
+                id: 'frame-1',
+                timestampSeconds: 12.5,
+              }),
+            ],
+            schemaVersion: 1,
+            selectedCandidateId: null,
+            status: 'ready',
+          }),
+        }),
+      }),
+    });
+  });
+
+  it('normalizes reference-frame state supplied through config updates', async () => {
+    prisma.clipProject.findFirst.mockResolvedValue({
+      config: { name: 'Existing' },
+      id: 'project-1',
+      organizationId: 'org-1',
+      progress: 45,
+      readiness: {},
+      status: 'analyzing',
+    });
+    prisma.clipProject.update.mockResolvedValue({
+      config: {},
+      id: 'project-1',
+      organizationId: 'org-1',
+      progress: 45,
+      readiness: {},
+      status: 'analyzing',
+    });
+
+    await service.patch('project-1', {
+      config: {
+        referenceFrames: {
+          candidates: [],
+          diagnostics: [
+            {
+              code: 'clip_reference_unavailable',
+              message: 'No source frames were available.',
+              severity: 'warning',
+            },
+          ],
+          schemaVersion: 1,
+          selectedCandidateId: null,
+          status: 'unavailable',
+        },
+      },
+    });
+
+    expect(prisma.clipProject.update).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        config: expect.objectContaining({
+          name: 'Existing',
+          referenceFrames: expect.objectContaining({
+            candidates: [],
+            status: 'unavailable',
+          }),
+        }),
+      }),
+      where: { id: 'project-1' },
+    });
+  });
+
+  it('rejects invalid reference-frame state before persistence', async () => {
+    prisma.clipProject.create.mockResolvedValue({});
+
+    await expect(
+      service.create({
+        organization: 'org-1',
+        referenceFrames: {
+          candidates: [
+            {
+              diagnostics: [],
+              id: 'frame-1',
+              status: 'available',
+              storageKey: '../frame-1.jpg',
+              timestampSeconds: 1,
+            },
+          ],
+          diagnostics: [],
+          schemaVersion: 1,
+          selectedCandidateId: 'missing-frame',
+          status: 'selected',
+        },
+        sourceVideoUrl: 'https://youtube.com/watch?v=source',
+      } as CreateClipProjectDto),
+    ).rejects.toThrow(ValidationException);
+
+    expect(prisma.clipProject.create).not.toHaveBeenCalled();
   });
 
   it('merges patch config and adds terminal readiness for completed projects', async () => {

--- a/apps/server/api/src/collections/clip-projects/clip-projects.service.ts
+++ b/apps/server/api/src/collections/clip-projects/clip-projects.service.ts
@@ -6,9 +6,17 @@ import {
   buildClipProjectReadiness,
   isTerminalClipStatus,
 } from '@api/collections/clip-shared/clip-terminal-contract.util';
+import { ValidationException } from '@api/helpers/exceptions/http/validation.exception';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { BaseService } from '@api/shared/services/base/base.service';
-import type { PopulateOption } from '@genfeedai/interfaces';
+import {
+  ClipReferenceFrameValidationError,
+  normalizeClipReferenceFrameSet,
+} from '@genfeedai/helpers';
+import type {
+  ClipReferenceFrameSet,
+  PopulateOption,
+} from '@genfeedai/interfaces';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
 
@@ -207,7 +215,16 @@ export class ClipProjectsService extends BaseService<
     }
 
     const suppliedConfig = this.readRecord(dto.config);
-    data.config = { ...config, ...suppliedConfig };
+    const mergedConfig = { ...config, ...suppliedConfig };
+    if (
+      Object.hasOwn(mergedConfig, 'referenceFrames') &&
+      mergedConfig.referenceFrames !== undefined
+    ) {
+      mergedConfig.referenceFrames = this.normalizeReferenceFrames(
+        mergedConfig.referenceFrames,
+      );
+    }
+    data.config = mergedConfig;
 
     this.applyTerminalDefaults(data, mode);
 
@@ -277,5 +294,20 @@ export class ClipProjectsService extends BaseService<
     }
 
     return null;
+  }
+
+  private normalizeReferenceFrames(value: unknown): ClipReferenceFrameSet {
+    try {
+      return normalizeClipReferenceFrameSet(value);
+    } catch (error: unknown) {
+      if (error instanceof ClipReferenceFrameValidationError) {
+        throw new ValidationException(
+          error.message,
+          'referenceFrames',
+          value,
+        );
+      }
+      throw error;
+    }
   }
 }

--- a/apps/server/api/src/collections/clip-projects/clip-projects.service.ts
+++ b/apps/server/api/src/collections/clip-projects/clip-projects.service.ts
@@ -301,11 +301,7 @@ export class ClipProjectsService extends BaseService<
       return normalizeClipReferenceFrameSet(value);
     } catch (error: unknown) {
       if (error instanceof ClipReferenceFrameValidationError) {
-        throw new ValidationException(
-          error.message,
-          'referenceFrames',
-          value,
-        );
+        throw new ValidationException(error.message, 'referenceFrames', value);
       }
       throw error;
     }

--- a/apps/server/api/src/collections/clip-projects/dto/create-clip-project.dto.ts
+++ b/apps/server/api/src/collections/clip-projects/dto/create-clip-project.dto.ts
@@ -2,6 +2,7 @@ import { ClipProjectStatus } from '@api/collections/clip-projects/schemas/clip-p
 import {
   CLIP_RESULT_MODES,
   DEFAULT_CLIP_RESULT_MODE,
+  type ClipReferenceFrameSet,
   type ClipResultMode,
 } from '@genfeedai/interfaces';
 import { OrganizationalCreateDto } from '@api/shared/dto/base/base.dto';
@@ -11,6 +12,7 @@ import {
   IsBoolean,
   IsIn,
   IsNumber,
+  IsObject,
   IsOptional,
   IsString,
   IsUrl,
@@ -146,4 +148,14 @@ export class CreateClipProjectDto extends OrganizationalCreateDto {
     type: ClipProjectSettingsDto,
   })
   readonly settings?: ClipProjectSettingsDto;
+
+  @IsOptional()
+  @IsObject()
+  @ApiProperty({
+    description:
+      'Versioned source-video reference-frame candidates and selection state',
+    required: false,
+    type: Object,
+  })
+  readonly referenceFrames?: ClipReferenceFrameSet;
 }

--- a/apps/server/api/src/collections/clip-projects/dto/create-clip-project.dto.ts
+++ b/apps/server/api/src/collections/clip-projects/dto/create-clip-project.dto.ts
@@ -1,11 +1,11 @@
 import { ClipProjectStatus } from '@api/collections/clip-projects/schemas/clip-project.schema';
+import { OrganizationalCreateDto } from '@api/shared/dto/base/base.dto';
 import {
   CLIP_RESULT_MODES,
-  DEFAULT_CLIP_RESULT_MODE,
   type ClipReferenceFrameSet,
   type ClipResultMode,
+  DEFAULT_CLIP_RESULT_MODE,
 } from '@genfeedai/interfaces';
-import { OrganizationalCreateDto } from '@api/shared/dto/base/base.dto';
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import {

--- a/apps/server/api/src/collections/clip-projects/schemas/clip-project.schema.ts
+++ b/apps/server/api/src/collections/clip-projects/schemas/clip-project.schema.ts
@@ -1,9 +1,9 @@
 import {
   CLIP_PROJECT_STATUSES,
-  type ClipReferenceFrameSet,
   type ClipReadinessContract,
-  type ClipProjectStatus as SharedClipProjectStatus,
+  type ClipReferenceFrameSet,
   type ClipResultMode,
+  type ClipProjectStatus as SharedClipProjectStatus,
 } from '@genfeedai/interfaces';
 import type { ClipProject as PrismaClipProject } from '@genfeedai/prisma';
 

--- a/apps/server/api/src/collections/clip-projects/schemas/clip-project.schema.ts
+++ b/apps/server/api/src/collections/clip-projects/schemas/clip-project.schema.ts
@@ -1,5 +1,6 @@
 import {
   CLIP_PROJECT_STATUSES,
+  type ClipReferenceFrameSet,
   type ClipReadinessContract,
   type ClipProjectStatus as SharedClipProjectStatus,
   type ClipResultMode,
@@ -61,6 +62,7 @@ export interface ClipProjectDocument extends ClipProjectRecord {
   organization?: string;
   pendingClipCount: number;
   progress: number;
+  referenceFrames?: ClipReferenceFrameSet;
   readiness: ClipReadinessContract | Record<string, unknown>;
   readyClipCount: number;
   settings?: ClipProjectSettings;

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -12,6 +12,7 @@ export * from './formatting/cn/cn.util';
 export * from './generation-controls.helper';
 export * from './generation-eta.helper';
 export * from './integrations/connect-genfeed.helper';
+export * from './media/clip-reference-frame.helper';
 export * from './media/provenance/provenance.helper';
 export * from './model-capability.helper';
 export * from './publisher/publishing-diagnostics.helper';

--- a/packages/helpers/src/media/clip-reference-frame.helper.test.ts
+++ b/packages/helpers/src/media/clip-reference-frame.helper.test.ts
@@ -51,6 +51,33 @@ describe('normalizeClipReferenceFrameSet', () => {
     expect(normalized.status).toBe('selected');
   });
 
+  it('normalizes null optional candidate fields as absent', () => {
+    const referenceFrames = createReferenceFrames();
+    const normalized = normalizeClipReferenceFrameSet({
+      ...referenceFrames,
+      candidates: [
+        {
+          ...referenceFrames.candidates[0],
+          assetId: null,
+          height: null,
+          mimeType: null,
+          url: null,
+          width: null,
+        },
+      ],
+    });
+
+    expect(normalized.candidates[0]).toEqual(
+      expect.objectContaining({
+        assetId: undefined,
+        height: undefined,
+        mimeType: undefined,
+        url: undefined,
+        width: undefined,
+      }),
+    );
+  });
+
   it('supports pending and unavailable states without candidates', () => {
     expect(
       normalizeClipReferenceFrameSet(

--- a/packages/helpers/src/media/clip-reference-frame.helper.test.ts
+++ b/packages/helpers/src/media/clip-reference-frame.helper.test.ts
@@ -1,0 +1,188 @@
+import {
+  CLIP_REFERENCE_FRAME_SCHEMA_VERSION,
+  type ClipReferenceFrameSet,
+} from '@genfeedai/interfaces';
+import {
+  ClipReferenceFrameValidationError,
+  normalizeClipReferenceFrameSet,
+} from '@helpers/media/clip-reference-frame.helper';
+
+function createReferenceFrames(
+  overrides: Partial<ClipReferenceFrameSet> = {},
+): ClipReferenceFrameSet {
+  return {
+    candidates: [
+      {
+        diagnostics: [],
+        height: 720,
+        id: 'frame-1',
+        mimeType: 'image/jpeg',
+        status: 'available',
+        storageKey: 'organizations/org-1/clips/project-1/frame-1.jpg',
+        timestampSeconds: 12.5,
+        url: 'https://cdn.example.com/frame-1.jpg',
+        width: 1280,
+      },
+    ],
+    diagnostics: [],
+    schemaVersion: CLIP_REFERENCE_FRAME_SCHEMA_VERSION,
+    selectedCandidateId: null,
+    status: 'ready',
+    ...overrides,
+  };
+}
+
+describe('normalizeClipReferenceFrameSet', () => {
+  it('normalizes a valid ready candidate set', () => {
+    expect(normalizeClipReferenceFrameSet(createReferenceFrames())).toEqual(
+      createReferenceFrames(),
+    );
+  });
+
+  it('accepts selected state only for an available candidate', () => {
+    const normalized = normalizeClipReferenceFrameSet(
+      createReferenceFrames({
+        selectedCandidateId: 'frame-1',
+        status: 'selected',
+      }),
+    );
+
+    expect(normalized.selectedCandidateId).toBe('frame-1');
+    expect(normalized.status).toBe('selected');
+  });
+
+  it('supports pending and unavailable states without candidates', () => {
+    expect(
+      normalizeClipReferenceFrameSet(
+        createReferenceFrames({
+          candidates: [],
+          status: 'pending',
+        }),
+      ).status,
+    ).toBe('pending');
+    expect(
+      normalizeClipReferenceFrameSet(
+        createReferenceFrames({
+          candidates: [],
+          diagnostics: [
+            {
+              code: 'clip_reference_extraction_failed',
+              message: 'No source frame could be extracted.',
+              severity: 'warning',
+            },
+          ],
+          status: 'unavailable',
+        }),
+      ).status,
+    ).toBe('unavailable');
+  });
+
+  it('rejects duplicate candidate ids', () => {
+    const candidate = createReferenceFrames().candidates[0];
+
+    expect(() =>
+      normalizeClipReferenceFrameSet(
+        createReferenceFrames({ candidates: [candidate, candidate] }),
+      ),
+    ).toThrow(/duplicate candidate id frame-1/);
+  });
+
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, -1])(
+    'rejects invalid timestamp %s',
+    (timestampSeconds) => {
+      expect(() =>
+        normalizeClipReferenceFrameSet(
+          createReferenceFrames({
+            candidates: [
+              {
+                ...createReferenceFrames().candidates[0],
+                timestampSeconds,
+              },
+            ],
+          }),
+        ),
+      ).toThrow(/finite non-negative number/);
+    },
+  );
+
+  it('rejects unsafe URLs, storage traversal, and non-image media types', () => {
+    const candidate = createReferenceFrames().candidates[0];
+
+    expect(() =>
+      normalizeClipReferenceFrameSet(
+        createReferenceFrames({
+          candidates: [{ ...candidate, url: 'file:///tmp/frame.jpg' }],
+        }),
+      ),
+    ).toThrow(/absolute HTTP\(S\) URL/);
+
+    expect(() =>
+      normalizeClipReferenceFrameSet(
+        createReferenceFrames({
+          candidates: [{ ...candidate, storageKey: '../frame.jpg' }],
+        }),
+      ),
+    ).toThrow(/without traversal segments/);
+
+    expect(() =>
+      normalizeClipReferenceFrameSet(
+        createReferenceFrames({
+          candidates: [{ ...candidate, mimeType: 'text/html' }],
+        }),
+      ),
+    ).toThrow(/image media type/);
+  });
+
+  it('rejects dangling or unavailable selections', () => {
+    expect(() =>
+      normalizeClipReferenceFrameSet(
+        createReferenceFrames({
+          selectedCandidateId: 'missing-frame',
+          status: 'selected',
+        }),
+      ),
+    ).toThrow(/available candidate/);
+
+    expect(() =>
+      normalizeClipReferenceFrameSet(
+        createReferenceFrames({
+          candidates: [
+            {
+              ...createReferenceFrames().candidates[0],
+              status: 'failed',
+            },
+          ],
+          selectedCandidateId: 'frame-1',
+          status: 'selected',
+        }),
+      ),
+    ).toThrow(ClipReferenceFrameValidationError);
+  });
+
+  it('rejects state that disagrees with candidate readiness', () => {
+    expect(() =>
+      normalizeClipReferenceFrameSet(
+        createReferenceFrames({ status: 'partial' }),
+      ),
+    ).toThrow(/status must be ready/);
+  });
+
+  it('requires a stable media reference without binary payloads', () => {
+    const candidate = createReferenceFrames().candidates[0];
+
+    expect(() =>
+      normalizeClipReferenceFrameSet(
+        createReferenceFrames({
+          candidates: [
+            {
+              ...candidate,
+              assetId: undefined,
+              storageKey: undefined,
+              url: undefined,
+            },
+          ],
+        }),
+      ),
+    ).toThrow(/assetId, storageKey, or url/);
+  });
+});

--- a/packages/helpers/src/media/clip-reference-frame.helper.test.ts
+++ b/packages/helpers/src/media/clip-reference-frame.helper.test.ts
@@ -87,23 +87,24 @@ describe('normalizeClipReferenceFrameSet', () => {
     ).toThrow(/duplicate candidate id frame-1/);
   });
 
-  it.each([Number.NaN, Number.POSITIVE_INFINITY, -1])(
-    'rejects invalid timestamp %s',
-    (timestampSeconds) => {
-      expect(() =>
-        normalizeClipReferenceFrameSet(
-          createReferenceFrames({
-            candidates: [
-              {
-                ...createReferenceFrames().candidates[0],
-                timestampSeconds,
-              },
-            ],
-          }),
-        ),
-      ).toThrow(/finite non-negative number/);
-    },
-  );
+  it.each([
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    -1,
+  ])('rejects invalid timestamp %s', (timestampSeconds) => {
+    expect(() =>
+      normalizeClipReferenceFrameSet(
+        createReferenceFrames({
+          candidates: [
+            {
+              ...createReferenceFrames().candidates[0],
+              timestampSeconds,
+            },
+          ],
+        }),
+      ),
+    ).toThrow(/finite non-negative number/);
+  });
 
   it('rejects unsafe URLs, storage traversal, and non-image media types', () => {
     const candidate = createReferenceFrames().candidates[0];

--- a/packages/helpers/src/media/clip-reference-frame.helper.ts
+++ b/packages/helpers/src/media/clip-reference-frame.helper.ts
@@ -50,7 +50,7 @@ function readRequiredString(value: unknown, field: string): string {
 }
 
 function readOptionalString(value: unknown, field: string): string | undefined {
-  if (value === undefined) {
+  if (value === undefined || value === null) {
     return undefined;
   }
 
@@ -61,7 +61,7 @@ function readPositiveInteger(
   value: unknown,
   field: string,
 ): number | undefined {
-  if (value === undefined) {
+  if (value === undefined || value === null) {
     return undefined;
   }
 

--- a/packages/helpers/src/media/clip-reference-frame.helper.ts
+++ b/packages/helpers/src/media/clip-reference-frame.helper.ts
@@ -1,0 +1,362 @@
+import {
+  CLIP_REFERENCE_FRAME_CANDIDATE_STATUSES,
+  CLIP_REFERENCE_FRAME_DIAGNOSTIC_SEVERITIES,
+  CLIP_REFERENCE_FRAME_SCHEMA_VERSION,
+  CLIP_REFERENCE_FRAME_STATUSES,
+  type ClipReferenceFrameCandidate,
+  type ClipReferenceFrameCandidateStatus,
+  type ClipReferenceFrameDiagnostic,
+  type ClipReferenceFrameDiagnosticSeverity,
+  type ClipReferenceFrameSet,
+  type ClipReferenceFrameStatus,
+} from '@genfeedai/interfaces';
+
+const candidateStatuses = new Set<string>(
+  CLIP_REFERENCE_FRAME_CANDIDATE_STATUSES,
+);
+const diagnosticSeverities = new Set<string>(
+  CLIP_REFERENCE_FRAME_DIAGNOSTIC_SEVERITIES,
+);
+const referenceFrameStatuses = new Set<string>(CLIP_REFERENCE_FRAME_STATUSES);
+const unsafeStorageKeySegment = /(^|[\\/])\.\.([\\/]|$)/;
+
+export class ClipReferenceFrameValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ClipReferenceFrameValidationError';
+  }
+}
+
+function readRecord(
+  value: unknown,
+  field: string,
+): Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new ClipReferenceFrameValidationError(`${field} must be an object`);
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function readRequiredString(value: unknown, field: string): string {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new ClipReferenceFrameValidationError(
+      `${field} must be a non-empty string`,
+    );
+  }
+
+  return value.trim();
+}
+
+function readOptionalString(
+  value: unknown,
+  field: string,
+): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  return readRequiredString(value, field);
+}
+
+function readPositiveInteger(
+  value: unknown,
+  field: string,
+): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (
+    typeof value !== 'number' ||
+    !Number.isInteger(value) ||
+    value <= 0
+  ) {
+    throw new ClipReferenceFrameValidationError(
+      `${field} must be a positive integer`,
+    );
+  }
+
+  return value;
+}
+
+function normalizeUrl(value: unknown, field: string): string | undefined {
+  const rawUrl = readOptionalString(value, field);
+  if (!rawUrl) {
+    return undefined;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new ClipReferenceFrameValidationError(
+      `${field} must be an absolute HTTP(S) URL`,
+    );
+  }
+
+  if (
+    !['http:', 'https:'].includes(parsed.protocol) ||
+    parsed.username.length > 0 ||
+    parsed.password.length > 0
+  ) {
+    throw new ClipReferenceFrameValidationError(
+      `${field} must be an absolute HTTP(S) URL without credentials`,
+    );
+  }
+
+  return rawUrl;
+}
+
+function normalizeStorageKey(
+  value: unknown,
+  field: string,
+): string | undefined {
+  const storageKey = readOptionalString(value, field);
+  if (!storageKey) {
+    return undefined;
+  }
+
+  if (
+    storageKey.startsWith('/') ||
+    storageKey.startsWith('\\') ||
+    unsafeStorageKeySegment.test(storageKey) ||
+    /[\u0000-\u001f]/.test(storageKey)
+  ) {
+    throw new ClipReferenceFrameValidationError(
+      `${field} must be a relative storage key without traversal segments`,
+    );
+  }
+
+  return storageKey;
+}
+
+function normalizeDiagnostic(
+  value: unknown,
+  field: string,
+): ClipReferenceFrameDiagnostic {
+  const diagnostic = readRecord(value, field);
+  const severity = readRequiredString(
+    diagnostic.severity,
+    `${field}.severity`,
+  );
+
+  if (!diagnosticSeverities.has(severity)) {
+    throw new ClipReferenceFrameValidationError(
+      `${field}.severity must be one of ${CLIP_REFERENCE_FRAME_DIAGNOSTIC_SEVERITIES.join(', ')}`,
+    );
+  }
+
+  return {
+    candidateId: readOptionalString(
+      diagnostic.candidateId,
+      `${field}.candidateId`,
+    ),
+    code: readRequiredString(diagnostic.code, `${field}.code`),
+    message: readRequiredString(diagnostic.message, `${field}.message`),
+    severity: severity as ClipReferenceFrameDiagnosticSeverity,
+  };
+}
+
+function normalizeDiagnostics(
+  value: unknown,
+  field: string,
+): ClipReferenceFrameDiagnostic[] {
+  if (value === undefined) {
+    return [];
+  }
+
+  if (!Array.isArray(value)) {
+    throw new ClipReferenceFrameValidationError(`${field} must be an array`);
+  }
+
+  return value.map((diagnostic, index) =>
+    normalizeDiagnostic(diagnostic, `${field}[${index}]`),
+  );
+}
+
+function normalizeCandidate(
+  value: unknown,
+  index: number,
+): ClipReferenceFrameCandidate {
+  const field = `referenceFrames.candidates[${index}]`;
+  const candidate = readRecord(value, field);
+  const id = readRequiredString(candidate.id, `${field}.id`);
+  const status = readRequiredString(candidate.status, `${field}.status`);
+
+  if (!candidateStatuses.has(status)) {
+    throw new ClipReferenceFrameValidationError(
+      `${field}.status must be one of ${CLIP_REFERENCE_FRAME_CANDIDATE_STATUSES.join(', ')}`,
+    );
+  }
+
+  if (
+    typeof candidate.timestampSeconds !== 'number' ||
+    !Number.isFinite(candidate.timestampSeconds) ||
+    candidate.timestampSeconds < 0
+  ) {
+    throw new ClipReferenceFrameValidationError(
+      `${field}.timestampSeconds must be a finite non-negative number`,
+    );
+  }
+
+  const assetId = readOptionalString(candidate.assetId, `${field}.assetId`);
+  const storageKey = normalizeStorageKey(
+    candidate.storageKey,
+    `${field}.storageKey`,
+  );
+  const url = normalizeUrl(candidate.url, `${field}.url`);
+
+  if (!assetId && !storageKey && !url) {
+    throw new ClipReferenceFrameValidationError(
+      `${field} must include assetId, storageKey, or url`,
+    );
+  }
+
+  const mimeType = readOptionalString(
+    candidate.mimeType,
+    `${field}.mimeType`,
+  );
+  if (mimeType && !mimeType.startsWith('image/')) {
+    throw new ClipReferenceFrameValidationError(
+      `${field}.mimeType must be an image media type`,
+    );
+  }
+
+  return {
+    assetId,
+    diagnostics: normalizeDiagnostics(
+      candidate.diagnostics,
+      `${field}.diagnostics`,
+    ),
+    height: readPositiveInteger(candidate.height, `${field}.height`),
+    id,
+    mimeType,
+    status: status as ClipReferenceFrameCandidateStatus,
+    storageKey,
+    timestampSeconds: candidate.timestampSeconds,
+    url,
+    width: readPositiveInteger(candidate.width, `${field}.width`),
+  };
+}
+
+function deriveStatus(
+  requestedStatus: ClipReferenceFrameStatus,
+  candidates: ClipReferenceFrameCandidate[],
+  selectedCandidateId: string | null,
+): ClipReferenceFrameStatus {
+  if (selectedCandidateId) {
+    return 'selected';
+  }
+
+  if (candidates.length === 0) {
+    if (requestedStatus === 'pending' || requestedStatus === 'unavailable') {
+      return requestedStatus;
+    }
+
+    throw new ClipReferenceFrameValidationError(
+      'referenceFrames without candidates must be pending or unavailable',
+    );
+  }
+
+  const availableCount = candidates.filter(
+    (candidate) => candidate.status === 'available',
+  ).length;
+  const pendingCount = candidates.filter(
+    (candidate) => candidate.status === 'pending',
+  ).length;
+
+  if (availableCount === candidates.length) {
+    return 'ready';
+  }
+
+  if (availableCount > 0) {
+    return 'partial';
+  }
+
+  return pendingCount > 0 ? 'pending' : 'unavailable';
+}
+
+export function normalizeClipReferenceFrameSet(
+  value: unknown,
+): ClipReferenceFrameSet {
+  const referenceFrames = readRecord(value, 'referenceFrames');
+
+  if (
+    referenceFrames.schemaVersion !== CLIP_REFERENCE_FRAME_SCHEMA_VERSION
+  ) {
+    throw new ClipReferenceFrameValidationError(
+      `referenceFrames.schemaVersion must be ${CLIP_REFERENCE_FRAME_SCHEMA_VERSION}`,
+    );
+  }
+
+  const requestedStatus = readRequiredString(
+    referenceFrames.status,
+    'referenceFrames.status',
+  );
+  if (!referenceFrameStatuses.has(requestedStatus)) {
+    throw new ClipReferenceFrameValidationError(
+      `referenceFrames.status must be one of ${CLIP_REFERENCE_FRAME_STATUSES.join(', ')}`,
+    );
+  }
+
+  if (!Array.isArray(referenceFrames.candidates)) {
+    throw new ClipReferenceFrameValidationError(
+      'referenceFrames.candidates must be an array',
+    );
+  }
+
+  const candidates = referenceFrames.candidates.map(normalizeCandidate);
+  const candidateIds = new Set<string>();
+  for (const candidate of candidates) {
+    if (candidateIds.has(candidate.id)) {
+      throw new ClipReferenceFrameValidationError(
+        `referenceFrames contains duplicate candidate id ${candidate.id}`,
+      );
+    }
+    candidateIds.add(candidate.id);
+  }
+
+  const selectedCandidateId =
+    referenceFrames.selectedCandidateId === null ||
+    referenceFrames.selectedCandidateId === undefined
+      ? null
+      : readRequiredString(
+          referenceFrames.selectedCandidateId,
+          'referenceFrames.selectedCandidateId',
+        );
+
+  if (selectedCandidateId) {
+    const selectedCandidate = candidates.find(
+      (candidate) => candidate.id === selectedCandidateId,
+    );
+    if (!selectedCandidate || selectedCandidate.status !== 'available') {
+      throw new ClipReferenceFrameValidationError(
+        'referenceFrames.selectedCandidateId must resolve to an available candidate',
+      );
+    }
+  }
+
+  const status = deriveStatus(
+    requestedStatus as ClipReferenceFrameStatus,
+    candidates,
+    selectedCandidateId,
+  );
+
+  if (status !== requestedStatus) {
+    throw new ClipReferenceFrameValidationError(
+      `referenceFrames.status must be ${status} for the supplied candidates and selection`,
+    );
+  }
+
+  return {
+    candidates,
+    diagnostics: normalizeDiagnostics(
+      referenceFrames.diagnostics,
+      'referenceFrames.diagnostics',
+    ),
+    schemaVersion: CLIP_REFERENCE_FRAME_SCHEMA_VERSION,
+    selectedCandidateId,
+    status,
+  };
+}

--- a/packages/helpers/src/media/clip-reference-frame.helper.ts
+++ b/packages/helpers/src/media/clip-reference-frame.helper.ts
@@ -20,6 +20,10 @@ const diagnosticSeverities = new Set<string>(
 const referenceFrameStatuses = new Set<string>(CLIP_REFERENCE_FRAME_STATUSES);
 const unsafeStorageKeySegment = /(^|[\\/])\.\.([\\/]|$)/;
 
+function hasControlCharacter(value: string): boolean {
+  return [...value].some((character) => character.charCodeAt(0) <= 31);
+}
+
 export class ClipReferenceFrameValidationError extends Error {
   constructor(message: string) {
     super(message);
@@ -27,10 +31,7 @@ export class ClipReferenceFrameValidationError extends Error {
   }
 }
 
-function readRecord(
-  value: unknown,
-  field: string,
-): Record<string, unknown> {
+function readRecord(value: unknown, field: string): Record<string, unknown> {
   if (value === null || typeof value !== 'object' || Array.isArray(value)) {
     throw new ClipReferenceFrameValidationError(`${field} must be an object`);
   }
@@ -48,10 +49,7 @@ function readRequiredString(value: unknown, field: string): string {
   return value.trim();
 }
 
-function readOptionalString(
-  value: unknown,
-  field: string,
-): string | undefined {
+function readOptionalString(value: unknown, field: string): string | undefined {
   if (value === undefined) {
     return undefined;
   }
@@ -67,11 +65,7 @@ function readPositiveInteger(
     return undefined;
   }
 
-  if (
-    typeof value !== 'number' ||
-    !Number.isInteger(value) ||
-    value <= 0
-  ) {
+  if (typeof value !== 'number' || !Number.isInteger(value) || value <= 0) {
     throw new ClipReferenceFrameValidationError(
       `${field} must be a positive integer`,
     );
@@ -121,7 +115,7 @@ function normalizeStorageKey(
     storageKey.startsWith('/') ||
     storageKey.startsWith('\\') ||
     unsafeStorageKeySegment.test(storageKey) ||
-    /[\u0000-\u001f]/.test(storageKey)
+    hasControlCharacter(storageKey)
   ) {
     throw new ClipReferenceFrameValidationError(
       `${field} must be a relative storage key without traversal segments`,
@@ -136,10 +130,7 @@ function normalizeDiagnostic(
   field: string,
 ): ClipReferenceFrameDiagnostic {
   const diagnostic = readRecord(value, field);
-  const severity = readRequiredString(
-    diagnostic.severity,
-    `${field}.severity`,
-  );
+  const severity = readRequiredString(diagnostic.severity, `${field}.severity`);
 
   if (!diagnosticSeverities.has(severity)) {
     throw new ClipReferenceFrameValidationError(
@@ -213,10 +204,7 @@ function normalizeCandidate(
     );
   }
 
-  const mimeType = readOptionalString(
-    candidate.mimeType,
-    `${field}.mimeType`,
-  );
+  const mimeType = readOptionalString(candidate.mimeType, `${field}.mimeType`);
   if (mimeType && !mimeType.startsWith('image/')) {
     throw new ClipReferenceFrameValidationError(
       `${field}.mimeType must be an image media type`,
@@ -282,9 +270,7 @@ export function normalizeClipReferenceFrameSet(
 ): ClipReferenceFrameSet {
   const referenceFrames = readRecord(value, 'referenceFrames');
 
-  if (
-    referenceFrames.schemaVersion !== CLIP_REFERENCE_FRAME_SCHEMA_VERSION
-  ) {
+  if (referenceFrames.schemaVersion !== CLIP_REFERENCE_FRAME_SCHEMA_VERSION) {
     throw new ClipReferenceFrameValidationError(
       `referenceFrames.schemaVersion must be ${CLIP_REFERENCE_FRAME_SCHEMA_VERSION}`,
     );
@@ -330,7 +316,7 @@ export function normalizeClipReferenceFrameSet(
     const selectedCandidate = candidates.find(
       (candidate) => candidate.id === selectedCandidateId,
     );
-    if (!selectedCandidate || selectedCandidate.status !== 'available') {
+    if (selectedCandidate?.status !== 'available') {
       throw new ClipReferenceFrameValidationError(
         'referenceFrames.selectedCandidateId must resolve to an available candidate',
       );

--- a/packages/interfaces/src/content/clip-reference-frame.interface.ts
+++ b/packages/interfaces/src/content/clip-reference-frame.interface.ts
@@ -1,0 +1,58 @@
+export const CLIP_REFERENCE_FRAME_SCHEMA_VERSION = 1 as const;
+
+export const CLIP_REFERENCE_FRAME_STATUSES = [
+  'pending',
+  'ready',
+  'partial',
+  'unavailable',
+  'selected',
+] as const;
+
+export type ClipReferenceFrameStatus =
+  (typeof CLIP_REFERENCE_FRAME_STATUSES)[number];
+
+export const CLIP_REFERENCE_FRAME_CANDIDATE_STATUSES = [
+  'pending',
+  'available',
+  'failed',
+] as const;
+
+export type ClipReferenceFrameCandidateStatus =
+  (typeof CLIP_REFERENCE_FRAME_CANDIDATE_STATUSES)[number];
+
+export const CLIP_REFERENCE_FRAME_DIAGNOSTIC_SEVERITIES = [
+  'info',
+  'warning',
+  'error',
+] as const;
+
+export type ClipReferenceFrameDiagnosticSeverity =
+  (typeof CLIP_REFERENCE_FRAME_DIAGNOSTIC_SEVERITIES)[number];
+
+export interface ClipReferenceFrameDiagnostic {
+  code: string;
+  message: string;
+  severity: ClipReferenceFrameDiagnosticSeverity;
+  candidateId?: string;
+}
+
+export interface ClipReferenceFrameCandidate {
+  id: string;
+  timestampSeconds: number;
+  status: ClipReferenceFrameCandidateStatus;
+  assetId?: string;
+  storageKey?: string;
+  url?: string;
+  mimeType?: string;
+  width?: number;
+  height?: number;
+  diagnostics: ClipReferenceFrameDiagnostic[];
+}
+
+export interface ClipReferenceFrameSet {
+  schemaVersion: typeof CLIP_REFERENCE_FRAME_SCHEMA_VERSION;
+  status: ClipReferenceFrameStatus;
+  candidates: ClipReferenceFrameCandidate[];
+  selectedCandidateId: string | null;
+  diagnostics: ClipReferenceFrameDiagnostic[];
+}

--- a/packages/interfaces/src/content/index.ts
+++ b/packages/interfaces/src/content/index.ts
@@ -2,6 +2,7 @@ export * from './account-publishing-context.interface';
 export * from './agent-mention.interface';
 export * from './article.interface';
 export * from './article-extended.interface';
+export * from './clip-reference-frame.interface';
 export * from './clip-terminal-contract.interface';
 export * from './composer-content.interface';
 export * from './content-run.interface';

--- a/packages/interfaces/src/index.ts
+++ b/packages/interfaces/src/index.ts
@@ -84,6 +84,7 @@ export * from './content/account-publishing-context.interface';
 export * from './content/agent-mention.interface';
 export * from './content/article.interface';
 export * from './content/article-extended.interface';
+export * from './content/clip-reference-frame.interface';
 export * from './content/clip-terminal-contract.interface';
 export * from './content/composer-content.interface';
 export * from './content/content-run.interface';

--- a/packages/serializers/__tests__/clip-project.serializer.test.ts
+++ b/packages/serializers/__tests__/clip-project.serializer.test.ts
@@ -1,0 +1,44 @@
+import { ClipProjectSerializer } from '@serializers/server/content/clip-project.serializer';
+import { describe, expect, it } from 'vitest';
+
+describe('ClipProjectSerializer reference-frame contract', () => {
+  type SerializedResource = {
+    data: { id: string; type: string; attributes: Record<string, unknown> };
+  };
+
+  it('exposes versioned reference-frame state when present', () => {
+    const referenceFrames = {
+      candidates: [
+        {
+          diagnostics: [],
+          id: 'frame-1',
+          status: 'available',
+          storageKey: 'organizations/org-1/clips/project-1/frame-1.jpg',
+          timestampSeconds: 12.5,
+        },
+      ],
+      diagnostics: [],
+      schemaVersion: 1,
+      selectedCandidateId: null,
+      status: 'ready',
+    };
+
+    const output = ClipProjectSerializer.serialize({
+      id: 'project-1',
+      referenceFrames,
+      status: 'analyzed',
+    }) as SerializedResource;
+
+    expect(output.data.type).toBe('clip-project');
+    expect(output.data.attributes.referenceFrames).toEqual(referenceFrames);
+  });
+
+  it('omits reference-frame state for legacy projects', () => {
+    const output = ClipProjectSerializer.serialize({
+      id: 'project-legacy',
+      status: 'analyzed',
+    }) as SerializedResource;
+
+    expect('referenceFrames' in output.data.attributes).toBe(false);
+  });
+});

--- a/packages/serializers/src/attributes/content/clip-project.attributes.ts
+++ b/packages/serializers/src/attributes/content/clip-project.attributes.ts
@@ -10,6 +10,7 @@ export const clipProjectAttributes = createEntityAttributes([
   'transcriptText',
   'transcriptSrt',
   'transcriptSegments',
+  'referenceFrames',
   'language',
   'status',
   'progress',


### PR DESCRIPTION
## Summary

- define a versioned shared contract for clip reference-frame candidates, diagnostics, and selection state
- validate and normalize reference-frame state before persisting it in ClipProject config
- expose the contract through the ClipProject serializer while preserving legacy records with no reference-frame state
- cover normalization, persistence, rejection, selection, nullable optional metadata, and serializer compatibility paths

## Verification

- `bunx @biomejs/biome@2.5.3 format --write <touched files>`
- `bunx @biomejs/biome@2.5.3 check <touched files>`
- `git diff --check`
- exact-head PR verification: 26 successful, 9 intentional skips, 0 failures, 0 pending
- green checks include format, lint, guards, OpenAPI drift, typecheck, build, package/server/API/app tests, server image, links, security, and automated review
- heavy local tests, typecheck, and build were skipped per repository machine policy and executed by PR CI instead

## Scope

This is the contract/persistence child of #233. Extraction, review UI, and provider handoff remain in #1950, #1951, and #1952.

Closes #1949