### PR TITLE
test(auth): cover session reload deployment modes

### DIFF
--- a/apps/server/api/src/auth/better-auth/better-auth-session.contract.spec.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth-session.contract.spec.ts
@@ -73,9 +73,7 @@ function getSessionCookie(response: Response): {
   setCookie: string;
 } {
   const setCookie = response.headers.get('set-cookie');
-  const cookie = setCookie?.match(
-    /(?:^|, )([^=;,]*session_token=[^;,]+)/,
-  )?.[1];
+  const cookie = setCookie?.match(/(?:^|, )([^=;,]*session_token=[^;,]+)/)?.[1];
 
   if (!setCookie || !cookie) {
     throw new Error('Expected password sign-up to set a session cookie');
@@ -85,50 +83,49 @@ function getSessionCookie(response: Response): {
 }
 
 describe('Better Auth session reload deployment contract', () => {
-  it.each(SESSION_CONTRACT_MODES)(
-    'restores the $name session from a fresh request with the intended cookie scope',
-    async (mode) => {
-      const harness = createSessionContractHarness(mode);
-      const email = `session-contract-${mode.name}@example.com`;
-      const signUpResponse = await harness.request('/sign-up/email', {
-        body: JSON.stringify({
-          email,
-          name: 'Session Contract',
-          password: TEST_PASSWORD,
-        }),
-        headers: { 'content-type': 'application/json' },
-        method: 'POST',
-      });
-      const { cookie, setCookie } = getSessionCookie(signUpResponse);
+  it.each(
+    SESSION_CONTRACT_MODES,
+  )('restores the $name session from a fresh request with the intended cookie scope', async (mode) => {
+    const harness = createSessionContractHarness(mode);
+    const email = `session-contract-${mode.name}@example.com`;
+    const signUpResponse = await harness.request('/sign-up/email', {
+      body: JSON.stringify({
+        email,
+        name: 'Session Contract',
+        password: TEST_PASSWORD,
+      }),
+      headers: { 'content-type': 'application/json' },
+      method: 'POST',
+    });
+    const { cookie, setCookie } = getSessionCookie(signUpResponse);
 
-      expect(signUpResponse.status).toBe(200);
-      expect(setCookie).toMatch(/;\s*HttpOnly/i);
-      if (mode.expectedCookieDomain) {
-        expect(setCookie).toMatch(
-          new RegExp(
-            `;\\s*Domain=\\.?${mode.expectedCookieDomain.replaceAll('.', '\\.')}\\b`,
-            'i',
-          ),
-        );
-      } else {
-        expect(setCookie).not.toMatch(/;\s*Domain=/i);
-      }
+    expect(signUpResponse.status).toBe(200);
+    expect(setCookie).toMatch(/;\s*HttpOnly/i);
+    if (mode.expectedCookieDomain) {
+      expect(setCookie).toMatch(
+        new RegExp(
+          `;\\s*Domain=\\.?${mode.expectedCookieDomain.replaceAll('.', '\\.')}\\b`,
+          'i',
+        ),
+      );
+    } else {
+      expect(setCookie).not.toMatch(/;\s*Domain=/i);
+    }
 
-      const sessionResponse = await harness.request('/get-session', {
-        headers: { cookie },
-      });
-      const session = (await sessionResponse.json()) as SessionBody;
+    const sessionResponse = await harness.request('/get-session', {
+      headers: { cookie },
+    });
+    const session = (await sessionResponse.json()) as SessionBody;
 
-      expect(sessionResponse.status).toBe(200);
-      expect(session.user.email).toBe(email);
-      expect(session.session.userId).toBe(session.user.id);
-      expect(session.session.token).toBeTruthy();
-      expect(harness.database.session ?? []).toHaveLength(1);
+    expect(sessionResponse.status).toBe(200);
+    expect(session.user.email).toBe(email);
+    expect(session.session.userId).toBe(session.user.id);
+    expect(session.session.token).toBeTruthy();
+    expect(harness.database.session ?? []).toHaveLength(1);
 
-      const anonymousResponse = await harness.request('/get-session');
+    const anonymousResponse = await harness.request('/get-session');
 
-      expect(anonymousResponse.status).toBe(200);
-      await expect(anonymousResponse.json()).resolves.toBeNull();
-    },
-  );
+    expect(anonymousResponse.status).toBe(200);
+    await expect(anonymousResponse.json()).resolves.toBeNull();
+  });
 });

--- a/apps/server/api/src/auth/better-auth/better-auth-session.contract.spec.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth-session.contract.spec.ts
@@ -1,0 +1,134 @@
+import { betterAuth } from 'better-auth';
+import { type MemoryDB, memoryAdapter } from 'better-auth/adapters/memory';
+import { describe, expect, it } from 'vitest';
+import { BETTER_AUTH_BASE_PATH } from './better-auth.constants';
+import { buildBetterAuthAdvancedOptions } from './better-auth.factory';
+
+const AUTH_SECRET =
+  'better-auth-session-contract-secret-with-sufficient-entropy';
+const TEST_PASSWORD = 'session-contract-password';
+
+interface SessionBody {
+  session: {
+    token: string;
+    userId: string;
+  };
+  user: {
+    email: string;
+    id: string;
+  };
+}
+
+interface SessionContractMode {
+  baseURL: string;
+  cookieDomain?: string;
+  expectedCookieDomain?: string;
+  name: string;
+}
+
+const SESSION_CONTRACT_MODES: SessionContractMode[] = [
+  {
+    baseURL: 'http://genfeed.localhost:3010',
+    name: 'self-hosted',
+  },
+  {
+    baseURL: 'https://api.genfeed.ai',
+    cookieDomain: '.genfeed.ai',
+    expectedCookieDomain: 'genfeed.ai',
+    name: 'cloud',
+  },
+];
+
+function createSessionContractHarness(mode: SessionContractMode) {
+  const database: MemoryDB = {
+    account: [],
+    session: [],
+    user: [],
+    verification: [],
+  };
+  const auth = betterAuth({
+    advanced: buildBetterAuthAdvancedOptions({
+      cookieDomain: mode.cookieDomain,
+    }),
+    basePath: BETTER_AUTH_BASE_PATH,
+    baseURL: mode.baseURL,
+    database: memoryAdapter(database),
+    emailAndPassword: { enabled: true },
+    rateLimit: { enabled: false },
+    secret: AUTH_SECRET,
+  });
+
+  return {
+    database,
+    request(path: string, init?: RequestInit): Promise<Response> {
+      return auth.handler(
+        new Request(`${mode.baseURL}${BETTER_AUTH_BASE_PATH}${path}`, init),
+      );
+    },
+  };
+}
+
+function getSessionCookie(response: Response): {
+  cookie: string;
+  setCookie: string;
+} {
+  const setCookie = response.headers.get('set-cookie');
+  const cookie = setCookie?.match(
+    /(?:^|, )([^=;,]*session_token=[^;,]+)/,
+  )?.[1];
+
+  if (!setCookie || !cookie) {
+    throw new Error('Expected password sign-up to set a session cookie');
+  }
+
+  return { cookie, setCookie };
+}
+
+describe('Better Auth session reload deployment contract', () => {
+  it.each(SESSION_CONTRACT_MODES)(
+    'restores the $name session from a fresh request with the intended cookie scope',
+    async (mode) => {
+      const harness = createSessionContractHarness(mode);
+      const email = `session-contract-${mode.name}@example.com`;
+      const signUpResponse = await harness.request('/sign-up/email', {
+        body: JSON.stringify({
+          email,
+          name: 'Session Contract',
+          password: TEST_PASSWORD,
+        }),
+        headers: { 'content-type': 'application/json' },
+        method: 'POST',
+      });
+      const { cookie, setCookie } = getSessionCookie(signUpResponse);
+
+      expect(signUpResponse.status).toBe(200);
+      expect(setCookie).toMatch(/;\s*HttpOnly/i);
+      if (mode.expectedCookieDomain) {
+        expect(setCookie).toMatch(
+          new RegExp(
+            `;\\s*Domain=\\.?${mode.expectedCookieDomain.replaceAll('.', '\\.')}\\b`,
+            'i',
+          ),
+        );
+      } else {
+        expect(setCookie).not.toMatch(/;\s*Domain=/i);
+      }
+
+      const sessionResponse = await harness.request('/get-session', {
+        headers: { cookie },
+      });
+      const session = (await sessionResponse.json()) as SessionBody;
+
+      expect(sessionResponse.status).toBe(200);
+      expect(session.user.email).toBe(email);
+      expect(session.session.userId).toBe(session.user.id);
+      expect(session.session.token).toBeTruthy();
+      expect(harness.database.session ?? []).toHaveLength(1);
+
+      const anonymousResponse = await harness.request('/get-session');
+
+      expect(anonymousResponse.status).toBe(200);
+      await expect(anonymousResponse.json()).resolves.toBeNull();
+    },
+  );
+});

--- a/apps/server/api/src/auth/better-auth/better-auth.factory.ts
+++ b/apps/server/api/src/auth/better-auth/better-auth.factory.ts
@@ -46,6 +46,31 @@ export const SIGN_UP_MAGIC_LINK_EXISTING_USER_MESSAGE =
   'An account already exists for this email. Sign in instead.';
 
 /**
+ * Build the deployment-sensitive Better Auth options in one testable boundary.
+ *
+ * Community/self-hosted deployments keep the default host-scoped cookie when
+ * `cookieDomain` is absent. Cloud can explicitly share the session cookie
+ * across sibling subdomains, while proxy-specific IP headers remain optional
+ * for deployments without that edge topology.
+ */
+export function buildBetterAuthAdvancedOptions({
+  cookieDomain,
+  ipAddressHeaders,
+}: Pick<
+  ICreateBetterAuthOptions,
+  'cookieDomain' | 'ipAddressHeaders'
+>): NonNullable<BetterAuthOptions['advanced']> {
+  return {
+    ...(ipAddressHeaders && ipAddressHeaders.length > 0
+      ? { ipAddress: { ipAddressHeaders } }
+      : {}),
+    ...(cookieDomain
+      ? { crossSubDomainCookies: { enabled: true, domain: cookieDomain } }
+      : {}),
+  };
+}
+
+/**
  * Adapt the shared Redis KV into Better Auth's `rateLimit.customStorage` shape
  * so all API instances share one counter window (per-process memory would let
  * the effective limit scale with instance count). Reads/writes are JSON; the
@@ -591,19 +616,10 @@ export function createBetterAuthInstance(options: ICreateBetterAuthOptions) {
     // Experimental single-query joins (Prisma adapter). Env-gated; off unless
     // explicitly enabled after staging verification.
     ...(experimentalJoins ? { experimental: { joins: true } } : {}),
-    advanced: {
-      // Pin the client-IP header(s) only when configured (e.g. `x-forwarded-for`
-      // behind the production ALB); unset keeps Better Auth's default detection
-      // for proxy-less / differently-fronted deployment modes.
-      ...(ipAddressHeaders && ipAddressHeaders.length > 0
-        ? { ipAddress: { ipAddressHeaders } }
-        : {}),
-      // Share the session cookie across sibling subdomains (api ↔ app) when a
-      // root domain is configured; host-scoped otherwise.
-      ...(cookieDomain
-        ? { crossSubDomainCookies: { enabled: true, domain: cookieDomain } }
-        : {}),
-    },
+    advanced: buildBetterAuthAdvancedOptions({
+      cookieDomain,
+      ipAddressHeaders,
+    }),
     user: {
       // Better Auth's `image` field maps onto the existing `User.avatar` column.
       fields: { image: 'avatar' },


### PR DESCRIPTION
## Summary
- extract deployment-sensitive Better Auth advanced options into a typed, directly testable boundary
- add an in-memory password-session contract for host-scoped self-hosted cookies and shared-domain Cloud cookies
- verify a fresh request restores the canonical user/session while an anonymous reload fails closed

## Verification
### Local lightweight checks
- `bunx @biomejs/biome@2.5.3 format --write apps/server/api/src/auth/better-auth/better-auth.factory.ts apps/server/api/src/auth/better-auth/better-auth-session.contract.spec.ts`
- `bunx @biomejs/biome@2.5.3 lint apps/server/api/src/auth/better-auth/better-auth.factory.ts apps/server/api/src/auth/better-auth/better-auth-session.contract.spec.ts`
- `(cd apps/server/api && bun run scripts/check-request-context-usage.ts)`
- `git diff --check`

### GitHub Actions — exact head `c941d247aad6db4271ed8fbb14cf65356c0381ad`
- CI run 29767177882 passed: changed API contract, typecheck, lint, format, guards, OpenAPI drift, build, security scans, and Tests Gate
- Server Image PR Guard run 29767178055 passed
- CodeRabbit, Fallow PR Audit, GitGuardian, and Socket checks passed

Local Vitest, typecheck, and build were intentionally skipped under the local-machine verification policy; the corresponding GitHub Actions jobs passed.

## Residual risk
No implementation blocker is known. Fleet Review remains the required exact-head merge gate.

Closes #1956
Refs #1593