### PR TITLE
fix(analytics): reconcile brand-count metrics to a single source

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/useContentTeamPage.ts
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/orchestration/useContentTeamPage.ts
@@ -1,4 +1,3 @@
-import { useBrand } from '@contexts/user/brand-context/brand-context';
 import { APP_ROUTES } from '@genfeedai/constants';
 import { formatCompactNumber } from '@helpers/formatting/format/format.helper';
 import { useAuthedService } from '@hooks/auth/use-authed-service/use-authed-service';
@@ -31,7 +30,6 @@ type SummaryCardProps = {
 export function useContentTeamPage() {
   const { href } = useOrgUrl();
   const notificationsService = NotificationsService.getInstance();
-  const { brands } = useBrand();
   const {
     strategies,
     isLoading: isStrategiesLoading,
@@ -73,11 +71,6 @@ export function useContentTeamPage() {
   const strategiesById = useMemo(
     () => new Map(strategies.map((strategy) => [strategy.id, strategy])),
     [strategies],
-  );
-
-  const brandLabelsById = useMemo(
-    () => new Map(brands.map((brand) => [brand.id, brand.label])),
-    [brands],
   );
 
   const groupedStrategies = useMemo(() => {
@@ -237,9 +230,9 @@ export function useContentTeamPage() {
       },
       {
         accent:
-          brandLabelsById.size > 0
-            ? `${brandLabelsById.size} brand context${brandLabelsById.size === 1 ? '' : 's'} available for shared defaults.`
-            : 'No brand context loaded.',
+          reviewInbox.readyCount > 0
+            ? `${reviewInbox.readyCount} ready for approval, ${reviewInbox.pendingCount} still generating.`
+            : 'Nothing waiting for approval right now.',
         href: APP_ROUTES.POSTS.REVIEW,
         label: 'Review Inbox',
         tone: 'Approvals',
@@ -247,8 +240,8 @@ export function useContentTeamPage() {
       },
     ],
     [
-      brandLabelsById.size,
       href,
+      reviewInbox.pendingCount,
       reviewInbox.readyCount,
       strategies,
       workflows.length,

--- a/apps/server/api/src/collections/posts/services/analytics-aggregation.service.spec.ts
+++ b/apps/server/api/src/collections/posts/services/analytics-aggregation.service.spec.ts
@@ -11,8 +11,12 @@ describe('AnalyticsAggregationService', () => {
     });
     const postAnalyticsGroupBy = vi.fn().mockResolvedValue([]);
     const postsCount = vi.fn().mockResolvedValue(0);
+    const brandCount = vi.fn().mockResolvedValue(0);
     const service = new AnalyticsAggregationService(
       {
+        brand: {
+          count: brandCount,
+        },
         postAnalytics: {
           aggregate: postAnalyticsAggregate,
           groupBy: postAnalyticsGroupBy,
@@ -53,6 +57,46 @@ describe('AnalyticsAggregationService', () => {
       brandId: 'brand_1',
       isDeleted: false,
       organizationId: 'org_1',
+    });
+    expect(brandCount).toHaveBeenCalledWith({
+      where: { isDeleted: false, organizationId: 'org_1' },
+    });
+  });
+
+  it('counts brands org-scoped, ignoring the brand filter', async () => {
+    const postAnalyticsAggregate = vi.fn().mockResolvedValue({
+      _avg: { engagementRate: null },
+      _count: { _all: 0 },
+      _sum: {},
+    });
+    const postAnalyticsGroupBy = vi.fn().mockResolvedValue([]);
+    const postsCount = vi.fn().mockResolvedValue(0);
+    const brandCount = vi.fn().mockResolvedValue(3);
+    const service = new AnalyticsAggregationService(
+      {
+        brand: {
+          count: brandCount,
+        },
+        postAnalytics: {
+          aggregate: postAnalyticsAggregate,
+          groupBy: postAnalyticsGroupBy,
+        },
+      } as unknown as PrismaService,
+      {
+        count: postsCount,
+      } as unknown as PostsService,
+    );
+
+    const metrics = await service.getOverviewMetrics(
+      'org_1',
+      undefined,
+      '2026-04-01',
+      '2026-04-14',
+    );
+
+    expect(metrics.totalBrands).toBe(3);
+    expect(brandCount).toHaveBeenCalledWith({
+      where: { isDeleted: false, organizationId: 'org_1' },
     });
   });
 });

--- a/apps/server/api/src/collections/posts/services/analytics-aggregation.service.ts
+++ b/apps/server/api/src/collections/posts/services/analytics-aggregation.service.ts
@@ -13,6 +13,7 @@ import { Injectable } from '@nestjs/common';
 
 export interface OverviewMetrics {
   totalPosts: number;
+  totalBrands: number;
   totalViews: number;
   totalLikes: number;
   totalComments: number;
@@ -256,6 +257,12 @@ export class AnalyticsAggregationService {
       ...(brandId ? { brandId } : {}),
     });
 
+    // Authoritative brand count for the organization — org-scoped and
+    // soft-delete-aware so the "Total Brands" metric matches the brand switcher.
+    const totalBrands = await this.prisma.brand.count({
+      where: { isDeleted: false, organizationId },
+    });
+
     const currentSums =
       (
         currentAggregate as {
@@ -298,6 +305,7 @@ export class AnalyticsAggregationService {
       avgEngagementRate,
       bestPerformingPlatform: bestPlatform,
       engagementGrowth,
+      totalBrands,
       totalComments,
       totalEngagement,
       totalLikes,
@@ -1226,6 +1234,12 @@ export class AnalyticsAggregationService {
     const prevEngagement = this.totalEngagementFromSums(previousSums);
     const totalPosts = this.readNumber(postCountRows[0]?.post_count);
 
+    // Authoritative brand count for the organization — org-scoped and
+    // soft-delete-aware so the "Total Brands" metric matches the brand switcher.
+    const totalBrands = await this.prisma.brand.count({
+      where: { isDeleted: false, organizationId },
+    });
+
     return {
       activePlatforms: [platform],
       avgEngagementRate,
@@ -1234,6 +1248,7 @@ export class AnalyticsAggregationService {
         totalEngagement,
         prevEngagement,
       ),
+      totalBrands,
       totalComments,
       totalEngagement,
       totalLikes,

--- a/apps/server/api/src/collections/posts/services/analytics-aggregation.service.ts
+++ b/apps/server/api/src/collections/posts/services/analytics-aggregation.service.ts
@@ -1,145 +1,28 @@
-import {
-  ViralHookPlatformMetricsEntity,
-  ViralHookSummaryEntity,
-} from '@api/collections/posts/entities/viral-hooks.entity';
-import type { PostAnalyticsDocument } from '@api/collections/posts/schemas/post-analytics.schema';
+import type {
+  DistinctPostCountRow,
+  PlatformComparisonRow,
+} from '@api/collections/posts/services/analytics-aggregation.types';
 import { PostsService } from '@api/collections/posts/services/posts.service';
 import { DateRangeUtil } from '@api/helpers/utils/date-range/date-range.util';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { AnalyticsMetric } from '@genfeedai/enums';
-import type { IViralHookPlatformAggResult } from '@genfeedai/interfaces';
 import { Prisma } from '@genfeedai/prisma';
 import { Injectable } from '@nestjs/common';
 
-export interface OverviewMetrics {
-  totalPosts: number;
-  totalBrands: number;
-  totalViews: number;
-  totalLikes: number;
-  totalComments: number;
-  totalShares: number;
-  totalSaves: number;
-  avgEngagementRate: number;
-  totalEngagement: number;
-  viewsGrowth: number;
-  engagementGrowth: number;
-  activePlatforms: string[];
-  bestPerformingPlatform: string;
-}
-
-export interface TimeSeriesDataPoint {
-  date: string;
-  views: number;
-  likes: number;
-  comments: number;
-  shares: number;
-  saves: number;
-  engagementRate: number;
-  totalEngagement: number;
-}
-
-export interface PlatformMetrics {
-  views: number;
-  likes: number;
-  comments: number;
-  shares: number;
-  saves: number;
-  engagementRate: number;
-}
-
-export interface TimeSeriesDataPointWithPlatforms {
-  date: string;
-  instagram: PlatformMetrics;
-  tiktok: PlatformMetrics;
-  youtube: PlatformMetrics;
-  facebook: PlatformMetrics;
-  twitter: PlatformMetrics;
-  linkedin: PlatformMetrics;
-  reddit: PlatformMetrics;
-  pinterest: PlatformMetrics;
-  medium: PlatformMetrics;
-}
-
-export interface PlatformComparison {
-  platform: string;
-  views: number;
-  likes: number;
-  comments: number;
-  shares: number;
-  saves: number;
-  engagementRate: number;
-  postCount: number;
-  avgViewsPerPost: number;
-}
-
-export interface TopContent {
-  postId: string;
-  ingredientId: string;
-  title: string;
-  description: string;
-  platform: string;
-  views: number;
-  likes: number;
-  comments: number;
-  shares: number;
-  engagementRate: number;
-  publishDate: Date;
-  url?: string;
-}
-
-export interface GrowthTrends {
-  views: {
-    current: number;
-    previous: number;
-    growth: number;
-    growthPercentage: number;
-  };
-  engagement: {
-    current: number;
-    previous: number;
-    growth: number;
-    growthPercentage: number;
-  };
-  bestDay: {
-    date: string;
-    views: number;
-  };
-  trendingDirection: 'up' | 'down' | 'stable';
-}
-
-export interface EngagementBreakdown {
-  likes: number;
-  comments: number;
-  shares: number;
-  saves: number;
-  total: number;
-  likesPercentage: number;
-  commentsPercentage: number;
-  sharesPercentage: number;
-  savesPercentage: number;
-}
-
-type NumericSqlValue = bigint | number | string | null;
-
-type DistinctPostCountRow = {
-  post_count: NumericSqlValue;
-};
-
-type PlatformComparisonRow = {
-  comments: NumericSqlValue;
-  engagement_rate: NumericSqlValue;
-  likes: NumericSqlValue;
-  platform: string | null;
-  post_count: NumericSqlValue;
-  saves: NumericSqlValue;
-  shares: NumericSqlValue;
-  views: NumericSqlValue;
-};
-
-type PostViewsRow = {
-  post_id: string;
-  total_views: NumericSqlValue;
-};
+export type {
+  DistinctPostCountRow,
+  EngagementBreakdown,
+  GrowthTrends,
+  NumericSqlValue,
+  OverviewMetrics,
+  PlatformComparison,
+  PlatformComparisonRow,
+  PlatformMetrics,
+  PostViewsRow,
+  TimeSeriesDataPoint,
+  TimeSeriesDataPointWithPlatforms,
+  TopContent,
+} from '@api/collections/posts/services/analytics-aggregation.types';
 
 @Injectable()
 export class AnalyticsAggregationService {
@@ -181,10 +64,6 @@ export class AnalyticsAggregationService {
 
   private buildBrandSqlPredicate(brandId?: string): Prisma.Sql {
     return brandId ? Prisma.sql`AND "brandId" = ${brandId}` : Prisma.empty;
-  }
-
-  private buildAliasedBrandSqlPredicate(brandId?: string): Prisma.Sql {
-    return brandId ? Prisma.sql`AND pa."brandId" = ${brandId}` : Prisma.empty;
   }
 
   /**
@@ -911,238 +790,6 @@ export class AnalyticsAggregationService {
       sharesPercentage: total > 0 ? (shares / total) * 100 : 0,
       total,
     };
-  }
-
-  async getViralHooksSummary(
-    organizationId: string,
-    brandId?: string,
-    startDateInput?: Date | string,
-    endDateInput?: Date | string,
-  ): Promise<ViralHookSummaryEntity> {
-    const { startDate, endDate } = DateRangeUtil.parseDateRange(
-      startDateInput,
-      endDateInput,
-    );
-
-    const where: Record<string, unknown> = {
-      date: { gte: startDate, lte: endDate },
-      organizationId,
-    };
-
-    if (brandId) where.brandId = brandId;
-
-    const topPostRows = await this.prisma.$queryRaw<PostViewsRow[]>(
-      Prisma.sql`
-        WITH per_platform AS (
-          SELECT
-            "postId",
-            "platform",
-            MAX("totalViews") AS views
-          FROM "post_analytics"
-          WHERE "organizationId" = ${organizationId}
-            AND "date" >= ${startDate}
-            AND "date" <= ${endDate}
-            ${this.buildBrandSqlPredicate(brandId)}
-          GROUP BY "postId", "platform"
-        )
-        SELECT
-          "postId" AS post_id,
-          SUM(views) AS total_views
-        FROM per_platform
-        GROUP BY "postId"
-        ORDER BY total_views DESC
-        LIMIT 25
-      `,
-    );
-
-    const postIds = topPostRows.map((row) => row.post_id);
-
-    const platformRows =
-      postIds.length > 0
-        ? await this.prisma.postAnalytics.groupBy({
-            _avg: { engagementRate: true },
-            _max: {
-              totalComments: true,
-              totalLikes: true,
-              totalSaves: true,
-              totalShares: true,
-              totalViews: true,
-            },
-            by: ['postId', 'platform'],
-            where: {
-              ...where,
-              postId: { in: postIds },
-            } as never,
-          } as never)
-        : [];
-
-    const postPlatformMap = new Map<
-      string,
-      Map<
-        string,
-        {
-          comments: number;
-          engagementRate: number;
-          likes: number;
-          saves: number;
-          shares: number;
-          views: number;
-        }
-      >
-    >();
-
-    for (const row of platformRows as Array<{
-      _avg?: { engagementRate?: unknown };
-      _max?: Record<string, unknown>;
-      platform: string;
-      postId: string;
-    }>) {
-      const max = row._max ?? {};
-      const platformMap = postPlatformMap.get(row.postId) ?? new Map();
-      platformMap.set(row.platform, {
-        comments: this.readNumber(max.totalComments),
-        engagementRate: this.readNumber(row._avg?.engagementRate),
-        likes: this.readNumber(max.totalLikes),
-        saves: this.readNumber(max.totalSaves),
-        shares: this.readNumber(max.totalShares),
-        views: this.readNumber(max.totalViews),
-      });
-      postPlatformMap.set(row.postId, platformMap);
-    }
-
-    const ranked = topPostRows.map((row) => ({
-      platforms: postPlatformMap.get(row.post_id) ?? new Map(),
-      postId: row.post_id,
-      totalViews: this.readNumber(row.total_views),
-    }));
-
-    // Fetch post details
-    const posts = await this.prisma.post.findMany({
-      select: {
-        createdAt: true,
-        description: true,
-        id: true,
-        label: true,
-        publicationDate: true,
-        url: true,
-      },
-      take: postIds.length,
-      where: { id: { in: postIds } },
-    });
-
-    const postsById = new Map(
-      (
-        posts as unknown as Array<{
-          id: string;
-          createdAt?: Date;
-          description?: string;
-          label?: string;
-          publicationDate?: Date;
-          url?: string;
-        }>
-      ).map((p) => [p.id, p]),
-    );
-
-    const toIsoString = (value?: Date | string | null): string => {
-      if (!value) return new Date().toISOString();
-      if (value instanceof Date) return value.toISOString();
-      const parsed = new Date(value);
-      return Number.isNaN(parsed.getTime())
-        ? new Date().toISOString()
-        : parsed.toISOString();
-    };
-
-    const videos = ranked.map((item) => {
-      const post = postsById.get(item.postId);
-      const platforms = Array.from(item.platforms.entries()).map(
-        ([platform, data]) => {
-          const viralScore = Math.min(
-            100,
-            Math.round(data.engagementRate * 5 + data.views / 1000),
-          );
-
-          return {
-            avgWatchTime: 0,
-            comments: data.comments,
-            completionRate: 0,
-            engagementRate: data.engagementRate,
-            likes: data.likes,
-            platform: platform.toLowerCase(),
-            saves: data.saves,
-            shares: data.shares,
-            views: data.views,
-            viralScore,
-          };
-        },
-      );
-
-      const publishDate =
-        post?.publicationDate ?? post?.createdAt ?? new Date();
-
-      return {
-        analysisNotes: undefined,
-        creator: 'Unknown Creator',
-        duration: 0,
-        hooks: [],
-        id: item.postId,
-        platforms,
-        thumbnail: undefined,
-        title: post?.label ?? post?.description ?? 'Untitled Video',
-        totalTimeTracked: 0,
-        uploadDate: toIsoString(publishDate),
-      };
-    });
-
-    const totalVideos = videos.length;
-    const totalTimeTracked = 0;
-
-    const platformStats = new Map<
-      string,
-      { totalViews: number; totalViralScore: number; count: number }
-    >();
-
-    videos.forEach((video) => {
-      video.platforms.forEach((platform: ViralHookPlatformMetricsEntity) => {
-        const stats = platformStats.get(platform.platform) ?? {
-          count: 0,
-          totalViews: 0,
-          totalViralScore: 0,
-        };
-
-        stats.totalViews += platform.views;
-        stats.totalViralScore += platform.viralScore;
-        stats.count += 1;
-
-        platformStats.set(platform.platform, stats);
-      });
-    });
-
-    const topPlatforms = Array.from(platformStats.entries())
-      .map(([platform, stats]) => ({
-        avgViralScore:
-          stats.count > 0
-            ? Number((stats.totalViralScore / stats.count).toFixed(1))
-            : 0,
-        platform,
-        totalViews: stats.totalViews,
-      }))
-      .sort((a, b) => b.totalViews - a.totalViews)
-      .slice(0, 5);
-
-    return new ViralHookSummaryEntity({
-      analysis: {
-        avgTimePerVideo:
-          totalVideos > 0
-            ? Math.round(totalTimeTracked / Math.max(totalVideos, 1))
-            : 0,
-        hookEffectiveness: [],
-        topHooks: [],
-        topPlatforms,
-        totalTime: totalTimeTracked,
-        totalVideos,
-      },
-      videos,
-    });
   }
 
   /**

--- a/apps/server/api/src/collections/posts/services/analytics-aggregation.service.ts
+++ b/apps/server/api/src/collections/posts/services/analytics-aggregation.service.ts
@@ -12,9 +12,9 @@ import type {
   TimeSeriesDataPointWithPlatforms,
   TopContent,
 } from '@api/collections/posts/services/analytics-aggregation.types';
-import type { PostsService } from '@api/collections/posts/services/posts.service';
+import { PostsService } from '@api/collections/posts/services/posts.service';
 import { DateRangeUtil } from '@api/helpers/utils/date-range/date-range.util';
-import type { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { AnalyticsMetric } from '@genfeedai/enums';
 import { Prisma } from '@genfeedai/prisma';
 import { Injectable } from '@nestjs/common';

--- a/apps/server/api/src/collections/posts/services/analytics-aggregation.service.ts
+++ b/apps/server/api/src/collections/posts/services/analytics-aggregation.service.ts
@@ -1,10 +1,20 @@
 import type {
   DistinctPostCountRow,
+  EngagementBreakdown,
+  GrowthTrends,
+  NumericSqlValue,
+  OverviewMetrics,
+  PlatformComparison,
   PlatformComparisonRow,
+  PlatformMetrics,
+  PostViewsRow,
+  TimeSeriesDataPoint,
+  TimeSeriesDataPointWithPlatforms,
+  TopContent,
 } from '@api/collections/posts/services/analytics-aggregation.types';
-import { PostsService } from '@api/collections/posts/services/posts.service';
+import type { PostsService } from '@api/collections/posts/services/posts.service';
 import { DateRangeUtil } from '@api/helpers/utils/date-range/date-range.util';
-import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import type { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { AnalyticsMetric } from '@genfeedai/enums';
 import { Prisma } from '@genfeedai/prisma';
 import { Injectable } from '@nestjs/common';
@@ -22,7 +32,7 @@ export type {
   TimeSeriesDataPoint,
   TimeSeriesDataPointWithPlatforms,
   TopContent,
-} from '@api/collections/posts/services/analytics-aggregation.types';
+};
 
 @Injectable()
 export class AnalyticsAggregationService {

--- a/apps/server/api/src/collections/posts/services/analytics-aggregation.types.ts
+++ b/apps/server/api/src/collections/posts/services/analytics-aggregation.types.ts
@@ -1,0 +1,129 @@
+export interface OverviewMetrics {
+  totalPosts: number;
+  totalBrands: number;
+  totalViews: number;
+  totalLikes: number;
+  totalComments: number;
+  totalShares: number;
+  totalSaves: number;
+  avgEngagementRate: number;
+  totalEngagement: number;
+  viewsGrowth: number;
+  engagementGrowth: number;
+  activePlatforms: string[];
+  bestPerformingPlatform: string;
+}
+
+export interface TimeSeriesDataPoint {
+  date: string;
+  views: number;
+  likes: number;
+  comments: number;
+  shares: number;
+  saves: number;
+  engagementRate: number;
+  totalEngagement: number;
+}
+
+export interface PlatformMetrics {
+  views: number;
+  likes: number;
+  comments: number;
+  shares: number;
+  saves: number;
+  engagementRate: number;
+}
+
+export interface TimeSeriesDataPointWithPlatforms {
+  date: string;
+  instagram: PlatformMetrics;
+  tiktok: PlatformMetrics;
+  youtube: PlatformMetrics;
+  facebook: PlatformMetrics;
+  twitter: PlatformMetrics;
+  linkedin: PlatformMetrics;
+  reddit: PlatformMetrics;
+  pinterest: PlatformMetrics;
+  medium: PlatformMetrics;
+}
+
+export interface PlatformComparison {
+  platform: string;
+  views: number;
+  likes: number;
+  comments: number;
+  shares: number;
+  saves: number;
+  engagementRate: number;
+  postCount: number;
+  avgViewsPerPost: number;
+}
+
+export interface TopContent {
+  postId: string;
+  ingredientId: string;
+  title: string;
+  description: string;
+  platform: string;
+  views: number;
+  likes: number;
+  comments: number;
+  shares: number;
+  engagementRate: number;
+  publishDate: Date;
+  url?: string;
+}
+
+export interface GrowthTrends {
+  views: {
+    current: number;
+    previous: number;
+    growth: number;
+    growthPercentage: number;
+  };
+  engagement: {
+    current: number;
+    previous: number;
+    growth: number;
+    growthPercentage: number;
+  };
+  bestDay: {
+    date: string;
+    views: number;
+  };
+  trendingDirection: 'up' | 'down' | 'stable';
+}
+
+export interface EngagementBreakdown {
+  likes: number;
+  comments: number;
+  shares: number;
+  saves: number;
+  total: number;
+  likesPercentage: number;
+  commentsPercentage: number;
+  sharesPercentage: number;
+  savesPercentage: number;
+}
+
+export type NumericSqlValue = bigint | number | string | null;
+
+export type DistinctPostCountRow = {
+  post_count: NumericSqlValue;
+};
+
+export type PlatformComparisonRow = {
+  comments: NumericSqlValue;
+  engagement_rate: NumericSqlValue;
+  likes: NumericSqlValue;
+  platform: string | null;
+  post_count: NumericSqlValue;
+  saves: NumericSqlValue;
+  shares: NumericSqlValue;
+  views: NumericSqlValue;
+};
+
+export type PostViewsRow = {
+  post_id: string;
+  total_views: NumericSqlValue;
+};

--- a/packages/pages/analytics/organization-overview/analytics-organization-overview.tsx
+++ b/packages/pages/analytics/organization-overview/analytics-organization-overview.tsx
@@ -268,7 +268,7 @@ export default function AnalyticsOrganizationOverview({
       <div className="bg-background p-6">
         <div className="flex items-center justify-between mb-4">
           <h3 className="text-lg font-semibold">
-            All Brands ({brandsData.length})
+            All Brands ({formatCompactNumberIntl(analytics?.totalBrands)})
           </h3>
         </div>
 


### PR DESCRIPTION
## Problem

Overnight QA surfaced the same brand data rendering two different numbers in one view:

- **Organization Overview** showed `0 TOTAL BRANDS` (and `All Brands (0)`) while the brand switcher showed `All Brands (1)`.
- The orchestration **Review Inbox** card showed a review count of `0` while its accent claimed `1 brand context available`.

These are the same entities counted by two different code paths — the dashboard looked broken.

## Root cause

Two unrelated code paths counted brands:

1. The Overview tile/header had **no authoritative brand count**. The `All Brands (n)` header fell back to `brandsData.length` — the paginated first page (`ITEMS_PER_PAGE`) — which also silently undercounts at scale, and the tile had nothing at all.
2. The orchestration Review Inbox card mixed an unrelated **brand-context count** into an approvals metric, so the accent and the value described different things.

## Fix (query/selector, not hardcoded)

- `getOverviewMetrics` + `getPlatformAnalytics` now compute an authoritative `totalBrands` via an org-scoped, soft-delete-aware count:
  ```ts
  await this.prisma.brand.count({ where: { isDeleted: false, organizationId } });
  ```
  `totalBrands` is added to the `OverviewMetrics` contract. It was already whitelisted in the analytics serializer attributes, so it flows to the client automatically — no serializer change needed.
- **Organization Overview** tile *and* `All Brands (n)` header both read the single `analytics.totalBrands` source. The header no longer uses the paginated `brandsData.length`, so both surfaces always agree and the count stays correct beyond the first page.
- **Orchestration Review Inbox** card accent now describes the same review-inbox metric as its `reviewInbox.readyCount` value (ready / still generating), dropping the unrelated brand-context accent and its now-orphaned `useBrand` wiring.

## Tests

- Existing `getOverviewMetrics` spec extended to assert the org-scoped, soft-delete-aware `brand.count` call.
- New spec: `counts brands org-scoped, ignoring the brand filter` — asserts `totalBrands` reflects the org count and ignores the passed brand filter.

## Scope

`fix/brand-metric-consistency` → `master`. 4 files, +64/-12. No serializer, schema, or migration changes.