### PR TITLE
chore(lint): ratchet assets unused imports

### DIFF
--- a/apps/server/api/src/collections/assets/controllers/operations/assets-operations.controller.ts
+++ b/apps/server/api/src/collections/assets/controllers/operations/assets-operations.controller.ts
@@ -10,7 +10,6 @@ import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticat
 import { CreateAssetDto } from '@api/collections/assets/dto/create-asset.dto';
 import { CreateFromIngredientDto } from '@api/collections/assets/dto/create-from-ingredient.dto';
 import { GenerateAssetDto } from '@api/collections/assets/dto/generate-asset.dto';
-import { AssetEntity } from '@api/collections/assets/entities/asset.entity';
 import { AssetsService } from '@api/collections/assets/services/assets.service';
 import { type BrandDocument } from '@api/collections/brands/schemas/brand.schema';
 import { BrandsService } from '@api/collections/brands/services/brands.service';

--- a/biome.json
+++ b/biome.json
@@ -137,6 +137,16 @@
       }
     },
     {
+      "includes": ["apps/server/api/src/collections/assets/**/*.ts"],
+      "linter": {
+        "rules": {
+          "correctness": {
+            "noUnusedImports": "error"
+          }
+        }
+      }
+    },
+    {
       "includes": [
         "ee/packages/**/*.{controller,service,module,resolver,guard,interceptor,pipe,middleware,filter}.ts"
       ],


### PR DESCRIPTION
Closes #2010
Parent: #1095

## Summary

- remove the sole unused `AssetEntity` import from the API assets collection
- ratchet `correctness.noUnusedImports` to `error` for `apps/server/api/src/collections/assets/**`
- preserve runtime, API, serializer, persistence, decorator, and test behavior

## Verification

- `bunx --bun @biomejs/biome@2.5.3 format --write biome.json apps/server/api/src/collections/assets/controllers/operations/assets-operations.controller.ts` — 2 files formatted, no fixes
- `bunx --bun @biomejs/biome@2.5.3 lint apps/server/api/src/collections/assets --only=correctness/noUnusedImports --reporter=json --max-diagnostics=none` — 0 errors, 0 warnings
- deliberate ratchet proof — temporarily restoring the unused import failed with exactly one `lint/correctness/noUnusedImports` error; proof edit reverted and the clean state passed
- `jq empty biome.json` — passed
- `git diff --check` and staged secret-pattern scan — passed

## Local machine policy

Tests, typechecks, builds, coverage, and E2E were not run locally. Broad validation is delegated to pull-request CI.

## Delivery

- default branch: `master`
- exact base: `173b3eb0e189c9c4e7b1c6b071c31483e8f4196b`
- implementation head: `407b34242bec392a39ef2f2e5357148ce1820031`

## Residual risk

The open bots ratchet PR also adds a disjoint override block to `biome.json`; merge ordering may require a trivial additive conflict resolution.