### PR TITLE
chore(infra): disable ECS Container Insights and cut log retention to 7d

### DIFF
--- a/infra/terraform/genfeed-prod/cluster.tf
+++ b/infra/terraform/genfeed-prod/cluster.tf
@@ -1,8 +1,12 @@
 resource "aws_ecs_cluster" "main" {
   name = local.name_prefix
+  # Container Insights publishes per-task/container custom metrics (~$40/mo at
+  # our service count) that we don't currently use — Sentry covers errors/perf
+  # and free ECS service metrics still drive alarms/autoscaling. Re-enable
+  # temporarily when debugging task-level resource issues (OOM, right-sizing).
   setting {
     name  = "containerInsights"
-    value = "enabled"
+    value = "disabled"
   }
 }
 

--- a/infra/terraform/genfeed-prod/services.tf
+++ b/infra/terraform/genfeed-prod/services.tf
@@ -59,7 +59,7 @@ module "service" {
 # ── One-off migration task (run via `aws ecs run-task` before api rolls) ─
 resource "aws_cloudwatch_log_group" "migrate" {
   name              = "/ecs/${local.name_prefix}/migrate"
-  retention_in_days = 30
+  retention_in_days = 7
 }
 
 resource "aws_ecs_task_definition" "migrate" {
@@ -97,7 +97,7 @@ resource "aws_ecs_task_definition" "migrate" {
 # ── One-off workflow backfill (run after Prisma migrations, before api rolls) ─
 resource "aws_cloudwatch_log_group" "workflow_backfill" {
   name              = "/ecs/${local.name_prefix}/workflow-backfill"
-  retention_in_days = 30
+  retention_in_days = 7
 }
 
 resource "aws_ecs_task_definition" "workflow_backfill" {
@@ -137,7 +137,7 @@ resource "aws_ecs_task_definition" "workflow_backfill" {
 # under the prod path — the same mechanism that feeds the running api service.
 resource "aws_cloudwatch_log_group" "credential_backfill" {
   name              = "/ecs/${local.name_prefix}/credential-backfill"
-  retention_in_days = 30
+  retention_in_days = 7
 }
 
 resource "aws_ecs_task_definition" "credential_backfill" {
@@ -176,7 +176,7 @@ resource "aws_ecs_task_definition" "credential_backfill" {
 # failures before any service rolls.
 resource "aws_cloudwatch_log_group" "boot_smoke" {
   name              = "/ecs/${local.name_prefix}/boot-smoke"
-  retention_in_days = 30
+  retention_in_days = 7
 }
 
 resource "aws_ecs_task_definition" "boot_smoke" {
@@ -246,7 +246,7 @@ resource "aws_ecs_task_definition" "boot_smoke" {
 # then fails with a dedicated CloudWatch log instead of churning ECS tasks.
 resource "aws_cloudwatch_log_group" "worker_boot_smoke" {
   name              = "/ecs/${local.name_prefix}/worker-boot-smoke"
-  retention_in_days = 30
+  retention_in_days = 7
 }
 
 resource "aws_ecs_task_definition" "worker_boot_smoke" {

--- a/infra/terraform/modules/service/variables.tf
+++ b/infra/terraform/modules/service/variables.tf
@@ -53,5 +53,5 @@ variable "max_percent" {
 }
 variable "log_retention_days" {
   type    = number
-  default = 30
+  default = 7
 }


### PR DESCRIPTION
## Why

CloudWatch cost was running ~\$1.20/day. Date-correlated the spike to the **#609 ECS-hybrid migration (2026-06-16)** — not any change this week. Two drivers:

1. **Container Insights** was enabled on the prod ECS cluster, publishing per-task/container **custom metrics** (~\$40/mo, ~85% of the spend) that we don't use.
2. Switching off SSH-Docker deploys created new per-service `/ecs/genfeed-production/*` **log groups** at the default **30-day** retention — a steady storage cost (notifications alone ~1.35GB).

## What

- **`cluster.tf`** — `containerInsights` `enabled` → `disabled`. Sentry already covers errors/perf (#634), and free ECS service metrics (`CPUUtilization`/`MemoryUtilization`) still drive alarms/autoscaling. Comment explains how to re-enable temporarily for task-level debugging (OOM, right-sizing).
- **`modules/service/variables.tf`** — `log_retention_days` default `30` → `7` (covers all steady service log groups: api, workers, notifications, files, mcp).
- **`genfeed-prod/services.tf`** — the 5 one-off task log groups (migrate, workflow-backfill, credential-backfill, boot-smoke, worker-boot-smoke) `30` → `7` for consistency.

## Impact

Expected steady-state CloudWatch drops from **~\$1.20/day → ~\$0.10–0.20/day**.

## Apply

Terraform-only; no app code touched. Takes effect on the next `terraform apply` for `genfeed-prod`. Container Insights disable is instant; retention change applies to existing log groups going forward.

## Not included (intentional)

Optional CloudWatch alarms were left out — deferred per "don't care about observability for now."