### PR TITLE
feat(clips): add raw-cut project flow

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/ClipModeSelector.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/ClipModeSelector.test.tsx
@@ -1,0 +1,27 @@
+import '@testing-library/jest-dom/vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import ClipModeSelector from './ClipModeSelector';
+
+describe('ClipModeSelector', () => {
+  it('shows raw-cut as selected and explains that identity is not required', () => {
+    render(<ClipModeSelector mode="raw-cut" onModeChange={vi.fn()} />);
+
+    expect(screen.getByRole('button', { name: /raw cut/i })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+    expect(
+      screen.getByText(/no avatar or voice required/i),
+    ).toBeInTheDocument();
+  });
+
+  it('switches to avatar mode', () => {
+    const onModeChange = vi.fn();
+    render(<ClipModeSelector mode="raw-cut" onModeChange={onModeChange} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /ai avatar/i }));
+
+    expect(onModeChange).toHaveBeenCalledWith('avatar');
+  });
+});

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/ClipModeSelector.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/ClipModeSelector.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { ButtonVariant } from '@genfeedai/enums';
+import type {
+  ClipModeSelectorProps,
+  ClipResultMode,
+} from '@props/studio/clips.props';
+import { Button } from '@ui/primitives/button';
+import { HiOutlineFilm, HiOutlineUserCircle } from 'react-icons/hi2';
+
+const MODE_OPTIONS: Array<{
+  description: string;
+  icon: typeof HiOutlineFilm;
+  label: string;
+  value: ClipResultMode;
+}> = [
+  {
+    description:
+      'Cut the original footage and burn captions. No avatar or voice required.',
+    icon: HiOutlineFilm,
+    label: 'Raw cut',
+    value: 'raw-cut',
+  },
+  {
+    description:
+      'Regenerate each highlight with your saved HeyGen avatar and voice.',
+    icon: HiOutlineUserCircle,
+    label: 'AI avatar',
+    value: 'avatar',
+  },
+];
+
+export default function ClipModeSelector({
+  mode,
+  onModeChange,
+}: ClipModeSelectorProps) {
+  return (
+    <fieldset>
+      <legend className="mb-2 text-sm font-medium text-zinc-300">
+        Generation mode
+      </legend>
+      <div className="grid gap-3 sm:grid-cols-2">
+        {MODE_OPTIONS.map((option) => {
+          const Icon = option.icon;
+          const isSelected = mode === option.value;
+
+          return (
+            <Button
+              key={option.value}
+              variant={ButtonVariant.UNSTYLED}
+              withWrapper={false}
+              aria-pressed={isSelected}
+              onClick={() => onModeChange(option.value)}
+              className={`min-h-24 rounded-lg border p-4 text-left transition-colors ${
+                isSelected
+                  ? 'border-primary bg-primary/10'
+                  : 'border-zinc-700 bg-zinc-800/30 hover:border-zinc-600'
+              }`}
+            >
+              <span className="flex items-start gap-3">
+                <Icon
+                  aria-hidden="true"
+                  className={`mt-0.5 size-5 shrink-0 ${isSelected ? 'text-primary' : 'text-zinc-500'}`}
+                />
+                <span>
+                  <span className="block text-sm font-medium text-zinc-200">
+                    {option.label}
+                  </span>
+                  <span className="mt-1 block text-xs leading-5 text-zinc-500">
+                    {option.description}
+                  </span>
+                </span>
+              </span>
+            </Button>
+          );
+        })}
+      </div>
+    </fieldset>
+  );
+}

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/ClipResultCard.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/ClipResultCard.test.tsx
@@ -18,6 +18,14 @@ vi.mock('@hooks/navigation/use-org-url', () => ({
   }),
 }));
 
+vi.mock('@ui/display/video-player/VideoPlayer', () => ({
+  default: ({ ariaLabel, src }: { ariaLabel: string; src: string }) => (
+    <div aria-label={ariaLabel} data-testid="video-player" role="img">
+      {src}
+    </div>
+  ),
+}));
+
 function makeClip(overrides?: Partial<ClipResult>): ClipResult {
   return {
     _id: 'clip-1',
@@ -88,6 +96,28 @@ describe('ClipResultCard', () => {
     );
 
     expect(screen.getByText('Generating')).toBeInTheDocument();
+  });
+
+  it('previews a completed raw cut', () => {
+    render(
+      <ClipResultCard
+        clip={makeClip({
+          mode: 'raw-cut',
+          status: 'completed',
+          videoUrl: 'https://cdn.example.com/raw-cut.mp4',
+        })}
+        clipsService={clipsService as never}
+        projectId="project-1"
+      />,
+    );
+
+    expect(screen.getByText('Raw cut')).toBeInTheDocument();
+    expect(screen.getByTestId('video-player')).toHaveTextContent(
+      'https://cdn.example.com/raw-cut.mp4',
+    );
+    expect(
+      screen.getByLabelText('Preview Test Clip Title'),
+    ).toBeInTheDocument();
   });
 
   it('should show action buttons only when status is completed', () => {

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/ClipResultCard.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/ClipResultCard.tsx
@@ -2,14 +2,17 @@
 
 import { COMPOSE_ROUTES } from '@genfeedai/constants';
 import { ButtonVariant, ComponentSize } from '@genfeedai/enums';
+import { downloadUrl } from '@helpers/media/download/download.helper';
 import { useOrgUrl } from '@hooks/navigation/use-org-url';
 import type {
   ClipReadyAction,
   ClipResult,
+  ClipResultMode,
   ClipStatus,
   ViralityBadgeProps,
 } from '@props/studio/clips.props';
 import Card from '@ui/card/Card';
+import VideoPlayer from '@ui/display/video-player/VideoPlayer';
 import Spinner from '@ui/feedback/spinner/Spinner';
 import { Badge } from '@ui/primitives/badge';
 import { Button } from '@ui/primitives/button';
@@ -25,6 +28,7 @@ import type { ClipsApiService } from '../services/clips-api.service';
 interface ClipResultCardProps {
   clip: ClipResult;
   clipsService: ClipsApiService;
+  mode?: ClipResultMode;
   projectId: string;
 }
 
@@ -73,6 +77,7 @@ function formatDuration(seconds: number): string {
 export default function ClipResultCard({
   clip,
   clipsService,
+  mode,
   projectId,
 }: ClipResultCardProps) {
   const { push } = useRouter();
@@ -139,13 +144,13 @@ export default function ClipResultCard({
     push,
   ]);
 
-  const handleDownload = useCallback(() => {
+  const handleDownload = useCallback(async () => {
     if (!videoUrl) return;
-    const link = document.createElement('a');
-    link.href = videoUrl;
-    link.download = `${clip.title.replace(/[^a-zA-Z0-9]/g, '_')}.mp4`;
-    link.target = '_blank';
-    link.click();
+
+    await downloadUrl(
+      videoUrl,
+      `${clip.title.replace(/[^a-zA-Z0-9]/g, '_')}.mp4`,
+    );
   }, [videoUrl, clip.title]);
 
   return (
@@ -170,9 +175,35 @@ export default function ClipResultCard({
               {clip.clipType}
             </Badge>
           )}
+          <Badge
+            variant="secondary"
+            className="rounded bg-secondary px-1.5 py-0.5 text-[10px] text-muted-foreground"
+          >
+            {(clip.mode ?? mode ?? 'avatar') === 'raw-cut'
+              ? 'Raw cut'
+              : 'AI avatar'}
+          </Badge>
         </div>
         <ViralityBadge score={clip.viralityScore} />
       </div>
+
+      {clip.status === 'completed' && videoUrl && (
+        <div className="mb-3 aspect-video overflow-hidden rounded-lg bg-black">
+          <VideoPlayer
+            ariaLabel={`Preview ${clip.title}`}
+            src={videoUrl}
+            className="bg-black"
+            config={{
+              autoPlay: false,
+              controls: true,
+              loop: false,
+              muted: false,
+              playsInline: true,
+              preload: 'metadata',
+            }}
+          />
+        </div>
+      )}
 
       {/* Title & Summary */}
       <h3 className="mb-1 line-clamp-2 text-sm font-medium text-foreground">

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/ClipsInputForm.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/ClipsInputForm.test.tsx
@@ -9,10 +9,12 @@ function renderForm(
 ) {
   const props = {
     error: null,
+    generationMode: 'avatar' as const,
     isSubmitting: false,
     maxClips: 10,
     minViralityScore: 50,
     onAnalyze: vi.fn(),
+    onModeChange: vi.fn(),
     onSetMaxClips: vi.fn(),
     onSetMinViralityScore: vi.fn(),
     onSetYoutubeUrl: vi.fn(),
@@ -62,5 +64,13 @@ describe('ClipsInputForm', () => {
         'No saved HeyGen defaults. Review highlights first to enter IDs manually.',
       ),
     ).toBeInTheDocument();
+  });
+
+  it('lets the user select raw-cut before starting a project', () => {
+    const { props } = renderForm();
+
+    fireEvent.click(screen.getByRole('button', { name: /raw cut/i }));
+
+    expect(props.onModeChange).toHaveBeenCalledWith('raw-cut');
   });
 });

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/ClipsInputForm.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/ClipsInputForm.tsx
@@ -1,31 +1,21 @@
 'use client';
 
 import { ButtonVariant, ComponentSize } from '@genfeedai/enums';
+import type { ClipsInputFormProps } from '@props/studio/clips.props';
 import Spinner from '@ui/feedback/spinner/Spinner';
 import { Button } from '@ui/primitives/button';
 import { Input } from '@ui/primitives/input';
 import { HiOutlineMagnifyingGlass, HiOutlineSparkles } from 'react-icons/hi2';
-
-interface ClipsInputFormProps {
-  error: string | null;
-  isSubmitting: boolean;
-  maxClips: number;
-  minViralityScore: number;
-  onAnalyze: () => void;
-  onStartQuick: () => void;
-  onSetMaxClips: (value: number) => void;
-  onSetMinViralityScore: (value: number) => void;
-  onSetYoutubeUrl: (value: string) => void;
-  quickStartHint: string;
-  youtubeUrl: string;
-}
+import ClipModeSelector from './ClipModeSelector';
 
 export default function ClipsInputForm({
   error,
+  generationMode,
   isSubmitting,
   maxClips,
   minViralityScore,
   onAnalyze,
+  onModeChange,
   onStartQuick,
   onSetMaxClips,
   onSetMinViralityScore,
@@ -45,8 +35,7 @@ export default function ClipsInputForm({
           AI Clip Factory
         </h1>
         <p className="mt-2 text-sm text-zinc-500">
-          Drop a YouTube URL, review AI-detected highlights, generate avatar
-          clips
+          Turn a YouTube video into captioned raw cuts or AI avatar clips
         </p>
       </div>
 
@@ -67,6 +56,8 @@ export default function ClipsInputForm({
             placeholder="https://www.youtube.com/watch?v=..."
           />
         </div>
+
+        <ClipModeSelector mode={generationMode} onModeChange={onModeChange} />
 
         {/* Max Clips Slider */}
         <div>

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/ClipsProgressView.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/ClipsProgressView.tsx
@@ -23,8 +23,12 @@ export default function ClipsProgressView({
 }: ClipsProgressViewProps) {
   const pendingDescription =
     selectedCount > 0
-      ? `Generating ${selectedCount} clips...`
-      : 'Processing YouTube video and generating clips...';
+      ? project.mode === 'raw-cut'
+        ? `Cutting ${selectedCount} selected highlights...`
+        : `Generating ${selectedCount} avatar clips...`
+      : project.mode === 'raw-cut'
+        ? 'Processing YouTube video and creating raw cuts...'
+        : 'Processing YouTube video and generating avatar clips...';
 
   return (
     <div className="mx-auto max-w-6xl px-6 py-10">
@@ -37,7 +41,7 @@ export default function ClipsProgressView({
         </div>
         <p className="mt-2 text-sm text-zinc-500">
           {project.status === 'completed'
-            ? `Done -- ${project.clips.length} clips generated`
+            ? `Done — ${project.clips.length} clip${project.clips.length === 1 ? '' : 's'} generated`
             : project.status === 'failed'
               ? 'Pipeline failed. Check logs for details.'
               : pendingDescription}
@@ -62,6 +66,7 @@ export default function ClipsProgressView({
               key={clip._id}
               clip={clip}
               clipsService={clipsService}
+              mode={project.mode}
               projectId={project.projectId}
             />
           ))}
@@ -71,7 +76,9 @@ export default function ClipsProgressView({
           <div className="flex flex-col items-center justify-center rounded-xl bg-secondary py-20 shadow-border">
             <Spinner size={ComponentSize.LG} className="mb-4 text-primary" />
             <p className="text-sm text-zinc-500">
-              Processing YouTube video and generating avatar clips…
+              {project.mode === 'raw-cut'
+                ? 'Processing YouTube video and creating captioned raw cuts…'
+                : 'Processing YouTube video and generating avatar clips…'}
             </p>
           </div>
         )

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/HighlightReviewCard.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/components/HighlightReviewCard.tsx
@@ -216,7 +216,7 @@ export default function HighlightReviewCard({
         onChange={(e) => onScriptEdit(e.target.value)}
         rows={3}
         className="w-full resize-none text-xs"
-        placeholder="Edit the script that will be read by the avatar..."
+        placeholder="Edit the script or caption text for this clip..."
       />
 
       {/* Viral rewrite controls */}

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/page.tsx
@@ -6,7 +6,7 @@ import Spinner from '@ui/feedback/spinner/Spinner';
 import { Button } from '@ui/primitives/button';
 import { Input } from '@ui/primitives/input';
 import { HiOutlineMagnifyingGlass, HiOutlineSparkles } from 'react-icons/hi2';
-
+import ClipModeSelector from './components/ClipModeSelector';
 import ClipsInputForm from './components/ClipsInputForm';
 import ClipsProgressView from './components/ClipsProgressView';
 import HighlightReviewCard from './components/HighlightReviewCard';
@@ -28,6 +28,7 @@ export default function StudioClipsPage() {
     clipsService,
     editedHighlights,
     error,
+    generationMode,
     handleAnalyze,
     handleGenerate,
     handleStartFromYoutube,
@@ -41,6 +42,7 @@ export default function StudioClipsPage() {
     selectedIds,
     setAvatarId,
     setAvatarProvider,
+    setGenerationMode,
     setMaxClips,
     setMinViralityScore,
     setVoiceId,
@@ -127,78 +129,87 @@ export default function StudioClipsPage() {
               ))}
             </div>
 
-            {/* Avatar & Voice config */}
-            <div className="mt-6 space-y-4 rounded-xl bg-secondary p-4 shadow-border">
-              <h3 className="text-sm font-medium text-zinc-300">
-                Avatar Configuration
-              </h3>
-              <div className="grid grid-cols-2 gap-4">
-                <div>
-                  <label
-                    htmlFor="avatar-id-review"
-                    className="mb-1 block text-xs text-zinc-500"
-                  >
-                    Avatar ID
-                  </label>
-                  <Input
-                    id="avatar-id-review"
-                    type="text"
-                    value={avatarId}
-                    onChange={(e) => setAvatarId(e.target.value)}
-                    placeholder="HeyGen avatar ID"
-                  />
-                </div>
-                <div>
-                  <label
-                    htmlFor="voice-id-review"
-                    className="mb-1 block text-xs text-zinc-500"
-                  >
-                    Voice ID
-                  </label>
-                  <Input
-                    id="voice-id-review"
-                    type="text"
-                    value={voiceId}
-                    onChange={(e) => setVoiceId(e.target.value)}
-                    placeholder="HeyGen voice ID"
-                  />
-                </div>
-              </div>
-
-              <p className="text-xs text-zinc-500">
-                {identityDefaults.isComplete
-                  ? identityDefaults.source === 'brand'
-                    ? 'Using saved brand HeyGen avatar and voice defaults.'
-                    : 'Using saved organization HeyGen voice default.'
-                  : `Missing ${identityDefaults.missing.join(' and ')} defaults. Enter IDs manually or save them in brand defaults.`}
-              </p>
-
-              {/* Provider */}
-              <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
-                {PROVIDER_OPTIONS.map((opt) => (
-                  <Button
-                    key={opt.value}
-                    variant={ButtonVariant.UNSTYLED}
-                    isDisabled={opt.disabled}
-                    onClick={() => setAvatarProvider(opt.value)}
-                    className={`relative rounded-lg border px-3 py-2 text-left transition-colors ${
-                      avatarProvider === opt.value
-                        ? 'border-primary bg-primary/10'
-                        : opt.disabled
-                          ? 'cursor-not-allowed border-zinc-800 bg-zinc-900/30 opacity-50'
-                          : 'border-zinc-700 bg-zinc-800/30 hover:border-zinc-600'
-                    }`}
-                  >
-                    <div className="text-xs font-medium text-zinc-200">
-                      {opt.label}
-                    </div>
-                    <div className="text-[10px] text-zinc-500">
-                      {opt.description}
-                    </div>
-                  </Button>
-                ))}
-              </div>
+            <div className="mt-6 rounded-xl bg-secondary p-4 shadow-border">
+              <ClipModeSelector
+                mode={generationMode}
+                onModeChange={setGenerationMode}
+              />
             </div>
+
+            {/* Avatar & Voice config */}
+            {generationMode === 'avatar' && (
+              <div className="mt-4 space-y-4 rounded-xl bg-secondary p-4 shadow-border">
+                <h3 className="text-sm font-medium text-zinc-300">
+                  Avatar Configuration
+                </h3>
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <label
+                      htmlFor="avatar-id-review"
+                      className="mb-1 block text-xs text-zinc-500"
+                    >
+                      Avatar ID
+                    </label>
+                    <Input
+                      id="avatar-id-review"
+                      type="text"
+                      value={avatarId}
+                      onChange={(e) => setAvatarId(e.target.value)}
+                      placeholder="HeyGen avatar ID"
+                    />
+                  </div>
+                  <div>
+                    <label
+                      htmlFor="voice-id-review"
+                      className="mb-1 block text-xs text-zinc-500"
+                    >
+                      Voice ID
+                    </label>
+                    <Input
+                      id="voice-id-review"
+                      type="text"
+                      value={voiceId}
+                      onChange={(e) => setVoiceId(e.target.value)}
+                      placeholder="HeyGen voice ID"
+                    />
+                  </div>
+                </div>
+
+                <p className="text-xs text-zinc-500">
+                  {identityDefaults.isComplete
+                    ? identityDefaults.source === 'brand'
+                      ? 'Using saved brand HeyGen avatar and voice defaults.'
+                      : 'Using saved organization HeyGen voice default.'
+                    : `Missing ${identityDefaults.missing.join(' and ')} defaults. Enter IDs manually or save them in brand defaults.`}
+                </p>
+
+                {/* Provider */}
+                <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+                  {PROVIDER_OPTIONS.map((opt) => (
+                    <Button
+                      key={opt.value}
+                      variant={ButtonVariant.UNSTYLED}
+                      isDisabled={opt.disabled}
+                      onClick={() => setAvatarProvider(opt.value)}
+                      className={`relative rounded-lg border px-3 py-2 text-left transition-colors ${
+                        avatarProvider === opt.value
+                          ? 'border-primary bg-primary/10'
+                          : opt.disabled
+                            ? 'cursor-not-allowed border-zinc-800 bg-zinc-900/30 opacity-50'
+                            : 'border-zinc-700 bg-zinc-800/30 hover:border-zinc-600'
+                      }`}
+                    >
+                      <div className="text-xs font-medium text-zinc-200">
+                        {opt.label}
+                      </div>
+                      <div className="text-[10px] text-zinc-500">
+                        {opt.description}
+                      </div>
+                    </Button>
+                  ))}
+                </div>
+              </div>
+            )}
 
             {/* Error */}
             {error && (
@@ -220,7 +231,9 @@ export default function StudioClipsPage() {
                 variant={ButtonVariant.UNSTYLED}
                 onClick={handleGenerate}
                 isDisabled={
-                  isSubmitting || selectedCount === 0 || !avatarId || !voiceId
+                  isSubmitting ||
+                  selectedCount === 0 ||
+                  (generationMode === 'avatar' && (!avatarId || !voiceId))
                 }
                 isLoading={isSubmitting}
                 className="flex items-center gap-2 rounded-lg bg-primary px-6 py-3 text-sm font-medium text-white transition-colors hover:bg-primary disabled:cursor-not-allowed disabled:opacity-50"
@@ -234,7 +247,7 @@ export default function StudioClipsPage() {
                 label={
                   isSubmitting
                     ? 'Generating…'
-                    : `Generate ${selectedCount} clip${selectedCount !== 1 ? 's' : ''} (${selectedCount} credit${selectedCount !== 1 ? 's' : ''})`
+                    : `Generate ${selectedCount} ${generationMode === 'raw-cut' ? 'raw cut' : 'avatar clip'}${selectedCount !== 1 ? 's' : ''} (${selectedCount} credit${selectedCount !== 1 ? 's' : ''})`
                 }
               />
             </div>
@@ -260,6 +273,7 @@ export default function StudioClipsPage() {
   // ═══════════════════════════════════════════════════════════════
   return (
     <ClipsInputForm
+      generationMode={generationMode}
       youtubeUrl={youtubeUrl}
       onSetYoutubeUrl={setYoutubeUrl}
       maxClips={maxClips}
@@ -269,13 +283,16 @@ export default function StudioClipsPage() {
       error={error}
       isSubmitting={isSubmitting}
       onAnalyze={handleAnalyze}
+      onModeChange={setGenerationMode}
       onStartQuick={handleStartFromYoutube}
       quickStartHint={
-        identityDefaults.isComplete
-          ? identityDefaults.source === 'brand'
-            ? 'Uses saved brand avatar and voice defaults.'
-            : 'Uses saved organization voice default.'
-          : 'No saved HeyGen defaults. Review highlights first to enter IDs manually.'
+        generationMode === 'raw-cut'
+          ? 'Uses the source footage and burns captions. No avatar defaults required.'
+          : identityDefaults.isComplete
+            ? identityDefaults.source === 'brand'
+              ? 'Uses saved brand avatar and voice defaults.'
+              : 'Uses saved organization voice default.'
+            : 'No saved HeyGen defaults. Review highlights first to enter IDs manually.'
       }
     />
   );

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/services/clips-api.service.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/services/clips-api.service.test.tsx
@@ -47,6 +47,7 @@ describe('ClipsApiService', () => {
         language: 'en',
         maxClips: 4,
         minViralityScore: 60,
+        mode: 'avatar',
         voiceId: 'voice-1',
         youtubeUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
       }),
@@ -66,6 +67,7 @@ describe('ClipsApiService', () => {
           language: 'en',
           maxClips: 4,
           minViralityScore: 60,
+          mode: 'avatar',
           voiceId: 'voice-1',
           youtubeUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
         }),
@@ -73,6 +75,62 @@ describe('ClipsApiService', () => {
           Authorization: 'Bearer token-1',
           'Content-Type': 'application/json',
         },
+        method: 'POST',
+      }),
+    );
+  });
+
+  it('starts a raw-cut project without avatar identity fields', async () => {
+    const service = new ClipsApiService(
+      vi.fn().mockResolvedValue('token-raw-cut'),
+    );
+
+    await service.createFromYoutube({
+      language: 'en',
+      maxClips: 3,
+      minViralityScore: 70,
+      mode: 'raw-cut',
+      youtubeUrl: 'https://www.youtube.com/watch?v=rawCut123',
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.test/v1/clip-projects/from-youtube',
+      expect.objectContaining({
+        body: JSON.stringify({
+          language: 'en',
+          maxClips: 3,
+          minViralityScore: 70,
+          mode: 'raw-cut',
+          youtubeUrl: 'https://www.youtube.com/watch?v=rawCut123',
+        }),
+        method: 'POST',
+      }),
+    );
+  });
+
+  it('generates selected raw cuts without avatar identity fields', async () => {
+    const service = new ClipsApiService(
+      vi.fn().mockResolvedValue('token-raw-cut'),
+    );
+
+    await service.generateClips('clip-project-1', {
+      editedHighlights: [
+        { id: 'highlight-1', summary: 'Edited caption', title: 'Hook' },
+      ],
+      mode: 'raw-cut',
+      selectedHighlightIds: ['highlight-1'],
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.test/v1/clip-projects/clip-project-1/generate',
+      expect.objectContaining({
+        body: JSON.stringify({
+          editedHighlights: [
+            { id: 'highlight-1', summary: 'Edited caption', title: 'Hook' },
+          ],
+          mode: 'raw-cut',
+          selectedHighlightIds: ['highlight-1'],
+        }),
         method: 'POST',
       }),
     );

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/services/clips-api.service.ts
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/services/clips-api.service.ts
@@ -1,4 +1,8 @@
-import type { ClipResult, IHighlight } from '@props/studio/clips.props';
+import type {
+  ClipResult,
+  ClipResultMode,
+  IHighlight,
+} from '@props/studio/clips.props';
 import { EnvironmentService } from '@services/core/environment.service';
 
 // ─── API Response Types ───────────────────────────────────────────
@@ -26,18 +30,20 @@ interface GenerateClipsPayload {
     title: string;
     summary: string;
   }>;
-  avatarId: string;
-  voiceId: string;
-  avatarProvider: string;
+  avatarId?: string;
+  avatarProvider?: string;
+  mode: ClipResultMode;
+  voiceId?: string;
 }
 
 interface CreateFromYoutubePayload {
-  avatarId: string;
-  avatarProvider: string;
+  avatarId?: string;
+  avatarProvider?: string;
   language: string;
   maxClips: number;
   minViralityScore: number;
-  voiceId: string;
+  mode: ClipResultMode;
+  voiceId?: string;
   youtubeUrl: string;
 }
 

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/useStudioClipsPage.ts
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/useStudioClipsPage.ts
@@ -6,6 +6,7 @@ import { resolveAuthToken } from '@helpers/auth/auth.helper';
 import { useDocumentVisibility } from '@hooks/ui/use-document-visibility/use-document-visibility';
 import type {
   AvatarProvider,
+  ClipResultMode,
   ClipsStep,
   IHighlight,
   ProjectState,
@@ -119,6 +120,8 @@ export function useStudioClipsPage() {
   const [voiceId, setVoiceId] = useState('');
   const [avatarProvider, setAvatarProvider] =
     useState<AvatarProvider>('heygen');
+  const [generationMode, setGenerationMode] =
+    useState<ClipResultMode>('avatar');
   const [maxClips, setMaxClips] = useState(10);
   const [minViralityScore, setMinViralityScore] = useState(50);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -184,6 +187,7 @@ export function useStudioClipsPage() {
       setProject({
         clips: [],
         highlights: [],
+        mode: generationMode,
         projectId: data.projectId,
         status: 'analyzing',
       });
@@ -193,7 +197,7 @@ export function useStudioClipsPage() {
     } finally {
       setIsSubmitting(false);
     }
-  }, [youtubeUrl, maxClips, minViralityScore, clipsService]);
+  }, [youtubeUrl, maxClips, minViralityScore, generationMode, clipsService]);
 
   // ─── Step 1: One-click YouTube clip factory ───────────────────
   const handleStartFromYoutube = useCallback(async () => {
@@ -205,7 +209,7 @@ export function useStudioClipsPage() {
     const quickAvatarId = avatarId || identityDefaults.avatarId;
     const quickVoiceId = voiceId || identityDefaults.voiceId;
 
-    if (!quickAvatarId || !quickVoiceId) {
+    if (generationMode === 'avatar' && (!quickAvatarId || !quickVoiceId)) {
       setError(
         'Saved HeyGen avatar and voice defaults are required for one-click generation. Review highlights first to enter IDs manually.',
       );
@@ -221,21 +225,29 @@ export function useStudioClipsPage() {
 
     try {
       const data = await clipsService.createFromYoutube({
-        avatarId: quickAvatarId,
-        avatarProvider,
+        ...(generationMode === 'avatar'
+          ? {
+              avatarId: quickAvatarId,
+              avatarProvider,
+              voiceId: quickVoiceId,
+            }
+          : {}),
         language: 'en',
         maxClips,
         minViralityScore,
-        voiceId: quickVoiceId,
+        mode: generationMode,
         youtubeUrl,
       });
 
-      setAvatarId(quickAvatarId);
-      setVoiceId(quickVoiceId);
+      if (generationMode === 'avatar') {
+        setAvatarId(quickAvatarId ?? '');
+        setVoiceId(quickVoiceId ?? '');
+      }
       setProject({
         clips: [],
         estimatedClips: data.estimatedClips,
         highlights: [],
+        mode: generationMode,
         projectId: data.projectId,
         status: data.status ?? 'processing',
       });
@@ -257,6 +269,7 @@ export function useStudioClipsPage() {
     voiceId,
     identityDefaults.avatarId,
     identityDefaults.voiceId,
+    generationMode,
     avatarProvider,
     maxClips,
     minViralityScore,
@@ -347,7 +360,12 @@ export function useStudioClipsPage() {
 
   // ─── Step 2: Generate selected highlights ─────────────────────
   const handleGenerate = useCallback(async () => {
-    if (!project?.projectId || !avatarId || !voiceId) {
+    if (!project?.projectId) {
+      setError('Clip project is required to generate clips.');
+      return;
+    }
+
+    if (generationMode === 'avatar' && (!avatarId || !voiceId)) {
       setError('Avatar ID and Voice ID are required to generate clips.');
       return;
     }
@@ -371,18 +389,21 @@ export function useStudioClipsPage() {
 
     try {
       await clipsService.generateClips(project.projectId, {
-        avatarId,
-        avatarProvider,
+        ...(generationMode === 'avatar'
+          ? { avatarId, avatarProvider, voiceId }
+          : {}),
         editedHighlights: selectedEditedHighlights.map((highlight) => ({
           id: highlight.id,
           summary: highlight.summary,
           title: highlight.title,
         })),
+        mode: generationMode,
         selectedHighlightIds: ids,
-        voiceId,
       });
 
-      setProject((prev) => (prev ? { ...prev, status: 'generating' } : prev));
+      setProject((prev) =>
+        prev ? { ...prev, mode: generationMode, status: 'generating' } : prev,
+      );
       setStep('progress');
     } catch (err: unknown) {
       clipCompletionReportedRef.current = project.projectId;
@@ -399,6 +420,7 @@ export function useStudioClipsPage() {
     avatarId,
     voiceId,
     avatarProvider,
+    generationMode,
     selectedIds,
     editedHighlights,
     clipsService,
@@ -524,6 +546,7 @@ export function useStudioClipsPage() {
     clipsService,
     editedHighlights,
     error,
+    generationMode,
     handleAnalyze,
     handleGenerate,
     handleStartFromYoutube,
@@ -537,6 +560,7 @@ export function useStudioClipsPage() {
     selectedIds,
     setAvatarId,
     setAvatarProvider,
+    setGenerationMode,
     setMaxClips,
     setMinViralityScore,
     setVoiceId,

--- a/packages/props/studio/clips.props.ts
+++ b/packages/props/studio/clips.props.ts
@@ -1,6 +1,7 @@
 import type {
   ClipReadinessContract,
   ClipReadyAction,
+  ClipResultMode,
   ClipResultStatus,
 } from '@genfeedai/interfaces';
 
@@ -12,7 +13,7 @@ export type ClipStatus = ClipResultStatus;
 
 export type ClipReadiness = ClipReadinessContract;
 
-export type { ClipReadyAction };
+export type { ClipReadyAction, ClipResultMode };
 
 export type ClipsStep = 'input' | 'review' | 'progress';
 
@@ -48,6 +49,7 @@ export interface ClipResult {
   videoUrl?: string;
   captionedVideoUrl?: string;
   clipType?: string;
+  mode?: ClipResultMode;
   duration: number;
   startTime: number;
   endTime: number;
@@ -60,10 +62,32 @@ export interface ProjectState {
   highlights: IHighlight[];
   clips: ClipResult[];
   estimatedClips?: number;
+  mode: ClipResultMode;
 }
 
 // ─── Component Props ──────────────────────────────────────────────
 
 export interface ViralityBadgeProps {
   score: number;
+}
+
+export interface ClipModeSelectorProps {
+  mode: ClipResultMode;
+  onModeChange: (mode: ClipResultMode) => void;
+}
+
+export interface ClipsInputFormProps {
+  error: string | null;
+  generationMode: ClipResultMode;
+  isSubmitting: boolean;
+  maxClips: number;
+  minViralityScore: number;
+  onAnalyze: () => void;
+  onModeChange: (mode: ClipResultMode) => void;
+  onStartQuick: () => void;
+  onSetMaxClips: (value: number) => void;
+  onSetMinViralityScore: (value: number) => void;
+  onSetYoutubeUrl: (value: string) => void;
+  quickStartHint: string;
+  youtubeUrl: string;
 }

--- a/packages/props/studio/video-player.props.ts
+++ b/packages/props/studio/video-player.props.ts
@@ -1,6 +1,7 @@
 import type { RefObject } from 'react';
 
 export interface VideoPlayerProps {
+  ariaLabel?: string;
   videoRef?: RefObject<HTMLVideoElement | null>;
   src?: string;
   thumbnail?: string;

--- a/packages/ui/src/components/display/video-player/VideoPlayer.tsx
+++ b/packages/ui/src/components/display/video-player/VideoPlayer.tsx
@@ -76,6 +76,7 @@ function VideoOverlayContent({
 }
 
 export default function VideoPlayer({
+  ariaLabel = 'Video player',
   videoRef,
   src = '',
   thumbnail = '',
@@ -161,7 +162,7 @@ export default function VideoPlayer({
       )}
 
       <video
-        aria-label="Video player"
+        aria-label={ariaLabel}
         controls={config?.controls}
         muted={config?.muted}
         loop={config?.loop}

--- a/playwright/e2e/tests/studio/clips.spec.ts
+++ b/playwright/e2e/tests/studio/clips.spec.ts
@@ -9,6 +9,7 @@ import { expect, test } from '../../fixtures/auth.fixture';
 
 const CLIPS_URL = '/studio/clips';
 const API_ANALYZE = '**/clip-projects/analyze';
+const API_CREATE_FROM_YOUTUBE = '**/clip-projects/from-youtube';
 const API_GENERATE = '**/clip-projects/*/generate';
 const API_HIGHLIGHTS = '**/clip-projects/*/highlights';
 const API_PROJECT = '**/clip-projects/*';
@@ -122,7 +123,9 @@ test.describe('Clip Factory', () => {
       'range',
     );
     await expect(
-      authenticatedPage.getByRole('button', { name: /analyze video/i }),
+      authenticatedPage.getByRole('button', {
+        name: /review highlights first/i,
+      }),
     ).toBeVisible();
   });
 
@@ -135,7 +138,7 @@ test.describe('Clip Factory', () => {
     await authenticatedPage.goto(CLIPS_URL);
     await authenticatedPage.getByLabel(/youtube url/i).fill(MOCK_YOUTUBE_URL);
     await authenticatedPage
-      .getByRole('button', { name: /analyze video/i })
+      .getByRole('button', { name: /review highlights first/i })
       .click();
 
     await expect(
@@ -172,7 +175,7 @@ test.describe('Clip Factory', () => {
 
     await authenticatedPage.route(API_PROJECT, async (route) => {
       if (route.request().method() !== 'GET') {
-        await route.continue();
+        await route.fallback();
         return;
       }
 
@@ -199,7 +202,7 @@ test.describe('Clip Factory', () => {
     await authenticatedPage.goto(CLIPS_URL);
     await authenticatedPage.getByLabel(/youtube url/i).fill(MOCK_YOUTUBE_URL);
     await authenticatedPage
-      .getByRole('button', { name: /analyze video/i })
+      .getByRole('button', { name: /review highlights first/i })
       .click();
 
     await expect(
@@ -217,7 +220,7 @@ test.describe('Clip Factory', () => {
     await authenticatedPage.getByLabel(/voice id/i).fill('heygen-voice-1');
 
     await authenticatedPage
-      .getByRole('button', { name: /generate 3 clips/i })
+      .getByRole('button', { name: /generate 3 avatar clips/i })
       .click();
 
     await expect.poll(() => generateRequestBody).not.toBeNull();
@@ -231,11 +234,12 @@ test.describe('Clip Factory', () => {
         }),
       ]),
       selectedHighlightIds: ['h1', 'h2', 'h3'],
+      mode: 'avatar',
       voiceId: 'heygen-voice-1',
     });
 
     await expect(
-      authenticatedPage.getByText(/generating 3 clips/i),
+      authenticatedPage.getByText(/generating 3 avatar clips/i),
     ).toBeVisible();
   });
 
@@ -262,7 +266,7 @@ test.describe('Clip Factory', () => {
 
     await authenticatedPage.route(API_PROJECT, async (route) => {
       if (route.request().method() !== 'GET') {
-        await route.continue();
+        await route.fallback();
         return;
       }
 
@@ -303,18 +307,18 @@ test.describe('Clip Factory', () => {
     await authenticatedPage.goto(CLIPS_URL);
     await authenticatedPage.getByLabel(/youtube url/i).fill(MOCK_YOUTUBE_URL);
     await authenticatedPage
-      .getByRole('button', { name: /analyze video/i })
+      .getByRole('button', { name: /review highlights first/i })
       .click();
 
     await authenticatedPage.getByLabel(/avatar id/i).fill('heygen-avatar-1');
     await authenticatedPage.getByLabel(/voice id/i).fill('heygen-voice-1');
 
     await authenticatedPage
-      .getByRole('button', { name: /generate 3 clips/i })
+      .getByRole('button', { name: /generate 3 avatar clips/i })
       .click();
 
     await expect(
-      authenticatedPage.getByText(/generating 3 clips/i),
+      authenticatedPage.getByText(/generating 3 avatar clips/i),
     ).toBeVisible();
     await expect
       .poll(() => projectPollCount, { timeout: 7000 })
@@ -323,7 +327,7 @@ test.describe('Clip Factory', () => {
       .poll(() => clipPollCount, { timeout: 7000 })
       .toBeGreaterThan(1);
     await expect(
-      authenticatedPage.getByText(/done — 1 clips generated/i),
+      authenticatedPage.getByText(/done — 1 clip generated/i),
     ).toBeVisible({ timeout: 8000 });
     await expect(
       authenticatedPage.getByRole('button', { name: /^edit$/i }),
@@ -351,7 +355,7 @@ test.describe('Clip Factory', () => {
     await authenticatedPage.goto(CLIPS_URL);
     await authenticatedPage.getByLabel(/youtube url/i).fill(MOCK_YOUTUBE_URL);
     await authenticatedPage
-      .getByRole('button', { name: /analyze video/i })
+      .getByRole('button', { name: /review highlights first/i })
       .click();
 
     await authenticatedPage
@@ -378,13 +382,145 @@ test.describe('Clip Factory', () => {
     await authenticatedPage.goto(CLIPS_URL);
     await authenticatedPage.getByLabel(/youtube url/i).fill(MOCK_YOUTUBE_URL);
     await authenticatedPage
-      .getByRole('button', { name: /analyze video/i })
+      .getByRole('button', { name: /review highlights first/i })
       .click();
 
     await expect(
       authenticatedPage.getByText(/internal server error/i),
     ).toBeVisible();
     await expect(authenticatedPage.getByLabel(/youtube url/i)).toBeVisible();
+  });
+
+  test('should complete a raw-cut project without avatar identity', async ({
+    authenticatedPage,
+  }) => {
+    let createRequestBody: Record<string, unknown> | null = null;
+
+    await authenticatedPage.route(API_CREATE_FROM_YOUTUBE, async (route) => {
+      createRequestBody = JSON.parse(
+        route.request().postData() ?? '{}',
+      ) as Record<string, unknown>;
+      await route.fulfill({
+        body: JSON.stringify({
+          batchJobId: 'raw-cut-job-1',
+          estimatedClips: 1,
+          projectId: MOCK_PROJECT_ID,
+          status: 'processing',
+        }),
+        contentType: 'application/json',
+        status: 202,
+      });
+    });
+
+    await authenticatedPage.route(API_PROJECT, async (route) => {
+      if (route.request().method() !== 'GET') {
+        await route.fallback();
+        return;
+      }
+
+      await route.fulfill({
+        body: JSON.stringify({
+          data: { _id: MOCK_PROJECT_ID, status: 'completed' },
+        }),
+        contentType: 'application/json',
+        status: 200,
+      });
+    });
+
+    await authenticatedPage.route(API_CLIP_RESULTS, async (route) => {
+      await route.fulfill({
+        body: JSON.stringify({
+          data: [
+            {
+              attributes: {
+                ...mockCompletedClipResult,
+                mode: 'raw-cut',
+                readiness: {
+                  blockingReasons: [],
+                  readyActions: ['download'],
+                  state: 'ready',
+                  terminal: true,
+                },
+              },
+              id: 'raw-cut-1',
+            },
+          ],
+        }),
+        contentType: 'application/json',
+        status: 200,
+      });
+    });
+
+    await authenticatedPage.route(
+      'https://cdn.genfeed.ai/**',
+      async (route) => {
+        await route.fulfill({
+          body: '',
+          contentType: 'video/mp4',
+          headers: { 'Access-Control-Allow-Origin': '*' },
+          status: 200,
+        });
+      },
+    );
+
+    await authenticatedPage.goto(CLIPS_URL);
+    await authenticatedPage.getByRole('button', { name: /raw cut/i }).click();
+    await authenticatedPage.getByLabel(/youtube url/i).fill(MOCK_YOUTUBE_URL);
+    await authenticatedPage
+      .getByRole('button', { name: /start clip factory/i })
+      .click();
+
+    await expect.poll(() => createRequestBody).not.toBeNull();
+    expect(createRequestBody).toMatchObject({
+      mode: 'raw-cut',
+      youtubeUrl: MOCK_YOUTUBE_URL,
+    });
+    expect(createRequestBody).not.toHaveProperty('avatarId');
+    expect(createRequestBody).not.toHaveProperty('voiceId');
+    await expect(authenticatedPage.getByText('Raw cut')).toBeVisible();
+    await expect(
+      authenticatedPage.getByLabel('Preview Edited Hook Title'),
+    ).toBeVisible();
+    await authenticatedPage.evaluate(() => {
+      const target = window as Window & {
+        clipDownloadHref?: string;
+        clipDownloadName?: string;
+      };
+      const originalDispatchEvent = HTMLAnchorElement.prototype.dispatchEvent;
+
+      HTMLAnchorElement.prototype.dispatchEvent = function captureDownloadClick(
+        event,
+      ) {
+        target.clipDownloadHref = this.href;
+        target.clipDownloadName = this.download;
+        HTMLAnchorElement.prototype.dispatchEvent = originalDispatchEvent;
+        return event.type === 'click';
+      };
+    });
+
+    await authenticatedPage
+      .getByRole('button', { name: /download video/i })
+      .click();
+    await expect
+      .poll(() =>
+        authenticatedPage.evaluate(
+          () =>
+            (window as Window & { clipDownloadHref?: string }).clipDownloadHref,
+        ),
+      )
+      .toMatch(/^blob:/);
+    await expect
+      .poll(() =>
+        authenticatedPage.evaluate(
+          () =>
+            (
+              window as Window & {
+                clipDownloadName?: string;
+              }
+            ).clipDownloadName,
+        ),
+      )
+      .toBe('Edited_Hook_Title.mp4');
   });
 
   test('unauthenticated user is redirected away from clip factory', async ({


### PR DESCRIPTION
## Summary

- adds an accessible raw-cut/avatar mode picker to clip creation and highlight review
- omits avatar and voice identity from raw-cut API requests while preserving avatar defaults and validation
- adds live mode-aware progress, playable result previews, and fetch-to-Blob downloads for CDN clips
- refreshes component, API, and mocked browser coverage for both generation paths

## Verification

- scoped Biome check passed for all 16 changed files
- DESIGN.md lint passed with no errors; existing unused-token warnings only
- design-system check passed
- git diff --check passed
- staged sensitive-filename and credential-shape scans passed
- supplementary correctness/accessibility review passed after download and video-label fixes
- local unit, typecheck, build, and Playwright execution skipped per MacBook resource policy; PR CI is the execution gate
- standalone Secretlint could not load its configured rule packages without installed workspace dependencies; repository CI secret scanners remain required

Fleet Review remains the required exact-head gate before merge.

Closes #1240