### PR TITLE
feat(webhooks): expose delivery attempt count

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/organization/webhooks/content.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/~/settings/(pages)/organization/webhooks/content.tsx
@@ -401,6 +401,14 @@ export default function SettingsWebhooksPage() {
             <dd>{formatDate(deliveryStatus?.completedAt)}</dd>
           </div>
           <div>
+            <dt className="text-muted-foreground">Attempt</dt>
+            <dd>
+              {typeof deliveryStatus?.attempt === 'number'
+                ? deliveryStatus.attempt
+                : 'Unknown'}
+            </dd>
+          </div>
+          <div>
             <dt className="text-muted-foreground">HTTP status</dt>
             <dd>{formatHttpStatus(deliveryStatus)}</dd>
           </div>

--- a/apps/server/api/src/services/webhook-client/publish-event-webhook.service.spec.ts
+++ b/apps/server/api/src/services/webhook-client/publish-event-webhook.service.spec.ts
@@ -99,6 +99,7 @@ describe('PublishEventWebhookService', () => {
     expect(settingsService.recordWebhookDeliveryStatus).toHaveBeenCalledWith(
       'org_123',
       expect.objectContaining({
+        attempt: 0,
         deliveryId: 'publish:target.published:post_123:post_123:published',
         event: 'target.published',
         status: 'queued',
@@ -356,6 +357,7 @@ describe('PublishEventWebhookService', () => {
     });
 
     expect(status).toMatchObject({
+      attempt: 0,
       event: 'target.published',
       isTest: true,
       status: 'queued',

--- a/apps/server/api/src/services/webhook-client/publish-event-webhook.service.ts
+++ b/apps/server/api/src/services/webhook-client/publish-event-webhook.service.ts
@@ -494,6 +494,7 @@ export class PublishEventWebhookService {
     );
 
     const status: IWebhookDeliveryStatus = {
+      attempt: 0,
       deliveryId,
       event: payload.event,
       isTest: Boolean(options.isTest),

--- a/apps/server/workers/src/processors/api/services/webhook-client/webhook-client.processor.spec.ts
+++ b/apps/server/workers/src/processors/api/services/webhook-client/webhook-client.processor.spec.ts
@@ -60,6 +60,7 @@ describe('WebhookClientProcessor', () => {
     ).toHaveBeenCalledWith(
       'org-1',
       expect.objectContaining({
+        attempt: 1,
         deliveryId: 'job-1',
         event: 'ingredient.generated',
         status: 'failed',
@@ -98,6 +99,7 @@ describe('WebhookClientProcessor', () => {
     ).toHaveBeenCalledWith(
       'org-1',
       expect.objectContaining({
+        attempt: 1,
         deliveryId: 'job-1',
         event: 'ingredient.generated',
         status: 'delivered',
@@ -138,6 +140,7 @@ describe('WebhookClientProcessor', () => {
     ).toHaveBeenCalledWith(
       'org-1',
       expect.objectContaining({
+        attempt: 1,
         deliveryId: 'job-1',
         event: 'ingredient.generated',
         status: 'failed',
@@ -178,6 +181,16 @@ describe('WebhookClientProcessor', () => {
         jobId: 'publish:target.failed:release-1:target-1:failed',
         maxAttempts: 5,
         organizationId: 'org-1',
+      }),
+    );
+    expect(
+      organizationSettingsService.recordWebhookDeliveryStatus,
+    ).toHaveBeenCalledWith(
+      'org-1',
+      expect.objectContaining({
+        attempt: 2,
+        deliveryId: 'publish:target.failed:release-1:target-1:failed',
+        status: 'failed',
       }),
     );
   });

--- a/apps/server/workers/src/processors/api/services/webhook-client/webhook-client.processor.ts
+++ b/apps/server/workers/src/processors/api/services/webhook-client/webhook-client.processor.ts
@@ -27,10 +27,11 @@ export class WebhookClientProcessor extends WorkerHost {
   async process(job: Job<WebhookJobData>): Promise<void> {
     const { endpoint, secret, payload, organizationId, ingredientId, isTest } =
       job.data;
+    const attempt = job.attemptsMade + 1;
     const deliveryId = job.data.deliveryId ?? job.id ?? 'unknown';
 
     this.logger.log(`${this.constructorName} processing webhook job`, {
-      attempt: job.attemptsMade + 1,
+      attempt,
       deliveryId,
       event: payload.event,
       ingredientId,
@@ -70,6 +71,7 @@ export class WebhookClientProcessor extends WorkerHost {
       await job.updateProgress(100);
 
       await this.recordDeliveryStatus(organizationId, {
+        attempt,
         attemptedAt: new Date().toISOString(),
         completedAt: new Date().toISOString(),
         deliveryId,
@@ -102,6 +104,7 @@ export class WebhookClientProcessor extends WorkerHost {
       }
     } catch (error: unknown) {
       await this.recordDeliveryStatus(organizationId, {
+        attempt,
         attemptedAt: new Date().toISOString(),
         deliveryId,
         error: (error as Error)?.message || 'Webhook delivery failed',
@@ -112,7 +115,7 @@ export class WebhookClientProcessor extends WorkerHost {
       });
 
       this.logger.error(`${this.constructorName} webhook delivery failed`, {
-        attempt: job.attemptsMade + 1,
+        attempt,
         // @ts-expect-error TS2339
         code: (error as Error)?.code,
         error: (error as Error)?.message,

--- a/packages/interfaces/src/organization/organization-setting.interface.ts
+++ b/packages/interfaces/src/organization/organization-setting.interface.ts
@@ -27,6 +27,7 @@ export type WebhookDeliveryStatusValue =
   | 'failed';
 
 export interface IWebhookDeliveryStatus {
+  attempt?: number;
   deliveryId: string;
   event: string;
   status: WebhookDeliveryStatusValue;


### PR DESCRIPTION
## Summary

- expose the BullMQ delivery attempt number through the existing webhook delivery-status contract
- record queued deliveries as attempt 0 and worker outcomes as the one-based current attempt
- display the latest attempt in the organization webhook settings surface
- extend focused API and worker assertions for queued, delivered, rejected, SSRF-failed, and retried deliveries

## Verification

- `bunx biome check --write <six changed files>` — passed
- `bunx biome check <six changed files>` — passed
- `git diff --check` — passed
- scoped changed-file secret, sensitive-filename, and oversized-artifact scan — passed
- focused Vitest, typecheck, build, and broad suites — not run locally per workstation policy; delegated to pull-request CI

## Risk

- Additive optional contract field; existing persisted status objects remain readable and render `Unknown` until the next delivery update.
- Queue payloads, signing, endpoint filtering, SSRF validation, retry options, and organization resolution are unchanged.

Closes #1961