### PR TITLE
feat(api-types): add bounded evergreen recurrence preview

### DIFF
--- a/packages/api-types/__tests__/recurrence-preview.contract.test.ts
+++ b/packages/api-types/__tests__/recurrence-preview.contract.test.ts
@@ -188,6 +188,25 @@ describe('recurrence preview contract', () => {
     });
   });
 
+  test('does not validate occurrences beyond the requested preview limit', () => {
+    const result = previewRecurrenceOccurrences({
+      limit: 1,
+      recurrence: {
+        frequency: PostFrequency.DAILY,
+        interval: 1,
+        maxRepeats: 3,
+      },
+      startAt: '2026-03-06T07:30:00.000Z',
+      timezone: 'America/New_York',
+    });
+
+    expect(result).toEqual({
+      isExhausted: false,
+      occurrences: ['2026-03-07T07:30:00.000Z'],
+      success: true,
+    });
+  });
+
   test('applies schema defaults deterministically', () => {
     const parsed = recurrencePreviewInputSchema.parse({
       recurrence: {

--- a/packages/api-types/__tests__/recurrence-preview.contract.test.ts
+++ b/packages/api-types/__tests__/recurrence-preview.contract.test.ts
@@ -18,7 +18,7 @@ describe('recurrence preview contract', () => {
     });
 
     expect(result).toEqual({
-      exhausted: true,
+      isExhausted: true,
       occurrences: [
         '2026-01-03T14:00:00.000Z',
         '2026-01-05T14:00:00.000Z',
@@ -41,7 +41,7 @@ describe('recurrence preview contract', () => {
     });
 
     expect(result).toEqual({
-      exhausted: true,
+      isExhausted: true,
       occurrences: [
         '2026-08-05T07:00:00.000Z',
         '2026-08-07T07:00:00.000Z',
@@ -63,7 +63,7 @@ describe('recurrence preview contract', () => {
     });
 
     expect(result).toEqual({
-      exhausted: true,
+      isExhausted: true,
       occurrences: [
         '2026-03-07T14:00:00.000Z',
         '2026-03-08T13:00:00.000Z',
@@ -85,7 +85,7 @@ describe('recurrence preview contract', () => {
     });
 
     expect(result).toEqual({
-      exhausted: true,
+      isExhausted: true,
       occurrences: ['2026-01-02T09:00:00.000Z', '2026-01-03T09:00:00.000Z'],
       success: true,
     });
@@ -104,7 +104,7 @@ describe('recurrence preview contract', () => {
     });
 
     expect(result).toEqual({
-      exhausted: true,
+      isExhausted: true,
       occurrences: [],
       success: true,
     });
@@ -147,6 +147,28 @@ describe('recurrence preview contract', () => {
     });
   });
 
+  test('returns a typed failure for a missing DST local time', () => {
+    const result = previewRecurrenceOccurrences({
+      recurrence: {
+        frequency: PostFrequency.DAILY,
+        interval: 1,
+        maxRepeats: 1,
+      },
+      startAt: '2026-03-07T07:30:00.000Z',
+      timezone: 'America/New_York',
+    });
+
+    expect(result).toEqual({
+      issues: [
+        {
+          code: 'invalid_local_time',
+          message: 'A recurrence occurrence falls in a missing local time.',
+        },
+      ],
+      success: false,
+    });
+  });
+
   test('caps previews without claiming the finite recurrence is exhausted', () => {
     const result = previewRecurrenceOccurrences({
       limit: 2,
@@ -160,7 +182,7 @@ describe('recurrence preview contract', () => {
     });
 
     expect(result).toEqual({
-      exhausted: false,
+      isExhausted: false,
       occurrences: ['2026-01-02T09:00:00.000Z', '2026-01-03T09:00:00.000Z'],
       success: true,
     });

--- a/packages/api-types/__tests__/recurrence-preview.contract.test.ts
+++ b/packages/api-types/__tests__/recurrence-preview.contract.test.ts
@@ -1,0 +1,189 @@
+import {
+  previewRecurrenceOccurrences,
+  recurrencePreviewInputSchema,
+} from '@api-types/contracts/recurrence-preview.contract';
+import { PostFrequency } from '@genfeedai/enums';
+import { describe, expect, test } from 'vitest';
+
+describe('recurrence preview contract', () => {
+  test('expands daily intervals and stops at the repeat cap', () => {
+    const result = previewRecurrenceOccurrences({
+      recurrence: {
+        frequency: PostFrequency.DAILY,
+        interval: 2,
+        maxRepeats: 3,
+      },
+      startAt: '2026-01-01T14:00:00.000Z',
+      timezone: 'America/New_York',
+    });
+
+    expect(result).toEqual({
+      exhausted: true,
+      occurrences: [
+        '2026-01-03T14:00:00.000Z',
+        '2026-01-05T14:00:00.000Z',
+        '2026-01-07T14:00:00.000Z',
+      ],
+      success: true,
+    });
+  });
+
+  test('expands selected weekdays only in active weekly intervals', () => {
+    const result = previewRecurrenceOccurrences({
+      recurrence: {
+        frequency: PostFrequency.WEEKLY,
+        interval: 2,
+        maxRepeats: 3,
+        weekdays: [1, 3, 5],
+      },
+      startAt: '2026-08-03T07:00:00.000Z',
+      timezone: 'Europe/Amsterdam',
+    });
+
+    expect(result).toEqual({
+      exhausted: true,
+      occurrences: [
+        '2026-08-05T07:00:00.000Z',
+        '2026-08-07T07:00:00.000Z',
+        '2026-08-17T07:00:00.000Z',
+      ],
+      success: true,
+    });
+  });
+
+  test('preserves local wall-clock time across daylight-saving changes', () => {
+    const result = previewRecurrenceOccurrences({
+      recurrence: {
+        frequency: PostFrequency.DAILY,
+        interval: 1,
+        maxRepeats: 3,
+      },
+      startAt: '2026-03-06T14:00:00.000Z',
+      timezone: 'America/New_York',
+    });
+
+    expect(result).toEqual({
+      exhausted: true,
+      occurrences: [
+        '2026-03-07T14:00:00.000Z',
+        '2026-03-08T13:00:00.000Z',
+        '2026-03-09T13:00:00.000Z',
+      ],
+      success: true,
+    });
+  });
+
+  test('stops at an inclusive end date', () => {
+    const result = previewRecurrenceOccurrences({
+      recurrence: {
+        endDate: '2026-01-03T09:00:00.000Z',
+        frequency: PostFrequency.DAILY,
+        interval: 1,
+      },
+      startAt: '2026-01-01T09:00:00.000Z',
+      timezone: 'UTC',
+    });
+
+    expect(result).toEqual({
+      exhausted: true,
+      occurrences: [
+        '2026-01-02T09:00:00.000Z',
+        '2026-01-03T09:00:00.000Z',
+      ],
+      success: true,
+    });
+  });
+
+  test('returns no occurrences when a repeat cap is already exhausted', () => {
+    const result = previewRecurrenceOccurrences({
+      recurrence: {
+        frequency: PostFrequency.MONTHLY,
+        interval: 1,
+        maxRepeats: 2,
+      },
+      repeatCount: 2,
+      startAt: '2026-01-31T09:00:00.000Z',
+      timezone: 'UTC',
+    });
+
+    expect(result).toEqual({
+      exhausted: true,
+      occurrences: [],
+      success: true,
+    });
+  });
+
+  test('returns typed failures for invalid input and IANA timezones', () => {
+    const invalidRule = previewRecurrenceOccurrences({
+      recurrence: {
+        frequency: PostFrequency.WEEKLY,
+        interval: 1,
+        maxRepeats: 2,
+        weekdays: [],
+      },
+      startAt: '2026-01-01T09:00:00.000Z',
+      timezone: 'UTC',
+    });
+    const invalidTimezone = previewRecurrenceOccurrences({
+      recurrence: {
+        frequency: PostFrequency.DAILY,
+        interval: 1,
+        maxRepeats: 2,
+      },
+      startAt: '2026-01-01T09:00:00.000Z',
+      timezone: 'Mars/Olympus_Mons',
+    });
+
+    expect(invalidRule).toMatchObject({
+      issues: [{ code: 'invalid_input', path: 'recurrence.weekdays' }],
+      success: false,
+    });
+    expect(invalidTimezone).toEqual({
+      issues: [
+        {
+          code: 'invalid_timezone',
+          message: 'Invalid IANA timezone: Mars/Olympus_Mons',
+          path: 'timezone',
+        },
+      ],
+      success: false,
+    });
+  });
+
+  test('caps previews without claiming the finite recurrence is exhausted', () => {
+    const result = previewRecurrenceOccurrences({
+      limit: 2,
+      recurrence: {
+        frequency: PostFrequency.DAILY,
+        interval: 1,
+        maxRepeats: 4,
+      },
+      startAt: '2026-01-01T09:00:00.000Z',
+      timezone: 'UTC',
+    });
+
+    expect(result).toEqual({
+      exhausted: false,
+      occurrences: [
+        '2026-01-02T09:00:00.000Z',
+        '2026-01-03T09:00:00.000Z',
+      ],
+      success: true,
+    });
+  });
+
+  test('applies schema defaults deterministically', () => {
+    const parsed = recurrencePreviewInputSchema.parse({
+      recurrence: {
+        frequency: PostFrequency.YEARLY,
+        interval: 1,
+        maxRepeats: 1,
+      },
+      startAt: '2026-01-01T09:00:00.000Z',
+      timezone: 'UTC',
+    });
+
+    expect(parsed.limit).toBe(100);
+    expect(parsed.repeatCount).toBe(0);
+  });
+});

--- a/packages/api-types/__tests__/recurrence-preview.contract.test.ts
+++ b/packages/api-types/__tests__/recurrence-preview.contract.test.ts
@@ -86,10 +86,7 @@ describe('recurrence preview contract', () => {
 
     expect(result).toEqual({
       exhausted: true,
-      occurrences: [
-        '2026-01-02T09:00:00.000Z',
-        '2026-01-03T09:00:00.000Z',
-      ],
+      occurrences: ['2026-01-02T09:00:00.000Z', '2026-01-03T09:00:00.000Z'],
       success: true,
     });
   });
@@ -164,10 +161,7 @@ describe('recurrence preview contract', () => {
 
     expect(result).toEqual({
       exhausted: false,
-      occurrences: [
-        '2026-01-02T09:00:00.000Z',
-        '2026-01-03T09:00:00.000Z',
-      ],
+      occurrences: ['2026-01-02T09:00:00.000Z', '2026-01-03T09:00:00.000Z'],
       success: true,
     });
   });

--- a/packages/api-types/__tests__/scheduler.contract.test.ts
+++ b/packages/api-types/__tests__/scheduler.contract.test.ts
@@ -50,6 +50,7 @@ describe('createReleaseGroupSchema', () => {
       recurrence: {
         frequency: PostFrequency.WEEKLY,
         interval: 1,
+        maxRepeats: 12,
         weekdays: [1, 3, 5],
       },
       status: ReleaseStatus.SCHEDULED,
@@ -112,6 +113,59 @@ describe('recurrenceInputSchema', () => {
       frequency: PostFrequency.WEEKLY,
       interval: 1,
       weekdays: [7],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('requires a finite max-repeat or end-date boundary', () => {
+    const result = recurrenceInputSchema.safeParse({
+      frequency: PostFrequency.DAILY,
+      interval: 1,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects a zero repeat cap', () => {
+    const result = recurrenceInputSchema.safeParse({
+      frequency: PostFrequency.DAILY,
+      interval: 1,
+      maxRepeats: 0,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('requires at least one unique weekday for weekly recurrence', () => {
+    const missingWeekdays = recurrenceInputSchema.safeParse({
+      frequency: PostFrequency.WEEKLY,
+      interval: 1,
+      maxRepeats: 3,
+    });
+    const duplicateWeekdays = recurrenceInputSchema.safeParse({
+      frequency: PostFrequency.WEEKLY,
+      interval: 1,
+      maxRepeats: 3,
+      weekdays: [1, 1],
+    });
+
+    expect(missingWeekdays.success).toBe(false);
+    expect(duplicateWeekdays.success).toBe(false);
+  });
+
+  test('rejects weekdays for non-weekly recurrence', () => {
+    const result = recurrenceInputSchema.safeParse({
+      frequency: PostFrequency.DAILY,
+      interval: 1,
+      maxRepeats: 3,
+      weekdays: [1],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects never as a recurrence frequency', () => {
+    const result = recurrenceInputSchema.safeParse({
+      frequency: PostFrequency.NEVER,
+      interval: 1,
+      maxRepeats: 3,
     });
     expect(result.success).toBe(false);
   });

--- a/packages/api-types/src/contracts/index.ts
+++ b/packages/api-types/src/contracts/index.ts
@@ -15,4 +15,5 @@ export * from './posts.contract';
 export * from './publish-approval.contract';
 export * from './publish-webhook-events.contract';
 export * from './publishing-readiness.contract';
+export * from './recurrence-preview.contract';
 export * from './scheduler.contract';

--- a/packages/api-types/src/contracts/recurrence-preview.contract.ts
+++ b/packages/api-types/src/contracts/recurrence-preview.contract.ts
@@ -1,0 +1,400 @@
+/**
+ * Deterministic, side-effect-free recurrence previews.
+ *
+ * The owning release supplies the initial scheduled instant and IANA timezone.
+ * Returned occurrences are repeats after that instant; the original scheduled
+ * release is not included. Calendar arithmetic happens in the owning timezone
+ * so the local wall-clock time remains stable when the UTC offset changes.
+ */
+
+import { PostFrequency } from '@genfeedai/enums';
+import { z } from 'zod';
+import { nonNegativeIntSchema, timezoneSchema } from '../helpers/common-schemas';
+import { recurrenceInputSchema } from './scheduler.contract';
+
+export const DEFAULT_RECURRENCE_PREVIEW_LIMIT = 100;
+export const MAX_RECURRENCE_PREVIEW_LIMIT = 500;
+
+const absoluteDateTimeSchema = z.string().datetime({ offset: true });
+
+export const recurrencePreviewInputSchema = z
+  .object({
+    limit: z
+      .number()
+      .int()
+      .positive()
+      .max(MAX_RECURRENCE_PREVIEW_LIMIT)
+      .default(DEFAULT_RECURRENCE_PREVIEW_LIMIT),
+    recurrence: recurrenceInputSchema,
+    repeatCount: nonNegativeIntSchema.default(0),
+    startAt: absoluteDateTimeSchema,
+    timezone: timezoneSchema,
+  })
+  .superRefine((input, context) => {
+    if (
+      input.recurrence.endDate &&
+      !absoluteDateTimeSchema.safeParse(input.recurrence.endDate).success
+    ) {
+      context.addIssue({
+        code: 'custom',
+        message: 'Recurrence preview endDate requires a timezone offset.',
+        path: ['recurrence', 'endDate'],
+      });
+    }
+  });
+
+export type RecurrencePreviewInput = z.input<
+  typeof recurrencePreviewInputSchema
+>;
+
+export interface RecurrencePreviewValidationIssue {
+  code: 'invalid_input' | 'invalid_local_time' | 'invalid_timezone';
+  message: string;
+  path?: string;
+}
+
+export type RecurrencePreviewResult =
+  | {
+      exhausted: boolean;
+      occurrences: string[];
+      success: true;
+    }
+  | {
+      issues: RecurrencePreviewValidationIssue[];
+      success: false;
+    };
+
+interface LocalDateTime {
+  day: number;
+  hour: number;
+  millisecond: number;
+  minute: number;
+  month: number;
+  second: number;
+  year: number;
+}
+
+const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1_000;
+
+function createFormatter(timezone: string): Intl.DateTimeFormat {
+  return new Intl.DateTimeFormat('en-US-u-ca-gregory-nu-latn', {
+    day: '2-digit',
+    hour: '2-digit',
+    hourCycle: 'h23',
+    minute: '2-digit',
+    month: '2-digit',
+    second: '2-digit',
+    timeZone: timezone,
+    year: 'numeric',
+  });
+}
+
+function readLocalDateTime(
+  formatter: Intl.DateTimeFormat,
+  instant: Date,
+): LocalDateTime {
+  const parts = new Map(
+    formatter
+      .formatToParts(instant)
+      .filter((part) => part.type !== 'literal')
+      .map((part) => [part.type, Number.parseInt(part.value, 10)]),
+  );
+
+  return {
+    day: parts.get('day') ?? 0,
+    hour: parts.get('hour') ?? 0,
+    millisecond: instant.getUTCMilliseconds(),
+    minute: parts.get('minute') ?? 0,
+    month: parts.get('month') ?? 0,
+    second: parts.get('second') ?? 0,
+    year: parts.get('year') ?? 0,
+  };
+}
+
+function localDateTimeValue(local: LocalDateTime): number {
+  return Date.UTC(
+    local.year,
+    local.month - 1,
+    local.day,
+    local.hour,
+    local.minute,
+    local.second,
+    local.millisecond,
+  );
+}
+
+function matchesLocalDateTime(
+  actual: LocalDateTime,
+  expected: LocalDateTime,
+): boolean {
+  return (
+    actual.year === expected.year &&
+    actual.month === expected.month &&
+    actual.day === expected.day &&
+    actual.hour === expected.hour &&
+    actual.minute === expected.minute &&
+    actual.second === expected.second &&
+    actual.millisecond === expected.millisecond
+  );
+}
+
+function localDateTimeToInstant(
+  local: LocalDateTime,
+  formatter: Intl.DateTimeFormat,
+): Date | null {
+  const desiredValue = localDateTimeValue(local);
+  if (!Number.isFinite(desiredValue)) {
+    return null;
+  }
+  let candidateValue = desiredValue;
+
+  // Offset iteration works across fractional-hour zones and offset changes.
+  for (let iteration = 0; iteration < 4; iteration += 1) {
+    const candidate = new Date(candidateValue);
+    const actualValue = localDateTimeValue(
+      readLocalDateTime(formatter, candidate),
+    );
+    const adjustment = desiredValue - actualValue;
+
+    if (adjustment === 0) {
+      return candidate;
+    }
+    candidateValue += adjustment;
+  }
+
+  const candidate = new Date(candidateValue);
+  return matchesLocalDateTime(readLocalDateTime(formatter, candidate), local)
+    ? candidate
+    : null;
+}
+
+function calendarDateValue(local: LocalDateTime): number {
+  return Date.UTC(local.year, local.month - 1, local.day);
+}
+
+function withCalendarDate(
+  local: LocalDateTime,
+  calendarDate: Date,
+): LocalDateTime {
+  return {
+    ...local,
+    day: calendarDate.getUTCDate(),
+    month: calendarDate.getUTCMonth() + 1,
+    year: calendarDate.getUTCFullYear(),
+  };
+}
+
+function addCalendarDays(local: LocalDateTime, days: number): LocalDateTime {
+  return withCalendarDate(
+    local,
+    new Date(calendarDateValue(local) + days * MILLISECONDS_PER_DAY),
+  );
+}
+
+function hasCalendarDay(year: number, month: number, day: number): boolean {
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return date.getUTCFullYear() === year && date.getUTCMonth() + 1 === month;
+}
+
+function addCalendarMonths(
+  local: LocalDateTime,
+  months: number,
+): LocalDateTime | null {
+  const monthIndex = local.month - 1 + months;
+  const year = local.year + Math.floor(monthIndex / 12);
+  const month = ((monthIndex % 12) + 12) % 12 + 1;
+
+  return hasCalendarDay(year, month, local.day)
+    ? { ...local, month, year }
+    : null;
+}
+
+function addCalendarYears(
+  local: LocalDateTime,
+  years: number,
+): LocalDateTime | null {
+  const year = local.year + years;
+  return hasCalendarDay(year, local.month, local.day)
+    ? { ...local, year }
+    : null;
+}
+
+function* dailyCandidates(
+  start: LocalDateTime,
+  interval: number,
+): Generator<LocalDateTime> {
+  for (let iteration = 1; ; iteration += 1) {
+    yield addCalendarDays(start, iteration * interval);
+  }
+}
+
+function* weeklyCandidates(
+  start: LocalDateTime,
+  interval: number,
+  weekdays: readonly number[],
+): Generator<LocalDateTime> {
+  const selectedWeekdays = [...weekdays].sort((left, right) => left - right);
+  const startDateValue = calendarDateValue(start);
+  const startWeekday = new Date(startDateValue).getUTCDay();
+  const anchorWeekStart = startDateValue - startWeekday * MILLISECONDS_PER_DAY;
+
+  for (let activeWeek = 0; ; activeWeek += interval) {
+    const activeWeekStart =
+      anchorWeekStart + activeWeek * 7 * MILLISECONDS_PER_DAY;
+
+    for (const weekday of selectedWeekdays) {
+      const candidateDateValue =
+        activeWeekStart + weekday * MILLISECONDS_PER_DAY;
+      if (candidateDateValue > startDateValue) {
+        yield withCalendarDate(start, new Date(candidateDateValue));
+      }
+    }
+  }
+}
+
+function* monthlyCandidates(
+  start: LocalDateTime,
+  interval: number,
+): Generator<LocalDateTime> {
+  for (let iteration = 1; ; iteration += 1) {
+    const candidate = addCalendarMonths(start, iteration * interval);
+    if (candidate) {
+      yield candidate;
+    }
+  }
+}
+
+function* yearlyCandidates(
+  start: LocalDateTime,
+  interval: number,
+): Generator<LocalDateTime> {
+  for (let iteration = 1; ; iteration += 1) {
+    const candidate = addCalendarYears(start, iteration * interval);
+    if (candidate) {
+      yield candidate;
+    }
+  }
+}
+
+function createCandidates(
+  start: LocalDateTime,
+  frequency: PostFrequency,
+  interval: number,
+  weekdays: readonly number[],
+): Generator<LocalDateTime> {
+  switch (frequency) {
+    case PostFrequency.DAILY:
+      return dailyCandidates(start, interval);
+    case PostFrequency.WEEKLY:
+      return weeklyCandidates(start, interval, weekdays);
+    case PostFrequency.MONTHLY:
+      return monthlyCandidates(start, interval);
+    case PostFrequency.YEARLY:
+      return yearlyCandidates(start, interval);
+    case PostFrequency.NEVER:
+      throw new Error('Non-repeating frequency passed recurrence validation.');
+  }
+
+  throw new Error(`Unsupported recurrence frequency: ${frequency}`);
+}
+
+function invalidInputResult(
+  result: z.ZodSafeParseError<unknown>,
+): RecurrencePreviewResult {
+  return {
+    issues: result.error.issues.map((issue) => ({
+      code: 'invalid_input',
+      message: issue.message,
+      path: issue.path.join('.'),
+    })),
+    success: false,
+  };
+}
+
+/**
+ * Preview future repeat instants without creating jobs or durable records.
+ */
+export function previewRecurrenceOccurrences(
+  input: RecurrencePreviewInput,
+): RecurrencePreviewResult {
+  const parsed = recurrencePreviewInputSchema.safeParse(input);
+  if (!parsed.success) {
+    return invalidInputResult(parsed);
+  }
+
+  const { limit, recurrence, repeatCount, startAt, timezone } = parsed.data;
+  let formatter: Intl.DateTimeFormat;
+  try {
+    formatter = createFormatter(timezone);
+  } catch {
+    return {
+      issues: [
+        {
+          code: 'invalid_timezone',
+          message: `Invalid IANA timezone: ${timezone}`,
+          path: 'timezone',
+        },
+      ],
+      success: false,
+    };
+  }
+
+  const startInstant = new Date(startAt);
+  const endInstant = recurrence.endDate
+    ? new Date(recurrence.endDate)
+    : undefined;
+  const remainingRepeats = recurrence.maxRepeats
+    ? recurrence.maxRepeats - repeatCount
+    : undefined;
+
+  if (
+    (remainingRepeats !== undefined && remainingRepeats <= 0) ||
+    (endInstant && endInstant <= startInstant)
+  ) {
+    return { exhausted: true, occurrences: [], success: true };
+  }
+
+  const startLocal = readLocalDateTime(formatter, startInstant);
+  const candidates = createCandidates(
+    startLocal,
+    recurrence.frequency,
+    recurrence.interval,
+    recurrence.weekdays ?? [],
+  );
+  const occurrences: string[] = [];
+
+  for (const localCandidate of candidates) {
+    if (
+      remainingRepeats !== undefined &&
+      occurrences.length >= remainingRepeats
+    ) {
+      return { exhausted: true, occurrences, success: true };
+    }
+
+    const candidate = localDateTimeToInstant(localCandidate, formatter);
+    if (!candidate) {
+      return {
+        issues: [
+          {
+            code: 'invalid_local_time',
+            message: 'A recurrence occurrence falls in a missing local time.',
+            path: 'startAt',
+          },
+        ],
+        success: false,
+      };
+    }
+
+    if (endInstant && candidate > endInstant) {
+      return { exhausted: true, occurrences, success: true };
+    }
+
+    if (occurrences.length >= limit) {
+      return { exhausted: false, occurrences, success: true };
+    }
+
+    occurrences.push(candidate.toISOString());
+  }
+
+  return { exhausted: true, occurrences, success: true };
+}

--- a/packages/api-types/src/contracts/recurrence-preview.contract.ts
+++ b/packages/api-types/src/contracts/recurrence-preview.contract.ts
@@ -7,18 +7,18 @@
  * so the local wall-clock time remains stable when the UTC offset changes.
  */
 
-import { PostFrequency } from '@genfeedai/enums';
-import { z } from 'zod';
 import {
   nonNegativeIntSchema,
   timezoneSchema,
-} from '../helpers/common-schemas';
+} from '@api-types/helpers/common-schemas';
+import { PostFrequency } from '@genfeedai/enums';
+import { z } from 'zod';
 import { recurrenceInputSchema } from './scheduler.contract';
 
 export const DEFAULT_RECURRENCE_PREVIEW_LIMIT = 100;
 export const MAX_RECURRENCE_PREVIEW_LIMIT = 500;
 
-const absoluteDateTimeSchema = z.string().datetime({ offset: true });
+const absoluteDateTimeSchema = z.iso.datetime({ offset: true });
 
 export const recurrencePreviewInputSchema = z
   .object({
@@ -58,7 +58,7 @@ export interface RecurrencePreviewValidationIssue {
 
 export type RecurrencePreviewResult =
   | {
-      exhausted: boolean;
+      isExhausted: boolean;
       occurrences: string[];
       success: true;
     }
@@ -356,7 +356,7 @@ function collectRecurrenceOccurrences(
     (remainingRepeats !== undefined && remainingRepeats <= 0) ||
     (endInstant && endInstant <= startInstant)
   ) {
-    return { exhausted: true, occurrences: [], success: true };
+    return { isExhausted: true, occurrences: [], success: true };
   }
 
   const startLocal = readLocalDateTime(formatter, startInstant);
@@ -373,7 +373,7 @@ function collectRecurrenceOccurrences(
       remainingRepeats !== undefined &&
       occurrences.length >= remainingRepeats
     ) {
-      return { exhausted: true, occurrences, success: true };
+      return { isExhausted: true, occurrences, success: true };
     }
 
     const candidate = localDateTimeToInstant(localCandidate, formatter);
@@ -383,7 +383,6 @@ function collectRecurrenceOccurrences(
           {
             code: 'invalid_local_time',
             message: 'A recurrence occurrence falls in a missing local time.',
-            path: 'startAt',
           },
         ],
         success: false,
@@ -391,17 +390,17 @@ function collectRecurrenceOccurrences(
     }
 
     if (endInstant && candidate > endInstant) {
-      return { exhausted: true, occurrences, success: true };
+      return { isExhausted: true, occurrences, success: true };
     }
 
     if (occurrences.length >= limit) {
-      return { exhausted: false, occurrences, success: true };
+      return { isExhausted: false, occurrences, success: true };
     }
 
     occurrences.push(candidate.toISOString());
   }
 
-  return { exhausted: true, occurrences, success: true };
+  return { isExhausted: true, occurrences, success: true };
 }
 
 /**

--- a/packages/api-types/src/contracts/recurrence-preview.contract.ts
+++ b/packages/api-types/src/contracts/recurrence-preview.contract.ts
@@ -380,6 +380,10 @@ function collectRecurrenceOccurrences(
       return { isExhausted: true, occurrences, success: true };
     }
 
+    if (occurrences.length >= limit) {
+      return { isExhausted: false, occurrences, success: true };
+    }
+
     const candidate = localDateTimeToInstant(localCandidate, formatter);
     if (!candidate) {
       return {
@@ -395,10 +399,6 @@ function collectRecurrenceOccurrences(
 
     if (endInstant && candidate > endInstant) {
       return { isExhausted: true, occurrences, success: true };
-    }
-
-    if (occurrences.length >= limit) {
-      return { isExhausted: false, occurrences, success: true };
     }
 
     occurrences.push(candidate.toISOString());

--- a/packages/api-types/src/contracts/recurrence-preview.contract.ts
+++ b/packages/api-types/src/contracts/recurrence-preview.contract.ts
@@ -9,7 +9,10 @@
 
 import { PostFrequency } from '@genfeedai/enums';
 import { z } from 'zod';
-import { nonNegativeIntSchema, timezoneSchema } from '../helpers/common-schemas';
+import {
+  nonNegativeIntSchema,
+  timezoneSchema,
+} from '../helpers/common-schemas';
 import { recurrenceInputSchema } from './scheduler.contract';
 
 export const DEFAULT_RECURRENCE_PREVIEW_LIMIT = 100;
@@ -64,6 +67,10 @@ export type RecurrencePreviewResult =
       success: false;
     };
 
+type ParsedRecurrencePreviewInput = z.output<
+  typeof recurrencePreviewInputSchema
+>;
+
 interface LocalDateTime {
   day: number;
   hour: number;
@@ -75,6 +82,14 @@ interface LocalDateTime {
 }
 
 const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1_000;
+
+function requiredDatePart(parts: Map<string, number>, name: string): number {
+  const value = parts.get(name);
+  if (value === undefined) {
+    throw new Error(`Intl.DateTimeFormat omitted the ${name} date part.`);
+  }
+  return value;
+}
 
 function createFormatter(timezone: string): Intl.DateTimeFormat {
   return new Intl.DateTimeFormat('en-US-u-ca-gregory-nu-latn', {
@@ -101,13 +116,13 @@ function readLocalDateTime(
   );
 
   return {
-    day: parts.get('day') ?? 0,
-    hour: parts.get('hour') ?? 0,
+    day: requiredDatePart(parts, 'day'),
+    hour: requiredDatePart(parts, 'hour'),
     millisecond: instant.getUTCMilliseconds(),
-    minute: parts.get('minute') ?? 0,
-    month: parts.get('month') ?? 0,
-    second: parts.get('second') ?? 0,
-    year: parts.get('year') ?? 0,
+    minute: requiredDatePart(parts, 'minute'),
+    month: requiredDatePart(parts, 'month'),
+    second: requiredDatePart(parts, 'second'),
+    year: requiredDatePart(parts, 'year'),
   };
 }
 
@@ -127,15 +142,7 @@ function matchesLocalDateTime(
   actual: LocalDateTime,
   expected: LocalDateTime,
 ): boolean {
-  return (
-    actual.year === expected.year &&
-    actual.month === expected.month &&
-    actual.day === expected.day &&
-    actual.hour === expected.hour &&
-    actual.minute === expected.minute &&
-    actual.second === expected.second &&
-    actual.millisecond === expected.millisecond
-  );
+  return localDateTimeValue(actual) === localDateTimeValue(expected);
 }
 
 function localDateTimeToInstant(
@@ -154,12 +161,7 @@ function localDateTimeToInstant(
     const actualValue = localDateTimeValue(
       readLocalDateTime(formatter, candidate),
     );
-    const adjustment = desiredValue - actualValue;
-
-    if (adjustment === 0) {
-      return candidate;
-    }
-    candidateValue += adjustment;
+    candidateValue += desiredValue - actualValue;
   }
 
   const candidate = new Date(candidateValue);
@@ -202,7 +204,7 @@ function addCalendarMonths(
 ): LocalDateTime | null {
   const monthIndex = local.month - 1 + months;
   const year = local.year + Math.floor(monthIndex / 12);
-  const month = ((monthIndex % 12) + 12) % 12 + 1;
+  const month = (((monthIndex % 12) + 12) % 12) + 1;
 
   return hasCalendarDay(year, month, local.day)
     ? { ...local, month, year }
@@ -298,9 +300,18 @@ function createCandidates(
   throw new Error(`Unsupported recurrence frequency: ${frequency}`);
 }
 
+type RecurrencePreviewFailure = Extract<
+  RecurrencePreviewResult,
+  { success: false }
+>;
+
+type PreviewFormatterResult =
+  | { formatter: Intl.DateTimeFormat; success: true }
+  | RecurrencePreviewFailure;
+
 function invalidInputResult(
   result: z.ZodSafeParseError<unknown>,
-): RecurrencePreviewResult {
+): RecurrencePreviewFailure {
   return {
     issues: result.error.issues.map((issue) => ({
       code: 'invalid_input',
@@ -311,21 +322,9 @@ function invalidInputResult(
   };
 }
 
-/**
- * Preview future repeat instants without creating jobs or durable records.
- */
-export function previewRecurrenceOccurrences(
-  input: RecurrencePreviewInput,
-): RecurrencePreviewResult {
-  const parsed = recurrencePreviewInputSchema.safeParse(input);
-  if (!parsed.success) {
-    return invalidInputResult(parsed);
-  }
-
-  const { limit, recurrence, repeatCount, startAt, timezone } = parsed.data;
-  let formatter: Intl.DateTimeFormat;
+function createPreviewFormatter(timezone: string): PreviewFormatterResult {
   try {
-    formatter = createFormatter(timezone);
+    return { formatter: createFormatter(timezone), success: true };
   } catch {
     return {
       issues: [
@@ -338,7 +337,13 @@ export function previewRecurrenceOccurrences(
       success: false,
     };
   }
+}
 
+function collectRecurrenceOccurrences(
+  input: ParsedRecurrencePreviewInput,
+  formatter: Intl.DateTimeFormat,
+): RecurrencePreviewResult {
+  const { limit, recurrence, repeatCount, startAt } = input;
   const startInstant = new Date(startAt);
   const endInstant = recurrence.endDate
     ? new Date(recurrence.endDate)
@@ -397,4 +402,23 @@ export function previewRecurrenceOccurrences(
   }
 
   return { exhausted: true, occurrences, success: true };
+}
+
+/**
+ * Preview future repeat instants without creating jobs or durable records.
+ */
+export function previewRecurrenceOccurrences(
+  input: RecurrencePreviewInput,
+): RecurrencePreviewResult {
+  const parsed = recurrencePreviewInputSchema.safeParse(input);
+  if (!parsed.success) {
+    return invalidInputResult(parsed);
+  }
+
+  const formatterResult = createPreviewFormatter(parsed.data.timezone);
+  if (!formatterResult.success) {
+    return formatterResult;
+  }
+
+  return collectRecurrenceOccurrences(parsed.data, formatterResult.formatter);
 }

--- a/packages/api-types/src/contracts/recurrence-preview.contract.ts
+++ b/packages/api-types/src/contracts/recurrence-preview.contract.ts
@@ -7,12 +7,12 @@
  * so the local wall-clock time remains stable when the UTC offset changes.
  */
 
+import { PostFrequency } from '@genfeedai/enums';
+import { z } from 'zod';
 import {
   nonNegativeIntSchema,
   timezoneSchema,
-} from '@api-types/helpers/common-schemas';
-import { PostFrequency } from '@genfeedai/enums';
-import { z } from 'zod';
+} from '../helpers/common-schemas';
 import { recurrenceInputSchema } from './scheduler.contract';
 
 export const DEFAULT_RECURRENCE_PREVIEW_LIMIT = 100;

--- a/packages/api-types/src/contracts/recurrence-preview.contract.ts
+++ b/packages/api-types/src/contracts/recurrence-preview.contract.ts
@@ -50,11 +50,15 @@ export type RecurrencePreviewInput = z.input<
   typeof recurrencePreviewInputSchema
 >;
 
-export interface RecurrencePreviewValidationIssue {
-  code: 'invalid_input' | 'invalid_local_time' | 'invalid_timezone';
-  message: string;
-  path?: string;
-}
+export const recurrencePreviewValidationIssueSchema = z.object({
+  code: z.enum(['invalid_input', 'invalid_local_time', 'invalid_timezone']),
+  message: z.string(),
+  path: z.string().optional(),
+});
+
+export type RecurrencePreviewValidationIssue = z.infer<
+  typeof recurrencePreviewValidationIssueSchema
+>;
 
 export type RecurrencePreviewResult =
   | {
@@ -71,7 +75,7 @@ type ParsedRecurrencePreviewInput = z.output<
   typeof recurrencePreviewInputSchema
 >;
 
-interface LocalDateTime {
+type LocalDateTime = {
   day: number;
   hour: number;
   millisecond: number;
@@ -79,7 +83,7 @@ interface LocalDateTime {
   month: number;
   second: number;
   year: number;
-}
+};
 
 const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1_000;
 

--- a/packages/api-types/src/contracts/scheduler.contract.ts
+++ b/packages/api-types/src/contracts/scheduler.contract.ts
@@ -88,45 +88,46 @@ export const recurrenceInputSchema = z
     maxRepeats: z.number().int().positive().optional(),
     weekdays: daysOfWeekSchema.optional(),
   })
-  .superRefine((recurrence, context) => {
-    if (recurrence.frequency === PostFrequency.NEVER) {
-      context.addIssue({
-        code: 'custom',
-        message: 'A recurrence frequency must repeat.',
-        path: ['frequency'],
-      });
-    }
-
-    if (recurrence.maxRepeats === undefined && !recurrence.endDate) {
-      context.addIssue({
-        code: 'custom',
-        message: 'A recurrence requires maxRepeats or endDate.',
-        path: ['maxRepeats'],
-      });
-    }
-
-    if (recurrence.frequency === PostFrequency.WEEKLY) {
-      if (!recurrence.weekdays || recurrence.weekdays.length === 0) {
-        context.addIssue({
-          code: 'custom',
-          message: 'Weekly recurrence requires at least one weekday.',
-          path: ['weekdays'],
-        });
-      } else if (new Set(recurrence.weekdays).size !== recurrence.weekdays.length) {
-        context.addIssue({
-          code: 'custom',
-          message: 'Weekly recurrence weekdays must be unique.',
-          path: ['weekdays'],
-        });
-      }
-    } else if (recurrence.weekdays !== undefined) {
-      context.addIssue({
-        code: 'custom',
-        message: 'Weekdays are only valid for weekly recurrence.',
-        path: ['weekdays'],
-      });
-    }
-  });
+  .refine((recurrence) => recurrence.frequency !== PostFrequency.NEVER, {
+    message: 'A recurrence frequency must repeat.',
+    path: ['frequency'],
+  })
+  .refine(
+    (recurrence) =>
+      recurrence.maxRepeats !== undefined || Boolean(recurrence.endDate),
+    {
+      message: 'A recurrence requires maxRepeats or endDate.',
+      path: ['maxRepeats'],
+    },
+  )
+  .refine(
+    (recurrence) =>
+      recurrence.frequency !== PostFrequency.WEEKLY ||
+      Boolean(recurrence.weekdays?.length),
+    {
+      message: 'Weekly recurrence requires at least one weekday.',
+      path: ['weekdays'],
+    },
+  )
+  .refine(
+    (recurrence) =>
+      recurrence.frequency !== PostFrequency.WEEKLY ||
+      recurrence.weekdays === undefined ||
+      new Set(recurrence.weekdays).size === recurrence.weekdays.length,
+    {
+      message: 'Weekly recurrence weekdays must be unique.',
+      path: ['weekdays'],
+    },
+  )
+  .refine(
+    (recurrence) =>
+      recurrence.frequency === PostFrequency.WEEKLY ||
+      recurrence.weekdays === undefined,
+    {
+      message: 'Weekdays are only valid for weekly recurrence.',
+      path: ['weekdays'],
+    },
+  );
 
 /** First comment / thread segment / signature attached to a release or target. */
 export const releaseAttachmentInputSchema = z.object({

--- a/packages/api-types/src/contracts/scheduler.contract.ts
+++ b/packages/api-types/src/contracts/scheduler.contract.ts
@@ -83,7 +83,7 @@ export const releaseMediaReferenceSchema = z.object({
 export const recurrenceInputSchema = z
   .object({
     endDate: dateStringSchema.optional(),
-    frequency: z.nativeEnum(PostFrequency),
+    frequency: z.enum(PostFrequency),
     interval: z.number().int().positive(),
     maxRepeats: z.number().int().positive().optional(),
     weekdays: daysOfWeekSchema.optional(),

--- a/packages/api-types/src/contracts/scheduler.contract.ts
+++ b/packages/api-types/src/contracts/scheduler.contract.ts
@@ -80,13 +80,53 @@ export const releaseMediaReferenceSchema = z.object({
 });
 
 /** Recurrence rule for evergreen / repeating releases. */
-export const recurrenceInputSchema = z.object({
-  endDate: dateStringSchema.optional(),
-  frequency: z.nativeEnum(PostFrequency),
-  interval: z.number().int().positive(),
-  maxRepeats: nonNegativeIntSchema.optional(),
-  weekdays: daysOfWeekSchema.optional(),
-});
+export const recurrenceInputSchema = z
+  .object({
+    endDate: dateStringSchema.optional(),
+    frequency: z.nativeEnum(PostFrequency),
+    interval: z.number().int().positive(),
+    maxRepeats: z.number().int().positive().optional(),
+    weekdays: daysOfWeekSchema.optional(),
+  })
+  .superRefine((recurrence, context) => {
+    if (recurrence.frequency === PostFrequency.NEVER) {
+      context.addIssue({
+        code: 'custom',
+        message: 'A recurrence frequency must repeat.',
+        path: ['frequency'],
+      });
+    }
+
+    if (recurrence.maxRepeats === undefined && !recurrence.endDate) {
+      context.addIssue({
+        code: 'custom',
+        message: 'A recurrence requires maxRepeats or endDate.',
+        path: ['maxRepeats'],
+      });
+    }
+
+    if (recurrence.frequency === PostFrequency.WEEKLY) {
+      if (!recurrence.weekdays || recurrence.weekdays.length === 0) {
+        context.addIssue({
+          code: 'custom',
+          message: 'Weekly recurrence requires at least one weekday.',
+          path: ['weekdays'],
+        });
+      } else if (new Set(recurrence.weekdays).size !== recurrence.weekdays.length) {
+        context.addIssue({
+          code: 'custom',
+          message: 'Weekly recurrence weekdays must be unique.',
+          path: ['weekdays'],
+        });
+      }
+    } else if (recurrence.weekdays !== undefined) {
+      context.addIssue({
+        code: 'custom',
+        message: 'Weekdays are only valid for weekly recurrence.',
+        path: ['weekdays'],
+      });
+    }
+  });
 
 /** First comment / thread segment / signature attached to a release or target. */
 export const releaseAttachmentInputSchema = z.object({

--- a/packages/interfaces/src/scheduler/recurrence-rule.interface.ts
+++ b/packages/interfaces/src/scheduler/recurrence-rule.interface.ts
@@ -20,9 +20,9 @@ export interface IRecurrenceRule {
   interval: number;
   /** Weekdays to fire on for weekly cadences (0 = Sunday .. 6 = Saturday). */
   weekdays: number[];
-  /** Hard cap on total occurrences; `null` for unbounded until `endDate`. */
+  /** Hard cap on repeat occurrences; omit only when a finite `endDate` exists. */
   maxRepeats?: number | null;
-  /** ISO 8601 date after which no further occurrences fire; `null` for open-ended. */
+  /** ISO 8601 date after which no further occurrences fire. */
   endDate?: string | null;
   /** ISO 8601 timestamp of the next scheduled occurrence, if any. */
   nextRunAt?: string | null;


### PR DESCRIPTION
## Summary

- require evergreen recurrence rules to have a positive repeat cap or finite end date
- enforce weekly weekday semantics and reject one-off/invalid recurrence shapes
- add a deterministic, side-effect-free UTC occurrence preview using the owning IANA timezone
- preserve local wall-clock time across DST and return typed failures for invalid zones or missing local times
- cover intervals, weekly selection, caps, end dates, DST, exhaustion, validation, and preview limits

## Verification

- `bunx @biomejs/biome@2.5.3 check packages/api-types/src/contracts/scheduler.contract.ts packages/api-types/src/contracts/recurrence-preview.contract.ts packages/api-types/src/contracts/index.ts packages/api-types/__tests__/scheduler.contract.test.ts packages/api-types/__tests__/recurrence-preview.contract.test.ts packages/interfaces/src/scheduler/recurrence-rule.interface.ts`
- `git diff af09889aa7a661f4d97640508d3fa9bcadcb3c6d..HEAD --check`
- staged credential and sensitive-filename scan before both commits
- local Vitest, TypeScript, build, and broad suites intentionally skipped under the repository machine policy; PR CI is the execution gate

## Scope

This is the contract-only first slice of #1130. It does not create jobs or durable occurrence records; idempotent series materialization remains in #1972 and UI/lineage work remains in #1973.

Closes #1971
