### PR TITLE
chore(observability): cut log/render noise across API, notifications, and app

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/runs/mission-control.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/runs/mission-control.tsx
@@ -74,6 +74,17 @@ function MissionControlContent() {
   });
   const { activeRuns, refresh: refreshActive } = useActiveAgentRuns();
 
+  // The active-runs poll (/runs/active) and the history query (/runs?historyOnly)
+  // overlap the instant a run finishes: the just-failed run lands in history
+  // while it's still in the active poll, so the same run.error rendered in both
+  // ActiveRunsPanel and RunHistoryList — one failure shown twice. History is the
+  // canonical/persistent source, so drop any active run already present there.
+  const dedupedActiveRuns = useMemo(() => {
+    if (activeRuns.length === 0) return activeRuns;
+    const historyRunIds = new Set(runs.map((run) => run.id));
+    return activeRuns.filter((run) => !historyRunIds.has(run.id));
+  }, [activeRuns, runs]);
+
   const refreshAll = useCallback(async () => {
     await Promise.all([refresh(), refreshActive()]);
   }, [refresh, refreshActive]);
@@ -165,7 +176,7 @@ function MissionControlContent() {
 
         <RunRoutingInsights stats={stats} />
 
-        <ActiveRunsPanel runs={activeRuns} onCancel={cancelRun} />
+        <ActiveRunsPanel runs={dedupedActiveRuns} onCancel={cancelRun} />
 
         <div className="grid gap-3 md:grid-cols-4">
           <FormSearchbar

--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.tsx
@@ -226,9 +226,9 @@ function WorkspacePageContentContent({
       right={isOverviewSection ? undefined : workspaceHeaderActions}
     >
       {workspaceActionError ? (
-        <p className="mb-4 rounded-md border border-rose-400/30 bg-rose-400/8 px-3 py-2 text-xs text-rose-200">
+        <Alert type={AlertCategory.ERROR} className="mb-4">
           {workspaceActionError}
-        </p>
+        </Alert>
       ) : null}
 
       {workspaceLoadWarning ? (

--- a/apps/server/api/src/helpers/filters/http-exception/http-exception.filter.spec.ts
+++ b/apps/server/api/src/helpers/filters/http-exception/http-exception.filter.spec.ts
@@ -116,7 +116,8 @@ describe('HttpExceptionFilter', () => {
 
     filter.catch(exception, mockArgumentsHost);
 
-    expect(mockLoggerService.error).toHaveBeenCalled();
+    expect(mockLoggerService.warn).toHaveBeenCalled();
+    expect(mockLoggerService.error).not.toHaveBeenCalled();
     expect(Sentry.captureException).not.toHaveBeenCalled();
     expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.BAD_REQUEST);
     expect(mockResponse.json).toHaveBeenCalledWith(
@@ -336,20 +337,21 @@ describe('HttpExceptionFilter', () => {
   });
 
   describe('Logging Behavior', () => {
-    it('should log 4xx errors locally without reporting them to Sentry in production', () => {
+    it('should log 4xx errors locally at warn without a stack trace or Sentry in production', () => {
       // Production environment setup is already done in beforeEach
       const exception = new HttpException('Test error', HttpStatus.BAD_REQUEST);
 
       filter.catch(exception, mockArgumentsHost);
 
-      expect(mockLoggerService.error).toHaveBeenCalledWith(
-        'HTTP exception occurred',
-        exception,
+      // 4xx must not pass the exception (stack trace) and must not hit .error().
+      expect(mockLoggerService.warn).toHaveBeenCalledWith(
+        'HTTP client error occurred',
         expect.objectContaining({
           status: HttpStatus.BAD_REQUEST,
           url: '/test',
         }),
       );
+      expect(mockLoggerService.error).not.toHaveBeenCalled();
       expect(Sentry.captureException).not.toHaveBeenCalled();
       expect(mockLoggerService.log).not.toHaveBeenCalled();
     });

--- a/apps/server/api/src/helpers/filters/http-exception/http-exception.filter.ts
+++ b/apps/server/api/src/helpers/filters/http-exception/http-exception.filter.ts
@@ -38,10 +38,25 @@ export class HttpExceptionFilter extends AllExceptionFilter {
       detail = response;
     }
 
-    if (this.SENTRY_ENVIRONMENT !== 'development' && status >= 500) {
-      Sentry.captureException(exception);
+    if (status >= 500) {
+      if (this.SENTRY_ENVIRONMENT !== 'development') {
+        Sentry.captureException(exception);
+      } else {
+        this.loggerService.error('HTTP exception occurred', exception, {
+          method: req.method,
+          operation: 'catch',
+          service: 'HttpExceptionFilter',
+          status,
+          url: req.originalUrl,
+        });
+      }
     } else {
-      this.loggerService.error('HTTP exception occurred', exception, {
+      // 4xx are expected client/bot traffic (bad input, 404 probes such as
+      // /favicon.ico). Log at warn without the exception stack and never page
+      // Sentry — mirrors AllExceptionFilter's 4xx handling. Previously every
+      // 4xx hit .error() with the raw exception, emitting a stack trace on
+      // every missing-static-asset request.
+      this.loggerService.warn('HTTP client error occurred', {
         method: req.method,
         operation: 'catch',
         service: 'HttpExceptionFilter',

--- a/apps/server/notifications/src/services/discord/discord.service.ts
+++ b/apps/server/notifications/src/services/discord/discord.service.ts
@@ -21,12 +21,11 @@ export class DiscordService {
     private readonly loggerService: LoggerService,
     private readonly discordBotService: DiscordBotService,
   ) {
+    // Only the enabled path logs here. The "not configured" boot warning is
+    // owned solely by DiscordBotService.onModuleInit — emitting it here too
+    // double-warned on every boot with Discord disabled.
     if (this.configService.isDiscordEnabled()) {
       this.loggerService.log('Discord service initialized with bot webhooks');
-    } else {
-      this.loggerService.warn(
-        'Discord service is not configured - notifications disabled',
-      );
     }
   }
 

--- a/packages/libs/logger/logger.service.spec.ts
+++ b/packages/libs/logger/logger.service.spec.ts
@@ -105,7 +105,7 @@ describe('LoggerService', () => {
   });
 
   describe('error', () => {
-    it('should call winston.error and super.error with formatted message', () => {
+    it('should call winston.error with formatted message', () => {
       const message = 'Test error message';
       const trace = new Error('Test error');
       const context = { operation: 'test-op', service: 'test' };

--- a/packages/libs/logger/logger.service.ts
+++ b/packages/libs/logger/logger.service.ts
@@ -63,10 +63,11 @@ export class LoggerService extends ConsoleLogger {
       ...(errorData !== undefined && { error: errorData }),
     };
 
+    // winston already serializes the full error (message, name, stack) into
+    // errorContext.error above. Emitting a second line via super.error() only
+    // duplicated every backend error in the console — removed. winston is the
+    // single sink for this runtime (see class-level boundary note).
     this.winston.error(formattedMessage, errorContext);
-
-    const contextString = this.extractContextString(context, contextObj);
-    this.logToConsole(formattedMessage, trace, contextString);
   }
 
   private serializeError(trace?: string | Error | unknown): unknown {
@@ -104,33 +105,6 @@ export class LoggerService extends ConsoleLogger {
       return trace;
     }
     return undefined;
-  }
-
-  private extractContextString(
-    context?: unknown,
-    contextObj?: Record<string, unknown>,
-  ): string | undefined {
-    if (typeof context === 'string') {
-      return context;
-    }
-    if (typeof contextObj?.service === 'string') {
-      return contextObj.service;
-    }
-    return undefined;
-  }
-
-  private logToConsole(
-    message: string,
-    trace?: string | Error | unknown,
-    contextString?: string,
-  ): void {
-    if (trace instanceof Error) {
-      super.error(message, trace.stack, contextString);
-    } else if (typeof trace === 'string') {
-      super.error(message, trace, contextString);
-    } else {
-      super.error(message, contextString);
-    }
   }
 
   protected formatMessage(

--- a/packages/services/core/socket.service.ts
+++ b/packages/services/core/socket.service.ts
@@ -38,6 +38,13 @@ export class SocketService {
       timeout: 20_000,
       transports: ['websocket', 'polling'],
       upgrade: true,
+      // Capped exponential backoff. Without these, socket.io-client falls back
+      // to a 5s reconnect ceiling and retries forever, flooding the gateway on
+      // every outage. Delay doubles from 1s up to a 30s cap (with jitter).
+      reconnection: true,
+      reconnectionDelay: 1_000,
+      reconnectionDelayMax: 30_000,
+      randomizationFactor: 0.5,
       ...(token && {
         auth: { token },
         extraHeaders: { Authorization: `Bearer ${token}` },


### PR DESCRIPTION
## Summary

Overnight-QA observability + noise cleanup bundle: six small, independent fixes, each at its **source** (not the symptom). All six were reproduced and fixed — **none skipped**.

| # | Symptom | Root cause | Fix |
|---|---------|-----------|-----|
| 1 | Favicon 404s logged at `ERROR` with a stack trace on every page load | `HttpExceptionFilter` sent *all* non-5xx through `.error()` with the raw exception | 4xx now `warn` without the exception and never page Sentry; 5xx unchanged (Sentry in prod, `.error()` in dev) |
| 2 | Socket.IO reconnects flood with no backoff | client `socketConfig` left reconnection defaults implicit | added capped exponential backoff — `reconnectionDelay: 1s`, `reconnectionDelayMax: 30s`, `randomizationFactor: 0.5` |
| 3 | A single run failure renders **3×** in the UI | active-runs poll (`/runs/active`) and history query (`/runs?historyOnly`) overlap the instant a run finishes; the same `run.error` renders in both panels | page-level dedupe: drop active runs already present in history (canonical source) |
| 4 | Some backend log lines emitted twice | `LoggerService.error()` wrote to winston **and** `super.error()` (console) | winston is the single sink; removed the `super.error()` emit + now-dead `extractContextString`/`logToConsole` helpers |
| 5 | Duplicate Discord "not configured" warnings on boot | both `DiscordBotService` and `DiscordService` warned | only `DiscordBotService.onModuleInit` owns the boot warning; `DiscordService` logs only the enabled-path message |
| 6 | `workspaceActionError` rendered with hand-rolled markup | not routed through the shared primitive | now uses `<Alert type={AlertCategory.ERROR}>`, matching the sibling `workspaceLoadWarning` |

## Files

- `apps/server/api/src/helpers/filters/http-exception/http-exception.filter.ts` (+ spec) — item 1
- `packages/services/core/socket.service.ts` — item 2
- `apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/runs/mission-control.tsx` — item 3
- `packages/libs/logger/logger.service.ts` (+ spec) — item 4
- `apps/server/notifications/src/services/discord/discord.service.ts` — item 5
- `apps/app/app/(protected)/[orgSlug]/[brandSlug]/workspace/workspace-page.tsx` — item 6

## Notes / caveats

- **Item 3** — QA reported *3* render sites; I confirmed **2** (the active-runs panel and the history list, both feeding the shared `AgentRunCard`). A distinct third render path was not located. The dedupe eliminates the confirmed duplication (same run in both panels); if a third source exists it's outside these two data hooks and would need its own repro.
- **Item 6** — the QA note referenced #2004 as a same-class fix to copy. That premise didn't hold: #2004 (now merged) touches `AgentComposerStatusStack.tsx` and does **not** use an `Alert` primitive. There are also **two** `Alert` components — `@ui/primitives/alert` (variant-driven, unused in production) and `@ui/feedback/alert/Alert` (`AlertCategory`-driven, ~30 usages). I used the **feedback** `Alert` for consistency with the adjacent `workspaceLoadWarning` in the same file.

## Verification

Lint-staged gates passed on commit (secretlint, biome, control-guard, no-bespoke-card). Type-check / unit / e2e left to PR CI per the MacBook verification policy.