### PR TITLE
feat(ui): add shared EmptyState primitive and adopt on calendar, trends, org overview

### DIFF
--- a/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/calendar/content-calendar-page.tsx
+++ b/apps/app/app/(protected)/[orgSlug]/[brandSlug]/posts/calendar/content-calendar-page.tsx
@@ -21,10 +21,11 @@ import { PostsService } from '@services/content/posts.service';
 import { logger } from '@services/core/logger.service';
 import { NotificationsService } from '@services/core/notifications.service';
 import ContentCalendar from '@ui/calendar/content-calendar/ContentCalendar';
+import { EmptyState } from '@ui/feedback';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { HiDocumentText, HiListBullet } from 'react-icons/hi2';
+import { HiCalendarDays, HiDocumentText, HiListBullet } from 'react-icons/hi2';
 
 const DEFAULT_COLOR = '#8b5cf6';
 const ARTICLE_STATUS_COLORS: Record<string, string> = {
@@ -98,6 +99,7 @@ export default function ContentCalendarPage(): React.JSX.Element {
   const [posts, setPosts] = useState<Post[]>([]);
   const [articles, setArticles] = useState<IArticle[]>([]);
   const [selectedPostId, setSelectedPostId] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
   const [dateRange, setDateRange] = useCalendarWeekRange();
 
   useEffect(() => {
@@ -105,7 +107,11 @@ export default function ContentCalendarPage(): React.JSX.Element {
       return;
     }
 
+    let isActive = true;
+
     const loadContent = async () => {
+      setIsLoading(true);
+
       try {
         const [postsService, articlesService] = await Promise.all([
           getPostsService(),
@@ -129,15 +135,30 @@ export default function ContentCalendarPage(): React.JSX.Element {
           articlesService.findAll(articlesQuery),
         ]);
 
+        if (!isActive) {
+          return;
+        }
+
         setPosts(fetchedPosts);
         setArticles(fetchedArticles);
       } catch (error) {
+        if (!isActive) {
+          return;
+        }
         logger.error('Failed to load calendar content', error);
         notificationsService.error('Failed to load calendar content');
+      } finally {
+        if (isActive) {
+          setIsLoading(false);
+        }
       }
     };
 
     loadContent();
+
+    return () => {
+      isActive = false;
+    };
   }, [
     dateRange,
     brandId,
@@ -223,6 +244,19 @@ export default function ContentCalendarPage(): React.JSX.Element {
     />
   );
 
+  const emptyState =
+    !isLoading && calendarItems.length === 0 ? (
+      <EmptyState
+        icon={HiCalendarDays}
+        title="Nothing scheduled yet"
+        description="Plan and schedule your first post to see it on the calendar."
+        action={{
+          label: 'Create a post',
+          onClick: () => push(COMPOSE_ROUTES.POST),
+        }}
+      />
+    ) : undefined;
+
   return (
     <ContentCalendar
       items={calendarItems}
@@ -231,6 +265,7 @@ export default function ContentCalendarPage(): React.JSX.Element {
       getEventColor={getEventColor}
       filterControls={filterControls}
       modal={modal}
+      emptyState={emptyState}
     />
   );
 }

--- a/packages/pages/analytics/organization-overview/analytics-organization-overview.tsx
+++ b/packages/pages/analytics/organization-overview/analytics-organization-overview.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useAnalyticsContext } from '@contexts/analytics/analytics-context';
-import { ITEMS_PER_PAGE } from '@genfeedai/constants';
+import { APP_ROUTES, ITEMS_PER_PAGE } from '@genfeedai/constants';
 import { AnalyticsMetric, PageScope } from '@genfeedai/enums';
 import {
   formatCompactNumberIntl,
@@ -21,11 +21,12 @@ import Card from '@ui/card/Card';
 import { DashboardGrid } from '@ui/dashboard/DashboardGrid';
 import { Skeleton } from '@ui/display/skeleton/skeleton';
 import Table from '@ui/display/table/Table';
+import { EmptyStateCard } from '@ui/feedback';
 import dynamic from 'next/dynamic';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
-import { HiArrowRight } from 'react-icons/hi2';
+import { HiArrowRight, HiBuildingOffice2 } from 'react-icons/hi2';
 
 const BrandPerformanceChart = dynamic(
   () =>
@@ -78,6 +79,8 @@ function OrganizationMetricStrip({
   analytics: ReturnType<typeof useAnalytics>['analytics'];
   isLoading: boolean;
 }) {
+  const router = useRouter();
+
   const metrics: OrganizationMetricCard[] = [
     {
       accent: 'Active brands',
@@ -101,6 +104,15 @@ function OrganizationMetricStrip({
     },
   ];
 
+  // Once loaded, an org with no brands/posts/views/members has nothing to chart.
+  // Show a real "create your first brand" next step instead of a strip of 0s.
+  const hasNoData =
+    !isLoading &&
+    !analytics?.totalBrands &&
+    !analytics?.totalPosts &&
+    !analytics?.totalViews &&
+    !analytics?.totalUsers;
+
   return (
     <section aria-labelledby="organization-metrics-heading">
       <h2
@@ -110,29 +122,41 @@ function OrganizationMetricStrip({
         Organization Metrics
       </h2>
 
-      <DashboardGrid>
-        {metrics.map((metric) => (
-          <Card key={metric.label} bodyClassName="p-4">
-            {isLoading ? (
-              <Skeleton variant="text" height={32} className="w-16" />
-            ) : (
-              <div className="text-2xl font-semibold tracking-[-0.02em] text-foreground">
-                {metric.value}
-              </div>
-            )}
-            <p className="mt-1 text-[10px] font-medium uppercase tracking-[0.14em] text-foreground/55">
-              {metric.label}
-            </p>
-            {isLoading ? (
-              <Skeleton variant="text" height={12} className="mt-2 w-28" />
-            ) : (
-              <p className="mt-1.5 text-[11px] text-foreground/45">
-                {metric.accent}
+      {hasNoData ? (
+        <EmptyStateCard
+          icon={HiBuildingOffice2}
+          title="No organization activity yet"
+          description="Create your first brand to start publishing content and tracking performance across your organization."
+          action={{
+            label: 'Create your first brand',
+            onClick: () => router.push(APP_ROUTES.ONBOARDING.BRAND),
+          }}
+        />
+      ) : (
+        <DashboardGrid>
+          {metrics.map((metric) => (
+            <Card key={metric.label} bodyClassName="p-4">
+              {isLoading ? (
+                <Skeleton variant="text" height={32} className="w-16" />
+              ) : (
+                <div className="text-2xl font-semibold tracking-[-0.02em] text-foreground">
+                  {metric.value}
+                </div>
+              )}
+              <p className="mt-1 text-[10px] font-medium uppercase tracking-[0.14em] text-foreground/55">
+                {metric.label}
               </p>
-            )}
-          </Card>
-        ))}
-      </DashboardGrid>
+              {isLoading ? (
+                <Skeleton variant="text" height={12} className="mt-2 w-28" />
+              ) : (
+                <p className="mt-1.5 text-[11px] text-foreground/45">
+                  {metric.accent}
+                </p>
+              )}
+            </Card>
+          ))}
+        </DashboardGrid>
+      )}
     </section>
   );
 }

--- a/packages/pages/trends/list/trends-list.tsx
+++ b/packages/pages/trends/list/trends-list.tsx
@@ -25,6 +25,7 @@ import { useQuery } from '@tanstack/react-query';
 import ButtonRefresh from '@ui/buttons/refresh/button-refresh/ButtonRefresh';
 import Card from '@ui/card/Card';
 import Badge from '@ui/display/badge/Badge';
+import { EmptyStateCard } from '@ui/feedback';
 import Alert from '@ui/feedback/alert/Alert';
 import Container from '@ui/layout/container/Container';
 import SectionTopbar from '@ui/layout/section-topbar/SectionTopbar';
@@ -283,39 +284,50 @@ function TrendContentEmptyTable({
   );
 }
 
-function ViralVideosEmptyState({ isLoading }: { isLoading: boolean }) {
-  const cards = [
-    {
-      label: 'Hook pattern',
-      value: isLoading ? 'Loading' : 'Pending',
-    },
-    {
-      label: 'Creator format',
-      value: isLoading ? 'Loading' : 'Pending',
-    },
-    {
-      label: 'Remix angle',
-      value: isLoading ? 'Loading' : 'Pending',
-    },
-  ];
+function ViralVideosLoadingCards() {
+  const labels = ['Hook pattern', 'Creator format', 'Remix angle'];
 
   return (
     <div className="overflow-hidden rounded-card border border-white/[0.06] bg-card">
       <div className="grid grid-cols-1 divide-y divide-white/[0.06] md:grid-cols-3 md:divide-x md:divide-y-0">
-        {cards.map((card) => (
-          <div key={card.label} className="bg-background/30 p-4">
+        {labels.map((label) => (
+          <div key={label} className="bg-background/30 p-4">
             <div className="flex items-center gap-2 text-sm font-medium text-foreground">
               <HiOutlineSparkles className="size-4 text-foreground/52" />
-              {card.label}
+              {label}
             </div>
             <div className="mt-4 text-xs uppercase tracking-[0.18em] text-foreground/35">
-              {card.value}
+              Loading
             </div>
             <div className="mt-2 h-2 w-full rounded-full bg-white/[0.04]" />
           </div>
         ))}
       </div>
     </div>
+  );
+}
+
+function ViralVideosEmptyState({
+  isLoading,
+  onRefresh,
+}: {
+  isLoading: boolean;
+  onRefresh: () => void;
+}) {
+  if (isLoading) {
+    return <ViralVideosLoadingCards />;
+  }
+
+  return (
+    <EmptyStateCard
+      icon={HiOutlineFilm}
+      title="No viral videos yet"
+      description="Breakout video patterns will surface here once trend syncs pull in videos adjacent to your saved feed."
+      action={{
+        label: 'Refresh videos',
+        onClick: onRefresh,
+      }}
+    />
   );
 }
 
@@ -526,7 +538,12 @@ export default function TrendsList() {
               />
 
               {viralVideos.length === 0 ? (
-                <ViralVideosEmptyState isLoading={isLoadingVideos} />
+                <ViralVideosEmptyState
+                  isLoading={isLoadingVideos}
+                  onRefresh={() => {
+                    void refetchVideos();
+                  }}
+                />
               ) : (
                 <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
                   {viralVideos.map((video: ITrendVideo) => {

--- a/packages/props/components/calendar.props.ts
+++ b/packages/props/components/calendar.props.ts
@@ -17,4 +17,10 @@ export interface ContentCalendarProps<T extends CalendarItem> {
   getEventColor: (item: T) => string;
   filterControls?: ReactNode;
   modal?: ReactNode;
+  /**
+   * Rendered in place of the (otherwise blank) time grid when there are no
+   * schedulable events. Lets the host surface a meaningful empty state instead
+   * of a full 48-row grid that reads as broken rather than "no events".
+   */
+  emptyState?: ReactNode;
 }

--- a/packages/props/ui/feedback/empty-state.props.ts
+++ b/packages/props/ui/feedback/empty-state.props.ts
@@ -1,0 +1,29 @@
+import type { CardEmptySize, CardVariant } from '@genfeedai/enums';
+import type { CardEmptyAction } from '@genfeedai/props/ui/cards/card-empty.props';
+import type { ComponentType } from 'react';
+
+/**
+ * Shared contract for the `EmptyState` primitive.
+ *
+ * Deliberately stricter than {@link CardEmptyProps}: an empty state must always
+ * tell the user *what* is empty (`title`) and offer a concrete next step
+ * (`action`). This prevents surfaces from shipping bare skeleton chrome — an
+ * empty grid, pending placeholder cards, or zero-value tiles — as if it were
+ * content. Optional `icon`/`description` add context; the primitive delegates
+ * rendering to `CardEmptyContent` (mapping `title` -> `label`).
+ */
+export interface EmptyStateProps {
+  /** Required headline describing what is empty, in the user's terms. */
+  title: string;
+  /** Required next step. An empty state must always offer an action. */
+  action: CardEmptyAction;
+  /** Optional leading icon; sized by `size`. */
+  icon?: ComponentType<{ className?: string }>;
+  iconClassName?: string;
+  /** Optional supporting copy under the title. */
+  description?: string;
+  className?: string;
+  size?: CardEmptySize;
+  /** Card visual variant — applies to the card-wrapped `EmptyStateCard` only. */
+  variant?: CardVariant;
+}

--- a/packages/ui/src/components/calendar/content-calendar/ContentCalendar.tsx
+++ b/packages/ui/src/components/calendar/content-calendar/ContentCalendar.tsx
@@ -106,6 +106,7 @@ export default function ContentCalendar<T extends CalendarItem>({
   getEventColor,
   filterControls,
   modal,
+  emptyState,
 }: ContentCalendarProps<T>) {
   const dateRangeRef = useRef<CalendarDateRange | null>(null);
   const [, setDateRange] = useState<CalendarDateRange | null>(null);
@@ -206,9 +207,13 @@ export default function ContentCalendar<T extends CalendarItem>({
             border-color: rgba(255, 255, 255, 0.06) !important;
           }
         `}</style>
-        <div className="fullcalendar-container">
-          <FullCalendarHost options={calendarOptions} />
-        </div>
+        {events.length === 0 && emptyState ? (
+          emptyState
+        ) : (
+          <div className="fullcalendar-container">
+            <FullCalendarHost options={calendarOptions} />
+          </div>
+        )}
       </Card>
 
       {modal}

--- a/packages/ui/src/components/card/EmptyState.stories.tsx
+++ b/packages/ui/src/components/card/EmptyState.stories.tsx
@@ -16,35 +16,41 @@ const VideoIcon = ({ className }: { className?: string }) => (
   <HiVideoCamera className={className} />
 );
 
+const noop = () => {
+  // Action clicked
+};
+
 /**
- * EmptyState component displays a message when there's no data to show.
- * Supports icons, labels, descriptions, and action buttons.
+ * EmptyState is the shared primitive for "nothing here yet" surfaces. Both a
+ * `title` and an `action` are required — an empty state must always name what
+ * is empty and offer a concrete next step, never render bare skeleton chrome.
+ * Icons and descriptions are optional context.
  */
 const meta = {
   argTypes: {
     action: {
       control: 'object',
-      description: 'Action button configuration',
+      description: 'Required next-step action button configuration',
     },
     description: {
       control: 'text',
-      description: 'Description text',
+      description: 'Optional supporting copy under the title',
     },
     icon: {
-      description: 'Icon element to display',
-    },
-    label: {
-      control: 'text',
-      description: 'Main label text',
+      description: 'Optional icon element to display',
     },
     size: {
       control: 'select',
       description: 'Size variant',
       options: ['sm', 'default', 'lg'],
     },
+    title: {
+      control: 'text',
+      description: 'Required headline describing what is empty',
+    },
     variant: {
       control: 'select',
-      description: 'Visual variant',
+      description: 'Visual variant (EmptyStateCard only)',
       options: ['default', 'subtle', 'prominent'],
     },
   },
@@ -72,27 +78,12 @@ export const Default: Story = {
   render: () => (
     <EmptyState
       icon={InboxIcon}
-      label="No items found"
+      title="No items found"
       description="Get started by creating your first item."
       action={{
         label: 'Create Item',
-        onClick: () => {
-          // Action clicked
-        },
+        onClick: noop,
       }}
-    />
-  ),
-};
-
-/**
- * Without action button
- */
-export const NoAction: Story = {
-  render: () => (
-    <EmptyState
-      icon={PhotoIcon}
-      label="No images yet"
-      description="Upload your first image to get started."
     />
   ),
 };
@@ -104,14 +95,12 @@ export const Small: Story = {
   render: () => (
     <EmptyState
       icon={VideoIcon}
-      label="No videos"
+      title="No videos"
       description="Create your first video."
       size={CardEmptySize.SM}
       action={{
         label: 'Create Video',
-        onClick: () => {
-          // Action clicked
-        },
+        onClick: noop,
       }}
     />
   ),
@@ -124,14 +113,12 @@ export const Large: Story = {
   render: () => (
     <EmptyState
       icon={InboxIcon}
-      label="No content available"
+      title="No content available"
       description="This section is empty. Start by adding some content."
       size={CardEmptySize.LG}
       action={{
         label: 'Get Started',
-        onClick: () => {
-          // Action clicked
-        },
+        onClick: noop,
       }}
     />
   ),
@@ -144,13 +131,11 @@ export const SecondaryAction: Story = {
   render: () => (
     <EmptyState
       icon={PlusIcon}
-      label="No projects"
+      title="No projects"
       description="Create your first project to get started."
       action={{
         label: 'New Project',
-        onClick: () => {
-          // Action clicked
-        },
+        onClick: noop,
         variant: ButtonVariant.SECONDARY,
       }}
     />
@@ -164,13 +149,11 @@ export const OutlineAction: Story = {
   render: () => (
     <EmptyState
       icon={PhotoIcon}
-      label="No gallery items"
+      title="No gallery items"
       description="Add images to your gallery."
       action={{
         label: 'Upload Images',
-        onClick: () => {
-          // Action clicked
-        },
+        onClick: noop,
         variant: ButtonVariant.OUTLINE,
       }}
     />
@@ -187,13 +170,11 @@ export const Card: Story = {
   render: () => (
     <EmptyStateCard
       icon={InboxIcon}
-      label="No items found"
+      title="No items found"
       description="Get started by creating your first item."
       action={{
         label: 'Create Item',
-        onClick: () => {
-          // Action clicked
-        },
+        onClick: noop,
       }}
     />
   ),
@@ -210,21 +191,24 @@ export const SizeComparison: Story = {
     <div className="space-y-12 p-8">
       <EmptyState
         icon={InboxIcon}
-        label="Small Empty State"
+        title="Small Empty State"
         description="This is the small size variant."
         size={CardEmptySize.SM}
+        action={{ label: 'Create Item', onClick: noop }}
       />
       <EmptyState
         icon={InboxIcon}
-        label="Default Empty State"
+        title="Default Empty State"
         description="This is the default size variant."
         size={CardEmptySize.DEFAULT}
+        action={{ label: 'Create Item', onClick: noop }}
       />
       <EmptyState
         icon={InboxIcon}
-        label="Large Empty State"
+        title="Large Empty State"
         description="This is the large size variant."
         size={CardEmptySize.LG}
+        action={{ label: 'Create Item', onClick: noop }}
       />
     </div>
   ),

--- a/packages/ui/src/components/card/EmptyState.tsx
+++ b/packages/ui/src/components/card/EmptyState.tsx
@@ -1,4 +1,60 @@
+import type { EmptyStateProps } from '@genfeedai/props/ui/feedback/empty-state.props';
 import CardEmpty, { CardEmptyContent } from '@ui/card/empty/CardEmpty';
 
-export const EmptyState = CardEmptyContent;
-export const EmptyStateCard = CardEmpty;
+export type { EmptyStateProps };
+
+/**
+ * EmptyState - shared empty-state primitive (no card wrapper).
+ *
+ * Stricter than `CardEmptyContent`: `title` and `action` are required so a
+ * surface can never ship bare skeleton chrome as if it were content. Delegates
+ * rendering to `CardEmptyContent`, mapping `title` -> `label`.
+ */
+export function EmptyState({
+  title,
+  action,
+  icon,
+  iconClassName,
+  description,
+  className,
+  size,
+}: EmptyStateProps) {
+  return (
+    <CardEmptyContent
+      icon={icon}
+      iconClassName={iconClassName}
+      label={title}
+      description={description}
+      action={action}
+      className={className}
+      size={size}
+    />
+  );
+}
+
+/**
+ * EmptyStateCard - the same primitive wrapped in a `Card`.
+ */
+export function EmptyStateCard({
+  title,
+  action,
+  icon,
+  iconClassName,
+  description,
+  className,
+  size,
+  variant,
+}: EmptyStateProps) {
+  return (
+    <CardEmpty
+      icon={icon}
+      iconClassName={iconClassName}
+      label={title}
+      description={description}
+      action={action}
+      className={className}
+      size={size}
+      variant={variant}
+    />
+  );
+}

--- a/packages/ui/src/components/feedback/EmptyState.tsx
+++ b/packages/ui/src/components/feedback/EmptyState.tsx
@@ -1,1 +1,5 @@
-export { EmptyState, EmptyStateCard } from '@ui/card/EmptyState';
+export {
+  EmptyState,
+  EmptyStateCard,
+  type EmptyStateProps,
+} from '@ui/card/EmptyState';

--- a/packages/ui/src/components/feedback/index.ts
+++ b/packages/ui/src/components/feedback/index.ts
@@ -1,4 +1,8 @@
-export { EmptyState, EmptyStateCard } from '@ui/feedback/EmptyState';
+export {
+  EmptyState,
+  EmptyStateCard,
+  type EmptyStateProps,
+} from '@ui/feedback/EmptyState';
 export {
   default as LoadingState,
   type LoadingStateProps,


### PR DESCRIPTION
## Summary

Overnight QA surfaced surfaces that ship **skeleton chrome as content** when they have no data — the emptiness reads as *broken*, not *"nothing here yet."* Root cause: there was no shared empty-state contract, so each surface improvised (or didn't).

This PR adds **one** `EmptyState` primitive and adopts it on the three worst offenders. Scope is deliberately held to the primitive + 3 surfaces; the rest are listed as follow-up.

## What changed

### 1. Shared primitive (`packages/ui`)
- Contract lives in `packages/props/ui/feedback/empty-state.props.ts` — `title` **(required)** + `action` **(required next step)**; optional `icon`, `description`, `size`, `variant`.
- `packages/ui/src/components/card/EmptyState.tsx` exposes two functions, both delegating to the existing `CardEmpty`/`CardEmptyContent` DRY renderer (no new bespoke card):
  - `EmptyState` — unwrapped, for surfaces that own their container (e.g. inside a `Card`).
  - `EmptyStateCard` — card-wrapped, for bare surfaces.
- Re-exported from `@ui/feedback` alongside `LoadingState`. Stories updated (`label`→`title`, required `action` on every story).

An empty state **must** offer a next step, so `action` is non-optional by design.

### 2. Adopted on the 3 offenders
- **Calendar** (`apps/app/.../posts/calendar` + `ContentCalendar`): a 48-row empty time grid now renders `EmptyState` ("Nothing scheduled yet" → *Create a post*). Added an `emptyState?: ReactNode` slot to `ContentCalendarProps` + a mount-guarded `isLoading` so the empty state only shows after load settles, never during fetch.
- **Trends / research** (`packages/pages/trends/list`): PENDING placeholder cards split into a real loading shimmer vs. `EmptyStateCard` ("No viral videos yet" → *Refresh videos*).
- **Org overview** (`packages/pages/analytics/organization-overview`): the `TOTAL BRANDS 0 / TOTAL MEMBERS 0` zero-tile strip now collapses to `EmptyStateCard` ("No organization activity yet" → *Create your first brand*) when every metric is zero/absent. Heading preserved.

## Out of scope / follow-up

Not converted here to keep the diff reviewable. These still render skeleton-as-content or ad-hoc empties and should adopt the primitive next:
- Library / media grids (empty asset lists)
- Brand-scoped analytics overview (per-brand zero state, mirror of the org fix)
- Publisher posts list (beyond the calendar view)
- Any surface still using a local one-off `EmptyState` (content-runs detail, agent `DynamicBlockGrid`, browser-extension `IdeasPage`, mobile app) — intentionally **left untouched**; they have their own local component and should migrate deliberately, not in this PR.

## Testing

CI only (Vincent's MacBook rule — no local typecheck/build/e2e). Pre-commit gates passed locally: secretlint, biome, control-guard, no-bespoke-card, no-raw-html.

## Design reference

`/default/default/settings` and `/default/default/messages` already do empty states right (meaningful copy + clear CTA) — the primitive's copy/CTA shape follows them.
