### PR TITLE
feat(files): extract clip reference candidates

### DIFF
--- a/apps/server/files/package.json
+++ b/apps/server/files/package.json
@@ -1,7 +1,9 @@
 {
   "dependencies": {
     "@genfeedai/config": "workspace:*",
+    "@genfeedai/constants": "workspace:*",
     "@genfeedai/enums": "workspace:*",
+    "@genfeedai/helpers": "workspace:*",
     "@genfeedai/interfaces": "workspace:*",
     "@genfeedai/storage": "workspace:*",
     "@genfeedai/utils": "workspace:*",

--- a/apps/server/files/src/controllers/files.controller.spec.ts
+++ b/apps/server/files/src/controllers/files.controller.spec.ts
@@ -592,9 +592,7 @@ describe('FilesController', () => {
       };
       const result = await controller.processVideo(body);
 
-      expect(
-        videoQueueService.addExtractReferenceFramesJob,
-      ).toHaveBeenCalled();
+      expect(videoQueueService.addExtractReferenceFramesJob).toHaveBeenCalled();
       expect(result.jobId).toBe('job_123');
     });
 

--- a/apps/server/files/src/controllers/files.controller.spec.ts
+++ b/apps/server/files/src/controllers/files.controller.spec.ts
@@ -77,6 +77,7 @@ describe('FilesController', () => {
   const mockVideoQueueService = {
     addCaptionsJob: vi.fn().mockResolvedValue(mockJob),
     addExtractFramesJob: vi.fn().mockResolvedValue(mockJob),
+    addExtractReferenceFramesJob: vi.fn().mockResolvedValue(mockJob),
     addGetVideoMetadataJob: vi.fn().mockResolvedValue(mockJob),
     addGifConversionJob: vi.fn().mockResolvedValue(mockJob),
     addMergeJob: vi.fn().mockResolvedValue(mockJob),
@@ -577,6 +578,23 @@ describe('FilesController', () => {
       const result = await controller.processVideo(body);
 
       expect(videoQueueService.addExtractFramesJob).toHaveBeenCalled();
+      expect(result.jobId).toBe('job_123');
+    });
+
+    it('should process EXTRACT_REFERENCE_FRAMES job', async () => {
+      const body = {
+        ...baseBody,
+        params: {
+          inputPath: 'https://www.youtube.com/watch?v=test',
+          timestamps: [5, 15],
+        },
+        type: JOB_TYPES.EXTRACT_REFERENCE_FRAMES,
+      };
+      const result = await controller.processVideo(body);
+
+      expect(
+        videoQueueService.addExtractReferenceFramesJob,
+      ).toHaveBeenCalled();
       expect(result.jobId).toBe('job_123');
     });
 

--- a/apps/server/files/src/controllers/files.controller.ts
+++ b/apps/server/files/src/controllers/files.controller.ts
@@ -177,6 +177,11 @@ export class FilesController {
           job = await this.videoQueueService.addExtractFramesJob(jobData);
           break;
 
+        case JOB_TYPES.EXTRACT_REFERENCE_FRAMES:
+          job =
+            await this.videoQueueService.addExtractReferenceFramesJob(jobData);
+          break;
+
         case JOB_TYPES.GET_VIDEO_METADATA:
           job = await this.videoQueueService.addGetVideoMetadataJob(jobData);
           break;

--- a/apps/server/files/src/processors/video.processor.spec.ts
+++ b/apps/server/files/src/processors/video.processor.spec.ts
@@ -135,6 +135,9 @@ describe('VideoProcessor', () => {
   let remotionRenderJobService: {
     process: ReturnType<typeof vi.fn>;
   };
+  let clipReferenceFrameExtractionService: {
+    extract: ReturnType<typeof vi.fn>;
+  };
   let ffmpegService: MockFFmpegService;
   let s3Service: MockS3Service;
   let webSocketService: MockWebSocketService;
@@ -189,6 +192,15 @@ describe('VideoProcessor', () => {
     remotionRenderJobService = {
       process: vi.fn().mockResolvedValue({ success: true }),
     };
+    clipReferenceFrameExtractionService = {
+      extract: vi.fn().mockResolvedValue({
+        candidates: [],
+        diagnostics: [],
+        schemaVersion: 1,
+        selectedCandidateId: null,
+        status: 'unavailable',
+      }),
+    };
 
     // VideoProcessor constructor order: FFmpegService, HookRemixService,
     // VideoMergeJobService, S3Service, WebSocketService, RedisService,
@@ -202,6 +214,7 @@ describe('VideoProcessor', () => {
       redisService,
       loggerService as unknown as never,
       remotionRenderJobService as never,
+      clipReferenceFrameExtractionService as never,
     );
   });
 
@@ -349,6 +362,25 @@ describe('VideoProcessor', () => {
       await processor.process(job);
 
       expect(ffmpegService.extractFrame).toHaveBeenCalled();
+    });
+
+    it('should route EXTRACT_REFERENCE_FRAMES job correctly', async () => {
+      const data = createMockJobData({
+        params: {
+          inputPath: 'https://www.youtube.com/watch?v=test',
+          timestamps: [10],
+        },
+      });
+      const job = createMockJob(JOB_TYPES.EXTRACT_REFERENCE_FRAMES, data);
+
+      await processor.process(job);
+
+      expect(clipReferenceFrameExtractionService.extract).toHaveBeenCalledWith({
+        organizationId: 'org-123',
+        projectId: 'test-ingredient-123',
+        sourceUrl: 'https://www.youtube.com/watch?v=test',
+        timestamps: [10],
+      });
     });
 
     it('should route GET_VIDEO_METADATA job correctly', async () => {

--- a/apps/server/files/src/processors/video.processor.ts
+++ b/apps/server/files/src/processors/video.processor.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs';
 import path from 'node:path';
 import { JOB_TYPES, QUEUE_NAMES } from '@files/queues/queue.constants';
+import { ClipReferenceFrameExtractionService } from '@files/services/clip-reference-frames/clip-reference-frame-extraction.service';
 import { FFmpegService } from '@files/services/ffmpeg/services/ffmpeg.service';
 import type { HookRemixJobData } from '@files/services/hook-remix/hook-remix.interfaces';
 import { HookRemixService } from '@files/services/hook-remix/hook-remix.service';
@@ -53,6 +54,7 @@ export class VideoProcessor extends WorkerHost {
     private redisService: RedisService,
     private readonly logger: LoggerService,
     private readonly remotionRenderJobService: RemotionRenderJobService,
+    private readonly clipReferenceFrameExtractionService: ClipReferenceFrameExtractionService,
   ) {
     super();
   }
@@ -85,6 +87,8 @@ export class VideoProcessor extends WorkerHost {
         return await this.handleVideoToAudio(job);
       case JOB_TYPES.EXTRACT_FRAMES:
         return await this.handleExtractFrames(job);
+      case JOB_TYPES.EXTRACT_REFERENCE_FRAMES:
+        return await this.handleExtractReferenceFrames(job);
       case JOB_TYPES.GET_VIDEO_METADATA:
         return await this.handleGetVideoMetadata(job);
       case JOB_TYPES.HOOK_REMIX:
@@ -875,6 +879,21 @@ export class VideoProcessor extends WorkerHost {
       );
       throw error;
     }
+  }
+
+  async handleExtractReferenceFrames(
+    job: Job<VideoJobData>,
+  ): Promise<JobResult> {
+    const { ingredientId, organizationId, params } = job.data;
+    const referenceFrames =
+      await this.clipReferenceFrameExtractionService.extract({
+        organizationId,
+        projectId: ingredientId,
+        sourceUrl: params.inputPath || '',
+        timestamps: params.timestamps || [],
+      });
+
+    return { referenceFrames, success: true };
   }
 
   async handleGetVideoMetadata(job: Job<VideoJobData>): Promise<JobResult> {

--- a/apps/server/files/src/queues/queue.constants.ts
+++ b/apps/server/files/src/queues/queue.constants.ts
@@ -21,6 +21,7 @@ export const JOB_TYPES = {
   // File operations
   DOWNLOAD_FILE: 'download-file',
   EXTRACT_FRAMES: 'extract-frames',
+  EXTRACT_REFERENCE_FRAMES: 'extract-reference-frames',
   GET_VIDEO_METADATA: 'get-video-metadata',
   HOOK_REMIX: 'hook-remix',
 

--- a/apps/server/files/src/queues/video-queue.service.spec.ts
+++ b/apps/server/files/src/queues/video-queue.service.spec.ts
@@ -97,4 +97,28 @@ describe('VideoQueueService', () => {
       expect.not.objectContaining({ jobId: expect.anything() }),
     );
   });
+
+  it('queues clip reference extraction with the bounded job type', async () => {
+    const data = {
+      createdAt: new Date(),
+      id: 'clip-reference-frames-project-1',
+      ingredientId: 'project-1',
+      metadata: { websocketUrl: '' },
+      organizationId: 'org-1',
+      params: {
+        inputPath: 'https://www.youtube.com/watch?v=test',
+        timestamps: [5, 15],
+      },
+      type: JOB_TYPES.EXTRACT_REFERENCE_FRAMES,
+      userId: 'user-1',
+    } as VideoJobData;
+
+    await service.addExtractReferenceFramesJob(data);
+
+    expect(mockQueue.add).toHaveBeenCalledWith(
+      JOB_TYPES.EXTRACT_REFERENCE_FRAMES,
+      data,
+      expect.objectContaining({ attempts: 2 }),
+    );
+  });
 });

--- a/apps/server/files/src/queues/video-queue.service.ts
+++ b/apps/server/files/src/queues/video-queue.service.ts
@@ -73,6 +73,11 @@ const VIDEO_JOB_CONFIGS: Partial<Record<JobType, JobConfig>> = {
     defaultPriority: JOB_PRIORITY.NORMAL,
     delay: 2000,
   },
+  [JOB_TYPES.EXTRACT_REFERENCE_FRAMES]: {
+    attempts: 2,
+    defaultPriority: JOB_PRIORITY.NORMAL,
+    delay: 1000,
+  },
   [JOB_TYPES.GET_VIDEO_METADATA]: {
     attempts: 2,
     defaultPriority: JOB_PRIORITY.HIGH,
@@ -176,6 +181,16 @@ export class VideoQueueService extends BaseQueueService<VideoJobData> {
 
   async addExtractFramesJob(data: VideoJobData): Promise<Job<VideoJobData>> {
     return this.addJob(JOB_TYPES.EXTRACT_FRAMES, data, 'extract frames');
+  }
+
+  async addExtractReferenceFramesJob(
+    data: VideoJobData,
+  ): Promise<Job<VideoJobData>> {
+    return this.addJob(
+      JOB_TYPES.EXTRACT_REFERENCE_FRAMES,
+      data,
+      'extract clip reference frames',
+    );
   }
 
   async addGetVideoMetadataJob(data: VideoJobData): Promise<Job<VideoJobData>> {

--- a/apps/server/files/src/services/clip-reference-frames/clip-reference-frame-extraction.service.spec.ts
+++ b/apps/server/files/src/services/clip-reference-frames/clip-reference-frame-extraction.service.spec.ts
@@ -14,7 +14,9 @@ describe('ClipReferenceFrameExtractionService', () => {
     }),
   };
   const ytDlpService = {
-    downloadVideo: vi.fn().mockResolvedValue('/tmp/reference-frames/source.mp4'),
+    downloadVideo: vi
+      .fn()
+      .mockResolvedValue('/tmp/reference-frames/source.mp4'),
   };
   const logger = {
     warn: vi.fn(),
@@ -51,9 +53,9 @@ describe('ClipReferenceFrameExtractionService', () => {
 
     expect(result.status).toBe('ready');
     expect(result.candidates).toHaveLength(5);
-    expect(result.candidates.map((candidate) => candidate.timestampSeconds)).toEqual(
-      [10, 20, 30, 40, 50],
-    );
+    expect(
+      result.candidates.map((candidate) => candidate.timestampSeconds),
+    ).toEqual([10, 20, 30, 40, 50]);
     expect(result.candidates[0]).toMatchObject({
       height: 720,
       id: 'frame-1-10000',
@@ -117,9 +119,7 @@ describe('ClipReferenceFrameExtractionService', () => {
       candidates: [],
       status: 'unavailable',
     });
-    expect(result.diagnostics[0]?.code).toBe(
-      'clip_reference_invalid_source',
-    );
+    expect(result.diagnostics[0]?.code).toBe('clip_reference_invalid_source');
     expect(ytDlpService.downloadVideo).not.toHaveBeenCalled();
   });
 
@@ -136,9 +136,7 @@ describe('ClipReferenceFrameExtractionService', () => {
     });
 
     expect(result.status).toBe('unavailable');
-    expect(result.diagnostics[0]?.code).toBe(
-      'clip_reference_download_failed',
-    );
+    expect(result.diagnostics[0]?.code).toBe('clip_reference_download_failed');
     expect(ffmpegService.cleanupTempFiles).toHaveBeenCalledWith(
       '/tmp/reference-frames/source.mp4',
       '/tmp/reference-frames/frame-1.jpg',

--- a/apps/server/files/src/services/clip-reference-frames/clip-reference-frame-extraction.service.spec.ts
+++ b/apps/server/files/src/services/clip-reference-frames/clip-reference-frame-extraction.service.spec.ts
@@ -1,0 +1,147 @@
+import { ClipReferenceFrameExtractionService } from '@files/services/clip-reference-frames/clip-reference-frame-extraction.service';
+
+describe('ClipReferenceFrameExtractionService', () => {
+  const ffmpegService = {
+    cleanupTempFiles: vi.fn().mockResolvedValue(undefined),
+    extractFrame: vi.fn().mockResolvedValue('/tmp/frame.jpg'),
+    getTempPath: vi.fn().mockReturnValue('/tmp/reference-frames'),
+  };
+  const uploadService = {
+    uploadToS3: vi.fn().mockResolvedValue({
+      height: 720,
+      publicUrl: 'https://cdn.test/reference.jpg',
+      width: 1280,
+    }),
+  };
+  const ytDlpService = {
+    downloadVideo: vi.fn().mockResolvedValue('/tmp/reference-frames/source.mp4'),
+  };
+  const logger = {
+    warn: vi.fn(),
+  };
+
+  let service: ClipReferenceFrameExtractionService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ffmpegService.extractFrame.mockResolvedValue('/tmp/frame.jpg');
+    uploadService.uploadToS3.mockResolvedValue({
+      height: 720,
+      publicUrl: 'https://cdn.test/reference.jpg',
+      width: 1280,
+    });
+    ytDlpService.downloadVideo.mockResolvedValue(
+      '/tmp/reference-frames/source.mp4',
+    );
+    service = new ClipReferenceFrameExtractionService(
+      ffmpegService as never,
+      uploadService as never,
+      ytDlpService as never,
+      logger as never,
+    );
+  });
+
+  it('downloads once and uploads at most five deterministic candidates', async () => {
+    const result = await service.extract({
+      organizationId: 'org-123',
+      projectId: 'project-123',
+      sourceUrl: 'https://www.youtube.com/watch?v=test',
+      timestamps: [30, 10, 20, 40, 50, 60, 10],
+    });
+
+    expect(result.status).toBe('ready');
+    expect(result.candidates).toHaveLength(5);
+    expect(result.candidates.map((candidate) => candidate.timestampSeconds)).toEqual(
+      [10, 20, 30, 40, 50],
+    );
+    expect(result.candidates[0]).toMatchObject({
+      height: 720,
+      id: 'frame-1-10000',
+      mimeType: 'image/jpeg',
+      status: 'available',
+      storageKey:
+        'ingredients/images/organizations/org-123/clips/project-123/reference-frames/frame-1-10000.jpg',
+      width: 1280,
+    });
+    expect(ytDlpService.downloadVideo).toHaveBeenCalledOnce();
+    expect(ffmpegService.extractFrame).toHaveBeenCalledTimes(5);
+    expect(uploadService.uploadToS3).toHaveBeenCalledTimes(5);
+    expect(ffmpegService.cleanupTempFiles).toHaveBeenCalledWith(
+      '/tmp/reference-frames/source.mp4',
+      '/tmp/reference-frames/frame-1.jpg',
+      '/tmp/reference-frames/frame-2.jpg',
+      '/tmp/reference-frames/frame-3.jpg',
+      '/tmp/reference-frames/frame-4.jpg',
+      '/tmp/reference-frames/frame-5.jpg',
+    );
+  });
+
+  it('returns a partial contract when one candidate fails', async () => {
+    ffmpegService.extractFrame
+      .mockResolvedValueOnce('/tmp/frame-1.jpg')
+      .mockRejectedValueOnce(new Error('ffmpeg failed'));
+
+    const result = await service.extract({
+      organizationId: 'org-123',
+      projectId: 'project-123',
+      sourceUrl: 'https://youtu.be/test',
+      timestamps: [5, 15],
+    });
+
+    expect(result.status).toBe('partial');
+    expect(result.candidates).toEqual([
+      expect.objectContaining({ id: 'frame-1-5000', status: 'available' }),
+      expect.objectContaining({
+        assetId: 'frame-2-15000',
+        id: 'frame-2-15000',
+        status: 'failed',
+      }),
+    ]);
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({
+        code: 'clip_reference_candidates_incomplete',
+        severity: 'warning',
+      }),
+    ]);
+  });
+
+  it('rejects non-YouTube sources without downloading them', async () => {
+    const result = await service.extract({
+      organizationId: 'org-123',
+      projectId: 'project-123',
+      sourceUrl: 'https://example.com/video.mp4',
+      timestamps: [5],
+    });
+
+    expect(result).toMatchObject({
+      candidates: [],
+      status: 'unavailable',
+    });
+    expect(result.diagnostics[0]?.code).toBe(
+      'clip_reference_invalid_source',
+    );
+    expect(ytDlpService.downloadVideo).not.toHaveBeenCalled();
+  });
+
+  it('returns unavailable and cleans up when the source download fails', async () => {
+    ytDlpService.downloadVideo.mockRejectedValueOnce(
+      new Error('source unavailable'),
+    );
+
+    const result = await service.extract({
+      organizationId: 'org-123',
+      projectId: 'project-123',
+      sourceUrl: 'https://www.youtube.com/watch?v=test',
+      timestamps: [5],
+    });
+
+    expect(result.status).toBe('unavailable');
+    expect(result.diagnostics[0]?.code).toBe(
+      'clip_reference_download_failed',
+    );
+    expect(ffmpegService.cleanupTempFiles).toHaveBeenCalledWith(
+      '/tmp/reference-frames/source.mp4',
+      '/tmp/reference-frames/frame-1.jpg',
+    );
+  });
+});

--- a/apps/server/files/src/services/clip-reference-frames/clip-reference-frame-extraction.service.ts
+++ b/apps/server/files/src/services/clip-reference-frames/clip-reference-frame-extraction.service.ts
@@ -1,0 +1,228 @@
+import path from 'node:path';
+import { FFmpegService } from '@files/services/ffmpeg/services/ffmpeg.service';
+import { UploadService } from '@files/services/upload/upload.service';
+import { YtDlpService } from '@files/services/ytdlp/ytdlp.service';
+import {
+  CLIP_REFERENCE_FRAME_SCHEMA_VERSION,
+  type ClipReferenceFrameCandidate,
+  type ClipReferenceFrameDiagnostic,
+  type ClipReferenceFrameSet,
+} from '@genfeedai/interfaces';
+import { LoggerService } from '@libs/logger/logger.service';
+import { Injectable } from '@nestjs/common';
+
+const MAX_REFERENCE_FRAMES = 5;
+const YOUTUBE_HOSTS = new Set([
+  'm.youtube.com',
+  'music.youtube.com',
+  'www.youtube.com',
+  'youtu.be',
+  'youtube.com',
+]);
+
+export interface ClipReferenceFrameExtractionInput {
+  organizationId: string;
+  projectId: string;
+  sourceUrl: string;
+  timestamps: number[];
+}
+
+function unavailableReferenceFrames(
+  code: string,
+  message: string,
+): ClipReferenceFrameSet {
+  return {
+    candidates: [],
+    diagnostics: [{ code, message, severity: 'warning' }],
+    schemaVersion: CLIP_REFERENCE_FRAME_SCHEMA_VERSION,
+    selectedCandidateId: null,
+    status: 'unavailable',
+  };
+}
+
+function normalizeTimestamps(timestamps: number[]): number[] {
+  return [
+    ...new Set(
+      timestamps
+        .filter(
+          (timestamp) => Number.isFinite(timestamp) && timestamp >= 0,
+        )
+        .map((timestamp) => Math.round(timestamp * 1000) / 1000),
+    ),
+  ]
+    .sort((left, right) => left - right)
+    .slice(0, MAX_REFERENCE_FRAMES);
+}
+
+function validatePublicYoutubeUrl(sourceUrl: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(sourceUrl);
+  } catch {
+    throw new Error('Source URL is invalid');
+  }
+
+  if (
+    parsed.protocol !== 'https:' ||
+    parsed.username.length > 0 ||
+    parsed.password.length > 0 ||
+    !YOUTUBE_HOSTS.has(parsed.hostname.toLowerCase())
+  ) {
+    throw new Error('Source URL must be a public HTTPS YouTube URL');
+  }
+
+  return parsed.toString();
+}
+
+function storageSegment(value: string): string {
+  if (value.trim().length === 0) {
+    throw new Error('Storage scope is missing');
+  }
+
+  return encodeURIComponent(value.trim());
+}
+
+@Injectable()
+export class ClipReferenceFrameExtractionService {
+  constructor(
+    private readonly ffmpegService: FFmpegService,
+    private readonly uploadService: UploadService,
+    private readonly ytDlpService: YtDlpService,
+    private readonly logger: LoggerService,
+  ) {}
+
+  async extract(
+    input: ClipReferenceFrameExtractionInput,
+  ): Promise<ClipReferenceFrameSet> {
+    const timestamps = normalizeTimestamps(input.timestamps);
+    if (timestamps.length === 0) {
+      return unavailableReferenceFrames(
+        'clip_reference_no_timestamps',
+        'No valid source timestamps were available for reference extraction.',
+      );
+    }
+
+    let sourceUrl: string;
+    let organizationId: string;
+    let projectId: string;
+    try {
+      sourceUrl = validatePublicYoutubeUrl(input.sourceUrl);
+      organizationId = storageSegment(input.organizationId);
+      projectId = storageSegment(input.projectId);
+    } catch (error: unknown) {
+      this.logger.warn('Clip reference source validation failed', error);
+      return unavailableReferenceFrames(
+        'clip_reference_invalid_source',
+        'The source could not be used for reference extraction.',
+      );
+    }
+
+    const tempDir = this.ffmpegService.getTempPath(
+      'clip-reference-frames',
+      projectId,
+    );
+    const sourcePath = path.join(tempDir, 'source.mp4');
+    const framePaths = timestamps.map((_, index) =>
+      path.join(tempDir, `frame-${index + 1}.jpg`),
+    );
+
+    try {
+      await this.ytDlpService.downloadVideo(sourceUrl, sourcePath);
+
+      const candidates: ClipReferenceFrameCandidate[] = [];
+      for (const [index, timestampSeconds] of timestamps.entries()) {
+        const timestampMs = Math.round(timestampSeconds * 1000);
+        const candidateId = `frame-${index + 1}-${timestampMs}`;
+        const framePath = framePaths[index]!;
+        const storageKey =
+          `ingredients/images/organizations/${organizationId}/clips/` +
+          `${projectId}/reference-frames/${candidateId}.jpg`;
+
+        try {
+          await this.ffmpegService.extractFrame(
+            sourcePath,
+            framePath,
+            timestampSeconds,
+          );
+          const uploaded = await this.uploadService.uploadToS3(
+            `organizations/${organizationId}/clips/${projectId}/` +
+              `reference-frames/${candidateId}.jpg`,
+            'images',
+            { path: framePath, type: 'file' },
+          );
+
+          candidates.push({
+            assetId: candidateId,
+            diagnostics: [],
+            height: uploaded.height || undefined,
+            id: candidateId,
+            mimeType: 'image/jpeg',
+            status: 'available',
+            storageKey,
+            timestampSeconds,
+            url: uploaded.publicUrl,
+            width: uploaded.width || undefined,
+          });
+        } catch (error: unknown) {
+          this.logger.warn('Clip reference candidate extraction failed', {
+            candidateId,
+            error,
+            projectId: input.projectId,
+          });
+          candidates.push({
+            assetId: candidateId,
+            diagnostics: [
+              {
+                candidateId,
+                code: 'clip_reference_candidate_failed',
+                message: 'This reference frame could not be extracted.',
+                severity: 'warning',
+              },
+            ],
+            id: candidateId,
+            status: 'failed',
+            timestampSeconds,
+          });
+        }
+      }
+
+      const availableCount = candidates.filter(
+        (candidate) => candidate.status === 'available',
+      ).length;
+      const diagnostics: ClipReferenceFrameDiagnostic[] =
+        availableCount === candidates.length
+          ? []
+          : [
+              {
+                code: 'clip_reference_candidates_incomplete',
+                message: `${candidates.length - availableCount} reference frame candidate(s) could not be extracted.`,
+                severity: 'warning',
+              },
+            ];
+
+      return {
+        candidates,
+        diagnostics,
+        schemaVersion: CLIP_REFERENCE_FRAME_SCHEMA_VERSION,
+        selectedCandidateId: null,
+        status:
+          availableCount === candidates.length
+            ? 'ready'
+            : availableCount > 0
+              ? 'partial'
+              : 'unavailable',
+      };
+    } catch (error: unknown) {
+      this.logger.warn('Clip reference source download failed', {
+        error,
+        projectId: input.projectId,
+      });
+      return unavailableReferenceFrames(
+        'clip_reference_download_failed',
+        'The source video was unavailable for reference extraction.',
+      );
+    } finally {
+      await this.ffmpegService.cleanupTempFiles(sourcePath, ...framePaths);
+    }
+  }
+}

--- a/apps/server/files/src/services/clip-reference-frames/clip-reference-frame-extraction.service.ts
+++ b/apps/server/files/src/services/clip-reference-frames/clip-reference-frame-extraction.service.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import { FFmpegService } from '@files/services/ffmpeg/services/ffmpeg.service';
 import { UploadService } from '@files/services/upload/upload.service';
 import { YtDlpService } from '@files/services/ytdlp/ytdlp.service';
+import { normalizeClipReferenceTimestamps } from '@genfeedai/helpers';
 import {
   CLIP_REFERENCE_FRAME_SCHEMA_VERSION,
   type ClipReferenceFrameCandidate,
@@ -12,7 +13,6 @@ import {
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
 
-const MAX_REFERENCE_FRAMES = 5;
 const YOUTUBE_HOSTS = new Set([
   'm.youtube.com',
   'music.youtube.com',
@@ -32,18 +32,6 @@ function unavailableReferenceFrames(
     selectedCandidateId: null,
     status: 'unavailable',
   };
-}
-
-function normalizeTimestamps(timestamps: number[]): number[] {
-  return [
-    ...new Set(
-      timestamps
-        .filter((timestamp) => Number.isFinite(timestamp) && timestamp >= 0)
-        .map((timestamp) => Math.round(timestamp * 1000) / 1000),
-    ),
-  ]
-    .sort((left, right) => left - right)
-    .slice(0, MAX_REFERENCE_FRAMES);
 }
 
 function validatePublicYoutubeUrl(sourceUrl: string): string {
@@ -86,7 +74,7 @@ export class ClipReferenceFrameExtractionService {
   async extract(
     input: ClipReferenceFrameExtractionInput,
   ): Promise<ClipReferenceFrameSet> {
-    const timestamps = normalizeTimestamps(input.timestamps);
+    const timestamps = normalizeClipReferenceTimestamps(input.timestamps);
     if (timestamps.length === 0) {
       return unavailableReferenceFrames(
         'clip_reference_no_timestamps',
@@ -126,9 +114,10 @@ export class ClipReferenceFrameExtractionService {
         const timestampMs = Math.round(timestampSeconds * 1000);
         const candidateId = `frame-${index + 1}-${timestampMs}`;
         const framePath = path.join(tempDir, `frame-${index + 1}.jpg`);
-        const storageKey =
-          `ingredients/images/organizations/${organizationId}/clips/` +
-          `${projectId}/reference-frames/${candidateId}.jpg`;
+        const uploadKey =
+          `organizations/${organizationId}/clips/${projectId}/` +
+          `reference-frames/${candidateId}.jpg`;
+        const storageKey = `ingredients/images/${uploadKey}`;
 
         try {
           await this.ffmpegService.extractFrame(
@@ -137,8 +126,7 @@ export class ClipReferenceFrameExtractionService {
             timestampSeconds,
           );
           const uploaded = await this.uploadService.uploadToS3(
-            `organizations/${organizationId}/clips/${projectId}/` +
-              `reference-frames/${candidateId}.jpg`,
+            uploadKey,
             'images',
             { path: framePath, type: 'file' },
           );

--- a/apps/server/files/src/services/clip-reference-frames/clip-reference-frame-extraction.service.ts
+++ b/apps/server/files/src/services/clip-reference-frames/clip-reference-frame-extraction.service.ts
@@ -6,6 +6,7 @@ import {
   CLIP_REFERENCE_FRAME_SCHEMA_VERSION,
   type ClipReferenceFrameCandidate,
   type ClipReferenceFrameDiagnostic,
+  type ClipReferenceFrameExtractionInput,
   type ClipReferenceFrameSet,
 } from '@genfeedai/interfaces';
 import { LoggerService } from '@libs/logger/logger.service';
@@ -19,13 +20,6 @@ const YOUTUBE_HOSTS = new Set([
   'youtu.be',
   'youtube.com',
 ]);
-
-export interface ClipReferenceFrameExtractionInput {
-  organizationId: string;
-  projectId: string;
-  sourceUrl: string;
-  timestamps: number[];
-}
 
 function unavailableReferenceFrames(
   code: string,

--- a/apps/server/files/src/services/clip-reference-frames/clip-reference-frame-extraction.service.ts
+++ b/apps/server/files/src/services/clip-reference-frames/clip-reference-frame-extraction.service.ts
@@ -44,9 +44,7 @@ function normalizeTimestamps(timestamps: number[]): number[] {
   return [
     ...new Set(
       timestamps
-        .filter(
-          (timestamp) => Number.isFinite(timestamp) && timestamp >= 0,
-        )
+        .filter((timestamp) => Number.isFinite(timestamp) && timestamp >= 0)
         .map((timestamp) => Math.round(timestamp * 1000) / 1000),
     ),
   ]
@@ -133,7 +131,7 @@ export class ClipReferenceFrameExtractionService {
       for (const [index, timestampSeconds] of timestamps.entries()) {
         const timestampMs = Math.round(timestampSeconds * 1000);
         const candidateId = `frame-${index + 1}-${timestampMs}`;
-        const framePath = framePaths[index]!;
+        const framePath = path.join(tempDir, `frame-${index + 1}.jpg`);
         const storageKey =
           `ingredients/images/organizations/${organizationId}/clips/` +
           `${projectId}/reference-frames/${candidateId}.jpg`;

--- a/apps/server/files/src/services/clip-reference-frames/clip-reference-frames.module.ts
+++ b/apps/server/files/src/services/clip-reference-frames/clip-reference-frames.module.ts
@@ -1,0 +1,13 @@
+import { ClipReferenceFrameExtractionService } from '@files/services/clip-reference-frames/clip-reference-frame-extraction.service';
+import { FFmpegModule } from '@files/services/ffmpeg/ffmpeg.module';
+import { UploadModule } from '@files/services/upload/upload.module';
+import { YtDlpModule } from '@files/services/ytdlp/ytdlp.module';
+import { LoggerModule } from '@libs/logger/logger.module';
+import { Module } from '@nestjs/common';
+
+@Module({
+  exports: [ClipReferenceFrameExtractionService],
+  imports: [FFmpegModule, LoggerModule, UploadModule, YtDlpModule],
+  providers: [ClipReferenceFrameExtractionService],
+})
+export class ClipReferenceFramesModule {}

--- a/apps/server/files/src/services/services.module.ts
+++ b/apps/server/files/src/services/services.module.ts
@@ -1,5 +1,6 @@
 import { ConfigModule } from '@files/config/config.module';
 import { QUEUE_NAMES } from '@files/queues/queue.constants';
+import { ClipReferenceFramesModule } from '@files/services/clip-reference-frames/clip-reference-frames.module';
 import { FFmpegModule } from '@files/services/ffmpeg/ffmpeg.module';
 import { FilesModule } from '@files/services/files/files.module';
 import { HookRemixModule } from '@files/services/hook-remix/hook-remix.module';
@@ -18,6 +19,7 @@ import { Module } from '@nestjs/common';
 
 @Module({
   exports: [
+    ClipReferenceFramesModule,
     FFmpegModule,
     FilesModule,
     HookRemixModule,
@@ -33,6 +35,7 @@ import { Module } from '@nestjs/common';
     YtDlpModule,
   ],
   imports: [
+    ClipReferenceFramesModule,
     ConfigModule,
     FFmpegModule,
     FilesModule,

--- a/apps/server/files/src/services/ytdlp/ytdlp.service.spec.ts
+++ b/apps/server/files/src/services/ytdlp/ytdlp.service.spec.ts
@@ -17,6 +17,7 @@ vi.mock('node:child_process', () => ({
       on: (event: string, cb: (...args: unknown[]) => void) => {
         events[event] = cb;
       },
+      kill: vi.fn(),
     };
   }),
 }));
@@ -25,15 +26,18 @@ vi.mock('node:fs', () => ({
   default: {
     existsSync: vi.fn(),
     mkdirSync: vi.fn(),
+    unlinkSync: vi.fn(),
   },
   existsSync: vi.fn(),
   mkdirSync: vi.fn(),
+  unlinkSync: vi.fn(),
 }));
 
 type ProcessHandler = (...args: unknown[]) => void;
 
 type MockProcess = {
   emit: Mock<(event: string, ...args: unknown[]) => void>;
+  kill: Mock<(signal: NodeJS.Signals) => boolean>;
   on: Mock<(event: string, cb: ProcessHandler) => void>;
 };
 
@@ -44,6 +48,7 @@ function createMockProcess(): MockProcess {
     emit: vi.fn((event: string, ...args: unknown[]) => {
       events[event]?.(...args);
     }),
+    kill: vi.fn(() => true),
     on: vi.fn((event: string, cb: ProcessHandler) => {
       events[event] = cb;
     }),
@@ -79,6 +84,7 @@ describe('YtDlpService', () => {
   beforeEach(async () => {
     loggerMock = {
       log: vi.fn(),
+      warn: vi.fn(),
     };
 
     spawnMock = spawn as MockedFunction<typeof spawn>;
@@ -262,6 +268,26 @@ describe('YtDlpService', () => {
         outputPath,
         url,
       ]);
+    });
+
+    it('kills a timed-out process and removes partial output', async () => {
+      vi.useFakeTimers();
+      const outputPath = '/tmp/genfeed/video.mp4';
+      const mockProcess = useMockProcess(spawnMock);
+      fsMock.existsSync.mockReturnValue(true);
+
+      const promise = service.downloadVideo(
+        'https://youtube.com/watch?v=test',
+        outputPath,
+      );
+      const rejection = expect(promise).rejects.toThrow('yt-dlp timed out');
+      await vi.advanceTimersByTimeAsync(5 * 60_000);
+
+      await rejection;
+      expect(mockProcess.kill).toHaveBeenCalledWith('SIGKILL');
+      expect(fsMock.unlinkSync).toHaveBeenCalledWith(outputPath);
+      expect(fsMock.unlinkSync).toHaveBeenCalledWith(`${outputPath}.part`);
+      vi.useRealTimers();
     });
   });
 

--- a/apps/server/files/src/services/ytdlp/ytdlp.service.spec.ts
+++ b/apps/server/files/src/services/ytdlp/ytdlp.service.spec.ts
@@ -128,7 +128,9 @@ describe('YtDlpService', () => {
         '-o',
         expect.stringContaining('public/tmp/clips/'),
         url,
-      ]);
+      ], {
+        detached: process.platform !== 'win32',
+      });
       expect(result).toMatch(/\.mp3$/);
       expect(loggerMock.log).toHaveBeenCalledWith(
         expect.stringContaining('yt-dlp'),
@@ -267,10 +269,12 @@ describe('YtDlpService', () => {
         '-o',
         outputPath,
         url,
-      ]);
+      ], {
+        detached: process.platform !== 'win32',
+      });
     });
 
-    it('kills a timed-out process and removes partial output', async () => {
+    it('kills a timed-out process and removes partial output after close', async () => {
       vi.useFakeTimers();
       const outputPath = '/tmp/genfeed/video.mp4';
       const mockProcess = useMockProcess(spawnMock);
@@ -280,14 +284,41 @@ describe('YtDlpService', () => {
         'https://youtube.com/watch?v=test',
         outputPath,
       );
+      const settled = vi.fn();
+      void promise.then(settled, settled);
       const rejection = expect(promise).rejects.toThrow('yt-dlp timed out');
       await vi.advanceTimersByTimeAsync(5 * 60_000);
 
-      await rejection;
       expect(mockProcess.kill).toHaveBeenCalledWith('SIGKILL');
+      expect(settled).not.toHaveBeenCalled();
+      expect(fsMock.unlinkSync).not.toHaveBeenCalled();
+
+      closeProcess(mockProcess, 137);
+
+      await rejection;
+      expect(settled).toHaveBeenCalledOnce();
       expect(fsMock.unlinkSync).toHaveBeenCalledWith(outputPath);
       expect(fsMock.unlinkSync).toHaveBeenCalledWith(`${outputPath}.part`);
       vi.useRealTimers();
+    });
+
+    it('rejects a successful process that did not create an output file', async () => {
+      const outputPath = '/tmp/genfeed/video.mp4';
+      const mockProcess = useMockProcess(spawnMock);
+      fsMock.existsSync
+        .mockReturnValueOnce(true)
+        .mockReturnValueOnce(false)
+        .mockReturnValue(false);
+
+      const promise = service.downloadVideo(
+        'https://youtube.com/watch?v=test',
+        outputPath,
+      );
+      closeProcess(mockProcess, 0);
+
+      await expect(promise).rejects.toThrow(
+        'without creating an output file',
+      );
     });
   });
 
@@ -312,7 +343,9 @@ describe('YtDlpService', () => {
         '-o',
         outputPath,
         url,
-      ]);
+      ], {
+        detached: process.platform !== 'win32',
+      });
     });
   });
 });

--- a/apps/server/files/src/services/ytdlp/ytdlp.service.spec.ts
+++ b/apps/server/files/src/services/ytdlp/ytdlp.service.spec.ts
@@ -121,16 +121,20 @@ describe('YtDlpService', () => {
 
       const result = await promise;
 
-      expect(spawnMock).toHaveBeenCalledWith('yt-dlp', [
-        '-x',
-        '--audio-format',
-        'mp3',
-        '-o',
-        expect.stringContaining('public/tmp/clips/'),
-        url,
-      ], {
-        detached: process.platform !== 'win32',
-      });
+      expect(spawnMock).toHaveBeenCalledWith(
+        'yt-dlp',
+        [
+          '-x',
+          '--audio-format',
+          'mp3',
+          '-o',
+          expect.stringContaining('public/tmp/clips/'),
+          url,
+        ],
+        {
+          detached: process.platform !== 'win32',
+        },
+      );
       expect(result).toMatch(/\.mp3$/);
       expect(loggerMock.log).toHaveBeenCalledWith(
         expect.stringContaining('yt-dlp'),
@@ -256,22 +260,26 @@ describe('YtDlpService', () => {
       closeProcess(mockProcess, 0);
 
       await expect(promise).resolves.toBe(outputPath);
-      expect(spawnMock).toHaveBeenCalledWith('yt-dlp', [
-        '--no-playlist',
-        '--socket-timeout',
-        '30',
-        '--max-filesize',
-        '500M',
-        '-f',
-        'bestvideo[height<=720]+bestaudio/best[height<=720]',
-        '--merge-output-format',
-        'mp4',
-        '-o',
-        outputPath,
-        url,
-      ], {
-        detached: process.platform !== 'win32',
-      });
+      expect(spawnMock).toHaveBeenCalledWith(
+        'yt-dlp',
+        [
+          '--no-playlist',
+          '--socket-timeout',
+          '30',
+          '--max-filesize',
+          '500M',
+          '-f',
+          'bestvideo[height<=720]+bestaudio/best[height<=720]',
+          '--merge-output-format',
+          'mp4',
+          '-o',
+          outputPath,
+          url,
+        ],
+        {
+          detached: process.platform !== 'win32',
+        },
+      );
     });
 
     it('kills a timed-out process and removes partial output after close', async () => {
@@ -316,9 +324,7 @@ describe('YtDlpService', () => {
       );
       closeProcess(mockProcess, 0);
 
-      await expect(promise).rejects.toThrow(
-        'without creating an output file',
-      );
+      await expect(promise).rejects.toThrow('without creating an output file');
     });
   });
 
@@ -334,18 +340,22 @@ describe('YtDlpService', () => {
       closeProcess(mockProcess, 0);
 
       await expect(promise).resolves.toBe(outputPath);
-      expect(spawnMock).toHaveBeenCalledWith('yt-dlp', [
-        '-x',
-        '--audio-format',
-        'mp3',
-        '--audio-quality',
-        '9',
-        '-o',
-        outputPath,
-        url,
-      ], {
-        detached: process.platform !== 'win32',
-      });
+      expect(spawnMock).toHaveBeenCalledWith(
+        'yt-dlp',
+        [
+          '-x',
+          '--audio-format',
+          'mp3',
+          '--audio-quality',
+          '9',
+          '-o',
+          outputPath,
+          url,
+        ],
+        {
+          detached: process.platform !== 'win32',
+        },
+      );
     });
   });
 });

--- a/apps/server/files/src/services/ytdlp/ytdlp.service.spec.ts
+++ b/apps/server/files/src/services/ytdlp/ytdlp.service.spec.ts
@@ -249,6 +249,11 @@ describe('YtDlpService', () => {
 
       await expect(promise).resolves.toBe(outputPath);
       expect(spawnMock).toHaveBeenCalledWith('yt-dlp', [
+        '--no-playlist',
+        '--socket-timeout',
+        '30',
+        '--max-filesize',
+        '500M',
         '-f',
         'bestvideo[height<=720]+bestaudio/best[height<=720]',
         '--merge-output-format',

--- a/apps/server/files/src/services/ytdlp/ytdlp.service.ts
+++ b/apps/server/files/src/services/ytdlp/ytdlp.service.ts
@@ -88,23 +88,23 @@ export class YtDlpService {
       const proc = spawn('yt-dlp', args, {
         detached: process.platform !== 'win32',
       });
-      let settled = false;
-      let timedOut = false;
+      let isSettled = false;
+      let hasTimedOut = false;
       const settle = (callback: () => void): void => {
-        if (settled) {
+        if (isSettled) {
           return;
         }
-        settled = true;
+        isSettled = true;
         callback();
       };
       const timeout = setTimeout(() => {
-        timedOut = true;
+        hasTimedOut = true;
         this.terminateProcessTree(proc);
       }, YT_DLP_PROCESS_TIMEOUT_MS);
 
       proc.on('close', (code: number | null) => {
         clearTimeout(timeout);
-        if (timedOut) {
+        if (hasTimedOut) {
           this.cleanupPartialOutput(outputPath);
           settle(() =>
             reject(
@@ -135,7 +135,7 @@ export class YtDlpService {
       });
       proc.on('error', (error) => {
         clearTimeout(timeout);
-        if (!timedOut) {
+        if (!hasTimedOut) {
           settle(() => reject(error));
         }
       });

--- a/apps/server/files/src/services/ytdlp/ytdlp.service.ts
+++ b/apps/server/files/src/services/ytdlp/ytdlp.service.ts
@@ -36,6 +36,11 @@ export class YtDlpService {
       outputPath || path.join(outputDir, `${timestamp}.mp4`);
 
     const args = [
+      '--no-playlist',
+      '--socket-timeout',
+      '30',
+      '--max-filesize',
+      '500M',
       '-f',
       'bestvideo[height<=720]+bestaudio/best[height<=720]',
       '--merge-output-format',

--- a/apps/server/files/src/services/ytdlp/ytdlp.service.ts
+++ b/apps/server/files/src/services/ytdlp/ytdlp.service.ts
@@ -6,6 +6,8 @@ import { Injectable } from '@nestjs/common';
 
 // Download audio from a YouTube video
 
+const YT_DLP_PROCESS_TIMEOUT_MS = 5 * 60_000;
+
 @Injectable()
 export class YtDlpService {
   constructor(private readonly logger: LoggerService) {}
@@ -85,14 +87,43 @@ export class YtDlpService {
 
     return new Promise((resolve, reject) => {
       const proc = spawn('yt-dlp', args);
+      const timeout = setTimeout(() => {
+        proc.kill('SIGKILL');
+        this.cleanupPartialOutput(outputPath);
+        reject(
+          new Error(
+            `yt-dlp timed out after ${YT_DLP_PROCESS_TIMEOUT_MS}ms`,
+          ),
+        );
+      }, YT_DLP_PROCESS_TIMEOUT_MS);
+
       proc.on('close', (code: number | null) => {
+        clearTimeout(timeout);
         if (code === 0) {
           resolve(outputPath);
         } else {
           reject(new Error(`yt-dlp exited with code ${code}`));
         }
       });
-      proc.on('error', reject);
+      proc.on('error', (error) => {
+        clearTimeout(timeout);
+        reject(error);
+      });
     });
+  }
+
+  private cleanupPartialOutput(outputPath: string): void {
+    for (const partialPath of [outputPath, `${outputPath}.part`]) {
+      try {
+        if (fs.existsSync(partialPath)) {
+          fs.unlinkSync(partialPath);
+        }
+      } catch (error: unknown) {
+        this.logger.warn('Failed to clean timed-out yt-dlp output', {
+          error,
+          outputPath: partialPath,
+        });
+      }
+    }
   }
 }

--- a/apps/server/files/src/services/ytdlp/ytdlp.service.ts
+++ b/apps/server/files/src/services/ytdlp/ytdlp.service.ts
@@ -91,9 +91,7 @@ export class YtDlpService {
         proc.kill('SIGKILL');
         this.cleanupPartialOutput(outputPath);
         reject(
-          new Error(
-            `yt-dlp timed out after ${YT_DLP_PROCESS_TIMEOUT_MS}ms`,
-          ),
+          new Error(`yt-dlp timed out after ${YT_DLP_PROCESS_TIMEOUT_MS}ms`),
         );
       }, YT_DLP_PROCESS_TIMEOUT_MS);
 

--- a/apps/server/files/src/services/ytdlp/ytdlp.service.ts
+++ b/apps/server/files/src/services/ytdlp/ytdlp.service.ts
@@ -1,12 +1,11 @@
-import { spawn } from 'node:child_process';
+import { type ChildProcess, spawn } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
+import { YT_DLP_PROCESS_TIMEOUT_MS } from '@genfeedai/constants';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
 
 // Download audio from a YouTube video
-
-const YT_DLP_PROCESS_TIMEOUT_MS = 5 * 60_000;
 
 @Injectable()
 export class YtDlpService {
@@ -86,28 +85,77 @@ export class YtDlpService {
     this.logger.log(`yt-dlp ${args.join(' ')}`);
 
     return new Promise((resolve, reject) => {
-      const proc = spawn('yt-dlp', args);
+      const proc = spawn('yt-dlp', args, {
+        detached: process.platform !== 'win32',
+      });
+      let settled = false;
+      let timedOut = false;
+      const settle = (callback: () => void): void => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        callback();
+      };
       const timeout = setTimeout(() => {
-        proc.kill('SIGKILL');
-        this.cleanupPartialOutput(outputPath);
-        reject(
-          new Error(`yt-dlp timed out after ${YT_DLP_PROCESS_TIMEOUT_MS}ms`),
-        );
+        timedOut = true;
+        this.terminateProcessTree(proc);
       }, YT_DLP_PROCESS_TIMEOUT_MS);
 
       proc.on('close', (code: number | null) => {
         clearTimeout(timeout);
+        if (timedOut) {
+          this.cleanupPartialOutput(outputPath);
+          settle(() =>
+            reject(
+              new Error(
+                `yt-dlp timed out after ${YT_DLP_PROCESS_TIMEOUT_MS}ms`,
+              ),
+            ),
+          );
+          return;
+        }
+
         if (code === 0) {
-          resolve(outputPath);
+          if (!fs.existsSync(outputPath)) {
+            this.cleanupPartialOutput(outputPath);
+            settle(() =>
+              reject(
+                new Error(
+                  'yt-dlp exited successfully without creating an output file',
+                ),
+              ),
+            );
+            return;
+          }
+          settle(() => resolve(outputPath));
         } else {
-          reject(new Error(`yt-dlp exited with code ${code}`));
+          settle(() => reject(new Error(`yt-dlp exited with code ${code}`)));
         }
       });
       proc.on('error', (error) => {
         clearTimeout(timeout);
-        reject(error);
+        if (!timedOut) {
+          settle(() => reject(error));
+        }
       });
     });
+  }
+
+  private terminateProcessTree(proc: ChildProcess): void {
+    if (process.platform !== 'win32' && proc.pid) {
+      try {
+        process.kill(-proc.pid, 'SIGKILL');
+        return;
+      } catch (error: unknown) {
+        this.logger.warn('Failed to terminate yt-dlp process group', {
+          error,
+          pid: proc.pid,
+        });
+      }
+    }
+
+    proc.kill('SIGKILL');
   }
 
   private cleanupPartialOutput(outputPath: string): void {

--- a/apps/server/files/src/shared/interfaces/job.interface.ts
+++ b/apps/server/files/src/shared/interfaces/job.interface.ts
@@ -1,6 +1,7 @@
 import type { JobPriority, JobType } from '@files/queues/queue.constants';
 import type { VideoEaseCurve, VideoTransition } from '@genfeedai/enums';
 import type {
+  ClipReferenceFrameSet,
   IEditorRenderCorrelation,
   IEditorRenderJobParams,
 } from '@genfeedai/interfaces';
@@ -130,6 +131,7 @@ export interface VideoProcessingParams {
   // Frame extraction params
   outputDir?: string;
   frameCount?: number;
+  timestamps?: number[];
 
   // Video metadata params
   videoPath?: string;
@@ -237,6 +239,7 @@ export interface JobProgress {
 
 export interface JobResult {
   success: boolean;
+  referenceFrames?: ClipReferenceFrameSet;
   jobId?: string;
   jobType?: string;
   outputPath?: string;

--- a/apps/server/workers/src/processors/api/queues/clip-analyze/clip-analyze.processor.spec.ts
+++ b/apps/server/workers/src/processors/api/queues/clip-analyze/clip-analyze.processor.spec.ts
@@ -45,7 +45,7 @@ describe('ClipAnalyzeProcessor', () => {
             content: JSON.stringify([
               {
                 clip_type: 'hook',
-                end_time: 60,
+                end_time: 100,
                 start_time: 0,
                 summary: 'Great opening',
                 tags: ['intro'],
@@ -54,7 +54,7 @@ describe('ClipAnalyzeProcessor', () => {
               },
               {
                 clip_type: 'educational',
-                end_time: 30,
+                end_time: 40,
                 start_time: 25,
                 summary: 'Key insight',
                 tags: ['learning'],
@@ -143,11 +143,11 @@ describe('ClipAnalyzeProcessor', () => {
               referenceFrames: {
                 candidates: [
                   {
-                    assetId: 'frame-1-27500',
+                    assetId: 'frame-1-32500',
                     diagnostics: [],
-                    id: 'frame-1-27500',
+                    id: 'frame-1-32500',
                     status: 'available',
-                    timestampSeconds: 27.5,
+                    timestampSeconds: 32.5,
                     url: 'https://cdn.test/frame.jpg',
                   },
                 ],
@@ -229,7 +229,7 @@ describe('ClipAnalyzeProcessor', () => {
         ingredientId: 'proj-123',
         params: {
           inputPath: mockJobData.youtubeUrl,
-          timestamps: [27.5, 30],
+          timestamps: [32.5, 50],
         },
         type: 'extract-reference-frames',
       }),
@@ -243,7 +243,7 @@ describe('ClipAnalyzeProcessor', () => {
       pendingPatch?.[1]?.referenceFrames?.candidates.map(
         (candidate) => candidate.id,
       ),
-    ).toEqual(['frame-1-27500', 'frame-2-30000']);
+    ).toEqual(['frame-1-32500', 'frame-2-50000']);
   });
 
   it('should preserve analysis when reference extraction fails', async () => {

--- a/apps/server/workers/src/processors/api/queues/clip-analyze/clip-analyze.processor.spec.ts
+++ b/apps/server/workers/src/processors/api/queues/clip-analyze/clip-analyze.processor.spec.ts
@@ -45,7 +45,7 @@ describe('ClipAnalyzeProcessor', () => {
             content: JSON.stringify([
               {
                 clip_type: 'hook',
-                end_time: 30,
+                end_time: 60,
                 start_time: 0,
                 summary: 'Great opening',
                 tags: ['intro'],
@@ -54,7 +54,7 @@ describe('ClipAnalyzeProcessor', () => {
               },
               {
                 clip_type: 'educational',
-                end_time: 60,
+                end_time: 30,
                 start_time: 25,
                 summary: 'Key insight',
                 tags: ['learning'],
@@ -143,11 +143,11 @@ describe('ClipAnalyzeProcessor', () => {
               referenceFrames: {
                 candidates: [
                   {
-                    assetId: 'frame-1-15000',
+                    assetId: 'frame-1-27500',
                     diagnostics: [],
-                    id: 'frame-1-15000',
+                    id: 'frame-1-27500',
                     status: 'available',
-                    timestampSeconds: 15,
+                    timestampSeconds: 27.5,
                     url: 'https://cdn.test/frame.jpg',
                   },
                 ],
@@ -229,7 +229,7 @@ describe('ClipAnalyzeProcessor', () => {
         ingredientId: 'proj-123',
         params: {
           inputPath: mockJobData.youtubeUrl,
-          timestamps: [15, 42.5],
+          timestamps: [27.5, 30],
         },
         type: 'extract-reference-frames',
       }),
@@ -239,6 +239,11 @@ describe('ClipAnalyzeProcessor', () => {
       (call) => call[1]?.referenceFrames?.status === 'pending',
     );
     expect(pendingPatch?.[1]).toMatchObject({ progress: 75 });
+    expect(
+      pendingPatch?.[1]?.referenceFrames?.candidates.map(
+        (candidate) => candidate.id,
+      ),
+    ).toEqual(['frame-1-27500', 'frame-2-30000']);
   });
 
   it('should preserve analysis when reference extraction fails', async () => {

--- a/apps/server/workers/src/processors/api/queues/clip-analyze/clip-analyze.processor.spec.ts
+++ b/apps/server/workers/src/processors/api/queues/clip-analyze/clip-analyze.processor.spec.ts
@@ -122,17 +122,45 @@ describe('ClipAnalyzeProcessor', () => {
     httpService.post
       .mockReturnValueOnce(of({ data: { jobId: 'audio-job-1' } }) as never)
       // OpenRouter LLM call
-      .mockReturnValueOnce(of(mockHighlightsResponse) as never);
+      .mockReturnValueOnce(of(mockHighlightsResponse) as never)
+      // Reference frame extraction POST
+      .mockReturnValueOnce(of({ data: { jobId: 'frames-job-1' } }) as never);
 
     // Audio job poll GET
-    httpService.get.mockReturnValueOnce(
-      of({
-        data: {
-          result: { outputUrl: 'https://cdn.test/audio.mp3' },
-          status: 'completed',
-        },
-      }) as never,
-    );
+    httpService.get
+      .mockReturnValueOnce(
+        of({
+          data: {
+            result: { outputUrl: 'https://cdn.test/audio.mp3' },
+            state: 'completed',
+          },
+        }) as never,
+      )
+      .mockReturnValueOnce(
+        of({
+          data: {
+            result: {
+              referenceFrames: {
+                candidates: [
+                  {
+                    assetId: 'frame-1-15000',
+                    diagnostics: [],
+                    id: 'frame-1-15000',
+                    status: 'available',
+                    timestampSeconds: 15,
+                    url: 'https://cdn.test/frame.jpg',
+                  },
+                ],
+                diagnostics: [],
+                schemaVersion: 1,
+                selectedCandidateId: null,
+                status: 'ready',
+              },
+            },
+            state: 'completed',
+          },
+        }) as never,
+      );
   }
 
   it('should complete the analysis pipeline and set status to analyzed', async () => {
@@ -143,6 +171,7 @@ describe('ClipAnalyzeProcessor', () => {
     expect(lastPatchCall?.[0]).toBe('proj-123');
     expect(lastPatchCall?.[1]).toMatchObject({
       progress: 100,
+      referenceFrames: { status: 'ready' },
       status: 'analyzed',
     });
     expect(lastPatchCall?.[1]).toHaveProperty('highlights');
@@ -187,6 +216,58 @@ describe('ClipAnalyzeProcessor', () => {
     expect(transcriptPatch).toBeDefined();
     expect(transcriptPatch?.[1]?.transcriptText).toBe(mockTranscription.text);
     expect(transcriptPatch?.[1]?.transcriptSrt).toBe(mockTranscription.srt);
+  });
+
+  it('should derive bounded reference timestamps from accepted highlights', async () => {
+    setupHttpMocks();
+    await processor.process(createMockJob());
+
+    expect(httpService.post).toHaveBeenNthCalledWith(
+      3,
+      expect.stringContaining('/v1/files/process/video'),
+      expect.objectContaining({
+        ingredientId: 'proj-123',
+        params: {
+          inputPath: mockJobData.youtubeUrl,
+          timestamps: [15, 42.5],
+        },
+        type: 'extract-reference-frames',
+      }),
+      expect.any(Object),
+    );
+    const pendingPatch = clipProjectsService.patch.mock.calls.find(
+      (call) => call[1]?.referenceFrames?.status === 'pending',
+    );
+    expect(pendingPatch?.[1]).toMatchObject({ progress: 75 });
+  });
+
+  it('should preserve analysis when reference extraction fails', async () => {
+    setupHttpMocks();
+    httpService.get.mockReset();
+    httpService.get
+      .mockReturnValueOnce(
+        of({
+          data: {
+            result: { outputUrl: 'https://cdn.test/audio.mp3' },
+            state: 'completed',
+          },
+        }) as never,
+      )
+      .mockReturnValueOnce(
+        of({ data: { state: 'failed' } }) as never,
+      );
+
+    await processor.process(createMockJob());
+
+    const lastPatchCall = clipProjectsService.patch.mock.calls.at(-1);
+    expect(lastPatchCall?.[1]).toMatchObject({
+      progress: 100,
+      referenceFrames: {
+        status: 'unavailable',
+      },
+      status: 'analyzed',
+    });
+    expect(lastPatchCall?.[1]).toHaveProperty('highlights');
   });
 
   it('should set status to failed on error', async () => {

--- a/apps/server/workers/src/processors/api/queues/clip-analyze/clip-analyze.processor.spec.ts
+++ b/apps/server/workers/src/processors/api/queues/clip-analyze/clip-analyze.processor.spec.ts
@@ -253,9 +253,7 @@ describe('ClipAnalyzeProcessor', () => {
           },
         }) as never,
       )
-      .mockReturnValueOnce(
-        of({ data: { state: 'failed' } }) as never,
-      );
+      .mockReturnValueOnce(of({ data: { state: 'failed' } }) as never);
 
     await processor.process(createMockJob());
 

--- a/apps/server/workers/src/processors/api/queues/clip-analyze/clip-analyze.processor.spec.ts
+++ b/apps/server/workers/src/processors/api/queues/clip-analyze/clip-analyze.processor.spec.ts
@@ -45,8 +45,8 @@ describe('ClipAnalyzeProcessor', () => {
             content: JSON.stringify([
               {
                 clip_type: 'hook',
-                end_time: 100,
-                start_time: 0,
+                end_time: 90,
+                start_time: 10,
                 summary: 'Great opening',
                 tags: ['intro'],
                 title: 'Epic intro',

--- a/apps/server/workers/src/processors/api/queues/clip-analyze/clip-analyze.processor.ts
+++ b/apps/server/workers/src/processors/api/queues/clip-analyze/clip-analyze.processor.ts
@@ -363,9 +363,7 @@ export class ClipAnalyzeProcessor extends WorkerHost {
       const status = payload?.status || payload?.state;
 
       if (status === 'completed' || status === 'COMPLETED') {
-        return normalizeClipReferenceFrameSet(
-          payload?.result?.referenceFrames,
-        );
+        return normalizeClipReferenceFrameSet(payload?.result?.referenceFrames);
       }
 
       if (status === 'failed' || status === 'FAILED') {

--- a/apps/server/workers/src/processors/api/queues/clip-analyze/clip-analyze.processor.ts
+++ b/apps/server/workers/src/processors/api/queues/clip-analyze/clip-analyze.processor.ts
@@ -48,7 +48,6 @@ function deriveReferenceTimestamps(highlights: IHighlight[]): number[] {
             highlight.start_time >= 0 &&
             highlight.end_time >= highlight.start_time,
         )
-        .sort((left, right) => left.start_time - right.start_time)
         .map(
           (highlight) =>
             Math.round(
@@ -56,7 +55,9 @@ function deriveReferenceTimestamps(highlights: IHighlight[]): number[] {
             ) / 1000,
         ),
     ),
-  ].slice(0, MAX_REFERENCE_FRAMES);
+  ]
+    .sort((left, right) => left - right)
+    .slice(0, MAX_REFERENCE_FRAMES);
 }
 
 function pendingReferenceFrames(timestamps: number[]): ClipReferenceFrameSet {

--- a/apps/server/workers/src/processors/api/queues/clip-analyze/clip-analyze.processor.ts
+++ b/apps/server/workers/src/processors/api/queues/clip-analyze/clip-analyze.processor.ts
@@ -6,7 +6,8 @@
  * 2. Transcribe via WhisperService (Replicate)
  * 3. Detect highlights via OpenRouter LLM (GPT-4o)
  * 4. Filter by minViralityScore
- * 5. Save highlights to ClipProject (status: 'analyzed')
+ * 5. Extract bounded reference frames from highlight timestamps
+ * 6. Save highlights and reference frames (status: 'analyzed')
  *
  * Does NOT generate avatar videos — that's the clip-factory queue.
  */
@@ -15,6 +16,11 @@ import { randomUUID } from 'node:crypto';
 import { ClipProjectsService } from '@api/collections/clip-projects/clip-projects.service';
 import type { IHighlight } from '@api/collections/clip-projects/schemas/clip-project.schema';
 import { WhisperService } from '@api/services/whisper/whisper.service';
+import { normalizeClipReferenceFrameSet } from '@genfeedai/helpers';
+import {
+  CLIP_REFERENCE_FRAME_SCHEMA_VERSION,
+  type ClipReferenceFrameSet,
+} from '@genfeedai/interfaces';
 import {
   CLIP_ANALYZE_CONCURRENCY,
   CLIP_ANALYZE_QUEUE,
@@ -28,6 +34,59 @@ import { ClipHighlightDetector } from '@workers/processors/api/queues/shared/cli
 
 import type { Job } from 'bullmq';
 import { firstValueFrom } from 'rxjs';
+
+const MAX_REFERENCE_FRAMES = 5;
+
+function deriveReferenceTimestamps(highlights: IHighlight[]): number[] {
+  return [
+    ...new Set(
+      highlights
+        .filter(
+          (highlight) =>
+            Number.isFinite(highlight.start_time) &&
+            Number.isFinite(highlight.end_time) &&
+            highlight.start_time >= 0 &&
+            highlight.end_time >= highlight.start_time,
+        )
+        .sort((left, right) => left.start_time - right.start_time)
+        .map(
+          (highlight) =>
+            Math.round(
+              ((highlight.start_time + highlight.end_time) / 2) * 1000,
+            ) / 1000,
+        ),
+    ),
+  ].slice(0, MAX_REFERENCE_FRAMES);
+}
+
+function pendingReferenceFrames(timestamps: number[]): ClipReferenceFrameSet {
+  return {
+    candidates: timestamps.map((timestampSeconds, index) => ({
+      assetId: `frame-${index + 1}-${Math.round(timestampSeconds * 1000)}`,
+      diagnostics: [],
+      id: `frame-${index + 1}-${Math.round(timestampSeconds * 1000)}`,
+      status: 'pending',
+      timestampSeconds,
+    })),
+    diagnostics: [],
+    schemaVersion: CLIP_REFERENCE_FRAME_SCHEMA_VERSION,
+    selectedCandidateId: null,
+    status: 'pending',
+  };
+}
+
+function unavailableReferenceFrames(
+  code: string,
+  message: string,
+): ClipReferenceFrameSet {
+  return {
+    candidates: [],
+    diagnostics: [{ code, message, severity: 'warning' }],
+    schemaVersion: CLIP_REFERENCE_FRAME_SCHEMA_VERSION,
+    selectedCandidateId: null,
+    status: 'unavailable',
+  };
+}
 
 @Processor(CLIP_ANALYZE_QUEUE, {
   concurrency: CLIP_ANALYZE_CONCURRENCY,
@@ -110,10 +169,49 @@ export class ClipAnalyzeProcessor extends WorkerHost {
           id: randomUUID(),
         }));
 
-      // Stage 5: Save highlights — pipeline complete (no generation)
+      // Stage 5: Extract reference candidates without making analysis depend on
+      // source video availability.
+      const referenceTimestamps = deriveReferenceTimestamps(highlights);
+      let referenceFrames: ClipReferenceFrameSet;
+
+      if (referenceTimestamps.length === 0) {
+        referenceFrames = unavailableReferenceFrames(
+          'clip_reference_no_timestamps',
+          'No eligible highlight timestamps were available for reference extraction.',
+        );
+      } else {
+        await this.updateProject(projectId, {
+          highlights,
+          progress: 75,
+          referenceFrames: pendingReferenceFrames(referenceTimestamps),
+        });
+
+        try {
+          referenceFrames = await this.extractReferenceFrames(
+            data.youtubeUrl,
+            data.orgId,
+            data.userId,
+            projectId,
+            referenceTimestamps,
+          );
+        } catch (error: unknown) {
+          this.logger.warn(
+            `${this.logContext} reference extraction unavailable`,
+            { error, projectId },
+          );
+          referenceFrames = unavailableReferenceFrames(
+            'clip_reference_extraction_failed',
+            'Reference frames could not be extracted from the source video.',
+          );
+        }
+      }
+
+      // Stage 6: Save analysis output. Reference extraction failures are
+      // represented in the contract and do not discard transcript/highlights.
       await this.updateProject(projectId, {
         highlights,
         progress: 100,
+        referenceFrames,
         status: 'analyzed',
       });
 
@@ -139,6 +237,42 @@ export class ClipAnalyzeProcessor extends WorkerHost {
 
       throw error;
     }
+  }
+
+  private async extractReferenceFrames(
+    youtubeUrl: string,
+    organizationId: string,
+    userId: string,
+    projectId: string,
+    timestamps: number[],
+  ): Promise<ClipReferenceFrameSet> {
+    const filesUrl =
+      this.configService.get('GENFEEDAI_MICROSERVICES_FILES_URL') ||
+      'http://localhost:3012';
+
+    const response = await firstValueFrom(
+      this.httpService.post(
+        `${filesUrl}/v1/files/process/video`,
+        {
+          id: `clip-reference-frames-${projectId}`,
+          ingredientId: projectId,
+          organizationId,
+          params: { inputPath: youtubeUrl, timestamps },
+          type: 'extract-reference-frames',
+          userId,
+        },
+        { headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    const jobId = response.data?.jobId || response.data?.data?.jobId;
+    if (!jobId) {
+      throw new Error(
+        'Files microservice did not return a jobId for reference extraction',
+      );
+    }
+
+    return this.waitForReferenceFrameJob(filesUrl, jobId);
   }
 
   /**
@@ -193,11 +327,11 @@ export class ClipAnalyzeProcessor extends WorkerHost {
         this.httpService.get(`${filesUrl}/v1/files/job/${jobId}`),
       );
 
-      const status = response.data?.status || response.data?.data?.status;
+      const payload = response.data?.data || response.data;
+      const status = payload?.status || payload?.state;
 
       if (status === 'completed' || status === 'COMPLETED') {
-        const result =
-          response.data?.result || response.data?.data?.result || response.data;
+        const result = payload?.result || payload;
         return result.outputUrl || result.url;
       }
 
@@ -210,6 +344,39 @@ export class ClipAnalyzeProcessor extends WorkerHost {
 
     throw new Error(
       `Audio extraction job ${jobId} timed out after ${timeoutMs}ms`,
+    );
+  }
+
+  private async waitForReferenceFrameJob(
+    filesUrl: string,
+    jobId: string,
+    timeoutMs = 180_000,
+  ): Promise<ClipReferenceFrameSet> {
+    const pollInterval = 2_000;
+    const start = Date.now();
+
+    while (Date.now() - start < timeoutMs) {
+      const response = await firstValueFrom(
+        this.httpService.get(`${filesUrl}/v1/files/job/${jobId}`),
+      );
+      const payload = response.data?.data || response.data;
+      const status = payload?.status || payload?.state;
+
+      if (status === 'completed' || status === 'COMPLETED') {
+        return normalizeClipReferenceFrameSet(
+          payload?.result?.referenceFrames,
+        );
+      }
+
+      if (status === 'failed' || status === 'FAILED') {
+        throw new Error(`Reference extraction job ${jobId} failed`);
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, pollInterval));
+    }
+
+    throw new Error(
+      `Reference extraction job ${jobId} timed out after ${timeoutMs}ms`,
     );
   }
 

--- a/apps/server/workers/src/processors/api/queues/clip-analyze/clip-analyze.processor.ts
+++ b/apps/server/workers/src/processors/api/queues/clip-analyze/clip-analyze.processor.ts
@@ -16,7 +16,11 @@ import { randomUUID } from 'node:crypto';
 import { ClipProjectsService } from '@api/collections/clip-projects/clip-projects.service';
 import type { IHighlight } from '@api/collections/clip-projects/schemas/clip-project.schema';
 import { WhisperService } from '@api/services/whisper/whisper.service';
-import { normalizeClipReferenceFrameSet } from '@genfeedai/helpers';
+import { CLIP_REFERENCE_FRAME_JOB_TIMEOUT_MS } from '@genfeedai/constants';
+import {
+  normalizeClipReferenceFrameSet,
+  normalizeClipReferenceTimestamps,
+} from '@genfeedai/helpers';
 import {
   CLIP_REFERENCE_FRAME_SCHEMA_VERSION,
   type ClipReferenceFrameSet,
@@ -35,29 +39,18 @@ import { ClipHighlightDetector } from '@workers/processors/api/queues/shared/cli
 import type { Job } from 'bullmq';
 import { firstValueFrom } from 'rxjs';
 
-const MAX_REFERENCE_FRAMES = 5;
-
 function deriveReferenceTimestamps(highlights: IHighlight[]): number[] {
-  return [
-    ...new Set(
-      highlights
-        .filter(
-          (highlight) =>
-            Number.isFinite(highlight.start_time) &&
-            Number.isFinite(highlight.end_time) &&
-            highlight.start_time >= 0 &&
-            highlight.end_time >= highlight.start_time,
-        )
-        .map(
-          (highlight) =>
-            Math.round(
-              ((highlight.start_time + highlight.end_time) / 2) * 1000,
-            ) / 1000,
-        ),
-    ),
-  ]
-    .sort((left, right) => left - right)
-    .slice(0, MAX_REFERENCE_FRAMES);
+  return normalizeClipReferenceTimestamps(
+    highlights
+      .filter(
+        (highlight) =>
+          Number.isFinite(highlight.start_time) &&
+          Number.isFinite(highlight.end_time) &&
+          highlight.start_time >= 0 &&
+          highlight.end_time >= highlight.start_time,
+      )
+      .map((highlight) => (highlight.start_time + highlight.end_time) / 2),
+  );
 }
 
 function pendingReferenceFrames(timestamps: number[]): ClipReferenceFrameSet {
@@ -351,7 +344,7 @@ export class ClipAnalyzeProcessor extends WorkerHost {
   private async waitForReferenceFrameJob(
     filesUrl: string,
     jobId: string,
-    timeoutMs = 180_000,
+    timeoutMs = CLIP_REFERENCE_FRAME_JOB_TIMEOUT_MS,
   ): Promise<ClipReferenceFrameSet> {
     const pollInterval = 2_000;
     const start = Date.now();

--- a/bun.lock
+++ b/bun.lock
@@ -445,7 +445,9 @@
       "version": "1.0.0",
       "dependencies": {
         "@genfeedai/config": "workspace:*",
+        "@genfeedai/constants": "workspace:*",
         "@genfeedai/enums": "workspace:*",
+        "@genfeedai/helpers": "workspace:*",
         "@genfeedai/interfaces": "workspace:*",
         "@genfeedai/storage": "workspace:*",
         "@genfeedai/utils": "workspace:*",

--- a/packages/constants/src/media.constant.test.ts
+++ b/packages/constants/src/media.constant.test.ts
@@ -1,10 +1,13 @@
 import { IngredientFormat } from '@genfeedai/enums';
 import { describe, expect, it } from 'vitest';
 import {
+  CLIP_REFERENCE_FRAME_JOB_TIMEOUT_MS,
+  CLIP_REFERENCE_FRAME_MAX_CANDIDATES,
   DEFAULT_LABELS,
   VIDEO_DIMENSIONS,
   VIDEO_FORMAT_DIMENSIONS,
   VIDEO_MERGE_LIMITS,
+  YT_DLP_PROCESS_TIMEOUT_MS,
 } from './media.constant';
 
 describe('media.constant', () => {
@@ -44,6 +47,15 @@ describe('media.constant', () => {
     it('requires at least 2 and at most 10 videos', () => {
       expect(VIDEO_MERGE_LIMITS.MIN_VIDEOS).toBe(2);
       expect(VIDEO_MERGE_LIMITS.MAX_VIDEOS).toBe(10);
+    });
+  });
+
+  describe('clip reference frame limits', () => {
+    it('keeps the job budget above the source download timeout', () => {
+      expect(CLIP_REFERENCE_FRAME_MAX_CANDIDATES).toBe(5);
+      expect(CLIP_REFERENCE_FRAME_JOB_TIMEOUT_MS).toBeGreaterThan(
+        YT_DLP_PROCESS_TIMEOUT_MS,
+      );
     });
   });
 

--- a/packages/constants/src/media.constant.ts
+++ b/packages/constants/src/media.constant.ts
@@ -18,6 +18,11 @@ export const VIDEO_MERGE_LIMITS = {
   MIN_VIDEOS: 2,
 } as const;
 
+export const CLIP_REFERENCE_FRAME_MAX_CANDIDATES = 5;
+export const YT_DLP_PROCESS_TIMEOUT_MS = 5 * 60_000;
+export const CLIP_REFERENCE_FRAME_JOB_TIMEOUT_MS =
+  YT_DLP_PROCESS_TIMEOUT_MS + 60_000;
+
 export const DEFAULT_LABELS = {
   MERGED_STORYBOARD: 'Merged Storyboard',
 } as const;

--- a/packages/helpers/src/media/clip-reference-frame.helper.test.ts
+++ b/packages/helpers/src/media/clip-reference-frame.helper.test.ts
@@ -5,6 +5,7 @@ import {
 import {
   ClipReferenceFrameValidationError,
   normalizeClipReferenceFrameSet,
+  normalizeClipReferenceTimestamps,
 } from '@helpers/media/clip-reference-frame.helper';
 
 function createReferenceFrames(
@@ -212,5 +213,23 @@ describe('normalizeClipReferenceFrameSet', () => {
         }),
       ),
     ).toThrow(/assetId, storageKey, or url/);
+  });
+});
+
+describe('normalizeClipReferenceTimestamps', () => {
+  it('filters, rounds, deduplicates, sorts, and caps timestamps', () => {
+    expect(
+      normalizeClipReferenceTimestamps([
+        30,
+        Number.NaN,
+        10.0004,
+        -1,
+        20,
+        40,
+        50,
+        60,
+        10.00049,
+      ]),
+    ).toEqual([10, 20, 30, 40, 50]);
   });
 });

--- a/packages/helpers/src/media/clip-reference-frame.helper.ts
+++ b/packages/helpers/src/media/clip-reference-frame.helper.ts
@@ -1,3 +1,4 @@
+import { CLIP_REFERENCE_FRAME_MAX_CANDIDATES } from '@genfeedai/constants';
 import {
   CLIP_REFERENCE_FRAME_CANDIDATE_STATUSES,
   CLIP_REFERENCE_FRAME_DIAGNOSTIC_SEVERITIES,
@@ -19,6 +20,20 @@ const diagnosticSeverities = new Set<string>(
 );
 const referenceFrameStatuses = new Set<string>(CLIP_REFERENCE_FRAME_STATUSES);
 const unsafeStorageKeySegment = /(^|[\\/])\.\.([\\/]|$)/;
+
+export function normalizeClipReferenceTimestamps(
+  timestamps: readonly number[],
+): number[] {
+  return [
+    ...new Set(
+      timestamps
+        .filter((timestamp) => Number.isFinite(timestamp) && timestamp >= 0)
+        .map((timestamp) => Math.round(timestamp * 1000) / 1000),
+    ),
+  ]
+    .sort((left, right) => left - right)
+    .slice(0, CLIP_REFERENCE_FRAME_MAX_CANDIDATES);
+}
 
 function hasControlCharacter(value: string): boolean {
   return [...value].some((character) => character.charCodeAt(0) <= 31);

--- a/packages/interfaces/src/content/clip-reference-frame.interface.ts
+++ b/packages/interfaces/src/content/clip-reference-frame.interface.ts
@@ -56,3 +56,10 @@ export interface ClipReferenceFrameSet {
   selectedCandidateId: string | null;
   diagnostics: ClipReferenceFrameDiagnostic[];
 }
+
+export interface ClipReferenceFrameExtractionInput {
+  organizationId: string;
+  projectId: string;
+  sourceUrl: string;
+  timestamps: number[];
+}


### PR DESCRIPTION
Closes #1950

## Summary
- add a bounded files-service job for public YouTube reference-frame extraction
- derive up to five deterministic timestamps from accepted clip highlights
- upload tenant-scoped candidates with stable IDs, storage keys, URLs, and dimensions
- persist pending/ready/partial/unavailable reference-frame contracts without failing transcript or highlight analysis
- clean temporary source/frame files on success and failure
- couple worker and yt-dlp time budgets, terminate timed-out process groups, and defer cleanup until process close
- share timestamp normalization and candidate limits across files and workers

## Verification
- `bunx @biomejs/biome@2.5.3 format <changed files>`
- `bunx @biomejs/biome@2.5.3 check <changed files>`
- `git diff --check`
- scoped credential-pattern scan
- GitHub Actions is the broad verification gate; local unit tests, typechecks, and builds intentionally skipped per repository MacBook policy

## Claude Opus 4.8 audit
- full exact-head review at `027766b1c`: findings fixed in `ac8c9fef2`
- structured post-fix verification: **PASS** with no findings
- verified timeout/process lifecycle, output existence, tenant-scoped storage paths, shared timestamp normalization, packaging, and lockfile changes

## Residual risk
- live yt-dlp/FFmpeg/storage integration depends on deployed files-service binaries and credentials; failures degrade to an unavailable diagnostic and preserve analysis output.