### PR TITLE
test(auth): cover magic-link lifecycle contracts

### DIFF
--- a/apps/server/api/src/auth/better-auth/better-auth-magic-link.contract.spec.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth-magic-link.contract.spec.ts
@@ -38,7 +38,12 @@ interface SessionBody {
 }
 
 function createMagicLinkContractHarness() {
-  const database: MemoryDB = {};
+  const database: MemoryDB = {
+    account: [],
+    session: [],
+    user: [],
+    verification: [],
+  };
   let deliveredMagicLink: IBetterAuthMagicLinkParams | undefined;
   const sendMagicLink = vi.fn(
     async (params: IBetterAuthMagicLinkParams): Promise<void> => {

--- a/apps/server/api/src/auth/better-auth/better-auth-magic-link.contract.spec.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth-magic-link.contract.spec.ts
@@ -1,0 +1,206 @@
+import { betterAuth } from 'better-auth';
+import { type MemoryDB, memoryAdapter } from 'better-auth/adapters/memory';
+import { magicLink } from 'better-auth/plugins';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { buildBetterAuthMagicLinkOptions } from './better-auth.factory';
+import type {
+  IBetterAuthMagicLinkParams,
+  ICreateBetterAuthOptions,
+} from './better-auth.types';
+
+const AUTH_BASE_URL = 'http://localhost:3000';
+const AUTH_BASE_PATH = '/api/auth';
+const AUTH_SECRET =
+  'better-auth-magic-link-contract-secret-with-sufficient-entropy';
+const TEST_EMAIL = 'magic-link-contract@example.com';
+
+interface MagicLinkVerificationBody {
+  session: {
+    token: string;
+    userId: string;
+  };
+  token: string;
+  user: {
+    email: string;
+    id: string;
+  };
+}
+
+interface SessionBody {
+  session: {
+    token: string;
+    userId: string;
+  };
+  user: {
+    email: string;
+    id: string;
+  };
+}
+
+function createMagicLinkContractHarness() {
+  const database: MemoryDB = {};
+  let deliveredMagicLink: IBetterAuthMagicLinkParams | undefined;
+  const sendMagicLink = vi.fn(
+    async (params: IBetterAuthMagicLinkParams): Promise<void> => {
+      deliveredMagicLink = params;
+    },
+  );
+  const prisma = {
+    user: {
+      findFirst: vi.fn(),
+    },
+  } as unknown as ICreateBetterAuthOptions['prisma'];
+  const magicLinkOptions = buildBetterAuthMagicLinkOptions({
+    prisma,
+    sendMagicLink,
+  });
+  const auth = betterAuth({
+    baseURL: AUTH_BASE_URL,
+    database: memoryAdapter(database),
+    rateLimit: { enabled: false },
+    secret: AUTH_SECRET,
+    plugins: [magicLink(magicLinkOptions)],
+  });
+
+  return {
+    database,
+    expiresInSeconds: magicLinkOptions.expiresIn ?? 300,
+    getDeliveredMagicLink(): IBetterAuthMagicLinkParams {
+      if (!deliveredMagicLink) {
+        throw new Error('Expected Better Auth to deliver a magic link');
+      }
+      return deliveredMagicLink;
+    },
+    request(path: string, init?: RequestInit): Promise<Response> {
+      return auth.handler(
+        new Request(`${AUTH_BASE_URL}${AUTH_BASE_PATH}${path}`, init),
+      );
+    },
+    sendMagicLink,
+  };
+}
+
+async function requestMagicLink(
+  harness: ReturnType<typeof createMagicLinkContractHarness>,
+): Promise<Response> {
+  return harness.request('/sign-in/magic-link', {
+    body: JSON.stringify({ email: TEST_EMAIL }),
+    headers: { 'content-type': 'application/json' },
+    method: 'POST',
+  });
+}
+
+async function verifyMagicLink(
+  harness: ReturnType<typeof createMagicLinkContractHarness>,
+  token: string,
+): Promise<Response> {
+  return harness.request(
+    `/magic-link/verify?token=${encodeURIComponent(token)}`,
+  );
+}
+
+function getSessionCookie(response: Response): string {
+  const setCookie = response.headers.get('set-cookie');
+  const sessionCookie = setCookie?.match(
+    /(?:^|, )([^=;,]*session_token=[^;,]+)/,
+  )?.[1];
+
+  if (!sessionCookie) {
+    throw new Error('Expected magic-link verification to set a session cookie');
+  }
+  return sessionCookie;
+}
+
+async function expectRecoverableInvalidTokenResponse(
+  response: Response,
+  rawToken: string,
+): Promise<void> {
+  const location = response.headers.get('location');
+  const body = await response.text();
+
+  expect(response.status).toBe(302);
+  expect(location).toBe(`${AUTH_BASE_URL}/?error=INVALID_TOKEN`);
+  expect(location).not.toContain(rawToken);
+  expect(body).not.toContain(rawToken);
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('Better Auth magic-link lifecycle contract', () => {
+  it('delivers the one-time link through the canonical callback without exposing token material in the request response', async () => {
+    const harness = createMagicLinkContractHarness();
+
+    const response = await requestMagicLink(harness);
+    const responseBody = await response.text();
+    const delivered = harness.getDeliveredMagicLink();
+
+    expect(response.status).toBe(200);
+    expect(JSON.parse(responseBody)).toEqual({ status: true });
+    expect(harness.sendMagicLink).toHaveBeenCalledOnce();
+    expect(delivered.email).toBe(TEST_EMAIL);
+    expect(delivered.url).toContain('/api/auth/magic-link/verify');
+    expect(delivered.url).toContain(encodeURIComponent(delivered.token));
+    expect(responseBody).not.toContain(delivered.token);
+    expect(response.headers.get('location')).toBeNull();
+    expect(JSON.stringify(harness.database)).not.toContain(delivered.token);
+  });
+
+  it('establishes a session from a valid token and authenticates the session cookie', async () => {
+    const harness = createMagicLinkContractHarness();
+    await requestMagicLink(harness);
+    const delivered = harness.getDeliveredMagicLink();
+
+    const verificationResponse = await verifyMagicLink(
+      harness,
+      delivered.token,
+    );
+    const verification =
+      (await verificationResponse.json()) as MagicLinkVerificationBody;
+    const sessionCookie = getSessionCookie(verificationResponse);
+    const sessionResponse = await harness.request('/get-session', {
+      headers: { cookie: sessionCookie },
+    });
+    const session = (await sessionResponse.json()) as SessionBody;
+
+    expect(verificationResponse.status).toBe(200);
+    expect(verification.user.email).toBe(TEST_EMAIL);
+    expect(verification.session.userId).toBe(verification.user.id);
+    expect(verification.token).toBe(verification.session.token);
+    expect(sessionResponse.status).toBe(200);
+    expect(session.user).toEqual(verification.user);
+    expect(session.session.userId).toBe(verification.user.id);
+    expect(session.session.token).toBe(verification.session.token);
+  });
+
+  it('rejects an expired token without creating a session', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-20T12:00:00.000Z'));
+    const harness = createMagicLinkContractHarness();
+    await requestMagicLink(harness);
+    const delivered = harness.getDeliveredMagicLink();
+    vi.advanceTimersByTime((harness.expiresInSeconds + 1) * 1_000);
+
+    const response = await verifyMagicLink(harness, delivered.token);
+
+    await expectRecoverableInvalidTokenResponse(response, delivered.token);
+    expect(harness.database.session ?? []).toHaveLength(0);
+  });
+
+  it('rejects a replay after one successful verification without minting another session', async () => {
+    const harness = createMagicLinkContractHarness();
+    await requestMagicLink(harness);
+    const delivered = harness.getDeliveredMagicLink();
+
+    const firstResponse = await verifyMagicLink(harness, delivered.token);
+    const replayResponse = await verifyMagicLink(harness, delivered.token);
+
+    expect(firstResponse.status).toBe(200);
+    await expectRecoverableInvalidTokenResponse(
+      replayResponse,
+      delivered.token,
+    );
+    expect(harness.database.session ?? []).toHaveLength(1);
+  });
+});

--- a/apps/server/api/src/auth/better-auth/better-auth.factory.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.factory.ts
@@ -10,6 +10,7 @@ import {
 import { prismaAdapter } from 'better-auth/adapters/prisma';
 import {
   jwt,
+  type MagicLinkOptions,
   magicLink,
   type OrganizationOptions,
   organization,
@@ -29,9 +30,14 @@ const RATE_LIMIT_KEY_PREFIX = 'ba:ratelimit:';
 const RATE_LIMIT_TTL_SECONDS = 86_400;
 const BETTER_AUTH_CREATOR_ROLE = 'admin';
 const BETTER_AUTH_DEFAULT_ORGANIZATION_CATEGORY = 'BUSINESS';
+const BETTER_AUTH_MAGIC_LINK_EXPIRES_IN_SECONDS = 300;
 const SIGN_UP_MAGIC_LINK_INTENT = 'signup';
 
 type BetterAuthDatabaseHooks = NonNullable<BetterAuthOptions['databaseHooks']>;
+type BetterAuthMagicLinkDependencies = Pick<
+  ICreateBetterAuthOptions,
+  'prisma' | 'sendMagicLink'
+>;
 type BetterAuthUserBeforePayload = {
   email?: string | null;
   handle?: string;
@@ -128,6 +134,31 @@ export async function assertSignupMagicLinkCanCreateUser({
       message: SIGN_UP_MAGIC_LINK_EXISTING_USER_MESSAGE,
     });
   }
+}
+
+/**
+ * Keep the production magic-link security contract in one reusable boundary.
+ * Contract tests run these exact options against Better Auth's memory adapter,
+ * while production supplies the Prisma adapter to the enclosing auth instance.
+ */
+export function buildBetterAuthMagicLinkOptions({
+  prisma,
+  sendMagicLink,
+}: BetterAuthMagicLinkDependencies): MagicLinkOptions {
+  return {
+    expiresIn: BETTER_AUTH_MAGIC_LINK_EXPIRES_IN_SECONDS,
+    // Persist only the hash of magic-link tokens so a DB read cannot replay
+    // them. Lookup re-hashes the incoming token during verification.
+    storeToken: 'hashed',
+    sendMagicLink: async ({ email, metadata, url, token }) => {
+      await assertSignupMagicLinkCanCreateUser({
+        email,
+        metadata,
+        prisma,
+      });
+      await sendMagicLink({ email, metadata, url, token });
+    },
+  };
 }
 
 /**
@@ -623,20 +654,7 @@ export function createBetterAuthInstance(options: ICreateBetterAuthOptions) {
     databaseHooks: buildBetterAuthUserDatabaseHooks(onUserCreated),
     plugins: [
       ...(apiKey ? [dash({ apiKey })] : []),
-      magicLink({
-        // Persist only the hash of magic-link tokens so a DB read cannot replay
-        // them. Lookup re-hashes the incoming token, so any in-flight plaintext
-        // links issued before this change fail until they expire (~min TTL).
-        storeToken: 'hashed',
-        sendMagicLink: async ({ email, metadata, url, token }) => {
-          await assertSignupMagicLinkCanCreateUser({
-            email,
-            metadata,
-            prisma,
-          });
-          await sendMagicLink({ email, metadata, url, token });
-        },
-      }),
+      magicLink(buildBetterAuthMagicLinkOptions({ prisma, sendMagicLink })),
       organization(buildBetterAuthOrganizationOptions(prisma)),
       jwt({
         jwt: {


### PR DESCRIPTION
## Summary

- centralize the production Better Auth magic-link options and explicitly pin the existing five-minute expiry
- exercise the real Better Auth magic-link plugin with its in-memory adapter
- cover client-safe issuance, valid session establishment, expiry rejection, and atomic replay rejection without SMTP or external providers

Closes #1954

## Verification

- `bunx @biomejs/biome@2.5.3 check --write apps/server/api/src/auth/better-auth/better-auth.factory.ts apps/server/api/src/auth/better-auth/better-auth-magic-link.contract.spec.ts` — passed
- `git diff --cached --check` — passed before commit
- focused tests, typecheck, and build were not run locally per workstation policy; PR CI is the required execution environment