### PR TITLE
feat(agent): full-bleed conversation sidebar rows

### DIFF
--- a/apps/app/packages/components/AppProtectedLayoutAgentSidebar.tsx
+++ b/apps/app/packages/components/AppProtectedLayoutAgentSidebar.tsx
@@ -22,8 +22,8 @@ export default function AgentSidebarContent({
 
   return (
     <div className="flex h-full min-h-0 flex-col">
-      <div className="flex min-h-0 flex-1 flex-col px-3 pb-2 pt-2">
-        <div className="group/collapsible flex w-full items-center p-1 text-foreground/30">
+      <div className="flex min-h-0 flex-1 flex-col pb-2 pt-2">
+        <div className="group/collapsible flex w-full items-center px-3 py-1 text-foreground/30">
           <span className="text-[10px] font-bold uppercase tracking-[0.15em]">
             Conversations
           </span>
@@ -35,7 +35,7 @@ export default function AgentSidebarContent({
         <div className="pb-1 pt-1">
           <Button
             asChild
-            className="group flex h-8 w-full cursor-pointer items-center gap-3 rounded px-3 py-1.5 text-left text-foreground/72 transition-colors duration-150 hover:bg-foreground/[0.06] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
+            className="group flex h-8 w-full cursor-pointer items-center gap-3 px-3 py-1.5 text-left text-foreground/72 transition-colors duration-150 hover:bg-foreground/[0.06] hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary/60"
             variant={ButtonVariant.UNSTYLED}
             withWrapper={false}
           >

--- a/packages/agent/src/components/AgentThreadList.tsx
+++ b/packages/agent/src/components/AgentThreadList.tsx
@@ -173,7 +173,7 @@ export function AgentThreadList({
               </div>
             ) : null}
             {pinnedThreads.length > 0 && regularThreads.length > 0 ? (
-              <div aria-hidden="true" className="mx-1 border-t border-border" />
+              <div aria-hidden="true" className="border-t border-border" />
             ) : null}
             <div className="flex flex-col gap-0.5">
               {regularThreads.map((conv) => (

--- a/packages/agent/src/components/AgentThreadListRow.tsx
+++ b/packages/agent/src/components/AgentThreadListRow.tsx
@@ -143,7 +143,7 @@ export function AgentThreadListRow({
     <div
       key={conv.id}
       className={cn(
-        'group relative flex h-9 w-full items-center rounded-md transition-colors',
+        'group relative flex h-9 w-full items-center transition-colors',
         conv.status === AgentThreadStatus.ARCHIVED && 'opacity-55',
         conv.id === activeThreadId
           ? 'bg-foreground/[0.06]'
@@ -184,7 +184,7 @@ export function AgentThreadListRow({
       ) : (
         <Link
           href={getThreadHref(conv.id)}
-          className="flex h-full min-w-0 flex-1 items-center gap-1.5 rounded-md px-3 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
+          className="flex h-full min-w-0 flex-1 items-center gap-1.5 px-3 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary/60"
           onClick={() => {
             onSelect(conv);
           }}


### PR DESCRIPTION
## What

Makes the **CONVERSATIONS** thread list in the app sidebar render **edge-to-edge**, matching the Codex and Claude sidebars. Each row's hover/active highlight now spans the full sidebar width instead of sitting inside an inset rounded pill.

## Why

Reported: conversation rows weren't "full line" — the highlight was inset on both sides and pill-shaped, unlike the reference UIs. Root cause was compounding insets: `px-3` on the section container **plus** a `rounded-md` pill on each row.

## Changes

| File | Change |
|---|---|
| `AppProtectedLayoutAgentSidebar.tsx` | Drop `px-3` on the section container; move it onto the CONVERSATIONS label row only (heading stays aligned). Remove `rounded` from the New Thread button; add `focus-visible:ring-inset`. |
| `AgentThreadListRow.tsx` | Remove `rounded-md` from the row wrapper and its inner link so highlights are square full-width bars; add `focus-visible:ring-inset`. |
| `AgentThreadList.tsx` | Drop `mx-1` on the pinned/regular divider so it spans full width. |

`ring-inset` is added wherever the focus ring would otherwise be clipped at the now-flush sidebar edges.

## Scope notes

- **Archive-all button unchanged** — it already exists in the CONVERSATIONS header (hover-to-reveal, `HiOutlineArchiveBoxXMark`, "Archive all threads"). Confirmed the hover-only behavior stays as-is.
- CSS-only (Tailwind class removals); no behavior, data, or API changes.

## Verification

- Pre-commit gates green: secretlint, biome, control-guard, no-raw-html, no-bespoke-card.
- Sidebar is behind `(protected)` auth so it isn't cheaply previewable in isolation; relying on PR CI for build/lint. Visual outcome is deterministic (removal of inset/rounding utilities).

🤖 Generated with [Claude Code](https://claude.com/claude-code)