### PR TITLE
chore(lint): ratchet agent-goals unused imports

### DIFF
--- a/apps/server/api/src/collections/agent-goals/services/agent-goals.service.ts
+++ b/apps/server/api/src/collections/agent-goals/services/agent-goals.service.ts
@@ -2,7 +2,6 @@ import { CreateAgentGoalDto } from '@api/collections/agent-goals/dto/create-agen
 import { UpdateAgentGoalDto } from '@api/collections/agent-goals/dto/update-agent-goal.dto';
 import type { AgentGoalMetric } from '@api/collections/agent-goals/schemas/agent-goal.schema';
 import { AnalyticsService } from '@api/endpoints/analytics/analytics.service';
-import { NotFoundException } from '@api/helpers/exceptions/http/not-found.exception';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import {
   findOrThrow,

--- a/biome.json
+++ b/biome.json
@@ -127,6 +127,16 @@
       }
     },
     {
+      "includes": ["apps/server/api/src/collections/agent-goals/**/*.ts"],
+      "linter": {
+        "rules": {
+          "correctness": {
+            "noUnusedImports": "error"
+          }
+        }
+      }
+    },
+    {
       "includes": [
         "ee/packages/**/*.{controller,service,module,resolver,guard,interceptor,pipe,middleware,filter}.ts"
       ],


### PR DESCRIPTION
## Summary

- remove the sole unused import from the `agent-goals` collection
- ratchet `correctness.noUnusedImports` to `error` for that collection
- preserve runtime, API, serializer, and persistence behavior

## Verification

- `bunx @biomejs/biome@2.5.3 check biome.json apps/server/api/src/collections/agent-goals` — passed (6 files, no diagnostics; 2 pre-existing config infos)
- Red/green ratchet proof — temporarily restoring the unused import failed Biome with `lint/correctness/noUnusedImports`, then the clean state passed
- `jq empty biome.json` — passed
- `git diff --check` — passed

## Skipped locally

- Tests, typechecks, and builds were not run locally per repository machine policy; PR CI is the broad validation gate.
- The bundled Biome validator script is unreliable here because it strips `//` inside the `$schema` HTTPS URL and reports valid JSON as invalid.

## Residual risk

- Limited to Biome override precedence; direct red/green verification confirms the intended path-level severity.

Closes #1964