### PR TITLE
fix(fonts): decouple Satoshi/Zodiak next/font vars from --font-sans/--serif tokens

### DIFF
--- a/packages/fonts/fonts.ts
+++ b/packages/fonts/fonts.ts
@@ -35,7 +35,10 @@ export const satoshi = localFont({
       weight: '900',
     },
   ],
-  variable: '--font-sans',
+  // Distinct name so next/font's <html> class never collides with the
+  // `:root { --font-sans }` token. `:root` bridges --font-sans -> --font-satoshi
+  // with the system stack as fallback, removing the injection-order footgun.
+  variable: '--font-satoshi',
 });
 
 /**
@@ -85,7 +88,8 @@ export const zodiak = localFont({
       weight: '700',
     },
   ],
-  variable: '--font-serif',
+  // Distinct name — `:root` bridges --font-serif -> --font-zodiak (see satoshi).
+  variable: '--font-zodiak',
 });
 
 /**

--- a/packages/styles/globals.css
+++ b/packages/styles/globals.css
@@ -299,8 +299,9 @@ body.gf-studio-app {
  */
 :root {
   --font-sans:
-    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  --font-serif: Georgia, "Times New Roman", serif;
+    var(--font-satoshi), -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    sans-serif;
+  --font-serif: var(--font-zodiak), Georgia, "Times New Roman", serif;
 }
 
 html,

--- a/packages/ui/web-tokens.css
+++ b/packages/ui/web-tokens.css
@@ -12,9 +12,8 @@
   --info-foreground: 0 0% 0%;
 
   --font-sans:
-    var(--font-satoshi), -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-    sans-serif;
-  --font-serif: var(--font-zodiak), Georgia, "Times New Roman", serif;
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --font-serif: Georgia, "Times New Roman", serif;
   --font-size-xs: 11px;
   --font-size-sm: 12px;
   --font-size-md: 13px;

--- a/packages/ui/web-tokens.css
+++ b/packages/ui/web-tokens.css
@@ -12,8 +12,9 @@
   --info-foreground: 0 0% 0%;
 
   --font-sans:
-    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  --font-serif: Georgia, "Times New Roman", serif;
+    var(--font-satoshi), -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    sans-serif;
+  --font-serif: var(--font-zodiak), Georgia, "Times New Roman", serif;
   --font-size-xs: 11px;
   --font-size-sm: 12px;
   --font-size-md: 13px;


### PR DESCRIPTION
## Problem

next/font's \`localFont\` \`variable\` and the design-system \`:root\` token shared the **same names** (\`--font-sans\` / \`--font-serif\`). Both define CSS custom properties on \`<html>\` at **equal specificity (0,1,0)**:

- next/font emits a class on \`<html>\` (via \`fontVariables\`) setting \`--font-sans: <Satoshi + metric fallback>\`
- \`:root { --font-sans: <system stack> }\` also targets \`<html>\`

With equal specificity, the winner is decided purely by **stylesheet injection order**, which is undefined across dev / Turbopack / prod. This is a known next/font footgun — Satoshi/Zodiak could silently fall back to the system font stack in some builds.

## Fix

Give next/font **distinct** variable names (\`--font-satoshi\` / \`--font-zodiak\`) and have \`:root\` **bridge** the tokens to them with the system stack as fallback:

\`\`\`css
:root {
  --font-sans: var(--font-satoshi), -apple-system, …, sans-serif;
  --font-serif: var(--font-zodiak), Georgia, …, serif;
}
\`\`\`

- **No collision** — next/font and \`:root\` now write different properties.
- **Monotonic** — worst case is the same system fallback that already applied, so it **cannot regress**.
- Every consumer reads \`var(--font-sans)\` / \`var(--font-serif)\` (never the raw next/font var), so the bridge is fully backward-compatible.

## Files

- \`packages/fonts/fonts.ts\` — \`satoshi.variable\` → \`--font-satoshi\`, \`zodiak.variable\` → \`--font-zodiak\`
- \`packages/styles/globals.css\` — \`:root\` bridge
- \`packages/ui/web-tokens.css\` — \`:root\` bridge

## Notes

Mirrors the identical fix shipped to the private console repo in genfeedai/console.genfeed.ai#38. Wiring (\`fontVariables\` → \`<html>\` via \`apps/app/app/layout.tsx\`) was verified present and unchanged.