### PR TITLE
feat(settings): surface publishing readiness

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/settings/publishing/content.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/settings/publishing/content.test.tsx
@@ -21,8 +21,13 @@ const mocks = vi.hoisted(() => ({
     hasBrandId: true,
     isLoading: false,
   },
+  brandsService: {},
+  copyToClipboard: vi.fn(),
+  credentialsService: {},
   error: vi.fn(),
   getBrandsService: vi.fn(),
+  getCredentialsService: vi.fn(),
+  getPublishingContext: vi.fn(),
   loggerError: vi.fn(),
   success: vi.fn(),
   updateAgentConfig: vi.fn(),
@@ -33,7 +38,13 @@ vi.mock('@hooks/pages/use-brand-detail/use-brand-detail', () => ({
 }));
 
 vi.mock('@hooks/auth/use-authed-service/use-authed-service', () => ({
-  useAuthedService: () => mocks.getBrandsService,
+  useAuthedService: (factory: (token: string) => unknown) => {
+    const service = factory('test-token');
+
+    return service === mocks.credentialsService
+      ? mocks.getCredentialsService
+      : mocks.getBrandsService;
+  },
 }));
 
 vi.mock('@services/core/logger.service', () => ({
@@ -51,9 +62,23 @@ vi.mock('@services/core/notifications.service', () => ({
   },
 }));
 
+vi.mock('@services/core/clipboard.service', () => ({
+  ClipboardService: {
+    getInstance: () => ({
+      copyToClipboard: mocks.copyToClipboard,
+    }),
+  },
+}));
+
+vi.mock('@services/organization/credentials.service', () => ({
+  CredentialsService: {
+    getInstance: () => mocks.credentialsService,
+  },
+}));
+
 vi.mock('@services/social/brands.service', () => ({
   BrandsService: {
-    getInstance: vi.fn(),
+    getInstance: () => mocks.brandsService,
   },
 }));
 
@@ -137,9 +162,17 @@ describe('BrandSettingsPublishingPage', () => {
       isLoading: false,
     };
     mocks.updateAgentConfig.mockResolvedValue(undefined);
+    mocks.getPublishingContext.mockReset();
+    Object.assign(mocks.brandsService, {
+      updateAgentConfig: mocks.updateAgentConfig,
+    });
+    Object.assign(mocks.credentialsService, {
+      getPublishingContext: mocks.getPublishingContext,
+    });
     mocks.getBrandsService.mockResolvedValue({
       updateAgentConfig: mocks.updateAgentConfig,
     });
+    mocks.getCredentialsService.mockResolvedValue(mocks.credentialsService);
   });
 
   it('loads publishing defaults and saves schedule/autopublish settings', async () => {
@@ -224,5 +257,192 @@ describe('BrandSettingsPublishingPage', () => {
     expect(mocks.error).toHaveBeenCalledWith(
       'Failed to save brand publishing defaults',
     );
+  });
+
+  it('renders publish-capable and blocked account readiness safely', async () => {
+    mocks.brandDetail = {
+      ...mocks.brandDetail,
+      brand: {
+        agentConfig: {},
+        credentials: [
+          {
+            externalHandle: 'ready-account',
+            id: 'credential-ready',
+            isConnected: true,
+            platform: 'twitter',
+          },
+          {
+            externalHandle: 'blocked-account',
+            id: 'credential-blocked',
+            isConnected: true,
+            platform: 'linkedin',
+          },
+        ],
+      },
+    };
+    mocks.getPublishingContext.mockImplementation(
+      async (credentialId: string) => {
+        if (credentialId === 'credential-ready') {
+          return {
+            account: {
+              handle: 'ready-account',
+              id: credentialId,
+              label: 'Ready account',
+              platform: 'twitter',
+            },
+            readiness: {
+              appReviewStatus: 'pass',
+              callbackUrlStatus: 'pass',
+              canSchedule: true,
+              diagnostics: [],
+              isRetryable: false,
+              permissionScopeStatus: 'pass',
+              providerKey: 'twitter',
+              quotaStatus: 'pass',
+              state: 'publish_capable',
+              tokenFreshness: 'pass',
+            },
+            surface: 'post',
+          };
+        }
+
+        return {
+          account: {
+            handle: 'blocked-account',
+            id: credentialId,
+            label: 'Blocked account',
+            platform: 'linkedin',
+          },
+          readiness: {
+            appReviewStatus: 'fail',
+            callbackUrlStatus: 'pass',
+            canSchedule: false,
+            diagnostics: [
+              {
+                classification: 'missing_permission_scope',
+                code: 'missing_scope',
+                correctiveAction: 'Reconnect with publishing permissions.',
+                details: { token: 'must-not-render-or-copy' },
+                isRetryable: false,
+                message:
+                  'Publishing permission is missing. token=must-not-render-or-copy',
+                severity: 'error',
+              },
+            ],
+            isRetryable: false,
+            permissionScopeStatus: 'fail',
+            providerKey: 'linkedin',
+            quotaStatus: 'unknown',
+            requiredAction: 'Reconnect the LinkedIn account.',
+            state: 'blocked',
+            tokenFreshness: 'pass',
+          },
+          surface: 'post',
+        };
+      },
+    );
+
+    render(<BrandSettingsPublishingPage />);
+
+    expect(await screen.findByText('Ready account')).toBeVisible();
+    expect(screen.getByText('Publish Capable')).toBeVisible();
+    expect(screen.getByText('Blocked account')).toBeVisible();
+    expect(screen.getByText('Blocked')).toBeVisible();
+    expect(screen.getByText('Reconnect the LinkedIn account.')).toBeVisible();
+    expect(
+      screen.queryByText('must-not-render-or-copy'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText('Publishing permission is missing. token=[REDACTED]'),
+    ).toBeVisible();
+
+    fireEvent.click(screen.getAllByText('Copy diagnostics')[1]);
+
+    await waitFor(() => {
+      expect(mocks.copyToClipboard).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Publishing permission is missing. token=[REDACTED]',
+        ),
+      );
+    });
+    expect(mocks.copyToClipboard.mock.calls.at(-1)?.[0]).not.toContain(
+      'must-not-render-or-copy',
+    );
+    expect(mocks.copyToClipboard.mock.calls.at(-1)?.[0]).toContain(
+      'Token: Pass',
+    );
+  });
+
+  it('renders the no-connected-account state', () => {
+    mocks.brandDetail = {
+      ...mocks.brandDetail,
+      brand: {
+        agentConfig: {},
+        credentials: [],
+      },
+    };
+
+    render(<BrandSettingsPublishingPage />);
+
+    expect(
+      screen.getByText('No connected accounts are available for this brand.'),
+    ).toBeVisible();
+    expect(mocks.getPublishingContext).not.toHaveBeenCalled();
+  });
+
+  it('preserves successful readiness when another account fails', async () => {
+    mocks.brandDetail = {
+      ...mocks.brandDetail,
+      brand: {
+        agentConfig: {},
+        credentials: [
+          {
+            externalHandle: 'ready-account',
+            id: 'credential-ready',
+            isConnected: true,
+            platform: 'twitter',
+          },
+          {
+            externalHandle: 'failed-account',
+            id: 'credential-failed',
+            isConnected: true,
+            platform: 'youtube',
+          },
+        ],
+      },
+    };
+    mocks.getPublishingContext
+      .mockResolvedValueOnce({
+        account: {
+          id: 'credential-ready',
+          label: 'Ready account',
+          platform: 'twitter',
+        },
+        readiness: {
+          appReviewStatus: 'pass',
+          callbackUrlStatus: 'pass',
+          canSchedule: true,
+          diagnostics: [],
+          isRetryable: false,
+          permissionScopeStatus: 'pass',
+          providerKey: 'twitter',
+          quotaStatus: 'pass',
+          state: 'publish_capable',
+          tokenFreshness: 'pass',
+        },
+        surface: 'post',
+      })
+      .mockRejectedValueOnce(new Error('network error'));
+
+    render(<BrandSettingsPublishingPage />);
+
+    expect(await screen.findByText('Ready account')).toBeVisible();
+    expect(screen.getByText('@failed-account')).toBeVisible();
+    expect(screen.getByText('Unavailable')).toBeVisible();
+    expect(
+      screen.getByText(
+        'Publishing readiness could not be loaded for this account. Retry by refreshing this page.',
+      ),
+    ).toBeVisible();
   });
 });

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/settings/publishing/content.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/settings/publishing/content.test.tsx
@@ -353,7 +353,7 @@ describe('BrandSettingsPublishingPage', () => {
       screen.queryByText('must-not-render-or-copy'),
     ).not.toBeInTheDocument();
     expect(
-      screen.getByText('Publishing permission is missing. token=[REDACTED]'),
+      screen.getByText(/Publishing permission is missing\. token=\[REDACTED\]/),
     ).toBeVisible();
 
     fireEvent.click(screen.getAllByText('Copy diagnostics')[1]);

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/settings/publishing/content.test.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/settings/publishing/content.test.tsx
@@ -100,14 +100,16 @@ vi.mock('@ui/primitives/button', () => ({
   Button: ({
     children,
     isDisabled,
+    label,
     onClick,
   }: {
     children?: ReactNode;
     isDisabled?: boolean;
+    label?: string;
     onClick?: () => void;
   }) => (
     <button disabled={isDisabled} type="button" onClick={onClick}>
-      {children}
+      {label ?? children}
     </button>
   ),
 }));

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/settings/publishing/content.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/settings/publishing/content.tsx
@@ -1,16 +1,27 @@
 'use client';
 
+import { ButtonVariant } from '@genfeedai/enums';
+import { redactSensitiveString } from '@genfeedai/helpers';
+import type {
+  AccountPublishingContext,
+  ICredential,
+  PublishingReadinessState,
+  PublishingSetupCheckStatus,
+} from '@genfeedai/interfaces';
 import { useAuthedService } from '@hooks/auth/use-authed-service/use-authed-service';
 import { useBrandDetail } from '@hooks/pages/use-brand-detail/use-brand-detail';
+import { ClipboardService } from '@services/core/clipboard.service';
 import { logger } from '@services/core/logger.service';
 import { NotificationsService } from '@services/core/notifications.service';
+import { CredentialsService } from '@services/organization/credentials.service';
 import { BrandsService } from '@services/social/brands.service';
 import Card from '@ui/card/Card';
 import Loading from '@ui/loading/default/Loading';
+import { Badge } from '@ui/primitives/badge';
 import { Button } from '@ui/primitives/button';
 import { Input } from '@ui/primitives/input';
 import { Switch } from '@ui/primitives/switch';
-import { useCallback, useEffect, useReducer } from 'react';
+import { useCallback, useEffect, useMemo, useReducer, useState } from 'react';
 
 type PublishingConfig = {
   autoPublish?: {
@@ -41,6 +52,104 @@ type FormAction =
   | { type: 'SET_AUTO_PUBLISH_ENABLED'; value: boolean }
   | { type: 'SET_CONFIDENCE_THRESHOLD'; value: string }
   | { type: 'SET_SAVING'; value: boolean };
+
+const READINESS_CHECKS = [
+  ['tokenFreshness', 'Token'],
+  ['callbackUrlStatus', 'Callback'],
+  ['permissionScopeStatus', 'Permissions'],
+  ['appReviewStatus', 'App review'],
+  ['quotaStatus', 'Quota'],
+] as const;
+
+const MAX_EXPORTED_DIAGNOSTICS = 5;
+
+function getReadinessBadgeVariant(
+  state: PublishingReadinessState,
+): 'destructive' | 'outline' | 'success' | 'warning' {
+  if (state === 'publish_capable') {
+    return 'success';
+  }
+
+  if (state === 'degraded') {
+    return 'warning';
+  }
+
+  if (state === 'blocked') {
+    return 'destructive';
+  }
+
+  return 'outline';
+}
+
+function formatReadinessState(state: PublishingReadinessState): string {
+  return state
+    .split('_')
+    .map((word) => `${word.charAt(0).toUpperCase()}${word.slice(1)}`)
+    .join(' ');
+}
+
+function formatCheckStatus(status: PublishingSetupCheckStatus): string {
+  return `${status.charAt(0).toUpperCase()}${status.slice(1)}`;
+}
+
+function getCredentialLabel(credential: ICredential): string {
+  const handle = credential.externalHandle?.replace(/^@/, '');
+
+  return (
+    credential.label ??
+    credential.externalName ??
+    (handle ? `@${handle}` : credential.platform)
+  );
+}
+
+function buildPublishingReadinessSummary(
+  context: AccountPublishingContext,
+): string {
+  const { account, readiness } = context;
+  const lines = [
+    'Genfeed publishing readiness',
+    `Account: ${redactSensitiveString(account.label)}`,
+    `Provider: ${account.platform}`,
+    `State: ${formatReadinessState(readiness.state)}`,
+    `Can schedule: ${readiness.canSchedule ? 'yes' : 'no'}`,
+    `Token: ${formatCheckStatus(readiness.tokenFreshness)}`,
+    `Callback: ${formatCheckStatus(readiness.callbackUrlStatus)}`,
+    `Permissions: ${formatCheckStatus(readiness.permissionScopeStatus)}`,
+    `App review: ${formatCheckStatus(readiness.appReviewStatus)}`,
+    `Quota: ${formatCheckStatus(readiness.quotaStatus)}`,
+  ];
+
+  if (readiness.requiredAction) {
+    lines.push(
+      `Required action: ${redactSensitiveString(readiness.requiredAction)}`,
+    );
+  }
+
+  for (const diagnostic of readiness.diagnostics.slice(
+    0,
+    MAX_EXPORTED_DIAGNOSTICS,
+  )) {
+    lines.push(
+      `[${diagnostic.severity}] ${redactSensitiveString(
+        diagnostic.code,
+      )}: ${redactSensitiveString(diagnostic.message)}`,
+    );
+
+    if (diagnostic.correctiveAction) {
+      lines.push(
+        `Next step: ${redactSensitiveString(diagnostic.correctiveAction)}`,
+      );
+    }
+  }
+
+  if (readiness.diagnostics.length > MAX_EXPORTED_DIAGNOSTICS) {
+    lines.push(
+      `${readiness.diagnostics.length - MAX_EXPORTED_DIAGNOSTICS} additional diagnostics omitted`,
+    );
+  }
+
+  return lines.join('\n');
+}
 
 function buildStateFromConfig(
   config: PublishingConfig | undefined,
@@ -82,12 +191,28 @@ function formReducer(state: FormState, action: FormAction): FormState {
 export default function BrandSettingsPublishingPage() {
   const { brand, brandId, hasBrandId, isLoading, handleRefreshBrand } =
     useBrandDetail();
+  const clipboardService = ClipboardService.getInstance();
   const notifications = NotificationsService.getInstance();
   const getBrandsService = useAuthedService((token: string) =>
     BrandsService.getInstance(token),
   );
+  const getCredentialsService = useAuthedService((token: string) =>
+    CredentialsService.getInstance(token),
+  );
 
   const publishingConfig = brand?.agentConfig as PublishingConfig | undefined;
+  const connectedCredentials = useMemo(
+    () =>
+      (brand?.credentials ?? []).filter(
+        (credential) => credential.isConnected && credential.id,
+      ),
+    [brand?.credentials],
+  );
+  const [publishingContexts, setPublishingContexts] = useState<
+    AccountPublishingContext[]
+  >([]);
+  const [failedCredentialIds, setFailedCredentialIds] = useState<string[]>([]);
+  const [isReadinessLoading, setIsReadinessLoading] = useState(false);
 
   const [state, dispatch] = useReducer(formReducer, undefined, () => ({
     ...buildStateFromConfig(publishingConfig),
@@ -106,6 +231,68 @@ export default function BrandSettingsPublishingPage() {
   useEffect(() => {
     dispatch({ type: 'RESET', config: publishingConfig });
   }, [publishingConfig]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+
+    if (!brandId || connectedCredentials.length === 0) {
+      setPublishingContexts([]);
+      setFailedCredentialIds([]);
+      setIsReadinessLoading(false);
+      return () => controller.abort();
+    }
+
+    setPublishingContexts([]);
+    setFailedCredentialIds([]);
+    setIsReadinessLoading(true);
+
+    const loadPublishingReadiness = async () => {
+      try {
+        const service = await getCredentialsService();
+        const results = await Promise.allSettled(
+          connectedCredentials.map((credential) =>
+            service.getPublishingContext(
+              credential.id,
+              'post',
+              controller.signal,
+            ),
+          ),
+        );
+
+        if (controller.signal.aborted) {
+          return;
+        }
+
+        setPublishingContexts(
+          results.flatMap((result) =>
+            result.status === 'fulfilled' ? [result.value] : [],
+          ),
+        );
+        setFailedCredentialIds(
+          results.flatMap((result, index) =>
+            result.status === 'rejected'
+              ? [connectedCredentials[index].id]
+              : [],
+          ),
+        );
+      } catch (error) {
+        if (!controller.signal.aborted) {
+          logger.error('Failed to load publishing readiness', error);
+          setFailedCredentialIds(
+            connectedCredentials.map((credential) => credential.id),
+          );
+        }
+      } finally {
+        if (!controller.signal.aborted) {
+          setIsReadinessLoading(false);
+        }
+      }
+    };
+
+    void loadPublishingReadiness();
+
+    return () => controller.abort();
+  }, [brandId, connectedCredentials, getCredentialsService]);
 
   const handleSave = useCallback(async () => {
     if (!brandId) {
@@ -148,6 +335,15 @@ export default function BrandSettingsPublishingPage() {
     isScheduleEnabled,
     timezone,
   ]);
+
+  const handleCopyReadiness = useCallback(
+    (context: AccountPublishingContext) => {
+      void clipboardService.copyToClipboard(
+        buildPublishingReadinessSummary(context),
+      );
+    },
+    [clipboardService],
+  );
 
   if (!hasBrandId || isLoading) {
     return <Loading isFullSize={false} />;
@@ -254,6 +450,143 @@ export default function BrandSettingsPublishingPage() {
               }
             />
           </div>
+        </div>
+
+        <div className="border-t border-border pt-6">
+          <div>
+            <h2 className="text-lg font-semibold">
+              Connected Account Readiness
+            </h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Check provider credentials and setup before enabling automated
+              publishing.
+            </p>
+          </div>
+
+          {connectedCredentials.length === 0 ? (
+            <p className="mt-4 text-sm text-muted-foreground">
+              No connected accounts are available for this brand.
+            </p>
+          ) : (
+            <div className="mt-4 space-y-3">
+              {connectedCredentials.map((credential) => {
+                const context = publishingContexts.find(
+                  (candidate) => candidate.account.id === credential.id,
+                );
+                const hasFailed = failedCredentialIds.includes(credential.id);
+
+                if (!context) {
+                  return (
+                    <div
+                      key={credential.id}
+                      className="rounded-md bg-background-secondary p-4 shadow-border"
+                    >
+                      <div className="flex flex-wrap items-start justify-between gap-3">
+                        <div>
+                          <p className="text-sm font-medium">
+                            {getCredentialLabel(credential)}
+                          </p>
+                          <p className="text-xs text-muted-foreground">
+                            {credential.platform}
+                          </p>
+                        </div>
+                        <Badge variant={hasFailed ? 'destructive' : 'outline'}>
+                          {hasFailed
+                            ? 'Unavailable'
+                            : isReadinessLoading
+                              ? 'Checking'
+                              : 'Unknown'}
+                        </Badge>
+                      </div>
+                      {hasFailed ? (
+                        <p className="mt-3 text-sm text-destructive">
+                          Publishing readiness could not be loaded for this
+                          account. Retry by refreshing this page.
+                        </p>
+                      ) : null}
+                    </div>
+                  );
+                }
+
+                return (
+                  <div
+                    key={credential.id}
+                    className="rounded-md bg-background-secondary p-4 shadow-border"
+                  >
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div>
+                        <p className="text-sm font-medium">
+                          {context.account.label}
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                          {context.account.platform}
+                          {context.account.handle
+                            ? ` · @${context.account.handle.replace(/^@/, '')}`
+                            : ''}
+                        </p>
+                      </div>
+                      <Badge
+                        variant={getReadinessBadgeVariant(
+                          context.readiness.state,
+                        )}
+                      >
+                        {formatReadinessState(context.readiness.state)}
+                      </Badge>
+                    </div>
+
+                    <dl className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+                      {READINESS_CHECKS.map(([key, label]) => (
+                        <div key={key}>
+                          <dt className="text-xs text-muted-foreground">
+                            {label}
+                          </dt>
+                          <dd className="mt-1 text-sm font-medium">
+                            {formatCheckStatus(context.readiness[key])}
+                          </dd>
+                        </div>
+                      ))}
+                    </dl>
+
+                    {context.readiness.requiredAction ? (
+                      <p className="mt-4 text-sm text-foreground">
+                        {redactSensitiveString(
+                          context.readiness.requiredAction,
+                        )}
+                      </p>
+                    ) : null}
+
+                    {context.readiness.diagnostics.length > 0 ? (
+                      <ul className="mt-3 space-y-1 text-xs text-muted-foreground">
+                        {context.readiness.diagnostics.map((diagnostic) => (
+                          <li key={`${diagnostic.code}-${diagnostic.message}`}>
+                            {redactSensitiveString(diagnostic.message)}
+                            {diagnostic.correctiveAction
+                              ? ` Next: ${redactSensitiveString(
+                                  diagnostic.correctiveAction,
+                                )}`
+                              : ''}
+                          </li>
+                        ))}
+                      </ul>
+                    ) : (
+                      <p className="mt-3 text-sm text-muted-foreground">
+                        This account is ready to publish.
+                      </p>
+                    )}
+
+                    <div className="mt-4 flex justify-end">
+                      <Button
+                        label="Copy diagnostics"
+                        variant={ButtonVariant.SECONDARY}
+                        withWrapper={false}
+                        onClick={() => handleCopyReadiness(context)}
+                      />
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
         </div>
 
         <div className="flex justify-end">

--- a/packages/services/organization/credentials.service.test.ts
+++ b/packages/services/organization/credentials.service.test.ts
@@ -1,7 +1,14 @@
+import type { AccountPublishingContext } from '@genfeedai/interfaces';
 import { CredentialsService } from '@services/organization/credentials.service';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@services/core/base.service');
+
+type TestableCredentialsService = CredentialsService & {
+  instance: {
+    get: ReturnType<typeof vi.fn>;
+  };
+};
 
 describe('CredentialsService', () => {
   let service: CredentialsService;
@@ -42,6 +49,42 @@ describe('CredentialsService', () => {
     it('has delete method for removing credentials', () => {
       expect(service.delete).toBeDefined();
       expect(typeof service.delete).toBe('function');
+    });
+  });
+
+  describe('publishing readiness', () => {
+    it('loads the account publishing context with surface and cancellation', async () => {
+      const context = {
+        account: {
+          id: 'credential-1',
+          label: 'Genfeed',
+          platform: 'twitter',
+        },
+        readiness: {
+          appReviewStatus: 'pass',
+          callbackUrlStatus: 'pass',
+          canSchedule: true,
+          diagnostics: [],
+          isRetryable: false,
+          permissionScopeStatus: 'pass',
+          providerKey: 'twitter',
+          quotaStatus: 'pass',
+          state: 'publish_capable',
+          tokenFreshness: 'pass',
+        },
+        surface: 'post',
+      } as AccountPublishingContext;
+      const controller = new AbortController();
+      const get = vi.fn().mockResolvedValue({ data: context });
+      (service as unknown as TestableCredentialsService).instance = { get };
+
+      await expect(
+        service.getPublishingContext('credential-1', 'post', controller.signal),
+      ).resolves.toBe(context);
+      expect(get).toHaveBeenCalledWith('/credential-1/publishing-context', {
+        params: { surface: 'post' },
+        signal: controller.signal,
+      });
     });
   });
 });

--- a/packages/services/organization/credentials.service.ts
+++ b/packages/services/organization/credentials.service.ts
@@ -1,7 +1,9 @@
 import { API_ENDPOINTS } from '@genfeedai/constants';
 import type {
   AccountHealthSummary,
+  AccountPublishingContext,
   AssessAccountHealthRequest,
+  ContentSurface,
   ManualAccountHealthOverrideRequest,
 } from '@genfeedai/interfaces';
 import type { QuotaStatus } from '@genfeedai/interfaces/organization/quota-status.interface';
@@ -50,6 +52,21 @@ export class CredentialsService extends BaseService<Credential> {
   ): Promise<AccountHealthSummary[]> {
     const response = await this.instance.get<AccountHealthSummary[]>(
       `/brand/${brandId}/account-health`,
+    );
+    return response.data;
+  }
+
+  public async getPublishingContext(
+    credentialId: string,
+    surface: ContentSurface = 'post',
+    signal?: AbortSignal,
+  ): Promise<AccountPublishingContext> {
+    const response = await this.instance.get<AccountPublishingContext>(
+      `/${credentialId}/publishing-context`,
+      {
+        params: { surface },
+        signal,
+      },
     );
     return response.data;
   }


### PR DESCRIPTION
## Summary
- add a cancellable client for the existing tenant-scoped publishing context endpoint
- show per-account publish-capable, degraded, blocked, loading, empty, and partial-failure states in brand publishing settings
- expose bounded copyable diagnostics while redacting secret-shaped message/action content and omitting diagnostic details
- preserve existing schedule and auto-publish behavior

## Verification
- exact-head CI run 29985224880 passed: changed app/API tests, package/server/extension/web/desktop/mobile tests, typecheck, lint, format, security scans, React health, OpenAPI drift, guards, build, and Tests Gate
- exact-head Desktop Release QA and Build Server Image passed
- `bunx @biomejs/biome check <4 changed files>`
- `bun run design:lint` (0 errors; 9 existing unused-token warnings)
- `bun run check:design-system`
- scoped UI control guard
- scoped Secretlint
- `git diff --check`
- Opus adversarial review: PASS after verifying the three caveats against existing hook, Badge, type, and endpoint implementations
- Fallow audit: no findings

## Skipped locally
- tests, typecheck, build, coverage, and E2E per workstation policy; exact-head PR CI passed these validation gates remotely
- aggregate UI wrapper initially hit the existing nested-card `typescript` runtime import failure (`ts.ScriptTarget` undefined); exact-head CI Guards, including UI and design-system checks, passed

## Residual risk
- Fleet Review remains the required exact-head review gate before merge
- CodeRabbit completed only its summary/pre-merge checks because its line-review quota was rate-limited; no actionable review comment was emitted

Closes #1989