### PR TITLE
fix(api): restore module dependency ratchet

### DIFF
--- a/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.module.ts
+++ b/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.module.ts
@@ -75,7 +75,7 @@ import { forwardRef, Module } from '@nestjs/common';
     forwardRef(() => AgentThreadingModule),
     forwardRef(() => AgentRunsModule),
     forwardRef(() => AiActionsModule),
-    forwardRef(() => AdsResearchModule),
+    AdsResearchModule,
     forwardRef(() => AgentStreamPublisherModule),
     forwardRef(() => AnalyticsModule),
     forwardRef(() => BatchGenerationModule),

--- a/apps/server/api/src/services/instagram-inspiration/instagram-inspiration.module.ts
+++ b/apps/server/api/src/services/instagram-inspiration/instagram-inspiration.module.ts
@@ -3,15 +3,10 @@ import { CacheModule } from '@api/services/cache/cache.module';
 import { InstagramInspirationService } from '@api/services/instagram-inspiration/instagram-inspiration.service';
 import { ApifyModule } from '@api/services/integrations/apify/apify.module';
 import { createServiceModule } from '@api/shared/service-module.factory';
-import { forwardRef } from '@nestjs/common';
 
 export const InstagramInspirationModule = createServiceModule(
   InstagramInspirationService,
   {
-    additionalImports: [
-      forwardRef(() => ApifyModule),
-      CacheModule,
-      forwardRef(() => WorkflowsModule),
-    ],
+    additionalImports: [ApifyModule, CacheModule, WorkflowsModule],
   },
 );


### PR DESCRIPTION
## Summary

- remove three unnecessary `forwardRef()` wrappers introduced by #1981
- restore the API module-graph ratchet from 1,078 to its maximum of 1,075
- keep the same direct module dependencies and inspiration behavior

## Verification

- `forwardRef()` static count: 1,075
- pinned Biome 2.5.3 check passed for both changed modules
- `git diff --check` passed
- broad validation delegated to PR CI per workstation policy

Closes #1987
