### PR TITLE
fix(ui): sync controlled component state

### DIFF
--- a/packages/ui/src/components/analytics/charts/platform-time-series/platform-time-series-chart.test.tsx
+++ b/packages/ui/src/components/analytics/charts/platform-time-series/platform-time-series-chart.test.tsx
@@ -234,6 +234,24 @@ describe('PlatformTimeSeriesChart', () => {
       fireEvent.click(instagramButton);
       expect(instagramButton).toHaveClass('bg-white/10');
     });
+
+    it('reconciles active platforms when available platforms change', () => {
+      const { rerender } = render(
+        <PlatformTimeSeriesChart
+          data={mockData}
+          platforms={['instagram', 'tiktok']}
+        />,
+      );
+
+      fireEvent.click(getPlatformButton('Instagram'));
+      rerender(
+        <PlatformTimeSeriesChart data={mockData} platforms={['facebook']} />,
+      );
+
+      expect(screen.getByTestId('area-facebook')).toBeInTheDocument();
+      expect(screen.queryByTestId('area-tiktok')).not.toBeInTheDocument();
+      expect(getPlatformButton('Facebook')).toHaveClass('bg-white/10');
+    });
   });
 
   describe('Area Rendering', () => {

--- a/packages/ui/src/components/analytics/charts/platform-time-series/platform-time-series-chart.tsx
+++ b/packages/ui/src/components/analytics/charts/platform-time-series/platform-time-series-chart.tsx
@@ -55,6 +55,20 @@ const PLATFORM_LABELS = {
   youtube: 'YouTube',
 };
 
+type Platform = keyof typeof PLATFORM_COLORS;
+
+interface PlatformSelectionOverride {
+  sourcePlatforms: Platform[];
+  inactivePlatforms: Platform[];
+}
+
+function arePlatformsEqual(left: Platform[], right: Platform[]) {
+  return (
+    left.length === right.length &&
+    left.every((platform, index) => platform === right[index])
+  );
+}
+
 export function PlatformTimeSeriesChart({
   data,
   platforms = ['instagram', 'tiktok', 'youtube', 'twitter'],
@@ -62,8 +76,21 @@ export function PlatformTimeSeriesChart({
   height = 300,
   className = '',
 }: PlatformTimeSeriesChartProps) {
-  const [activePlatforms, setActivePlatforms] =
-    useState<(keyof typeof PLATFORM_COLORS)[]>(platforms);
+  const [selectionOverride, setSelectionOverride] =
+    useState<PlatformSelectionOverride | null>(null);
+  const activeSelectionOverride =
+    selectionOverride &&
+    arePlatformsEqual(selectionOverride.sourcePlatforms, platforms)
+      ? selectionOverride
+      : null;
+  const inactivePlatforms = activeSelectionOverride?.inactivePlatforms ?? [];
+  const availableActivePlatforms = platforms.filter(
+    (platform) => !inactivePlatforms.includes(platform),
+  );
+  const activePlatforms =
+    availableActivePlatforms.length > 0
+      ? availableActivePlatforms
+      : platforms.slice(0, 1);
   const chartConfig = useMemo(
     () =>
       Object.fromEntries(
@@ -80,15 +107,18 @@ export function PlatformTimeSeriesChart({
 
   const isEmpty = !data || data.length === 0;
 
-  const togglePlatform = (platform: keyof typeof PLATFORM_COLORS) => {
-    setActivePlatforms((previousPlatforms) => {
-      if (!previousPlatforms.includes(platform)) {
-        return [...previousPlatforms, platform];
-      }
+  const togglePlatform = (platform: Platform) => {
+    const nextInactivePlatforms = inactivePlatforms.includes(platform)
+      ? inactivePlatforms.filter(
+          (inactivePlatform) => inactivePlatform !== platform,
+        )
+      : activePlatforms.length > 1
+        ? [...inactivePlatforms, platform]
+        : inactivePlatforms;
 
-      return previousPlatforms.length > 1
-        ? previousPlatforms.filter((p) => p !== platform)
-        : previousPlatforms;
+    setSelectionOverride({
+      sourcePlatforms: [...platforms],
+      inactivePlatforms: nextInactivePlatforms,
     });
   };
 

--- a/packages/ui/src/components/modals/ingredients/music/ModalMusic.test.tsx
+++ b/packages/ui/src/components/modals/ingredients/music/ModalMusic.test.tsx
@@ -1,23 +1,30 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import ModalMusic from '@ui/modals/ingredients/music/ModalMusic';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  closeModal: vi.fn(),
+  findAll: vi.fn(),
+}));
 
 // Mock dependencies
 vi.mock('@ui/modals/modal/Modal', () => ({
-  default: ({ children }: any) => <div data-testid="modal">{children}</div>,
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="modal">{children}</div>
+  ),
 }));
 
 vi.mock('@genfeedai/hooks/auth/use-authed-service/use-authed-service', () => ({
   useAuthedService: () =>
     vi.fn(() =>
       Promise.resolve({
-        findAll: vi.fn(() => Promise.resolve([])),
+        findAll: mocks.findAll,
       }),
     ),
 }));
 
 vi.mock('@genfeedai/helpers/ui/modal/modal.helper', () => ({
-  closeModal: vi.fn(),
+  closeModal: mocks.closeModal,
 }));
 
 vi.mock('@genfeedai/services/core/logger.service', () => ({
@@ -32,8 +39,49 @@ describe('ModalMusic', () => {
     selectedMusicId: '',
   };
 
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.findAll.mockResolvedValue([]);
+  });
+
   it('renders music selection modal', () => {
     render(<ModalMusic {...defaultProps} />);
     expect(screen.getByTestId('modal')).toBeInTheDocument();
+  });
+
+  it('reflects parent selection changes without remounting', async () => {
+    const { rerender } = render(
+      <ModalMusic {...defaultProps} selectedMusicId="music-1" />,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Use Selected Music' }),
+    ).toBeInTheDocument();
+
+    rerender(<ModalMusic {...defaultProps} selectedMusicId="" />);
+
+    expect(
+      screen.getByRole('button', { name: 'Continue Without Music' }),
+    ).toBeInTheDocument();
+    await waitFor(() => expect(mocks.findAll).toHaveBeenCalled());
+  });
+
+  it('confirms a user-selected track exactly once', async () => {
+    const music = {
+      id: 'music-1',
+      ingredientUrl: 'https://example.com/music.mp3',
+      metadata: { label: 'Focus Track' },
+      metadataDuration: 120,
+    };
+    const onConfirm = vi.fn();
+    mocks.findAll.mockResolvedValue([music]);
+
+    render(<ModalMusic {...defaultProps} onConfirm={onConfirm} />);
+
+    fireEvent.click(await screen.findByRole('button', { name: /Focus Track/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'Use Selected Music' }));
+
+    expect(onConfirm).toHaveBeenCalledOnce();
+    expect(onConfirm).toHaveBeenCalledWith(music);
   });
 });

--- a/packages/ui/src/components/modals/ingredients/music/ModalMusic.tsx
+++ b/packages/ui/src/components/modals/ingredients/music/ModalMusic.tsx
@@ -21,16 +21,26 @@ import { Button } from '@ui/primitives/button';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { HiMusicalNote, HiPause, HiPlay, HiXMark } from 'react-icons/hi2';
 
+interface MusicSelectionOverride {
+  sourceId: string;
+  value: string;
+}
+
 export default function ModalMusic({
   brandId,
   selectedMusicId,
   onConfirm,
 }: ModalMusicProps) {
-  const [selectedMusic, setSelectedMusic] = useState<string>(selectedMusicId);
+  const [selectionOverride, setSelectionOverride] =
+    useState<MusicSelectionOverride | null>(null);
   const [availableMusic, setAvailableMusic] = useState<Music[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [playingId, setPlayingId] = useState<string>('');
   const audioElementRef = useRef<HTMLAudioElement | null>(null);
+  const selectedMusic =
+    selectionOverride?.sourceId === selectedMusicId
+      ? selectionOverride.value
+      : selectedMusicId;
 
   const getMusicsService = useAuthedService((token: string) =>
     MusicsService.getInstance(token),
@@ -97,6 +107,7 @@ export default function ModalMusic({
     if (audioElementRef.current) {
       audioElementRef.current.pause();
     }
+    setSelectionOverride(null);
     closeModal(ModalEnum.MUSIC);
   };
 
@@ -115,7 +126,7 @@ export default function ModalMusic({
   };
 
   const handleClearSelection = () => {
-    setSelectedMusic('');
+    setSelectionOverride({ sourceId: selectedMusicId, value: '' });
   };
 
   return (
@@ -166,7 +177,12 @@ export default function ModalMusic({
                     <div className="flex items-center gap-3">
                       <Button
                         className="flex min-w-0 flex-1 items-center gap-3 text-left"
-                        onClick={() => setSelectedMusic(music.id)}
+                        onClick={() =>
+                          setSelectionOverride({
+                            sourceId: selectedMusicId,
+                            value: music.id,
+                          })
+                        }
                         type="button"
                         variant={ButtonVariant.UNSTYLED}
                         withWrapper={false}

--- a/packages/ui/src/primitives/color-picker.test.tsx
+++ b/packages/ui/src/primitives/color-picker.test.tsx
@@ -1,0 +1,51 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import ColorPicker from '@ui/primitives/color-picker';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-color', () => ({
+  SketchPicker: ({
+    color,
+    onChange,
+  }: {
+    color: string;
+    onChange: (result: { hex: string }) => void;
+  }) => (
+    <button
+      data-color={color}
+      onClick={() => onChange({ hex: '#abcdef' })}
+      type="button"
+    >
+      Choose test color
+    </button>
+  ),
+}));
+
+describe('ColorPicker', () => {
+  it('reflects parent color changes without remounting', () => {
+    const { rerender } = render(<ColorPicker value="#111111" />);
+
+    rerender(<ColorPicker value="#222222" />);
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Select color, current: #222222',
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('#222222')).toBeInTheDocument();
+  });
+
+  it('emits a user-selected color exactly once', () => {
+    const onChange = vi.fn();
+    render(<ColorPicker value="#111111" onChange={onChange} />);
+
+    fireEvent.click(
+      screen.getByRole('button', {
+        name: 'Select color, current: #111111',
+      }),
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Choose test color' }));
+
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(onChange).toHaveBeenCalledWith('#abcdef');
+  });
+});

--- a/packages/ui/src/primitives/color-picker.tsx
+++ b/packages/ui/src/primitives/color-picker.tsx
@@ -76,7 +76,6 @@ export default function ColorPicker({
   presetColors,
 }: ColorPickerProps) {
   const [displayColorPicker, setDisplayColorPicker] = useState(false);
-  const [color, setColor] = useState(value);
 
   const resolvedPresetColors = useMemo(() => {
     if (presetColors && presetColors.length > 0) {
@@ -100,7 +99,6 @@ export default function ColorPicker({
 
   const updateColorPicker = (colorResult: ColorResult) => {
     const nextColor = showAlpha ? colorResult.hex : colorResult.hex;
-    setColor(nextColor);
     onChange(nextColor);
   };
 
@@ -114,15 +112,15 @@ export default function ColorPicker({
             onClick={activateColorPicker}
             isDisabled={isDisabled}
             className="h-10 w-full flex items-center gap-2"
-            ariaLabel={`Select color, current: ${color}`}
+            ariaLabel={`Select color, current: ${value}`}
             aria-expanded={displayColorPicker}
           >
             <div
               className="size-8 border border-white/[0.08]"
-              style={{ backgroundColor: color }}
+              style={{ backgroundColor: value }}
               aria-hidden="true"
             />
-            <span className="flex-1 text-left">{color}</span>
+            <span className="flex-1 text-left">{value}</span>
           </Button>
 
           {displayColorPicker && (
@@ -138,7 +136,7 @@ export default function ColorPicker({
                 className={`absolute z-20 mt-2 ${position === 'right' ? 'right-0' : 'left-0'}`}
               >
                 <SketchPicker
-                  color={color}
+                  color={value}
                   onChange={updateColorPicker}
                   disableAlpha={!showAlpha}
                   presetColors={resolvedPresetColors}

--- a/packages/ui/src/primitives/tags-editable.test.tsx
+++ b/packages/ui/src/primitives/tags-editable.test.tsx
@@ -1,0 +1,31 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import TagsEditable from '@ui/primitives/tags-editable';
+import { describe, expect, it, vi } from 'vitest';
+
+describe('TagsEditable', () => {
+  it('reflects parent tag changes without remounting', () => {
+    const { rerender } = render(
+      <TagsEditable label="Topics" value={['alpha']} />,
+    );
+
+    rerender(<TagsEditable label="Topics" value={['beta']} />);
+
+    expect(screen.getByText('beta')).toBeInTheDocument();
+    expect(screen.queryByText('alpha')).not.toBeInTheDocument();
+  });
+
+  it('saves a user-added tag exactly once', () => {
+    const onSave = vi.fn();
+    render(<TagsEditable label="Topics" value={['alpha']} onSave={onSave} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit tags' }));
+    fireEvent.change(screen.getByRole('textbox', { name: 'Add tag' }), {
+      target: { value: 'beta' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Add tag' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save tags' }));
+
+    expect(onSave).toHaveBeenCalledOnce();
+    expect(onSave).toHaveBeenCalledWith(['alpha', 'beta']);
+  });
+});

--- a/packages/ui/src/primitives/tags-editable.tsx
+++ b/packages/ui/src/primitives/tags-editable.tsx
@@ -3,8 +3,21 @@ import { type KeyboardEvent, useEffect, useRef, useState } from 'react';
 import { HiCheck, HiPencil, HiPlus, HiXMark } from 'react-icons/hi2';
 import { Badge } from './badge';
 import { Button } from './button';
+import { Input } from './input';
 
 const EMPTY_ARRAY: never[] = [];
+
+interface TagsDraft {
+  sourceValue: string[];
+  tags: string[];
+}
+
+function areTagsEqual(left: string[], right: string[]) {
+  return (
+    left.length === right.length &&
+    left.every((tag, index) => tag === right[index])
+  );
+}
 
 export interface TagsEditableProps {
   label: string;
@@ -25,10 +38,13 @@ export default function TagsEditable({
   maxTags = 10,
   className = '',
 }: TagsEditableProps) {
-  const [isEditing, setIsEditing] = useState(false);
-  const [tags, setTags] = useState<string[]>(value);
+  const [draft, setDraft] = useState<TagsDraft | null>(null);
   const [inputValue, setInputValue] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
+  const activeDraft =
+    draft && areTagsEqual(draft.sourceValue, value) ? draft : null;
+  const isEditing = activeDraft !== null;
+  const tags = activeDraft?.tags ?? value;
 
   useEffect(() => {
     if (isEditing) {
@@ -40,30 +56,41 @@ export default function TagsEditable({
   }, [isEditing]);
 
   const handleSave = () => {
-    if (onSave && JSON.stringify(tags) !== JSON.stringify(value)) {
+    if (onSave && !areTagsEqual(tags, value)) {
       onSave(tags);
     }
-    setIsEditing(false);
+    setDraft(null);
     setInputValue('');
   };
 
   const handleCancel = () => {
-    setTags(value);
-    setIsEditing(false);
+    setDraft(null);
     setInputValue('');
   };
 
   const handleAddTag = () => {
     const trimmedValue = inputValue.trim();
     if (trimmedValue && !tags.includes(trimmedValue) && tags.length < maxTags) {
-      setTags((previousTags) => [...previousTags, trimmedValue]);
+      setDraft((previousDraft) =>
+        previousDraft
+          ? {
+              ...previousDraft,
+              tags: [...previousDraft.tags, trimmedValue],
+            }
+          : previousDraft,
+      );
       setInputValue('');
     }
   };
 
   const handleRemoveTag = (tagToRemove: string) => {
-    setTags((previousTags) =>
-      previousTags.filter((tag) => tag !== tagToRemove),
+    setDraft((previousDraft) =>
+      previousDraft
+        ? {
+            ...previousDraft,
+            tags: previousDraft.tags.filter((tag) => tag !== tagToRemove),
+          }
+        : previousDraft,
     );
   };
 
@@ -84,7 +111,7 @@ export default function TagsEditable({
           <Button
             withWrapper={false}
             variant={ButtonVariant.UNSTYLED}
-            onClick={() => setIsEditing(true)}
+            onClick={() => setDraft({ sourceValue: value, tags: value })}
             className="h-6 px-2 inline-flex items-center justify-center hover:bg-accent hover:text-accent-foreground"
             ariaLabel="Edit tags"
           >
@@ -114,16 +141,16 @@ export default function TagsEditable({
 
           {tags.length < maxTags && (
             <div className="flex gap-2">
-              <input
+              <Input
                 aria-label="Add tag"
-                ref={inputRef}
+                inputRef={inputRef}
                 type="text"
                 value={inputValue}
                 onChange={(event) => setInputValue(event.target.value)}
                 onKeyDown={handleKeyDown}
                 placeholder={placeholder}
                 className="h-8 text-sm border border-input px-3 flex-1"
-                disabled={isDisabled}
+                isDisabled={isDisabled}
               />
 
               <Button


### PR DESCRIPTION
## Summary
- keep platform availability, music selection, color, and tags synchronized with parent updates
- preserve interaction-owned drafts without effect-driven prop mirroring
- add focused parent-rerender and callback regression coverage

## Verification
- `bunx @biomejs/biome@2.5.3 check <8 touched files>` — passed
- `bun run design:lint` — 0 errors (9 existing unused-token warnings)
- `bunx react-doctor@0.5.6 packages/ui --blocking error --diff false --verbose` — all four targeted `no-derived-useState` diagnostics absent
- `bun run scripts/run-secretlint.ts <8 touched files>` — passed
- Local tests, typecheck, and builds were skipped under the repository machine policy; PR CI is the execution gate.

Closes #1958
Parent: #338
