### PR TITLE
docs: fix raw-HTML scanner reference + document confirmed legacy-alias surface

### DIFF
--- a/.agents/memory/MEMORY.md
+++ b/.agents/memory/MEMORY.md
@@ -29,7 +29,7 @@
 - [Never lose code](never_lose_code.md) — Always branch+push WIP before destructive git ops
 - [Trunk PR workflow](trunk_pr_workflow.md) — Trunk-based: commit/push/PR on short-lived branches; master is PR-only; secret-scan every commit.
 - [proxy.ts is middleware](proxy_middleware.md) — Next.js 16 renamed middleware.ts → proxy.ts
-- [Use @ui/primitives](ui_primitives.md) — Never raw HTML elements — blocked by lint-no-raw-html.sh
+- [Use @ui/primitives](ui_primitives.md) — Never raw HTML elements — blocked by scripts/ui/control-guard.ts
 - [Codex adversarial review](codex_adversarial_review.md) — MANDATORY before ExitPlanMode
 - [GitHub issue worktree workflow](gh_issue_worktree_workflow.md) — Assigned issues use worktrees from master → PR to master
 - [Ready PRs by default](ready_pr_default.md) — Open normal ready PRs to master by default; draft only by explicit request or blocked WIP

--- a/.agents/memory/ui_primitives.md
+++ b/.agents/memory/ui_primitives.md
@@ -1,10 +1,10 @@
 ---
 name: Always use @ui/primitives components, never raw HTML
-description: Genfeed blocks raw HTML elements (button, input, textarea, select, dialog, table, hr, etc.) via scripts/lint-no-raw-html.sh — use @ui/primitives/* instead
+description: Genfeed blocks raw HTML elements (button, input, textarea, select, dialog, table, hr, etc.) via scripts/ui/control-guard.ts — use @ui/primitives/* instead
 type: feedback
 ---
 
-In this repo, **never write raw `<button>`, `<input>`, `<textarea>`, `<select>`, `<dialog>`, `<table>`, `<details>`, `<summary>`, `<progress>`, or `<hr>` elements** in production `.tsx` files. They are blocked by `scripts/lint-no-raw-html.sh` which runs as a pre-commit hook.
+In this repo, **never write raw `<button>`, `<input>`, `<textarea>`, `<select>`, `<dialog>`, `<table>`, `<details>`, `<summary>`, `<progress>`, or `<hr>` elements** in production `.tsx` files. They are blocked by `scripts/ui/control-guard.ts` — the single canonical raw-control scanner that replaced the old `check-raw-button-usage.ts`, `check-raw-ui-controls.ts`, and `lint-no-raw-html.sh`. It runs pre-commit via lint-staged (`lint-staged.config.mjs`) and repo-wide in CI via `bun run check:ui-guards`.
 
 **Use `@ui/primitives/*` instead:**
 - `<button>` → `Button` from `@ui/primitives/button`
@@ -24,4 +24,4 @@ In this repo, **never write raw `<button>`, `<input>`, `<textarea>`, `<select>`,
 
 **Why:** Enforces design system consistency and a11y. User has called out raw HTML violations multiple times.
 
-**How to apply:** Before adding any `<button>`, `<input>`, `<dialog>`, etc., check `packages/ui/src/primitives/` for the corresponding component. If a div with `role="button"` would be the natural choice, use `Button` with `variant={ButtonVariant.UNSTYLED}` instead. Exclusions (primitives, editors, tests, mocks, storybook) are hardcoded in `scripts/lint-no-raw-html.sh`.
+**How to apply:** Before adding any `<button>`, `<input>`, `<dialog>`, etc., check `packages/ui/src/primitives/` for the corresponding component. If a div with `role="button"` would be the natural choice, use `Button` with `variant={ButtonVariant.UNSTYLED}` instead. Exclusions (primitives, editors, tests, mocks, storybook) live in the single `ALLOWLIST` in `scripts/ui/control-guard.ts`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ bun run test --filter=@genfeedai/[name]  # Run specific package tests
 - AbortController in every useEffect with async calls
 - No `deletedAt` field — use `isDeleted: boolean`
 - Components use `function` declarations (not arrow), default export
-- **Never raw HTML elements** — use `@ui/primitives/*` instead. `<button>`, `<input>`, `<textarea>`, `<select>`, `<dialog>`, `<table>`, `<hr>`, etc. are blocked by `scripts/lint-no-raw-html.sh` pre-commit hook. For unstyled usage, use `Button` with `variant={ButtonVariant.UNSTYLED}` + `withWrapper={false}`. Never nest `Button` inside `Button` (invalid HTML) — restructure as siblings.
+- **Never raw HTML elements** — use `@ui/primitives/*` instead. `<button>`, `<input>`, `<textarea>`, `<select>`, `<dialog>`, `<table>`, `<hr>`, etc. are blocked by the canonical raw-control scanner `scripts/ui/control-guard.ts`, run pre-commit via lint-staged (`lint-staged.config.mjs`) and repo-wide in CI via `bun run check:ui-guards` (`scripts/ui/check-ui-guards.ts`). For unstyled usage, use `Button` with `variant={ButtonVariant.UNSTYLED}` + `withWrapper={false}`. Never nest `Button` inside `Button` (invalid HTML) — restructure as siblings.
 
 ### Backend (ALWAYS)
 - Compound indexes live in Prisma schema `@@index` directives or explicit migrations

--- a/apps/app/CLAUDE.md
+++ b/apps/app/CLAUDE.md
@@ -11,7 +11,7 @@ Next.js App Router. Next 16: the middleware file is `proxy.ts`, not `middleware.
 ## Component rules
 
 - `function` declarations (not arrow), default export. Colocated `*.test.tsx`.
-- Never raw HTML elements (`<button>`, `<input>`, `<table>`, …) — use `@ui/primitives/*`. Enforced by `scripts/lint-no-raw-html.sh` pre-commit. Unstyled usage: `Button` with `variant={ButtonVariant.UNSTYLED}` + `withWrapper={false}`. Never nest `Button` inside `Button` — restructure as siblings.
+- Never raw HTML elements (`<button>`, `<input>`, `<table>`, …) — use `@ui/primitives/*`. Enforced by `scripts/ui/control-guard.ts` (pre-commit via lint-staged, and CI `check:ui-guards`). Unstyled usage: `Button` with `variant={ButtonVariant.UNSTYLED}` + `withWrapper={false}`. Never nest `Button` inside `Button` — restructure as siblings.
 - Every `useEffect` with async calls uses an `AbortController`.
 - Prop interfaces live in `packages/props/`, never inline.
 - Card sizing via `size` prop; padding via `bodyClassName`. Premium surfaces use `gen-*` design classes.


### PR DESCRIPTION
## Housekeeping bundle from overnight QA

Two items were bundled for this pass. **Only Item #14 ships here** (docs-only,
zero runtime risk). Item #13 was fully investigated and **confirmed**, but the
confirmed surface turned out to be load-bearing security/tenancy/execution code
— not housekeeping — so it is documented below with a follow-up recommendation
rather than migrated blind in a doc PR.

---

### ✅ Item #14 — Doc drift: raw-HTML scanner name (shipped)

Docs referenced `scripts/lint-no-raw-html.sh` as the pre-commit hook enforcing
the "no raw HTML elements" rule. **That script does not exist.** The real
enforcement is `scripts/ui/control-guard.ts` — the single canonical raw-control
scanner that consolidated three predecessors (`check-raw-button-usage.ts`,
`check-raw-ui-controls.ts`, and the old `lint-no-raw-html.sh`). It runs:

- **pre-commit** via `lint-staged.config.mjs`, and
- **repo-wide in CI** via `bun run check:ui-guards`.

Corrected references (no invented mechanism — documents what is actually wired):

- `CLAUDE.md`
- `apps/app/CLAUDE.md`
- `.agents/memory/MEMORY.md`
- `.agents/memory/ui_primitives.md`

---

### 🔎 Item #13 — Legacy Mongo-era alias reads (investigated, deferred with evidence)

**Rule:** `.agents/memory/rules/prisma_legacy_alias_fields.md` +
`docs/identity-resolution.md` §"`*Document` alias fields are types, not data".
`*Document` types add **optional** aliases (`organization`, `user`, `brand`,
`role`, `_id`) over Prisma rows; the live data is in the scalar FKs
(`organizationId`, `userId`, …). Reading `row.organization` compiles and returns
`undefined` at runtime unless the query explicitly `include`d the relation.

**Runtime proof that the reads below are phantom** (both paths load the row with
*no* include, so the alias is `undefined`):

- `apps/server/api/src/shared/factories/entity/entity.factory.ts` L58-86 —
  `fromDocument()` only flattens a relation object → id when `populate.length > 0`.
- `apps/server/api/src/shared/services/base/base.service.ts` — `findOne()` calls
  `populateToInclude([])`, which returns `undefined` (`if (!populate.length) return undefined`).
  A plain `findOne` therefore issues **no** Prisma `include`.

**Confirmed phantom-read surface (two clusters, both behavior-changing):**

1. **`apps/server/api/src/shared/controllers/base-crud/base-crud.controller.ts` L475**
   — `canUserModifyEntity()` reads `entityRecord.user` (from an unpopulated
   `findOne`) to make an **ownership/authorization** decision. `.user` is
   `undefined`, so the default ownership check fails closed for non-superadmins.
   This is the base CRUD default → **blast radius of 9 controllers**.

2. **`apps/server/api/src/collections/workflows/services/legacy-workflow-step-runner.service.ts`**
   — `executeWorkflow()` self-loads the workflow via unpopulated `findOne`, then:
   - L79 `if (!workflow.user || !workflow.organization) throw` — **always throws**
     (both aliases undefined), gating a **live** execution path (the runner is
     provided in `workflows.module.ts` and injected into `workflow-scheduler`,
     `workflow-webhook`, `workflows.service`, and `cron-jobs`).
   - L277 / L309 `String(workflow.user)` → `"undefined"`.
   - L468 `organization: workflow.organization` / L475 `user: workflow.user` —
     tenancy/ownership assignment written from undefined aliases.
   - (L463 `brand: workflow.brandId` is **already correct** — scalar FK.)

**Why this is not migrated in this PR:**

- Both clusters change **authorization / tenancy / execution-gating** semantics
  (not display or logging). "Fixing" the read flips real allow/deny and
  execute/skip decisions.
- They require test coverage before merge, and this pass runs under a
  no-local-test constraint (verification via PR CI only). A blind edit to an
  auth guard's ownership default and a live scheduler/webhook execution gate
  does not belong in a docs housekeeping PR.
- Per the task's own rule — *"do the alias migration only for cases you can
  confirm; keep the PR small; if a case is ambiguous, leave it and note it in
  the PR body — do not break a real relation read."* These are confirmed but
  security-semantic, so they are surfaced here for dedicated handling.

**Non-phantom reads (correctly left alone):** `publicMetadata.user` /
`publicMetadata.organization` (resolved auth principal, genuinely populated by
the identity resolver), legacy **filter** keys (`matchFilter.user`, mapped by
`processSearchParams`), and client **DTO** fields (`dto.organization`).

**Recommended follow-up:** open a dedicated `fix:` issue to migrate the two
confirmed clusters to scalar FKs (`entityRecord.userId`; `workflow.userId` /
`workflow.organizationId`) **with** regression tests — an ownership test for the
base-CRUD default across the 9 controllers, and an `executeWorkflow` test
proving the runner no longer throws on a validly-scoped workflow.

---

### Verification

- Docs-only diff; no code paths touched. Relies on PR CI.
- Three-dot PR diff: `CLAUDE.md`, `apps/app/CLAUDE.md`, `.agents/memory/MEMORY.md`,
  `.agents/memory/ui_primitives.md` (6 insertions, 6 deletions).
