### PR TITLE
fix(app): replace leaked dev copy in workspace-shell inspector with human empty state

### DIFF
--- a/apps/app/src/components/workspace-shell/UniversalWorkspaceShell.test.tsx
+++ b/apps/app/src/components/workspace-shell/UniversalWorkspaceShell.test.tsx
@@ -543,9 +543,10 @@ describe('UniversalWorkspaceShell', () => {
       screen.getAllByText('Authoritative Analytics context').length,
     ).toBeGreaterThan(0);
     expect(screen.getByText('Visible analytics query')).toBeInTheDocument();
-    expect(
-      screen.queryByText('Registered analytics adapter slot'),
-    ).not.toBeInTheDocument();
+    // The inspector renders the adapter's real context, never developer copy:
+    // no raw `route:/…` breadcrumb and no `Registered … adapter slot` fallback.
+    expect(screen.queryByText(/adapter slot/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^route:\//)).not.toBeInTheDocument();
   });
 
   it('mounts the brand overview registration in the harness inspector', async () => {
@@ -563,9 +564,30 @@ describe('UniversalWorkspaceShell', () => {
       await screen.findByTestId('workspace-surface-adapter-inspector'),
     ).toHaveTextContent('Brand Workspace overview');
     expect(screen.getByTestId('canonical-brand-overview')).toBeInTheDocument();
+    // Resolved workspace adapters render the human title/description, never the
+    // terminal developer fallback string or a raw route pattern.
+    expect(screen.queryByText(/adapter slot/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^route:\//)).not.toBeInTheDocument();
+  });
+
+  it('renders a human empty state — not developer copy — when no surface adapter resolves', () => {
+    navigation.pathname = '/acme/moonrise/analytics/posts';
+    navigation.searchParams = new URLSearchParams({ thread: 'thread-1' });
+
+    render(
+      <UniversalWorkspaceShell agentApiService={agentApiService}>
+        <div data-testid="canonical-canvas">Analytics canvas</div>
+      </UniversalWorkspaceShell>,
+    );
+
+    // With no adapter registered, the inspector shows a user-facing empty state…
+    expect(screen.getByText(/context yet$/)).toBeInTheDocument();
     expect(
-      screen.queryByText('Registered workspace-overview adapter slot'),
-    ).not.toBeInTheDocument();
+      screen.queryByTestId('workspace-surface-adapter-inspector'),
+    ).toBeNull();
+    // …and never leaks the terminal adapter-slot string or a raw route pattern.
+    expect(screen.queryByText(/adapter slot/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^route:\//)).not.toBeInTheDocument();
   });
 
   it('launches the organization overview from organization conversation scope', () => {

--- a/apps/app/src/components/workspace-shell/UniversalWorkspaceShell.tsx
+++ b/apps/app/src/components/workspace-shell/UniversalWorkspaceShell.tsx
@@ -13,13 +13,14 @@ import {
   useAgentChatStore,
 } from '@genfeedai/agent';
 import { APP_ROUTES } from '@genfeedai/constants';
-import { ButtonSize, ButtonVariant } from '@genfeedai/enums';
+import { ButtonSize, ButtonVariant, CardEmptySize } from '@genfeedai/enums';
 import type {
   AgentArtifactReference,
   WorkspaceShellOverlayRequest,
 } from '@genfeedai/interfaces';
 import { cn } from '@helpers/formatting/cn/cn.util';
 import { useOrgUrl } from '@hooks/navigation/use-org-url';
+import { CardEmptyContent } from '@ui/card/empty/CardEmpty';
 import { Button } from '@ui/primitives/button';
 import {
   Drawer,
@@ -282,13 +283,17 @@ function UniversalWorkspaceShellContent({
     [rawPathname, searchParamsString],
   );
   const draftScopeKey = `${orgSlug || 'unknown'}:${effectiveThreadId ?? 'new'}:${activeThread?.contextVersion ?? 0}`;
+  // Human-readable breadcrumb leaf resolved from the route registry
+  // (param-interpolated), never the raw `route:/…` pattern from `routeKey`.
+  const inspectorBreadcrumbLabel =
+    routeRegistration?.breadcrumb.leafLabel ?? 'Workspace';
   const shellContextLabel =
     resolvedSurfacePresentationAdapter?.contextLabel ??
     (state === 'conversation'
       ? 'Conversation'
       : state === 'overlay'
         ? 'Overlay · conversation connected'
-        : `Canvas · ${shellLocation.routeKey.replace(/^canvas:/, '')}`);
+        : `Canvas · ${inspectorBreadcrumbLabel}`);
   const activeResearchSurfaceAdapter =
     researchSurfaceAdapter?.registration.surfaceKey === surfaceKey
       ? researchSurfaceAdapter.registration
@@ -883,31 +888,29 @@ function UniversalWorkspaceShellContent({
           activeResearchSurfaceAdapter.inspectorContent
         ) : resolvedSurfacePresentationAdapter ? (
           resolvedSurfacePresentationAdapter.inspector
-        ) : (
+        ) : resolvedWorkspaceSurfaceAdapter ? (
           <div
             className="gen-shell-empty-state p-4"
-            data-testid={
-              resolvedWorkspaceSurfaceAdapter
-                ? 'workspace-surface-adapter-inspector'
-                : undefined
-            }
+            data-testid="workspace-surface-adapter-inspector"
           >
             <p className="text-sm font-medium text-foreground">
-              {resolvedWorkspaceSurfaceAdapter
-                ? resolvedWorkspaceSurfaceAdapter.registration.title
-                : `Registered ${surfaceKey} adapter slot`}
+              {resolvedWorkspaceSurfaceAdapter.registration.title}
             </p>
             <p className="mt-1 text-xs leading-5 text-muted-foreground">
-              {resolvedWorkspaceSurfaceAdapter
-                ? resolvedWorkspaceSurfaceAdapter.registration.description
-                : 'Product-owned context adapters land here without changing their canonical route or granting execution authority.'}
+              {resolvedWorkspaceSurfaceAdapter.registration.description}
             </p>
-            {resolvedWorkspaceSurfaceAdapter ? (
-              <p className="mt-3 text-xs leading-5 text-muted-foreground">
-                Full management remains available on this canonical route.
-              </p>
-            ) : null}
+            <p className="mt-3 text-xs leading-5 text-muted-foreground">
+              Full management remains available on this canonical route.
+            </p>
           </div>
+        ) : (
+          <CardEmptyContent
+            className="gen-shell-empty-state rounded-lg py-8"
+            description={`Start a conversation or choose a workflow to build ${inspectorBreadcrumbLabel} context here.`}
+            icon={HiOutlineSquares2X2}
+            label={`No ${inspectorBreadcrumbLabel} context yet`}
+            size={CardEmptySize.SM}
+          />
         )}
         <Button
           icon={<HiOutlineBolt className="size-4" />}


### PR DESCRIPTION
## Problem

Overnight QA found developer-facing copy rendering **visibly** (confirmed via `getComputedStyle`, not `sr-only`) in the workspace right-rail inspector on every canvas surface **without** a bespoke adapter — every surface except `workflows`, `research/*`, and `messages`. Two strings leaked to users:

1. **Raw route pattern as breadcrumb** — e.g. `route:/:orgSlug/~/settings/brands`.
2. **Placeholder empty state** — `Registered <surfaceKey> adapter slot`.

## Root cause

In `UniversalWorkspaceShell.tsx`, the right-rail content is a 6-way ternary keyed on surface. The **terminal fallback branch** was never given real UI:

- The context label tried `` `Canvas · ${shellLocation.routeKey.replace(/^canvas:/, '')}` ``, but `routeKey` is prefixed `route:` (from the registry), so the `canvas:` strip never matched — the raw `route:/…` pattern printed straight through.
- The fallback inspector body rendered the literal `Registered <surfaceKey> adapter slot` placeholder.

## Fix

- **Breadcrumb** now derives from the route registry's param-interpolated `breadcrumb.leafLabel` (guaranteed human — the registry spec asserts it never contains `:`), with a `'Workspace'` default. No more raw pattern.
- **No-adapter inspector fallback** now renders a real user-facing empty state via the shared `CardEmptyContent` primitive (`@ui/card/empty/CardEmpty`) — human title + helpful description + icon, with the existing CTA buttons ("Choose workflow", "Open overlay preview", "Return to conversation") below.
- **Adapter-resolved surfaces are untouched** — the ternary was split so only the no-adapter path changed; the adapter path keeps its `registration.title/description` and `workspace-surface-adapter-inspector` testid.

Reused the existing `CardEmptyContent` empty-state primitive rather than building new UI; no raw HTML controls.

## Tests

`UniversalWorkspaceShell.test.tsx` — the two stale guard assertions (previously asserting the *presence path* around the literal `Registered … adapter slot`) were **updated, not deleted**, to lock the correct behavior:

- Assert no `route:/…` breadcrumb ever leaks (`/^route:\//`).
- Assert no `adapter slot` copy ever leaks (`/adapter slot/i`).
- **New** dedicated no-adapter fallback test: asserts the human empty state renders (`/context yet$/`), the `workspace-surface-adapter-inspector` testid is absent, and neither dev string leaks.

## Verification

Not run locally (per machine policy) — relying on PR CI for typecheck / lint / tests. Local pre-commit gates (secretlint, control-guard, biome, no-bespoke-card) passed on commit.

Scope: `apps/app/src/components/workspace-shell/` only — 2 files, +49/-24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)