### PR TITLE
docs(terraform): warn against bare local apply on genfeed-prod

### DIFF
--- a/infra/terraform/genfeed-prod/providers.tf
+++ b/infra/terraform/genfeed-prod/providers.tf
@@ -6,9 +6,9 @@
 # only exist so the config parses:
 #
 #   • image_tag          default "latest"  → CI passes the real commit SHA
-#                                             (TF_VAR_image_tag)
+#                                             (-var="image_tag=<sha>")
 #   • enable_dns_cutover  default false     → CI passes true
-#                                             (TF_VAR_enable_dns_cutover)
+#                                             (-var="enable_dns_cutover=true")
 #
 # A plain local apply runs with those wrong defaults and will plan destructive
 # drift against healthy production: it reverts all task definitions to :latest
@@ -18,7 +18,8 @@
 #
 # Deploy through CI. For an out-of-band change (e.g. a cost tweak), use a
 # `-target`ed apply scoped to the specific resources, never a full apply — or
-# export TF_VAR_image_tag=<current-sha> and TF_VAR_enable_dns_cutover=true first.
+# pass -var="image_tag=<current-sha>" -var="enable_dns_cutover=true" (or the
+# equivalent TF_VAR_* env vars) first.
 
 terraform {
   required_version = ">= 1.10"

--- a/infra/terraform/genfeed-prod/providers.tf
+++ b/infra/terraform/genfeed-prod/providers.tf
@@ -1,3 +1,25 @@
+# ┌─────────────────────────────────────────────────────────────────────────┐
+# │ ⚠  DO NOT run a bare `terraform/tofu apply` on this stack from a laptop.  │
+# └─────────────────────────────────────────────────────────────────────────┘
+# This config is CI-first. Two inputs are supplied at deploy time by GitHub
+# Actions and are NOT hardcoded here — their file defaults are placeholders that
+# only exist so the config parses:
+#
+#   • image_tag          default "latest"  → CI passes the real commit SHA
+#                                             (TF_VAR_image_tag)
+#   • enable_dns_cutover  default false     → CI passes true
+#                                             (TF_VAR_enable_dns_cutover)
+#
+# A plain local apply runs with those wrong defaults and will plan destructive
+# drift against healthy production: it reverts all task definitions to :latest
+# (a full redeploy) AND DESTROYS the api/mcp/notifications Route53 records
+# (prod DNS offline). Nothing is actually missing from AWS — the drift is purely
+# an artifact of applying without the CI-injected vars.
+#
+# Deploy through CI. For an out-of-band change (e.g. a cost tweak), use a
+# `-target`ed apply scoped to the specific resources, never a full apply — or
+# export TF_VAR_image_tag=<current-sha> and TF_VAR_enable_dns_cutover=true first.
+
 terraform {
   required_version = ">= 1.10"
 

--- a/infra/terraform/genfeed-prod/variables.tf
+++ b/infra/terraform/genfeed-prod/variables.tf
@@ -64,7 +64,7 @@ variable "route53_zone_id" {
 # Push the image, get services healthy, smoke-test the ALB DNS, THEN apply with
 # enable_dns_cutover=true to flip api/mcp/notifications hostnames onto the ALB.
 #
-# ⚠ CI passes TF_VAR_enable_dns_cutover=true. The `false` default is a first-run
+# ⚠ CI passes -var="enable_dns_cutover=true". The `false` default is a first-run
 # safety only — a bare local apply inherits it and would DESTROY the live
 # api/mcp/notifications A-records. See the header warning in providers.tf.
 variable "enable_dns_cutover" {
@@ -94,13 +94,13 @@ variable "asg_desired" {
 }
 
 # ── Image ────────────────────────────────────────────────────────────
-# ⚠ CI passes TF_VAR_image_tag=<commit-sha>. The "latest" default is a
+# ⚠ CI passes -var="image_tag=<commit-sha>". The "latest" default is a
 # placeholder — a bare local apply inherits it and would replace every task
 # definition (a full prod redeploy to :latest). See the header in providers.tf.
 variable "image_tag" {
   type        = string
   default     = "latest"
-  description = "ECR tag of genfeed/server to deploy (CI passes the commit SHA via TF_VAR_image_tag)."
+  description = "ECR tag of genfeed/server to deploy (CI passes the commit SHA via -var=\"image_tag=<sha>\")."
 }
 
 # ── Secrets ──────────────────────────────────────────────────────────

--- a/infra/terraform/genfeed-prod/variables.tf
+++ b/infra/terraform/genfeed-prod/variables.tf
@@ -63,6 +63,10 @@ variable "route53_zone_id" {
 # A-records, so the first apply never repoints live traffic at an empty ALB.
 # Push the image, get services healthy, smoke-test the ALB DNS, THEN apply with
 # enable_dns_cutover=true to flip api/mcp/notifications hostnames onto the ALB.
+#
+# ⚠ CI passes TF_VAR_enable_dns_cutover=true. The `false` default is a first-run
+# safety only — a bare local apply inherits it and would DESTROY the live
+# api/mcp/notifications A-records. See the header warning in providers.tf.
 variable "enable_dns_cutover" {
   type    = bool
   default = false
@@ -90,6 +94,9 @@ variable "asg_desired" {
 }
 
 # ── Image ────────────────────────────────────────────────────────────
+# ⚠ CI passes TF_VAR_image_tag=<commit-sha>. The "latest" default is a
+# placeholder — a bare local apply inherits it and would replace every task
+# definition (a full prod redeploy to :latest). See the header in providers.tf.
 variable "image_tag" {
   type        = string
   default     = "latest"


### PR DESCRIPTION
## What

Adds a prominent header warning to the `genfeed-prod` Terraform config plus inline flags on the two CI-injected variables. **Comment-only — no resource changes.**

## Why

The prod stack is **CI-first**. Two inputs are supplied at deploy time by GitHub Actions and are not hardcoded; their file defaults are placeholders that only exist so the config parses:

| Variable | File default | CI supplies |
|---|---|---|
| `image_tag` | `"latest"` | real commit SHA (`TF_VAR_image_tag`) |
| `enable_dns_cutover` | `false` | `true` (`TF_VAR_enable_dns_cutover`) |

A bare `terraform/tofu apply` from a laptop inherits those wrong defaults and plans **destructive drift against healthy production**:
- reverts all task definitions to `:latest` → full prod redeploy
- **destroys** the `api`/`mcp`/`notifications` Route53 A-records → prod DNS offline

Nothing is actually missing from AWS — the drift is purely an artifact of applying without the CI-injected vars. This surfaced during a targeted, out-of-band cost apply (Container Insights + log retention, PR #1994), where a full plan showed 13 add / 22 change / 16 destroy. The warning prevents the next person/agent from being startled — or worse, running it.

## Changes

- `providers.tf` — header warning block documenting the two required `TF_VAR_*` overrides and directing changes through CI or a `-target`'d apply.
- `variables.tf` — inline ⚠ flags on `image_tag` and `enable_dns_cutover` cross-referencing the header.

## Verification

- `tofu fmt -check` clean
- `tofu validate` → Success (config valid)