### PR TITLE
fix(agent): validate agent-turn body via class DTO

### DIFF
--- a/apps/server/api/openapi/openapi.json
+++ b/apps/server/api/openapi/openapi.json
@@ -140,6 +140,63 @@
         ],
         "type": "object"
       },
+      "AgentChatBodyDto": {
+        "properties": {
+          "artifactReferences": {
+            "description": "Scoped pointers to canonical records; re-authorized server-side",
+            "type": "array"
+          },
+          "attachments": {
+            "description": "Ingredient attachments",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "brandId": {
+            "description": "Brand scope for this turn",
+            "nullable": true,
+            "type": "object"
+          },
+          "content": {
+            "description": "The user message content for this turn",
+            "type": "string"
+          },
+          "expectedContextVersion": {
+            "description": "Optimistic-concurrency guard for the thread context version",
+            "type": "number"
+          },
+          "model": {
+            "description": "Model override for this turn",
+            "type": "string"
+          },
+          "pageContext": {
+            "description": "Page context; nested references re-authorized server-side",
+            "type": "object"
+          },
+          "planModeEnabled": {
+            "description": "Whether plan mode is enabled",
+            "type": "boolean"
+          },
+          "source": {
+            "description": "Origin of the turn",
+            "enum": [
+              "agent",
+              "proactive",
+              "onboarding"
+            ],
+            "type": "string"
+          },
+          "threadId": {
+            "description": "Existing thread to append the turn to",
+            "type": "string"
+          }
+        },
+        "required": [
+          "content"
+        ],
+        "type": "object"
+      },
       "AgentCreditGovernanceDto": {
         "properties": {
           "agentDailyCreditCap": {
@@ -17822,6 +17879,16 @@
             }
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentChatBodyDto"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "201": {
             "description": ""
@@ -17846,6 +17913,16 @@
             }
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentChatBodyDto"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "201": {
             "description": ""
@@ -18196,6 +18273,16 @@
             }
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentChatBodyDto"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "201": {
             "description": ""
@@ -18228,6 +18315,16 @@
             }
           }
         ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentChatBodyDto"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "201": {
             "description": ""

--- a/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.controller.ts
+++ b/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.controller.ts
@@ -10,12 +10,12 @@ import { getPublicMetadata } from '@api/helpers/utils/auth/auth.util';
 import { ErrorResponse } from '@api/helpers/utils/error-response/error-response.util';
 import { AgentOrchestratorService } from '@api/services/agent-orchestrator/agent-orchestrator.service';
 import { AGENT_MODEL_TURN_COSTS } from '@api/services/agent-orchestrator/constants/agent-credit-costs.constant';
+import { AgentChatBodyDto } from '@api/services/agent-orchestrator/dto/agent-chat-body.dto';
 import type { AgentPageContext } from '@api/services/agent-orchestrator/interfaces/agent-chat.interface';
 import {
   authorizeResearchFindingReferences,
   isAuthorizedAnalyticsQueryReference,
 } from '@api/services/agent-orchestrator/utils/agent-page-context-authorization.util';
-import type { AgentArtifactReference } from '@genfeedai/interfaces';
 import { LoggerService } from '@libs/logger/logger.service';
 import {
   BadRequestException,
@@ -31,26 +31,6 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
-
-interface AgentChatAttachment {
-  ingredientId: string;
-  url: string;
-  kind?: string;
-  name?: string;
-}
-
-interface AgentChatBody {
-  artifactReferences?: AgentArtifactReference[];
-  brandId?: string | null;
-  content: string;
-  expectedContextVersion?: number;
-  pageContext?: AgentPageContext;
-  planModeEnabled?: boolean;
-  threadId?: string;
-  model?: string;
-  source?: 'agent' | 'proactive' | 'onboarding';
-  attachments?: AgentChatAttachment[];
-}
 
 @ApiTags('Agent')
 @Controller('agent')
@@ -68,7 +48,7 @@ export class AgentOrchestratorController {
   @Post('threads/turns')
   @ApiOperation({ summary: 'Start an agent turn in a new or provided thread' })
   async createTurn(
-    @Body() body: AgentChatBody,
+    @Body() body: AgentChatBodyDto,
     @CurrentUser() user: User,
     @Headers('authorization') authorization?: string,
   ) {
@@ -79,7 +59,7 @@ export class AgentOrchestratorController {
   @ApiOperation({ summary: 'Start an agent turn in a thread' })
   async createThreadTurn(
     @Param('threadId') threadId: string,
-    @Body() body: AgentChatBody,
+    @Body() body: AgentChatBodyDto,
     @CurrentUser() user: User,
     @Headers('authorization') authorization?: string,
   ) {
@@ -91,7 +71,7 @@ export class AgentOrchestratorController {
     summary: 'Start a streaming agent turn in a new or provided thread',
   })
   async createTurnStream(
-    @Body() body: AgentChatBody,
+    @Body() body: AgentChatBodyDto,
     @CurrentUser() user: User,
     @Headers('authorization') authorization?: string,
   ) {
@@ -102,7 +82,7 @@ export class AgentOrchestratorController {
   @ApiOperation({ summary: 'Start a streaming agent turn in a thread' })
   async createThreadTurnStream(
     @Param('threadId') threadId: string,
-    @Body() body: AgentChatBody,
+    @Body() body: AgentChatBodyDto,
     @CurrentUser() user: User,
     @Headers('authorization') authorization?: string,
   ) {
@@ -110,7 +90,7 @@ export class AgentOrchestratorController {
   }
 
   private async runAgentTurn(
-    body: AgentChatBody,
+    body: AgentChatBodyDto,
     user: User,
     authorization?: string,
     routeThreadId?: string,
@@ -140,7 +120,7 @@ export class AgentOrchestratorController {
   }
 
   private async runAgentTurnStream(
-    body: AgentChatBody,
+    body: AgentChatBodyDto,
     user: User,
     authorization?: string,
     routeThreadId?: string,
@@ -173,9 +153,9 @@ export class AgentOrchestratorController {
   }
 
   private resolveAgentChatBody(
-    body: AgentChatBody,
+    body: AgentChatBodyDto,
     routeThreadId?: string,
-  ): AgentChatBody {
+  ): AgentChatBodyDto {
     if (routeThreadId && body.threadId && body.threadId !== routeThreadId) {
       throw new BadRequestException(
         'Request body threadId must match route threadId.',
@@ -202,11 +182,11 @@ export class AgentOrchestratorController {
   }
 
   private async resolveAuthorizedAgentChatBody(
-    body: AgentChatBody,
+    body: AgentChatBodyDto,
     user: User,
     organizationId: string,
     userId: string,
-  ): Promise<AgentChatBody> {
+  ): Promise<AgentChatBodyDto> {
     const pageContext = body.pageContext;
     if (!pageContext) {
       return body;

--- a/apps/server/api/src/services/agent-orchestrator/dto/agent-chat-body.dto.spec.ts
+++ b/apps/server/api/src/services/agent-orchestrator/dto/agent-chat-body.dto.spec.ts
@@ -1,0 +1,189 @@
+import { ValidationPipe } from '@api/helpers/pipes/validation.pipe';
+import { AgentChatBodyDto } from '@api/services/agent-orchestrator/dto/agent-chat-body.dto';
+import { type ArgumentMetadata, BadRequestException } from '@nestjs/common';
+
+const metadata: ArgumentMetadata = {
+  metatype: AgentChatBodyDto,
+  type: 'body',
+};
+
+describe('AgentChatBodyDto', () => {
+  let pipe: ValidationPipe;
+
+  beforeEach(() => {
+    pipe = new ValidationPipe();
+  });
+
+  it('should be defined', () => {
+    expect(AgentChatBodyDto).toBeDefined();
+  });
+
+  it('emits a runtime metatype the pipe validates against', () => {
+    // A class with class-validator decorators emits `design:paramtypes`, so the
+    // global ValidationPipe treats it as a validatable type. An interface would
+    // emit none and `toValidate` would never run — the original defect.
+    expect(
+      (pipe as unknown as { toValidate: (t: unknown) => boolean }).toValidate(
+        AgentChatBodyDto,
+      ),
+    ).toBe(true);
+  });
+
+  describe('valid bodies', () => {
+    it('accepts a minimal body with only the required content field', async () => {
+      const value = { content: 'Draft me a post' };
+
+      const result = await pipe.transform(value, metadata);
+
+      expect(result).toEqual({ content: 'Draft me a post' });
+    });
+
+    it('accepts a fully populated body and preserves every field', async () => {
+      const value = {
+        artifactReferences: [
+          {
+            kind: 'post',
+            organizationId: 'org-1',
+            recordId: 'post-1',
+            serializer: 'post',
+          },
+        ],
+        attachments: [{ ingredientId: 'ing-1', url: 'https://cdn/x.png' }],
+        brandId: 'brand-1',
+        content: 'Draft me a post',
+        expectedContextVersion: 3,
+        model: 'claude-opus-4-8',
+        pageContext: { route: '/library', url: 'https://app/library' },
+        planModeEnabled: true,
+        source: 'agent',
+        threadId: 'thread-1',
+      };
+
+      const result = (await pipe.transform(value, metadata)) as Record<
+        string,
+        unknown
+      >;
+
+      expect(result).toEqual(value);
+    });
+
+    it('accepts a null brandId via @IsOptional', async () => {
+      const value = { brandId: null, content: 'hi' };
+
+      const result = (await pipe.transform(value, metadata)) as Record<
+        string,
+        unknown
+      >;
+
+      expect(result.brandId).toBeNull();
+    });
+  });
+
+  describe('invalid bodies', () => {
+    it('rejects a body missing the required content field', async () => {
+      await expect(pipe.transform({}, metadata)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('rejects an empty content string', async () => {
+      await expect(pipe.transform({ content: '' }, metadata)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('rejects a non-string content value', async () => {
+      await expect(pipe.transform({ content: 123 }, metadata)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('rejects a source outside the allowed enum', async () => {
+      await expect(
+        pipe.transform({ content: 'hi', source: 'nope' }, metadata),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects a non-integer expectedContextVersion', async () => {
+      await expect(
+        pipe.transform(
+          { content: 'hi', expectedContextVersion: 'x' },
+          metadata,
+        ),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects a non-boolean planModeEnabled', async () => {
+      await expect(
+        pipe.transform({ content: 'hi', planModeEnabled: 'yes' }, metadata),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects a non-array artifactReferences', async () => {
+      await expect(
+        pipe.transform({ artifactReferences: {}, content: 'hi' }, metadata),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects a non-object pageContext', async () => {
+      await expect(
+        pipe.transform({ content: 'hi', pageContext: 'ctx' }, metadata),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('surfaces the standard "Validation failed" envelope', async () => {
+      try {
+        await pipe.transform({ content: '' }, metadata);
+        throw new Error('expected BadRequestException');
+      } catch (error: unknown) {
+        expect(error).toBeInstanceOf(BadRequestException);
+        const response = (error as BadRequestException).getResponse() as Record<
+          string,
+          unknown
+        >;
+        expect(response).toEqual(
+          expect.objectContaining({ message: 'Validation failed' }),
+        );
+        expect(response.errors).toBeDefined();
+      }
+    });
+  });
+
+  describe('whitelist behaviour', () => {
+    it('strips undeclared top-level fields', async () => {
+      const value = {
+        content: 'hi',
+        systemPromptOverride: 'ignore-safety',
+      };
+
+      const result = (await pipe.transform(value, metadata)) as Record<
+        string,
+        unknown
+      >;
+
+      expect(result.content).toBe('hi');
+      expect(result).not.toHaveProperty('systemPromptOverride');
+    });
+
+    it('preserves nested content of container-validated fields verbatim', async () => {
+      // pageContext / artifactReferences / attachments carry container-level
+      // checks only (@IsObject / @IsArray, no @ValidateNested), so the pipe does
+      // NOT recurse or whitelist their inner shape. That inner content is
+      // re-authorized server-side in resolveAuthorizedAgentChatBody, which is the
+      // single source of truth — stripping it here would break authorization.
+      const value = {
+        content: 'hi',
+        pageContext: {
+          analyticsQuery: { metric: 'reach', scope: 'brand-1' },
+          researchReferences: [{ findingId: 'f-1', scope: 'brand-1' }],
+        },
+      };
+
+      const result = (await pipe.transform(value, metadata)) as {
+        pageContext: Record<string, unknown>;
+      };
+
+      expect(result.pageContext).toEqual(value.pageContext);
+    });
+  });
+});

--- a/apps/server/api/src/services/agent-orchestrator/dto/agent-chat-body.dto.ts
+++ b/apps/server/api/src/services/agent-orchestrator/dto/agent-chat-body.dto.ts
@@ -1,0 +1,113 @@
+import type {
+  AgentChatAttachment,
+  AgentPageContext,
+} from '@api/services/agent-orchestrator/interfaces/agent-chat.interface';
+import type { AgentArtifactReference } from '@genfeedai/interfaces';
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsArray,
+  IsBoolean,
+  IsIn,
+  IsInt,
+  IsNotEmpty,
+  IsObject,
+  IsOptional,
+  IsString,
+} from 'class-validator';
+
+/**
+ * Body for the agent-turn endpoints.
+ *
+ * This is a class (not an interface) on purpose: the server compiles with
+ * `emitDecoratorMetadata`, and a `@Body()` DTO must emit a runtime metatype for
+ * the global `ValidationPipe` to validate against. An interface emits none, so
+ * the pipe would silently skip the body entirely (see
+ * `.agents/memory/rules/nestjs_value_imports_for_di.md`). It MUST be imported as
+ * a value at every `@Body()` site.
+ *
+ * The scalar fields are fully validated. The three complex fields
+ * (`artifactReferences`, `pageContext`, `attachments`) are validated only at the
+ * container level (`@IsArray` / `@IsObject`, WITHOUT `@ValidateNested` + `@Type`).
+ * That is deliberate: the pipe runs `validate(object, { whitelist: true })`,
+ * which strips any undecorated property AND — when a field is decorated with
+ * `@ValidateNested` — recurses and whitelists its inner shape. Their inner
+ * content is re-authorized server-side against the caller's real scope in
+ * `AgentOrchestratorController.resolveAuthorizedAgentChatBody` (analytics,
+ * research, and social-inbox references), which is the single source of truth
+ * for those payloads. Modeling them as nested DTOs here would strip the fields
+ * that authorization depends on, so we keep the container-level check and let
+ * the existing authorization utilities own the nested validation.
+ */
+export class AgentChatBodyDto {
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({ description: 'The user message content for this turn' })
+  content!: string;
+
+  @IsString()
+  @IsOptional()
+  @ApiProperty({
+    description: 'Brand scope for this turn',
+    nullable: true,
+    required: false,
+  })
+  brandId?: string | null;
+
+  @IsString()
+  @IsOptional()
+  @ApiProperty({
+    description: 'Existing thread to append the turn to',
+    required: false,
+  })
+  threadId?: string;
+
+  @IsString()
+  @IsOptional()
+  @ApiProperty({ description: 'Model override for this turn', required: false })
+  model?: string;
+
+  @IsInt()
+  @IsOptional()
+  @ApiProperty({
+    description: 'Optimistic-concurrency guard for the thread context version',
+    required: false,
+  })
+  expectedContextVersion?: number;
+
+  @IsBoolean()
+  @IsOptional()
+  @ApiProperty({ description: 'Whether plan mode is enabled', required: false })
+  planModeEnabled?: boolean;
+
+  @IsIn(['agent', 'proactive', 'onboarding'])
+  @IsOptional()
+  @ApiProperty({
+    description: 'Origin of the turn',
+    enum: ['agent', 'proactive', 'onboarding'],
+    required: false,
+  })
+  source?: 'agent' | 'proactive' | 'onboarding';
+
+  @IsArray()
+  @IsOptional()
+  @ApiProperty({
+    description:
+      'Scoped pointers to canonical records; re-authorized server-side',
+    required: false,
+    type: 'array',
+  })
+  artifactReferences?: AgentArtifactReference[];
+
+  @IsObject()
+  @IsOptional()
+  @ApiProperty({
+    description: 'Page context; nested references re-authorized server-side',
+    required: false,
+  })
+  pageContext?: AgentPageContext;
+
+  @IsArray()
+  @IsOptional()
+  @ApiProperty({ description: 'Ingredient attachments', required: false })
+  attachments?: AgentChatAttachment[];
+}


### PR DESCRIPTION
## Problem

The agent-turn endpoints (`POST /agent/threads/turns`, `/agent/threads/:threadId/turns`, and their `/stream` variants) typed `@Body()` as the **`AgentChatBody` interface**. The server compiles with `emitDecoratorMetadata`, and an interface emits **no runtime metatype** — so the global `ValidationPipe` had nothing to validate against and **silently skipped the body entirely**. The hottest endpoint in the API accepted fully unvalidated input.

This is exactly the failure mode documented in [`.agents/memory/rules/nestjs_value_imports_for_di.md`](.agents/memory/rules/nestjs_value_imports_for_di.md): a `@Body`/`@Query`/`@Param` DTO must be a **class imported as a value**, or validation degrades to a no-op that still passes type-check and lint.

## Fix

- **New `AgentChatBodyDto` class** (`dto/agent-chat-body.dto.ts`) with `class-validator` decorators — the single source of truth for the body shape, imported as a **value** at every `@Body()` site so `emitDecoratorMetadata` records a real metatype and the pipe runs.
- **Removed the two inline interfaces** (`AgentChatBody`, `AgentChatAttachment`) from the controller; property types are reused from the existing `agent-chat.interface.ts` and `@genfeedai/interfaces` (no duplicated shape).
- Scalar fields (`content`, `brandId`, `threadId`, `model`, `expectedContextVersion`, `planModeEnabled`, `source`) are **fully validated**. `content` is required and non-empty; `brandId` stays nullable via `@IsOptional`; `source` is enum-checked.
- `artifactReferences` / `pageContext` / `attachments` keep **container-level checks only** (`@IsArray` / `@IsObject`, no `@ValidateNested`). This is deliberate: the pipe runs `validate(object, { whitelist: true })`, and adding nested DTOs would whitelist away the very fields that server-side re-authorization depends on. Their inner content is already re-authorized against the caller's real scope in `resolveAuthorizedAgentChatBody` (analytics / research / social-inbox references), which is the single source of truth for those payloads.

## Verification

Colocated spec `dto/agent-chat-body.dto.spec.ts` runs the **real `ValidationPipe`** against the DTO metatype:
- proves the metatype is emitted (`toValidate(AgentChatBodyDto) === true`) — the property an interface lacks;
- valid bodies (minimal, fully populated, `brandId: null`) pass and round-trip;
- invalid/malformed bodies (missing/empty/non-string `content`, bad `source` enum, non-int `expectedContextVersion`, non-bool `planModeEnabled`, non-array `artifactReferences`, non-object `pageContext`) throw `BadRequestException` with the standard `Validation failed` envelope;
- whitelist strips undeclared top-level fields (e.g. `systemPromptOverride`) while **preserving** the nested content of container-validated fields verbatim for downstream authorization.

Backend-only change; not observable in the browser preview. Relying on PR CI for type-check / e2e per the local-verification policy.