### PR TITLE
fix(webhooks): use queue-safe publish event ids

### DIFF
--- a/apps/server/api/src/services/webhook-client/publish-event-webhook.service.spec.ts
+++ b/apps/server/api/src/services/webhook-client/publish-event-webhook.service.spec.ts
@@ -93,8 +93,9 @@ describe('PublishEventWebhookService', () => {
       schemaVersion: 1,
     });
     expect(queue.add.mock.calls[0][2]).toMatchObject({
-      jobId: 'publish:target.published:post_123:post_123:published',
+      jobId: expect.stringMatching(/^publish-webhook-[0-9a-f]{64}$/),
     });
+    expect(queue.add.mock.calls[0][2]?.jobId).not.toContain(':');
     expect(settingsService.recordWebhookDeliveryStatus).toHaveBeenCalledWith(
       'org_123',
       expect.objectContaining({
@@ -130,12 +131,13 @@ describe('PublishEventWebhookService', () => {
     await service.emitLegacyPostFailed(input);
 
     expect(queue.add).toHaveBeenCalledTimes(4);
-    expect(queue.add.mock.calls.map((call) => call[2]?.jobId)).toEqual([
-      'publish:target.failed:post_123:post_123:failed',
-      'publish:release.failed:post_123:release:failed',
-      'publish:target.failed:post_123:post_123:failed',
-      'publish:release.failed:post_123:release:failed',
-    ]);
+    const jobIds = queue.add.mock.calls.map((call) => call[2]?.jobId);
+    expect(jobIds[0]).toMatch(/^publish-webhook-[0-9a-f]{64}$/);
+    expect(jobIds[1]).toMatch(/^publish-webhook-[0-9a-f]{64}$/);
+    expect(jobIds[0]).toBe(jobIds[2]);
+    expect(jobIds[1]).toBe(jobIds[3]);
+    expect(new Set(jobIds).size).toBe(2);
+    expect(jobIds.every((jobId) => !jobId?.includes(':'))).toBe(true);
 
     for (const call of queue.add.mock.calls) {
       expect(call[2]).toMatchObject({
@@ -370,8 +372,11 @@ describe('PublishEventWebhookService', () => {
           release: expect.objectContaining({ id: 'release_test' }),
         }),
       }),
-      { jobId: status.deliveryId },
+      {
+        jobId: expect.stringMatching(/^publish-webhook-[0-9a-f]{64}$/),
+      },
     );
+    expect(queue.add.mock.calls[0][2]?.jobId).not.toContain(':');
     expect(settingsService.recordWebhookDeliveryStatus).toHaveBeenCalledWith(
       'org_123',
       expect.objectContaining({

--- a/apps/server/api/src/services/webhook-client/publish-event-webhook.service.ts
+++ b/apps/server/api/src/services/webhook-client/publish-event-webhook.service.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import { OrganizationSettingsService } from '@api/collections/organization-settings/services/organization-settings.service';
 import { PostsService } from '@api/collections/posts/services/posts.service';
 import { customLabels } from '@api/helpers/utils/pagination/pagination.util';
@@ -71,6 +72,7 @@ type TerminalTargetResolution =
 
 const PUBLISH_WEBHOOK_DEDUPE_RETENTION_SECONDS = 24 * 60 * 60;
 const PUBLISH_WEBHOOK_FAILED_RETENTION_SECONDS = 7 * 24 * 60 * 60;
+const PUBLISH_WEBHOOK_JOB_ID_PREFIX = 'publish-webhook-';
 
 @Injectable()
 export class PublishEventWebhookService {
@@ -475,11 +477,11 @@ export class PublishEventWebhookService {
       'send-webhook',
       jobData,
       options.isTest
-        ? { jobId: deliveryId }
+        ? { jobId: createPublishWebhookJobId(deliveryId) }
         : {
             // Retried publish workers must resolve to the same BullMQ jobId long
             // enough to suppress duplicate terminal events.
-            jobId: payload.eventId,
+            jobId: createPublishWebhookJobId(payload.eventId),
             removeOnComplete: {
               age: PUBLISH_WEBHOOK_DEDUPE_RETENTION_SECONDS,
               count: 10_000,
@@ -512,6 +514,12 @@ export class PublishEventWebhookService {
 
     return status;
   }
+}
+
+function createPublishWebhookJobId(eventId: string): string {
+  return `${PUBLISH_WEBHOOK_JOB_ID_PREFIX}${createHash('sha256')
+    .update(eventId)
+    .digest('hex')}`;
 }
 
 function readWebhookEventTypes(value: unknown): PublishWebhookEventType[] {


### PR DESCRIPTION
## Summary

- keep the public colon-delimited publish `eventId` contract unchanged
- derive deterministic SHA-256 BullMQ job IDs that contain no reserved `:` separator
- preserve target/release retry deduplication and cover test-delivery job IDs

## Verification

- `bunx @biomejs/biome@2.5.3 check --write <2 touched files>` — passed; no fixes needed
- `bunx @biomejs/biome@2.5.3 check <2 touched files>` — passed
- `git diff --cached --check` — passed
- `bun run scripts/run-secretlint.ts <2 touched files>` — passed
- staged sensitive-filename and credential-pattern scan — passed
- local tests, typecheck, and builds were skipped under the repository workstation policy; PR CI is the execution gate

## Scope

This closes the queue-emission defect in the already-landed publish webhook contract. Endpoint filtering, delivery history, retries, and documentation remain unchanged.

Closes #1960
Parent: #1169