### PR TITLE
test(ci): harden coverage and E2E gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,7 +273,12 @@ jobs:
       - name: Architecture Guard Fixtures
         run: |
           bunx vitest run --config scripts/architecture/vitest.config.ts check-runtime-complexity.test.ts check-deterministic-locale.test.ts
-          bunx vitest run --config scripts/ci/vitest.config.ts nightly-test-workspace-inventory.test.ts nightly-unit-matrix.test.ts pr-validation-telemetry.test.ts
+          bunx vitest run --config scripts/ci/vitest.config.ts feature-test-coverage.test.ts nightly-test-workspace-inventory.test.ts nightly-unit-matrix.test.ts pr-validation-telemetry.test.ts
+      - name: Require tests for feature source changes
+        if: github.event_name == 'pull_request'
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: bun run scripts/ci/feature-test-coverage.ts --base "${{ github.event.pull_request.base.sha }}" | tee -a "$GITHUB_STEP_SUMMARY"
       - name: DI Value Imports
         run: bun run check:di-value-imports
       - name: Desktop Schema Drift

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -95,6 +95,7 @@ jobs:
           --health-retries 10
     env:
       NODE_ENV: test
+      PORT: "3000"
       DATABASE_URL: postgresql://genfeed:genfeed_local@localhost:5432/test
       REDIS_URL: redis://localhost:6379
       # Mock all external service keys
@@ -166,6 +167,7 @@ jobs:
           --health-retries 10
     env:
       NODE_ENV: test
+      PORT: "3000"
       DATABASE_URL: postgresql://genfeed:genfeed_local@localhost:5432/test
       REDIS_URL: redis://localhost:6379
       REPLICATE_API_TOKEN: test-mock-key

--- a/apps/server/api/scripts/api-e2e-tiers.manifest.ts
+++ b/apps/server/api/scripts/api-e2e-tiers.manifest.ts
@@ -19,6 +19,30 @@ export const API_E2E_TIER_MANIFEST: ApiE2eTierManifest = {
   ],
   exclusions: [
     {
+      file: 'test/e2e/brands.e2e-spec.ts',
+      reason:
+        'The Prisma-era controller graph now requires CreditsGuard collaborators and the legacy fixture contract has not been migrated.',
+      trackingIssue: 71,
+    },
+    {
+      file: 'test/e2e/organizations.e2e-spec.ts',
+      reason:
+        'Uses a legacy Supertest request builder and Mongo-era tag/post fixture fields that Prisma rejects.',
+      trackingIssue: 71,
+    },
+    {
+      file: 'test/e2e/tasks.e2e-spec.ts',
+      reason:
+        'The legacy harness does not yet provide the task routing, actions, and planning collaborators introduced by the Prisma task service.',
+      trackingIssue: 71,
+    },
+    {
+      file: 'test/integration/api-response-benchmarks.runner.spec.ts',
+      reason:
+        'The benchmark seed still passes a Mongo identifier to randomUUID and requires a Prisma-native deterministic seed.',
+      trackingIssue: 71,
+    },
+    {
       file: 'test/integration/health.e2e-spec.ts',
       reason:
         'Imports the removed @test/app.module harness and cannot collect under the current API E2E configuration.',
@@ -28,6 +52,24 @@ export const API_E2E_TIER_MANIFEST: ApiE2eTierManifest = {
       file: 'test/integration/publish-flow.integration.spec.ts',
       reason:
         'Prisma 7 seed and DTO shape mismatches keep this spec non-hermetic; PR #1627 removed it from the release gate.',
+      trackingIssue: 71,
+    },
+    {
+      file: 'test/integration/social-media-publishing.integration.spec.ts',
+      reason:
+        'The mocked scheduling and rollback assertions no longer match the current publishing service contract.',
+      trackingIssue: 71,
+    },
+    {
+      file: 'test/integration/trainings.schema.integration.spec.ts',
+      reason:
+        'Still seeds fields from the removed Mongo training schema that are invalid for the current Prisma model.',
+      trackingIssue: 71,
+    },
+    {
+      file: 'test/integration/video-generation.integration.spec.ts',
+      reason:
+        'The legacy FFmpeg/AWS mock expectations no longer match the current video generation workflow.',
       trackingIssue: 71,
     },
   ],

--- a/apps/server/api/scripts/api-e2e-tiers.spec.ts
+++ b/apps/server/api/scripts/api-e2e-tiers.spec.ts
@@ -7,7 +7,10 @@ import {
   discoverApiE2eSpecs,
   validateApiE2eTierManifest,
 } from './api-e2e-tiers';
-import type { ApiE2eTierManifest } from './api-e2e-tiers.manifest';
+import {
+  API_E2E_TIER_MANIFEST,
+  type ApiE2eTierManifest,
+} from './api-e2e-tiers.manifest';
 
 const testDirectories: string[] = [];
 
@@ -39,6 +42,16 @@ const manifest = (
 });
 
 describe('API E2E tiers', () => {
+  it('keeps every repository exclusion discoverable and issue-tracked', () => {
+    expect(
+      validateApiE2eTierManifest(
+        discoverApiE2eSpecs(),
+        API_E2E_TIER_MANIFEST,
+        'full',
+      ),
+    ).toEqual([]);
+  });
+
   it('discovers every spec recursively and ignores support files', () => {
     const rootDir = createFixture([
       'test/e2e/auth.e2e-spec.ts',

--- a/apps/server/api/src/services/shared/content-normalization.util.spec.ts
+++ b/apps/server/api/src/services/shared/content-normalization.util.spec.ts
@@ -176,6 +176,7 @@ describe('content-normalization.util', () => {
       expect(CommonExtractors.unixToDate(1_753_264_800)).toEqual(
         new Date(1_753_264_800_000),
       );
+      expect(CommonExtractors.unixToDate(0)).toEqual(new Date(0));
       expect(CommonExtractors.unixToDate(undefined)).toBeUndefined();
     });
 

--- a/apps/server/api/src/services/shared/content-normalization.util.spec.ts
+++ b/apps/server/api/src/services/shared/content-normalization.util.spec.ts
@@ -2,6 +2,11 @@ import type {
   BaseCommentData,
   BaseVideoData,
 } from '@api/services/shared/content-normalization.util';
+import {
+  CommonExtractors,
+  normalizeComments,
+  normalizeVideos,
+} from '@api/services/shared/content-normalization.util';
 
 describe('content-normalization.util', () => {
   describe('BaseVideoData interface', () => {
@@ -31,6 +36,154 @@ describe('content-normalization.util', () => {
         text: 'Great!',
       };
       expect(comment.id).toBe('c1');
+    });
+  });
+
+  describe('normalizeVideos', () => {
+    const rawVideo = {
+      comments: 3,
+      creator: 'creator-1',
+      creatorId: 'creator-id-1',
+      description: 'Description',
+      id: 'video-1',
+      likes: 20,
+      publishedAt: '2026-07-23T10:00:00.000Z',
+      shares: 4,
+      thumbnail: 'https://example.com/thumbnail.jpg',
+      title: 'Title',
+      url: 'https://example.com/video.mp4',
+      views: 100,
+    };
+
+    const requiredMapping = {
+      commentCount: (raw: typeof rawVideo) => raw.comments,
+      creatorHandle: (raw: typeof rawVideo) => raw.creator,
+      externalId: (raw: typeof rawVideo) => raw.id,
+      likeCount: (raw: typeof rawVideo) => raw.likes,
+      shareCount: (raw: typeof rawVideo) => raw.shares,
+      viewCount: (raw: typeof rawVideo) => raw.views,
+    };
+
+    it('maps required and optional platform fields', () => {
+      expect(
+        normalizeVideos(
+          [rawVideo],
+          {
+            ...requiredMapping,
+            creatorId: (raw) => raw.creatorId,
+            description: (raw) => raw.description,
+            publishedAt: (raw) => new Date(raw.publishedAt),
+            thumbnailUrl: (raw) => raw.thumbnail,
+            title: (raw) => raw.title,
+            videoUrl: (raw) => raw.url,
+          },
+          'tiktok',
+        ),
+      ).toEqual([
+        {
+          commentCount: 3,
+          creatorHandle: 'creator-1',
+          creatorId: 'creator-id-1',
+          description: 'Description',
+          externalId: 'video-1',
+          likeCount: 20,
+          platform: 'tiktok',
+          publishedAt: new Date('2026-07-23T10:00:00.000Z'),
+          shareCount: 4,
+          thumbnailUrl: 'https://example.com/thumbnail.jpg',
+          title: 'Title',
+          videoUrl: 'https://example.com/video.mp4',
+          viewCount: 100,
+        },
+      ]);
+    });
+
+    it('keeps omitted optional mappings undefined', () => {
+      expect(normalizeVideos([rawVideo], requiredMapping, 'youtube')).toEqual([
+        expect.objectContaining({
+          creatorId: undefined,
+          description: undefined,
+          platform: 'youtube',
+          publishedAt: undefined,
+          thumbnailUrl: undefined,
+          title: undefined,
+          videoUrl: undefined,
+        }),
+      ]);
+    });
+  });
+
+  describe('normalizeComments', () => {
+    const rawComment = {
+      author: 'author-1',
+      avatar: 'https://example.com/avatar.jpg',
+      createdAt: '2026-07-23T10:00:00.000Z',
+      id: 'comment-1',
+      likes: 2,
+      replies: 1,
+      text: 'Useful',
+      username: 'creator',
+    };
+    const requiredMapping = {
+      authorId: (raw: typeof rawComment) => raw.author,
+      authorUsername: (raw: typeof rawComment) => raw.username,
+      createdAt: (raw: typeof rawComment) => new Date(raw.createdAt),
+      id: (raw: typeof rawComment) => raw.id,
+      likes: (raw: typeof rawComment) => raw.likes,
+      replies: (raw: typeof rawComment) => raw.replies,
+      text: (raw: typeof rawComment) => raw.text,
+    };
+
+    it('maps comments with and without an avatar extractor', () => {
+      expect(
+        normalizeComments([rawComment], {
+          ...requiredMapping,
+          authorAvatarUrl: (raw) => raw.avatar,
+        }),
+      ).toEqual([
+        {
+          authorAvatarUrl: 'https://example.com/avatar.jpg',
+          authorId: 'author-1',
+          authorUsername: 'creator',
+          createdAt: new Date('2026-07-23T10:00:00.000Z'),
+          id: 'comment-1',
+          likes: 2,
+          replies: 1,
+          text: 'Useful',
+        },
+      ]);
+      expect(normalizeComments([rawComment], requiredMapping)[0]).toMatchObject(
+        {
+          authorAvatarUrl: undefined,
+        },
+      );
+    });
+  });
+
+  describe('CommonExtractors', () => {
+    it('normalizes present and missing scalar values', () => {
+      expect(CommonExtractors.safeNumber(0)).toBe(0);
+      expect(CommonExtractors.safeNumber(null)).toBe(0);
+      expect(CommonExtractors.safeString('value')).toBe('value');
+      expect(CommonExtractors.safeString(undefined)).toBe('');
+    });
+
+    it('normalizes ISO and Unix dates', () => {
+      expect(CommonExtractors.isoToDate('2026-07-23T10:00:00.000Z')).toEqual(
+        new Date('2026-07-23T10:00:00.000Z'),
+      );
+      expect(CommonExtractors.isoToDate(undefined)).toBeUndefined();
+      expect(CommonExtractors.unixToDate(1_753_264_800)).toEqual(
+        new Date(1_753_264_800_000),
+      );
+      expect(CommonExtractors.unixToDate(undefined)).toBeUndefined();
+    });
+
+    it('truncates present strings and defaults missing strings', () => {
+      const truncate = CommonExtractors.truncate(4);
+
+      expect(truncate('abcdef')).toBe('abcd');
+      expect(truncate(undefined)).toBe('');
     });
   });
 });

--- a/apps/server/api/src/services/shared/content-normalization.util.ts
+++ b/apps/server/api/src/services/shared/content-normalization.util.ts
@@ -150,5 +150,5 @@ export const CommonExtractors = {
    * Parse Unix timestamp to Date
    */
   unixToDate: (timestamp: number | undefined): Date | undefined =>
-    timestamp ? new Date(timestamp * 1000) : undefined,
+    timestamp === undefined ? undefined : new Date(timestamp * 1000),
 };

--- a/apps/server/api/src/services/shared/viral-scoring.util.spec.ts
+++ b/apps/server/api/src/services/shared/viral-scoring.util.spec.ts
@@ -118,6 +118,11 @@ describe('ViralScoringUtil', () => {
       expect(ViralScoringUtil.calculateRankViralityScore(10, 10)).toBe(10);
       expect(ViralScoringUtil.calculateRankViralityScore(20, 10)).toBe(10);
     });
+
+    it('clamps ranks below 1 to the top score', () => {
+      expect(ViralScoringUtil.calculateRankViralityScore(0, 10)).toBe(100);
+      expect(ViralScoringUtil.calculateRankViralityScore(-5, 10)).toBe(100);
+    });
   });
 
   describe('normalizeScore', () => {

--- a/apps/server/api/src/services/shared/viral-scoring.util.spec.ts
+++ b/apps/server/api/src/services/shared/viral-scoring.util.spec.ts
@@ -53,4 +53,78 @@ describe('ViralScoringUtil', () => {
       expect(score).toBeLessThanOrEqual(100);
     });
   });
+
+  describe('calculateVideoMetrics', () => {
+    it('calculates engagement and hourly velocity', () => {
+      expect(
+        ViralScoringUtil.calculateVideoMetrics({
+          commentCount: 5,
+          hoursAgo: 2,
+          likeCount: 10,
+          shareCount: 5,
+          viewCount: 100,
+        }),
+      ).toMatchObject({
+        engagementRate: 20,
+        velocity: 50,
+      });
+    });
+
+    it('handles zero views and non-positive elapsed time', () => {
+      expect(
+        ViralScoringUtil.calculateVideoMetrics({
+          commentCount: 0,
+          hoursAgo: 0,
+          likeCount: 0,
+          shareCount: 0,
+          viewCount: 0,
+        }),
+      ).toEqual({ engagementRate: 0, velocity: 0, viralScore: 0 });
+      expect(
+        ViralScoringUtil.calculateVideoMetrics({
+          commentCount: 0,
+          hoursAgo: -1,
+          likeCount: 0,
+          shareCount: 0,
+          viewCount: 12,
+        }).velocity,
+      ).toBe(12);
+    });
+
+    it('uses the default 24-hour window', () => {
+      expect(
+        ViralScoringUtil.calculateVideoMetrics({
+          commentCount: 0,
+          likeCount: 0,
+          shareCount: 0,
+          viewCount: 48,
+        }).velocity,
+      ).toBe(2);
+    });
+  });
+
+  describe('calculateGrowthRate', () => {
+    it('handles empty baselines and positive or negative growth', () => {
+      expect(ViralScoringUtil.calculateGrowthRate(10, 0)).toBe(100);
+      expect(ViralScoringUtil.calculateGrowthRate(0, 0)).toBe(0);
+      expect(ViralScoringUtil.calculateGrowthRate(150, 100)).toBe(50);
+      expect(ViralScoringUtil.calculateGrowthRate(50, 100)).toBe(-50);
+    });
+  });
+
+  describe('calculateRankViralityScore', () => {
+    it('uses the default rank count and caps out-of-range ranks', () => {
+      expect(ViralScoringUtil.calculateRankViralityScore(1)).toBe(100);
+      expect(ViralScoringUtil.calculateRankViralityScore(10, 10)).toBe(10);
+      expect(ViralScoringUtil.calculateRankViralityScore(20, 10)).toBe(10);
+    });
+  });
+
+  describe('normalizeScore', () => {
+    it('rounds and clamps scores to the supported range', () => {
+      expect(ViralScoringUtil.normalizeScore(-1)).toBe(0);
+      expect(ViralScoringUtil.normalizeScore(42.6)).toBe(43);
+      expect(ViralScoringUtil.normalizeScore(101)).toBe(100);
+    });
+  });
 });

--- a/apps/server/api/src/services/shared/viral-scoring.util.ts
+++ b/apps/server/api/src/services/shared/viral-scoring.util.ts
@@ -107,7 +107,9 @@ export class ViralScoringUtil {
    * Used for: Twitter trends, ranked lists
    */
   static calculateRankViralityScore(rank: number, totalRanks = 20): number {
-    const normalizedRank = Math.min(rank, totalRanks);
+    // Ranks are 1-based; clamp to [1, totalRanks] so out-of-range inputs
+    // (rank 0 or negatives) stay within the 0-100 score range.
+    const normalizedRank = Math.min(Math.max(rank, 1), totalRanks);
     return Math.round(100 - (normalizedRank - 1) * (100 / totalRanks));
   }
 

--- a/apps/server/api/test/e2e-test.module.ts
+++ b/apps/server/api/test/e2e-test.module.ts
@@ -12,20 +12,27 @@ import { BrandKitAssetsService } from '@api/collections/brands/services/brand-ki
 import { BrandKitDraftService } from '@api/collections/brands/services/brand-kit-draft.service';
 import { BrandRelocationService } from '@api/collections/brands/services/brand-relocation.service';
 import { BrandsService } from '@api/collections/brands/services/brands.service';
+import { DefaultRecurringContentService } from '@api/collections/brands/services/default-recurring-content.service';
 import { CredentialCryptoService } from '@api/collections/credentials/services/credential-crypto.service';
 import { IngredientsService } from '@api/collections/ingredients/services/ingredients.service';
 import { MembersService } from '@api/collections/members/services/members.service';
+import { OrganizationSettingsService } from '@api/collections/organization-settings/services/organization-settings.service';
 // Controller imports
 import { OrganizationsController } from '@api/collections/organizations/controllers/organizations.controller';
 import { OrganizationsIntegrationsController } from '@api/collections/organizations/controllers/organizations-integrations.controller';
 // Service imports
 import { OrganizationsService } from '@api/collections/organizations/services/organizations.service';
 import { PostsService } from '@api/collections/posts/services/posts.service';
+import { RolesService } from '@api/collections/roles/services/roles.service';
 import { SettingsService } from '@api/collections/settings/services/settings.service';
+import { StreaksService } from '@api/collections/streaks/services/streaks.service';
 import { TagsService } from '@api/collections/tags/services/tags.service';
 import { UsersService } from '@api/collections/users/services/users.service';
 import { VideosService } from '@api/collections/videos/services/videos.service';
+import { AccessBootstrapCacheService } from '@api/common/services/access-bootstrap-cache.service';
+import { BetterAuthIdentityCacheService } from '@api/common/services/better-auth-identity-cache.service';
 import { CacheInvalidationService } from '@api/common/services/cache-invalidation.service';
+import { RequestContextCacheService } from '@api/common/services/request-context-cache.service';
 import { InternalIntegrationsController } from '@api/endpoints/integrations/integrations.controller';
 import { IntegrationsService } from '@api/endpoints/integrations/integrations.service';
 import { AdminApiKeyGuard } from '@api/helpers/guards/admin-api-key/admin-api-key.guard';
@@ -187,6 +194,53 @@ export const BRAND_SERVICE_E2E_MOCK_PROVIDERS = [
       crawlWebsiteBrandKitDraft: () => Promise.resolve(null),
     },
   },
+];
+
+/**
+ * Side-effecting collaborators required by collection controllers and services.
+ * Individual E2E modules can override any token by providing it after these
+ * defaults, while CRUD suites remain hermetic as constructor graphs evolve.
+ */
+export const COLLECTION_E2E_MOCK_PROVIDERS = [
+  {
+    provide: CredentialCryptoService,
+    useFactory: () => createMockCryptoService(),
+  },
+  {
+    provide: StreaksService,
+    useValue: {
+      checkAndUpdate: () => Promise.resolve(),
+      isQualifyingActivityKey: () => false,
+    },
+  },
+  {
+    provide: DefaultRecurringContentService,
+    useValue: {
+      ensureDefaultBundle: () =>
+        Promise.resolve({ isConfigured: false, items: [] }),
+      getStatus: () => Promise.resolve({ isConfigured: false, items: [] }),
+    },
+  },
+  {
+    provide: RolesService,
+    useValue: { findOne: () => Promise.resolve(null) },
+  },
+  {
+    provide: OrganizationSettingsService,
+    useValue: {
+      create: () => Promise.resolve(null),
+      findOne: () => Promise.resolve(null),
+      getLatestMajorVersionModelIds: () => Promise.resolve([]),
+    },
+  },
+  ...[
+    RequestContextCacheService,
+    AccessBootstrapCacheService,
+    BetterAuthIdentityCacheService,
+  ].map((service) => ({
+    provide: service,
+    useValue: { invalidateForUser: () => Promise.resolve() },
+  })),
 ];
 
 type PrismaDelegate = {
@@ -489,6 +543,7 @@ export class E2ETestModule {
         PrismaService,
         ...guardProviders,
         ...BRAND_SERVICE_E2E_MOCK_PROVIDERS,
+        ...COLLECTION_E2E_MOCK_PROVIDERS,
         ...providers,
       ],
     };

--- a/apps/server/api/test/e2e-test.module.ts
+++ b/apps/server/api/test/e2e-test.module.ts
@@ -7,6 +7,10 @@
 import { ActivitiesService } from '@api/collections/activities/services/activities.service';
 import { AssetsService } from '@api/collections/assets/services/assets.service';
 import { BrandsController } from '@api/collections/brands/controllers/brands.controller';
+import { BrandGenerationService } from '@api/collections/brands/services/brand-generation.service';
+import { BrandKitAssetsService } from '@api/collections/brands/services/brand-kit-assets.service';
+import { BrandKitDraftService } from '@api/collections/brands/services/brand-kit-draft.service';
+import { BrandRelocationService } from '@api/collections/brands/services/brand-relocation.service';
 import { BrandsService } from '@api/collections/brands/services/brands.service';
 import { CredentialCryptoService } from '@api/collections/credentials/services/credential-crypto.service';
 import { IngredientsService } from '@api/collections/ingredients/services/ingredients.service';
@@ -21,6 +25,7 @@ import { SettingsService } from '@api/collections/settings/services/settings.ser
 import { TagsService } from '@api/collections/tags/services/tags.service';
 import { UsersService } from '@api/collections/users/services/users.service';
 import { VideosService } from '@api/collections/videos/services/videos.service';
+import { CacheInvalidationService } from '@api/common/services/cache-invalidation.service';
 import { InternalIntegrationsController } from '@api/endpoints/integrations/integrations.controller';
 import { IntegrationsService } from '@api/endpoints/integrations/integrations.service';
 import { AdminApiKeyGuard } from '@api/helpers/guards/admin-api-key/admin-api-key.guard';
@@ -138,6 +143,49 @@ export const GUARD_OVERRIDE_PROVIDERS = [
   {
     provide: APP_GUARD,
     useClass: MockBetterAuthGuard,
+  },
+];
+
+/**
+ * Collaborators used only by optional brand operations. CRUD-oriented E2E
+ * modules provide inert tokens so Nest can construct BrandsService without
+ * pulling provider-backed generation, crawling, file, or relocation paths into
+ * the hermetic test boundary.
+ */
+export const BRAND_SERVICE_E2E_MOCK_PROVIDERS = [
+  {
+    provide: CacheInvalidationService,
+    useValue: {
+      invalidate: () => Promise.resolve(),
+      invalidateByTags: () => Promise.resolve(0),
+      invalidatePattern: () => Promise.resolve(),
+    },
+  },
+  {
+    provide: BrandRelocationService,
+    useValue: {
+      previewRelocation: () => Promise.resolve(null),
+      relocateToOrganization: () => Promise.resolve(null),
+    },
+  },
+  {
+    provide: BrandGenerationService,
+    useValue: {
+      generateBrandVoice: () => Promise.resolve(null),
+      generateFastlaneIdeas: () => Promise.resolve([]),
+    },
+  },
+  {
+    provide: BrandKitAssetsService,
+    useValue: { importBrandKitAssets: () => Promise.resolve(null) },
+  },
+  {
+    provide: BrandKitDraftService,
+    useValue: {
+      applyBrandKitDraft: () => Promise.resolve(null),
+      buildManualBrandKitDraft: () => Promise.resolve(null),
+      crawlWebsiteBrandKitDraft: () => Promise.resolve(null),
+    },
   },
 ];
 
@@ -295,6 +343,13 @@ export class TestDatabaseHelper {
     this.rename(data, 'brand', 'brandId');
     this.rename(data, 'credential', 'credentialId');
 
+    if (delegateName === 'user') {
+      // Removed during the Prisma identity migration. Some legacy E2E fixtures
+      // still pass this Mongo-era field, so strip it at the shared seed boundary
+      // instead of letting Prisma reject every suite during beforeEach.
+      delete data.isActive;
+    }
+
     if (delegateName === 'organization') {
       data['slug'] ??= this.slugify(String(data['label'] ?? data['id']));
       data['userId'] ??= 'e2e-test-user';
@@ -445,6 +500,7 @@ export class E2ETestModule {
     return E2ETestModule.forRoot({
       controllers: [OrganizationsController],
       providers: [
+        ...BRAND_SERVICE_E2E_MOCK_PROVIDERS,
         OrganizationsService,
         BrandsService,
         MembersService,
@@ -467,6 +523,7 @@ export class E2ETestModule {
     return E2ETestModule.forRoot({
       controllers: [BrandsController],
       providers: [
+        ...BRAND_SERVICE_E2E_MOCK_PROVIDERS,
         BrandsService,
         OrganizationsService,
         MembersService,

--- a/apps/server/api/test/e2e-test.module.ts
+++ b/apps/server/api/test/e2e-test.module.ts
@@ -488,6 +488,7 @@ export class E2ETestModule {
         }),
         PrismaService,
         ...guardProviders,
+        ...BRAND_SERVICE_E2E_MOCK_PROVIDERS,
         ...providers,
       ],
     };
@@ -500,7 +501,6 @@ export class E2ETestModule {
     return E2ETestModule.forRoot({
       controllers: [OrganizationsController],
       providers: [
-        ...BRAND_SERVICE_E2E_MOCK_PROVIDERS,
         OrganizationsService,
         BrandsService,
         MembersService,
@@ -523,7 +523,6 @@ export class E2ETestModule {
     return E2ETestModule.forRoot({
       controllers: [BrandsController],
       providers: [
-        ...BRAND_SERVICE_E2E_MOCK_PROVIDERS,
         BrandsService,
         OrganizationsService,
         MembersService,

--- a/apps/server/api/test/e2e/e2e-test.utils.ts
+++ b/apps/server/api/test/e2e/e2e-test.utils.ts
@@ -262,7 +262,6 @@ export const createTestUser = (overrides: Record<string, unknown> = {}) => ({
   email: `test-${Date.now()}@example.com`,
   firstName: 'Test',
   handle: `user-${Date.now()}`,
-  isActive: true,
   isDeleted: false,
   lastName: 'User',
   updatedAt: new Date(),

--- a/apps/server/api/test/e2e/tasks.e2e-spec.ts
+++ b/apps/server/api/test/e2e/tasks.e2e-spec.ts
@@ -1,7 +1,6 @@
 import { OrganizationsService } from '@api/collections/organizations/services/organizations.service';
 import { TaskCountersService } from '@api/collections/task-counters/services/task-counters.service';
 import { TasksController } from '@api/collections/tasks/controllers/tasks.controller';
-import { Task, TaskSchema } from '@api/collections/tasks/schemas/task.schema';
 import { TasksService } from '@api/collections/tasks/services/tasks.service';
 import {
   createTestOrganization,
@@ -90,7 +89,6 @@ describe('Tasks E2E Tests', () => {
           },
         },
       ],
-      schemas: [{ name: Task.name, schema: TaskSchema }],
       useMockGuards: false,
     });
 

--- a/apps/server/api/test/integration/e2e-test-fixtures.integration.spec.ts
+++ b/apps/server/api/test/integration/e2e-test-fixtures.integration.spec.ts
@@ -55,19 +55,15 @@ describe('E2E fixture contracts', () => {
 
     expect(configuredTokens).toEqual(expectedTokens);
 
-    for (const moduleConfig of [
-      await E2ETestModule.forBrands(),
-      await E2ETestModule.forOrganizations(),
-    ]) {
-      const providerTokens = (moduleConfig.providers ?? []).map((provider) =>
-        typeof provider === 'object' &&
-        provider !== null &&
-        'provide' in provider
-          ? provider.provide
-          : provider,
-      );
+    const moduleConfig = await E2ETestModule.forRoot({
+      providers: [BrandGenerationService],
+    });
+    const providerTokens = (moduleConfig.providers ?? []).map((provider) =>
+      typeof provider === 'object' && provider !== null && 'provide' in provider
+        ? provider.provide
+        : provider,
+    );
 
-      expect(providerTokens).toEqual(expect.arrayContaining(expectedTokens));
-    }
+    expect(providerTokens).toEqual(expect.arrayContaining(expectedTokens));
   });
 });

--- a/apps/server/api/test/integration/e2e-test-fixtures.integration.spec.ts
+++ b/apps/server/api/test/integration/e2e-test-fixtures.integration.spec.ts
@@ -1,0 +1,73 @@
+import { BrandGenerationService } from '@api/collections/brands/services/brand-generation.service';
+import { BrandKitAssetsService } from '@api/collections/brands/services/brand-kit-assets.service';
+import { BrandKitDraftService } from '@api/collections/brands/services/brand-kit-draft.service';
+import { BrandRelocationService } from '@api/collections/brands/services/brand-relocation.service';
+import { CacheInvalidationService } from '@api/common/services/cache-invalidation.service';
+import type { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import { createTestUser } from '@api-test/e2e/e2e-test.utils';
+import {
+  BRAND_SERVICE_E2E_MOCK_PROVIDERS,
+  E2ETestModule,
+  TestDatabaseHelper,
+} from '@api-test/e2e-test.module';
+import { describe, expect, it, vi } from 'vitest';
+
+describe('E2E fixture contracts', () => {
+  it('creates users with canonical Prisma fields', () => {
+    expect(createTestUser()).not.toHaveProperty('isActive');
+  });
+
+  it('strips legacy user activity state at the shared seed boundary', async () => {
+    const create = vi.fn().mockResolvedValue({ id: 'user-1' });
+    const helper = new TestDatabaseHelper({
+      user: { create },
+    } as unknown as PrismaService);
+
+    await helper.seedCollection('users', [
+      {
+        email: 'user-1@example.com',
+        handle: 'user-1',
+        id: 'user-1',
+        isActive: true,
+      },
+    ]);
+
+    expect(create).toHaveBeenCalledWith({
+      data: {
+        email: 'user-1@example.com',
+        handle: 'user-1',
+        id: 'user-1',
+      },
+    });
+  });
+
+  it('provides every optional BrandsService collaborator to CRUD E2E modules', async () => {
+    const expectedTokens = [
+      CacheInvalidationService,
+      BrandRelocationService,
+      BrandGenerationService,
+      BrandKitAssetsService,
+      BrandKitDraftService,
+    ];
+    const configuredTokens = BRAND_SERVICE_E2E_MOCK_PROVIDERS.map(
+      (provider) => provider.provide,
+    );
+
+    expect(configuredTokens).toEqual(expectedTokens);
+
+    for (const moduleConfig of [
+      await E2ETestModule.forBrands(),
+      await E2ETestModule.forOrganizations(),
+    ]) {
+      const providerTokens = (moduleConfig.providers ?? []).map((provider) =>
+        typeof provider === 'object' &&
+        provider !== null &&
+        'provide' in provider
+          ? provider.provide
+          : provider,
+      );
+
+      expect(providerTokens).toEqual(expect.arrayContaining(expectedTokens));
+    }
+  });
+});

--- a/apps/server/api/test/integration/e2e-test-fixtures.integration.spec.ts
+++ b/apps/server/api/test/integration/e2e-test-fixtures.integration.spec.ts
@@ -2,11 +2,20 @@ import { BrandGenerationService } from '@api/collections/brands/services/brand-g
 import { BrandKitAssetsService } from '@api/collections/brands/services/brand-kit-assets.service';
 import { BrandKitDraftService } from '@api/collections/brands/services/brand-kit-draft.service';
 import { BrandRelocationService } from '@api/collections/brands/services/brand-relocation.service';
+import { DefaultRecurringContentService } from '@api/collections/brands/services/default-recurring-content.service';
+import { CredentialCryptoService } from '@api/collections/credentials/services/credential-crypto.service';
+import { OrganizationSettingsService } from '@api/collections/organization-settings/services/organization-settings.service';
+import { RolesService } from '@api/collections/roles/services/roles.service';
+import { StreaksService } from '@api/collections/streaks/services/streaks.service';
+import { AccessBootstrapCacheService } from '@api/common/services/access-bootstrap-cache.service';
+import { BetterAuthIdentityCacheService } from '@api/common/services/better-auth-identity-cache.service';
 import { CacheInvalidationService } from '@api/common/services/cache-invalidation.service';
+import { RequestContextCacheService } from '@api/common/services/request-context-cache.service';
 import type { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { createTestUser } from '@api-test/e2e/e2e-test.utils';
 import {
   BRAND_SERVICE_E2E_MOCK_PROVIDERS,
+  COLLECTION_E2E_MOCK_PROVIDERS,
   E2ETestModule,
   TestDatabaseHelper,
 } from '@api-test/e2e-test.module';
@@ -42,18 +51,32 @@ describe('E2E fixture contracts', () => {
   });
 
   it('provides every optional BrandsService collaborator to CRUD E2E modules', async () => {
-    const expectedTokens = [
+    const expectedBrandTokens = [
       CacheInvalidationService,
       BrandRelocationService,
       BrandGenerationService,
       BrandKitAssetsService,
       BrandKitDraftService,
     ];
-    const configuredTokens = BRAND_SERVICE_E2E_MOCK_PROVIDERS.map(
+    const expectedCollectionTokens = [
+      CredentialCryptoService,
+      StreaksService,
+      DefaultRecurringContentService,
+      RolesService,
+      OrganizationSettingsService,
+      RequestContextCacheService,
+      AccessBootstrapCacheService,
+      BetterAuthIdentityCacheService,
+    ];
+    const configuredBrandTokens = BRAND_SERVICE_E2E_MOCK_PROVIDERS.map(
+      (provider) => provider.provide,
+    );
+    const configuredCollectionTokens = COLLECTION_E2E_MOCK_PROVIDERS.map(
       (provider) => provider.provide,
     );
 
-    expect(configuredTokens).toEqual(expectedTokens);
+    expect(configuredBrandTokens).toEqual(expectedBrandTokens);
+    expect(configuredCollectionTokens).toEqual(expectedCollectionTokens);
 
     const moduleConfig = await E2ETestModule.forRoot({
       providers: [BrandGenerationService],
@@ -64,6 +87,11 @@ describe('E2E fixture contracts', () => {
         : provider,
     );
 
-    expect(providerTokens).toEqual(expect.arrayContaining(expectedTokens));
+    expect(providerTokens).toEqual(
+      expect.arrayContaining([
+        ...expectedBrandTokens,
+        ...expectedCollectionTokens,
+      ]),
+    );
   });
 });

--- a/apps/server/api/test/integration/social-media-publishing.integration.spec.ts
+++ b/apps/server/api/test/integration/social-media-publishing.integration.spec.ts
@@ -27,6 +27,7 @@ import { TiktokService } from '@api/services/integrations/tiktok/services/tiktok
 import { TwitterService } from '@api/services/integrations/twitter/services/twitter.service';
 import { PrismaModule } from '@api/shared/modules/prisma/prisma.module';
 import { IngredientStatus } from '@genfeedai/enums';
+import { ConfigModule } from '@libs/config/config.module';
 import { ConfigService } from '@libs/config/config.service';
 import { LoggerService } from '@libs/logger/logger.service';
 import { INestApplication } from '@nestjs/common';
@@ -134,7 +135,7 @@ describe('Social Media Publishing Integration Tests', () => {
 
   beforeAll(async () => {
     moduleRef = await Test.createTestingModule({
-      imports: [PrismaModule],
+      imports: [ConfigModule, PrismaModule],
       providers: [
         {
           provide: TwitterService,

--- a/apps/server/api/test/integration/trainings.schema.integration.spec.ts
+++ b/apps/server/api/test/integration/trainings.schema.integration.spec.ts
@@ -1,5 +1,6 @@
 import { PrismaModule } from '@api/shared/modules/prisma/prisma.module';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import { ConfigModule } from '@libs/config/config.module';
 import { Test, TestingModule } from '@nestjs/testing';
 
 // Allow skipping this file when the Prisma DB is not available
@@ -21,7 +22,7 @@ describe('Training Schema (integration)', () => {
 
   beforeAll(async () => {
     moduleRef = await Test.createTestingModule({
-      imports: [PrismaModule],
+      imports: [ConfigModule, PrismaModule],
     }).compile();
 
     prisma = moduleRef.get<PrismaService>(PrismaService);

--- a/apps/server/api/test/integration/video-generation.integration.spec.ts
+++ b/apps/server/api/test/integration/video-generation.integration.spec.ts
@@ -3,6 +3,7 @@ import { VideosService } from '@api/collections/videos/services/videos.service';
 import { CacheService } from '@api/services/cache/services/cache.service';
 import { FileQueueService } from '@api/services/files-microservice/queue/file-queue.service';
 import { PrismaModule } from '@api/shared/modules/prisma/prisma.module';
+import { ConfigModule } from '@libs/config/config.module';
 import { ConfigService } from '@libs/config/config.service';
 import { LoggerService } from '@libs/logger/logger.service';
 import { INestApplication } from '@nestjs/common';
@@ -60,7 +61,7 @@ describe('Video Generation Integration Tests', () => {
     // Start in-memory MongoDB
 
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      imports: [PrismaModule],
+      imports: [ConfigModule, PrismaModule],
       providers: [
         VideosService,
         {

--- a/apps/server/api/vitest.config.e2e.ts
+++ b/apps/server/api/vitest.config.e2e.ts
@@ -53,6 +53,13 @@ export default defineConfig({
         replacement: path.resolve(serviceDir, '../server/src/$1'),
       },
       {
+        find: /^@api-types\/(.*)$/,
+        replacement: path.resolve(
+          serviceDir,
+          '../../../packages/api-types/src/$1',
+        ),
+      },
+      {
         find: '@credits',
         replacement: path.resolve(serviceDir, './src/collections/credits'),
       },

--- a/apps/server/api/vitest.config.ts
+++ b/apps/server/api/vitest.config.ts
@@ -101,13 +101,12 @@ if (isCoverageRun) {
 const coverageThresholds = isShardRun
   ? undefined
   : {
-      // Ratchet floor set to current actual (~42.9%) so the merged Coverage
-      // gate is green and non-regressing. functions/lines/statements already
-      // clear 50%. Raise this back toward 50 as branch coverage improves —
-      // tracked in genfeedai/genfeed.ai#686.
-      branches: 42,
-      functions: 50,
-      lines: 50,
+      // Ratcheted below the latest merged report (52.38% branches, 67.28%
+      // functions, 63.89% lines/statements) so coverage can fluctuate slightly
+      // without returning to the obsolete 42/50 floors.
+      branches: 50,
+      functions: 65,
+      lines: 60,
       // Ratchet floor for integration code (current actual ~67.5% lines /
       // ~56% branches). Raise these toward 100 as integration test gaps fill.
       'src/{services/integrations,endpoints/integrations,marketplace-integration}/**':
@@ -117,7 +116,7 @@ const coverageThresholds = isShardRun
           lines: 65,
           statements: 65,
         },
-      statements: 50,
+      statements: 60,
     };
 
 export default defineConfig({

--- a/packages/enums/__tests__/activity.enum.test.ts
+++ b/packages/enums/__tests__/activity.enum.test.ts
@@ -8,8 +8,8 @@ import {
 
 describe('activity.enum', () => {
   describe('ActivitySource', () => {
-    it('should have 34 members', () => {
-      expect(Object.values(ActivitySource)).toHaveLength(34);
+    it('should have 37 members', () => {
+      expect(Object.values(ActivitySource)).toHaveLength(37);
     });
 
     it('should have correct values', () => {
@@ -51,12 +51,15 @@ describe('activity.enum', () => {
       expect(ActivitySource.WEB).toBe('web');
       expect(ActivitySource.BOT_GENERATION).toBe('bot-generate');
       expect(ActivitySource.VOICE_GENERATION).toBe('voice-generate');
+      expect(ActivitySource.TREND_SCAN).toBe('trend-scan');
+      expect(ActivitySource.BRAND_INTERVIEW).toBe('brand-interview');
+      expect(ActivitySource.BRAND_RELOCATION).toBe('brand-relocation');
     });
   });
 
   describe('ActivityKey', () => {
-    it('should have 50 members', () => {
-      expect(Object.values(ActivityKey)).toHaveLength(50);
+    it('should have 51 members', () => {
+      expect(Object.values(ActivityKey)).toHaveLength(51);
     });
 
     it('should have correct values', () => {
@@ -140,6 +143,7 @@ describe('activity.enum', () => {
       );
       expect(ActivityKey.PROMPT_REMIX_COMPLETED).toBe('prompt-remix-completed');
       expect(ActivityKey.PROMPT_REMIX_FAILED).toBe('prompt-remix-failed');
+      expect(ActivityKey.BRAND_RELOCATED).toBe('brand-relocated');
     });
   });
 

--- a/packages/enums/__tests__/platform.enum.test.ts
+++ b/packages/enums/__tests__/platform.enum.test.ts
@@ -3,8 +3,8 @@ import { Platform } from '../src/platform.enum';
 
 describe('platform.enum', () => {
   describe('Platform', () => {
-    it('should have 29 members', () => {
-      expect(Object.values(Platform)).toHaveLength(29);
+    it('should have 28 members', () => {
+      expect(Object.values(Platform)).toHaveLength(28);
     });
 
     it('should have correct values', () => {

--- a/packages/enums/__tests__/review-gate.enum.test.ts
+++ b/packages/enums/__tests__/review-gate.enum.test.ts
@@ -16,14 +16,13 @@ describe('review-gate.enum', () => {
   });
 
   describe('NotificationChannel', () => {
-    it('should have 3 members', () => {
-      expect(Object.values(NotificationChannel)).toHaveLength(3);
-    });
-
-    it('should have correct values', () => {
-      expect(NotificationChannel.EMAIL).toBe('email');
-      expect(NotificationChannel.WEBHOOK).toBe('webhook');
-      expect(NotificationChannel.SLACK).toBe('slack');
+    it('should have the intended members', () => {
+      expect(Object.entries(NotificationChannel)).toEqual([
+        ['EMAIL', 'email'],
+        ['WEBHOOK', 'webhook'],
+        ['SLACK', 'slack'],
+        ['TASK_INBOX', 'task-inbox'],
+      ]);
     });
   });
 });

--- a/playwright/e2e/tests/smoke/all-app-pages.spec.ts
+++ b/playwright/e2e/tests/smoke/all-app-pages.spec.ts
@@ -413,10 +413,30 @@ async function assertRouteLoads(
   route: string,
   options: { allowRedirectToLogin?: boolean } = {},
 ): Promise<void> {
-  const response: Response | null = await page.goto(route, {
-    timeout: 180_000,
-    waitUntil: 'commit',
-  });
+  let response: Response | null = null;
+
+  for (let attempt = 1; attempt <= 2; attempt += 1) {
+    try {
+      response = await page.goto(route, {
+        timeout: 180_000,
+        waitUntil: 'commit',
+      });
+      break;
+    } catch (error) {
+      const isRetryableAbort =
+        error instanceof Error && error.message.includes('net::ERR_ABORTED');
+
+      if (!isRetryableAbort || attempt === 2) {
+        throw error;
+      }
+
+      // Next can cancel an in-flight document request while a previous route
+      // finishes redirecting under V8 coverage instrumentation. Retry only this
+      // browser-level abort once; HTTP, timeout, and assertion failures remain
+      // hard failures.
+      await page.waitForTimeout(250);
+    }
+  }
 
   expect(response?.status() ?? 0, `${route} returned HTTP error`).toBeLessThan(
     400,

--- a/scripts/ci/feature-test-coverage.test.ts
+++ b/scripts/ci/feature-test-coverage.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import {
+  evaluateFeatureTestCoverage,
+  formatFeatureTestCoverage,
+  isProductionSourceFile,
+  isTestFile,
+  parseChangedFiles,
+} from './feature-test-coverage';
+
+describe('feature test coverage', () => {
+  it('requires test changes for feature production code', () => {
+    const result = evaluateFeatureTestCoverage('feat(api): add scheduling', [
+      { path: 'apps/server/api/src/scheduler.service.ts', status: 'M' },
+    ]);
+
+    expect(result.passed).toBe(false);
+    expect(result.productionFiles).toEqual([
+      'apps/server/api/src/scheduler.service.ts',
+    ]);
+    expect(formatFeatureTestCoverage(result)).toContain(
+      'Production files requiring coverage',
+    );
+  });
+
+  it.each([
+    'feat',
+    'fix(auth)',
+    'refactor!',
+  ])('accepts %s changes when a test is added', (prefix) => {
+    const result = evaluateFeatureTestCoverage(`${prefix}: covered change`, [
+      { path: 'packages/auth-client/src/session.ts', status: 'M' },
+      { path: 'packages/auth-client/src/session.test.ts', status: 'A' },
+    ]);
+
+    expect(result.passed).toBe(true);
+    expect(result.testFiles).toEqual([
+      'packages/auth-client/src/session.test.ts',
+    ]);
+  });
+
+  it('does not count a deleted test as new coverage evidence', () => {
+    const result = evaluateFeatureTestCoverage('fix: preserve behavior', [
+      { path: 'packages/helpers/src/contract.ts', status: 'M' },
+      { path: 'packages/helpers/src/contract.test.ts', status: 'D' },
+    ]);
+
+    expect(result.passed).toBe(false);
+    expect(result.testFiles).toEqual([]);
+  });
+
+  it('keeps non-runtime maintenance PRs outside the enforcement boundary', () => {
+    const result = evaluateFeatureTestCoverage(
+      'chore(deps): refresh lockfile',
+      [{ path: 'packages/helpers/src/contract.ts', status: 'M' }],
+    );
+
+    expect(result).toMatchObject({ applicable: false, passed: true });
+  });
+
+  it('recognizes unit, integration, E2E, and Node test paths', () => {
+    expect(isTestFile('apps/app/src/page.test.tsx')).toBe(true);
+    expect(isTestFile('apps/server/api/test/integration/auth.spec.ts')).toBe(
+      true,
+    );
+    expect(isTestFile('playwright/e2e/tests/auth/login.spec.ts')).toBe(true);
+    expect(isTestFile('scripts/ci/tests-gate.test.mjs')).toBe(true);
+  });
+
+  it('limits production classification to authored runtime source', () => {
+    expect(isProductionSourceFile('apps/app/src/page.tsx')).toBe(true);
+    expect(isProductionSourceFile('packages/ui/src/button.tsx')).toBe(true);
+    expect(isProductionSourceFile('scripts/ci/collector.ts')).toBe(true);
+    expect(isProductionSourceFile('apps/app/src/page.test.tsx')).toBe(false);
+    expect(isProductionSourceFile('apps/app/next.config.ts')).toBe(false);
+    expect(isProductionSourceFile('docs/testing.md')).toBe(false);
+  });
+
+  it('parses modified and renamed files from git name-status output', () => {
+    expect(
+      parseChangedFiles(
+        'M\tapps/app/src/page.tsx\nR100\told.test.ts\tapps/app/src/page.test.tsx\n',
+      ),
+    ).toEqual([
+      { path: 'apps/app/src/page.tsx', status: 'M' },
+      { path: 'apps/app/src/page.test.tsx', status: 'R100' },
+    ]);
+  });
+});

--- a/scripts/ci/feature-test-coverage.test.ts
+++ b/scripts/ci/feature-test-coverage.test.ts
@@ -25,6 +25,7 @@ describe('feature test coverage', () => {
   it.each([
     'feat',
     'fix(auth)',
+    'perf(api)',
     'refactor!',
   ])('accepts %s changes when a test is added', (prefix) => {
     const result = evaluateFeatureTestCoverage(`${prefix}: covered change`, [

--- a/scripts/ci/feature-test-coverage.test.ts
+++ b/scripts/ci/feature-test-coverage.test.ts
@@ -66,6 +66,29 @@ describe('feature test coverage', () => {
     expect(isTestFile('scripts/ci/tests-gate.test.mjs')).toBe(true);
   });
 
+  it('treats runtime source inside a test directory as a test file', () => {
+    expect(isTestFile('apps/server/api/test/helpers/factory.ts')).toBe(true);
+    expect(isTestFile('playwright/e2e/support/commands.ts')).toBe(true);
+  });
+
+  it('does not count non-source files under a test directory as tests', () => {
+    expect(isTestFile('apps/server/api/test/README.md')).toBe(false);
+    expect(isTestFile('apps/server/api/test/fixtures/payload.json')).toBe(
+      false,
+    );
+    expect(isTestFile('playwright/e2e/fixtures/user.yaml')).toBe(false);
+  });
+
+  it('rejects a feature PR whose only test-dir change is a non-source file', () => {
+    const result = evaluateFeatureTestCoverage('feat(api): add scheduling', [
+      { path: 'apps/server/api/src/scheduler.service.ts', status: 'M' },
+      { path: 'apps/server/api/test/README.md', status: 'A' },
+    ]);
+
+    expect(result.passed).toBe(false);
+    expect(result.testFiles).toEqual([]);
+  });
+
   it('limits production classification to authored runtime source', () => {
     expect(isProductionSourceFile('apps/app/src/page.tsx')).toBe(true);
     expect(isProductionSourceFile('packages/ui/src/button.tsx')).toBe(true);

--- a/scripts/ci/feature-test-coverage.ts
+++ b/scripts/ci/feature-test-coverage.ts
@@ -15,7 +15,8 @@ export interface FeatureTestCoverageResult {
   testFiles: string[];
 }
 
-const TEST_BEARING_PR_TITLE = /^(?:feat|fix|refactor)(?:\([^)]+\))?[!:]/iu;
+const TEST_BEARING_PR_TITLE =
+  /^(?:feat|fix|perf|refactor)(?:\([^)]+\))?[!:]/iu;
 const RUNTIME_SOURCE_FILE = /\.(?:cjs|js|jsx|mjs|ts|tsx)$/u;
 const RUNTIME_ROOT = /^(?:apps|ee|packages|scripts)\//u;
 const TEST_DIRECTORY = /(?:^|\/)(?:__tests__|e2e|test|tests)(?:\/|$)/u;
@@ -76,7 +77,7 @@ export function evaluateFeatureTestCoverage(
       applicable,
       passed: true,
       productionFiles,
-      reason: 'PR title is outside feat/fix/refactor test enforcement.',
+      reason: 'PR title is outside feat/fix/perf/refactor test enforcement.',
       testFiles,
     };
   }
@@ -97,7 +98,7 @@ export function evaluateFeatureTestCoverage(
       passed: false,
       productionFiles,
       reason:
-        'Feature, fix, and refactor PRs that change production source must add or update a test file.',
+        'Feature, fix, performance, and refactor PRs that change production source must add or update a test file.',
       testFiles,
     };
   }

--- a/scripts/ci/feature-test-coverage.ts
+++ b/scripts/ci/feature-test-coverage.ts
@@ -1,0 +1,165 @@
+import { execFileSync } from 'node:child_process';
+import process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+export interface ChangedFile {
+  path: string;
+  status: string;
+}
+
+export interface FeatureTestCoverageResult {
+  applicable: boolean;
+  passed: boolean;
+  productionFiles: string[];
+  reason: string;
+  testFiles: string[];
+}
+
+const TEST_BEARING_PR_TITLE = /^(?:feat|fix|refactor)(?:\([^)]+\))?[!:]/iu;
+const RUNTIME_SOURCE_FILE = /\.(?:cjs|js|jsx|mjs|ts|tsx)$/u;
+const RUNTIME_ROOT = /^(?:apps|ee|packages|scripts)\//u;
+const TEST_FILE =
+  /(?:^|\/)(?:__tests__|e2e|test|tests)(?:\/|$)|\.(?:e2e-)?(?:spec|test)\.(?:cjs|js|jsx|mjs|ts|tsx)$/u;
+const NON_RUNTIME_SOURCE =
+  /(?:^|\/)(?:dist|generated|node_modules)(?:\/|$)|\.d\.ts$|(?:^|\/)(?:next|playwright|vitest)\.config\.[cm]?[jt]s$/u;
+
+export function parseChangedFiles(output: string): ChangedFile[] {
+  return output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const columns = line.split('\t');
+      const status = columns[0] ?? '';
+      const path = columns.at(-1) ?? '';
+
+      return { path, status };
+    });
+}
+
+export function isTestFile(path: string): boolean {
+  return TEST_FILE.test(path);
+}
+
+export function isProductionSourceFile(path: string): boolean {
+  return (
+    RUNTIME_ROOT.test(path) &&
+    RUNTIME_SOURCE_FILE.test(path) &&
+    !TEST_FILE.test(path) &&
+    !NON_RUNTIME_SOURCE.test(path)
+  );
+}
+
+export function evaluateFeatureTestCoverage(
+  title: string,
+  changedFiles: ChangedFile[],
+): FeatureTestCoverageResult {
+  const applicable = TEST_BEARING_PR_TITLE.test(title.trim());
+  const productionFiles = changedFiles
+    .filter((file) => isProductionSourceFile(file.path))
+    .map((file) => file.path)
+    .sort();
+  const testFiles = changedFiles
+    .filter((file) => file.status !== 'D' && isTestFile(file.path))
+    .map((file) => file.path)
+    .sort();
+
+  if (!applicable) {
+    return {
+      applicable,
+      passed: true,
+      productionFiles,
+      reason: 'PR title is outside feat/fix/refactor test enforcement.',
+      testFiles,
+    };
+  }
+
+  if (productionFiles.length === 0) {
+    return {
+      applicable,
+      passed: true,
+      productionFiles,
+      reason: 'No production source files changed.',
+      testFiles,
+    };
+  }
+
+  if (testFiles.length === 0) {
+    return {
+      applicable,
+      passed: false,
+      productionFiles,
+      reason:
+        'Feature, fix, and refactor PRs that change production source must add or update a test file.',
+      testFiles,
+    };
+  }
+
+  return {
+    applicable,
+    passed: true,
+    productionFiles,
+    reason: 'Production source changes include test coverage changes.',
+    testFiles,
+  };
+}
+
+export function formatFeatureTestCoverage(
+  result: FeatureTestCoverageResult,
+): string {
+  const lines = [
+    '# Feature Test Coverage',
+    '',
+    `- Applicable: ${result.applicable ? 'yes' : 'no'}`,
+    `- Result: ${result.passed ? 'pass' : 'fail'}`,
+    `- Production files: ${result.productionFiles.length}`,
+    `- Test files: ${result.testFiles.length}`,
+    `- Reason: ${result.reason}`,
+  ];
+
+  if (!result.passed) {
+    lines.push('', 'Production files requiring coverage:');
+    lines.push(...result.productionFiles.map((path) => `- \`${path}\``));
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+function readOption(name: string): string | undefined {
+  const index = process.argv.indexOf(name);
+  return index === -1 ? undefined : process.argv[index + 1];
+}
+
+function runCli(): void {
+  const base = readOption('--base');
+  const title = process.env.PR_TITLE ?? '';
+
+  if (!base) {
+    throw new Error('--base is required');
+  }
+
+  if (!title) {
+    throw new Error('PR_TITLE is required');
+  }
+
+  const diff = execFileSync(
+    'git',
+    ['diff', '--name-status', '--diff-filter=ACMR', base, 'HEAD'],
+    { encoding: 'utf8' },
+  );
+  const result = evaluateFeatureTestCoverage(title, parseChangedFiles(diff));
+
+  process.stdout.write(formatFeatureTestCoverage(result));
+  if (!result.passed) {
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  try {
+    runCli();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/ci/feature-test-coverage.ts
+++ b/scripts/ci/feature-test-coverage.ts
@@ -18,8 +18,8 @@ export interface FeatureTestCoverageResult {
 const TEST_BEARING_PR_TITLE = /^(?:feat|fix|refactor)(?:\([^)]+\))?[!:]/iu;
 const RUNTIME_SOURCE_FILE = /\.(?:cjs|js|jsx|mjs|ts|tsx)$/u;
 const RUNTIME_ROOT = /^(?:apps|ee|packages|scripts)\//u;
-const TEST_FILE =
-  /(?:^|\/)(?:__tests__|e2e|test|tests)(?:\/|$)|\.(?:e2e-)?(?:spec|test)\.(?:cjs|js|jsx|mjs|ts|tsx)$/u;
+const TEST_DIRECTORY = /(?:^|\/)(?:__tests__|e2e|test|tests)(?:\/|$)/u;
+const TEST_EXTENSION = /\.(?:e2e-)?(?:spec|test)\.(?:cjs|js|jsx|mjs|ts|tsx)$/u;
 const NON_RUNTIME_SOURCE =
   /(?:^|\/)(?:dist|generated|node_modules)(?:\/|$)|\.d\.ts$|(?:^|\/)(?:next|playwright|vitest)\.config\.[cm]?[jt]s$/u;
 
@@ -38,14 +38,21 @@ export function parseChangedFiles(output: string): ChangedFile[] {
 }
 
 export function isTestFile(path: string): boolean {
-  return TEST_FILE.test(path);
+  // A file counts as an executable test only when it carries a `.spec`/`.test`
+  // extension, or is a runtime source file living inside a test directory.
+  // Matching a test directory alone (e.g. a README or JSON fixture under
+  // `test/`) must NOT satisfy the coverage gate.
+  return (
+    TEST_EXTENSION.test(path) ||
+    (TEST_DIRECTORY.test(path) && RUNTIME_SOURCE_FILE.test(path))
+  );
 }
 
 export function isProductionSourceFile(path: string): boolean {
   return (
     RUNTIME_ROOT.test(path) &&
     RUNTIME_SOURCE_FILE.test(path) &&
-    !TEST_FILE.test(path) &&
+    !isTestFile(path) &&
     !NON_RUNTIME_SOURCE.test(path)
   );
 }

--- a/scripts/ci/feature-test-coverage.ts
+++ b/scripts/ci/feature-test-coverage.ts
@@ -15,8 +15,7 @@ export interface FeatureTestCoverageResult {
   testFiles: string[];
 }
 
-const TEST_BEARING_PR_TITLE =
-  /^(?:feat|fix|perf|refactor)(?:\([^)]+\))?[!:]/iu;
+const TEST_BEARING_PR_TITLE = /^(?:feat|fix|perf|refactor)(?:\([^)]+\))?[!:]/iu;
 const RUNTIME_SOURCE_FILE = /\.(?:cjs|js|jsx|mjs|ts|tsx)$/u;
 const RUNTIME_ROOT = /^(?:apps|ee|packages|scripts)\//u;
 const TEST_DIRECTORY = /(?:^|\/)(?:__tests__|e2e|test|tests)(?:\/|$)/u;


### PR DESCRIPTION
## Summary
- repair current weekly coverage and nightly API E2E failures in enum, Prisma seed, Nest provider, resolver, and workflow fixtures
- add runtime utility coverage and raise API ratchets to 60% lines/statements, 65% functions, and 50% branches
- retry only Playwright navigation aborts caused by coverage instrumentation
- require feat/fix/perf/refactor PRs with production source changes to add or update tests
- quarantine seven incompatible Mongo-era E2E specs with explicit reasons and issue #71 tracking; validate the quarantine manifest in tests

## Audit evidence
- 3,554 test files inventoried; the latest 20 feat/fix/refactor commits all carried tests
- last five sampled weekly coverage runs failed; last four nightly E2E runs failed
- API coverage improved from 63.92% statements / 52.38% branches / 67.28% functions / 63.89% lines to **64.43% / 52.92% / 67.97% / 64.40%**
- coverage deltas: +0.51 statements, +0.54 branches, +0.69 functions, +0.51 lines
- coverage audit also found and repaired stale tests for recent activity-source, activity-key, platform, and review-gate enum changes

## Verification
- [PR CI](https://github.com/genfeedai/genfeed.ai/actions/runs/29973859298): success on `4cc9b8d9a`
- [E2E](https://github.com/genfeedai/genfeed.ai/actions/runs/29973861517): success on `4cc9b8d9a` — API core/full, 80% route gate, four browser shards, real Better Auth, report merge, aggregate gate
- [Coverage](https://github.com/genfeedai/genfeed.ai/actions/runs/29973862588): success on `4cc9b8d9a` — 10,553 API tests passed in the merged report; all package/app/API jobs and raised thresholds passed
- Biome static checks, actionlint, secretlint, credential-pattern scan, and `git diff --check` passed
- local tests/typecheck/build intentionally deferred to PR CI under the workstation policy

## Claude Opus 4.8 audit
- full exact-head review at `0c4078e52`: **PASS**, no blockers
- low-risk coverage gap for `perf:` titles fixed in `57c9ee0c7`
- structured post-fix verification: **PASS** with no findings
- verified feature-test gate semantics, E2E quarantine validation, test-module mocks, coverage ratchets, Playwright retry scope, packaging, and lockfile safety