### PR TITLE
fix(agent): submit composer on Enter, newline on Shift+Enter

### DIFF
--- a/packages/agent/src/components/AgentChatInput.spec.tsx
+++ b/packages/agent/src/components/AgentChatInput.spec.tsx
@@ -354,4 +354,82 @@ describe('AgentChatInput', () => {
     expect(screen.getByText('1 reference')).toBeInTheDocument();
     expect(within(tray).getAllByText('^Launch post')).toHaveLength(1);
   });
+
+  it('sends the draft when Enter is pressed without a modifier', async () => {
+    const onSend = vi.fn();
+    storeState.composerSeed = {
+      content: 'Ship the composer fix',
+      nonce: 1,
+      threadId: null,
+    };
+
+    render(<AgentChatInput onSend={onSend} />);
+
+    const composer = screen.getByRole('textbox');
+    await waitFor(() =>
+      expect(composer).toHaveTextContent('Ship the composer fix'),
+    );
+
+    fireEvent.keyDown(composer, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(onSend).toHaveBeenCalledWith(
+        'Ship the composer fix',
+        undefined,
+        undefined,
+        { planModeEnabled: false },
+      );
+    });
+  });
+
+  it('inserts a newline instead of sending on Shift+Enter', async () => {
+    const onSend = vi.fn();
+    storeState.composerSeed = {
+      content: 'First line',
+      nonce: 1,
+      threadId: null,
+    };
+
+    render(<AgentChatInput onSend={onSend} />);
+
+    const composer = screen.getByRole('textbox');
+    await waitFor(() => expect(composer).toHaveTextContent('First line'));
+
+    fireEvent.keyDown(composer, { key: 'Enter', shiftKey: true });
+
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it('does not send on Enter when the composer is empty', () => {
+    const onSend = vi.fn();
+
+    render(<AgentChatInput onSend={onSend} />);
+
+    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Enter' });
+
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it('does not send on Enter while an IME composition is active', async () => {
+    const onSend = vi.fn();
+    storeState.composerSeed = {
+      content: 'こんにちは',
+      nonce: 1,
+      threadId: null,
+    };
+
+    render(<AgentChatInput onSend={onSend} />);
+
+    const composer = screen.getByRole('textbox');
+    await waitFor(() => expect(composer).toHaveTextContent('こんにちは'));
+
+    fireEvent.compositionStart(composer);
+    fireEvent.keyDown(composer, {
+      isComposing: true,
+      key: 'Enter',
+      keyCode: 229,
+    });
+
+    expect(onSend).not.toHaveBeenCalled();
+  });
 });

--- a/packages/agent/src/components/AgentChatInput.spec.tsx
+++ b/packages/agent/src/components/AgentChatInput.spec.tsx
@@ -432,4 +432,59 @@ describe('AgentChatInput', () => {
 
     expect(onSend).not.toHaveBeenCalled();
   });
+
+  it('does not send on Enter when the composer is disabled', async () => {
+    const onSend = vi.fn();
+    storeState.composerSeed = {
+      content: 'Held while disabled',
+      nonce: 1,
+      threadId: null,
+    };
+
+    render(<AgentChatInput disabled onSend={onSend} />);
+
+    const composer = screen.getByRole('textbox');
+    await waitFor(() =>
+      expect(composer).toHaveTextContent('Held while disabled'),
+    );
+
+    fireEvent.keyDown(composer, { key: 'Enter' });
+
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it('routes Enter only to the focused composer when two are mounted', async () => {
+    const onSendFirst = vi.fn();
+    const onSendSecond = vi.fn();
+    storeState.composerSeed = {
+      content: 'Route to the focused composer',
+      nonce: 1,
+      threadId: null,
+    };
+
+    render(
+      <>
+        <AgentChatInput onSend={onSendFirst} />
+        <AgentChatInput onSend={onSendSecond} />
+      </>,
+    );
+
+    const composers = screen.getAllByRole('textbox');
+    expect(composers).toHaveLength(2);
+    await waitFor(() =>
+      expect(composers[0]).toHaveTextContent('Route to the focused composer'),
+    );
+
+    fireEvent.keyDown(composers[0], { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(onSendFirst).toHaveBeenCalledWith(
+        'Route to the focused composer',
+        undefined,
+        undefined,
+        { planModeEnabled: false },
+      );
+    });
+    expect(onSendSecond).not.toHaveBeenCalled();
+  });
 });

--- a/packages/agent/src/components/useAgentChatInput.ts
+++ b/packages/agent/src/components/useAgentChatInput.ts
@@ -128,14 +128,29 @@ function extractMentions(json: JSONContent): ExtractedMention[] {
   return result;
 }
 
-const SendOnEnter = Extension.create({
+interface SendOnEnterOptions {
+  onEnter: () => boolean;
+}
+
+// Enter submits the message (mirroring the Send button); Shift+Enter falls
+// through to the HardBreak newline. Declared before the mention/slash
+// extensions so their Suggestion plugins keep Enter-to-select while a popup is
+// open, but ahead of the core newline keymap when no popup is active. The IME
+// guard prevents committing an in-progress composition (critical for CJK).
+const SendOnEnter = Extension.create<SendOnEnterOptions>({
   addKeyboardShortcuts() {
     return {
-      Enter: () => {
-        const event = new CustomEvent('agent-chat-send');
-        document.dispatchEvent(event);
-        return true;
+      Enter: ({ editor }) => {
+        if (editor.view.composing) {
+          return false;
+        }
+        return this.options.onEnter();
       },
+    };
+  },
+  addOptions() {
+    return {
+      onEnter: () => false,
     };
   },
   name: 'sendOnEnter',
@@ -297,6 +312,9 @@ export function useAgentChatInput({
       : [],
   );
   const editorRef = useRef<Editor | null>(null);
+  // Stable bridge so the module-scope SendOnEnter keymap can invoke the live,
+  // component-scoped handleSend without recreating the editor.
+  const handleSendRef = useRef<() => void>(() => {});
 
   const hasAttachments = attachments.length > 0;
   const hasCompletedAttachments =
@@ -348,6 +366,12 @@ export function useAgentChatInput({
       }),
       Placeholder.configure({
         placeholder,
+      }),
+      SendOnEnter.configure({
+        onEnter: () => {
+          handleSendRef.current();
+          return true;
+        },
       }),
       BrandMention.configure({
         HTMLAttributes: { class: 'mention mention-brand' },
@@ -404,7 +428,6 @@ export function useAgentChatInput({
         }),
       }),
       SlashCommands,
-      SendOnEnter,
     ],
     immediatelyRender: false,
   });
@@ -595,16 +618,12 @@ export function useAgentChatInput({
     surfaceArtifactReferences,
   ]);
 
-  // Handle Enter after handleSend is stable so keyboard and click paths share
-  // the same trusted-command checks and recovery behavior.
+  // Keep the SendOnEnter keymap pointed at the latest handleSend so the Enter
+  // and Send-button paths share the same trusted-command checks and recovery.
   useEffect(() => {
-    function handleSendEvent() {
+    handleSendRef.current = () => {
       void handleSend();
-    }
-
-    document.addEventListener('agent-chat-send', handleSendEvent);
-    return () =>
-      document.removeEventListener('agent-chat-send', handleSendEvent);
+    };
   }, [handleSend]);
 
   const handleSelectAction = useCallback(

--- a/packages/agent/tests/setup.ts
+++ b/packages/agent/tests/setup.ts
@@ -140,6 +140,39 @@ if (!Element.prototype.releasePointerCapture) {
   Element.prototype.releasePointerCapture = vi.fn();
 }
 
+// jsdom's Range implements no geometry, but ProseMirror's composition/coords
+// tracking creates a Range and calls getClientRects()/getBoundingClientRect()
+// on it (e.g. when an IME composition is active). Without these the composing
+// contenteditable editor throws "target.getClientRects is not a function" as an
+// unhandled error and fails the run even though every assertion passes. Return
+// empty geometry so the composition path is a no-op in tests.
+const createEmptyDomRect = (): DOMRect =>
+  ({
+    bottom: 0,
+    height: 0,
+    left: 0,
+    right: 0,
+    toJSON: () => ({}),
+    top: 0,
+    width: 0,
+    x: 0,
+    y: 0,
+  }) as DOMRect;
+
+const createEmptyDomRectList = (): DOMRectList =>
+  ({
+    item: () => null,
+    length: 0,
+    [Symbol.iterator]: [][Symbol.iterator].bind([]),
+  }) as unknown as DOMRectList;
+
+if (!Range.prototype.getClientRects) {
+  Range.prototype.getClientRects = () => createEmptyDomRectList();
+}
+if (!Range.prototype.getBoundingClientRect) {
+  Range.prototype.getBoundingClientRect = () => createEmptyDomRect();
+}
+
 // Mock fetch
 global.fetch = vi.fn();
 


### PR DESCRIPTION
## Problem

The conversation composer is a TipTap/ProseMirror `contenteditable` (`role="textbox"`), not a `<textarea>`. Enter previously ran through a module-scope extension that dispatched a **document-level `agent-chat-send` CustomEvent**. The intended submit path is a click on `button[aria-label="Send message"]`, so every user's first instinct — type and hit Enter — silently failed unless that brittle bridge fired. This is the app's #1 composer friction point.

## Fix

Replaces the CustomEvent hack with an idiomatic TipTap keymap in `useAgentChatInput.ts`:

- **Enter (no modifier)** invokes the exact same `handleSend` the Send button calls — no duplicated submit logic. The module-scope `SendOnEnter` extension can't close over the component-scoped handler and the editor is created once at mount, so it reads a live value through a stable `handleSendRef`.
- **Shift+Enter** falls through to StarterKit's `HardBreak` newline (standard chat behavior).
- **Empty / whitespace-only** drafts and **in-flight sends** stay gated by the existing `handleSend` guards, so Enter can't submit them.
- **IME compositions** are guarded via `editor.view.composing`, so Enter never commits an in-progress composition — critical for CJK input.

### Placement / precedence

The send extension is declared **before** the mention/slash extensions at **default priority (100)**. That lands its keymap *after* the Suggestion plugins and *before* the core newline `Keymap` in ProseMirror's precedence order:

- Mention (`#`) and slash (`/`) popups keep **Enter-to-select** while open — their `handleKeyDown` returns `true` for Enter only when the popup is active, so the send handler never runs in that case.
- When no popup is open, Enter beats the core newline keymap and submits.

No `editorProps.handleKeyDown` (would preempt the suggestion popups) and no high priority. The `agent-chat-send` CustomEvent listener is removed entirely.

## Tests

Adds coverage in `AgentChatInput.spec.tsx`:
- Enter (no modifier) fires `onSend` with the correct args.
- Shift+Enter does **not** send.
- Enter on an empty composer does **not** send.
- Enter during an active IME composition does **not** send.

## Verification

Package-level TipTap change (not browser-observable via a dev preview). Relies on the added unit tests + PR CI; biome/lint-staged/secretlint/UI control guards passed on commit.