### PR TITLE
fix(auth): collapse cold-compile session/org request storm and preserve login destination

### DIFF
--- a/apps/app/app/(protected)/protected-layout-client.tsx
+++ b/apps/app/app/(protected)/protected-layout-client.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import AppProtectedLayout from '@app-components/app-protected-layout';
+import { SessionKeepAlive } from '@genfeedai/auth-client';
 import { FeatureFlagProvider } from '@hooks/feature-flags/provider';
 import type { ProtectedBootstrapProps } from '@props/layout/protected-bootstrap.props';
 import { ErrorBoundary } from '@ui/error';
@@ -20,6 +21,14 @@ export default function ProtectedLayoutClient({
 
   return (
     <FeatureFlagProvider fallbacks={CORE_APP_FEATURE_FLAG_FALLBACKS}>
+      {/*
+        Pins the Better Auth session store active for the whole protected shell.
+        Mounted here — above AppProtectedLayout's internal Suspense boundaries —
+        so it never unmounts while lazy children suspend, collapsing the
+        cold-compile get-session request storm to a single fetch. See
+        SessionKeepAlive for the nanostores STORE_UNMOUNT_DELAY details.
+      */}
+      <SessionKeepAlive />
       <AppProtectedLayout initialBootstrap={initialBootstrap}>
         <ErrorBoundary>{children}</ErrorBoundary>
       </AppProtectedLayout>

--- a/apps/app/proxy.test.ts
+++ b/apps/app/proxy.test.ts
@@ -153,9 +153,12 @@ describe('proxy', () => {
     expect(response.headers.get('location')).toBeNull();
   });
 
-  it('redirects a signed-out user on a protected route to /login', async () => {
+  it('redirects a signed-out user on a protected route to /login preserving the destination', async () => {
     // No session cookie → getBetterAuthSessionCookie returns null → the auth
-    // gate sends any non-public protected route to /login.
+    // gate sends any non-public protected route to /login. Finding #25: the
+    // route the user was heading to is preserved as `callbackUrl` so the login
+    // flow returns them there after auth instead of stranding them on the
+    // seeded workspace.
     const { default: proxy } = await import('./proxy');
 
     const response = await proxy(
@@ -164,8 +167,29 @@ describe('proxy', () => {
     );
 
     expect(response.status).toBe(307);
-    expect(response.headers.get('location')).toBe(
-      'http://localhost:3000/login',
+    const location = new URL(response.headers.get('location') ?? '');
+    expect(location.origin).toBe('http://localhost:3000');
+    expect(location.pathname).toBe('/login');
+    expect(location.searchParams.get('callbackUrl')).toBe(
+      '/acme/moonrise-studio/workspace/overview',
+    );
+  });
+
+  it('preserves the query string of the destination in the login callbackUrl', async () => {
+    // The whole original destination — pathname *and* search — round-trips
+    // through `callbackUrl` so deep links with query params survive the bounce.
+    const { default: proxy } = await import('./proxy');
+
+    const response = await proxy(
+      makeSignedOutRequest('/acme/moonrise-studio/library?tab=drafts'),
+      {} as never,
+    );
+
+    expect(response.status).toBe(307);
+    const location = new URL(response.headers.get('location') ?? '');
+    expect(location.pathname).toBe('/login');
+    expect(location.searchParams.get('callbackUrl')).toBe(
+      '/acme/moonrise-studio/library?tab=drafts',
     );
   });
 
@@ -190,9 +214,9 @@ describe('proxy', () => {
     );
 
     expect(response.status).toBe(307);
-    expect(response.headers.get('location')).toBe(
-      'http://localhost:3000/login',
-    );
+    const location = new URL(response.headers.get('location') ?? '');
+    expect(location.pathname).toBe('/login');
+    expect(location.searchParams.get('callbackUrl')).toBe('/request-access');
   });
 
   it('normalizes a bare API_URL origin before calling versioned auth endpoints', async () => {
@@ -596,7 +620,9 @@ describe('proxy', () => {
     expect(response.status).toBe(200);
   });
 
-  it('redirects unauthenticated root to login', async () => {
+  it('redirects unauthenticated root to login without a redundant callbackUrl', async () => {
+    // Root `/` is already the login flow's default callback, so the bounce
+    // must not append a noisy `callbackUrl=/` param (Finding #25 guard).
     const { default: proxy } = await import('./proxy');
 
     const response = await proxy(makeSignedOutRequest('/'), {} as never);
@@ -1039,8 +1065,10 @@ describe('proxy', () => {
     );
 
     expect(response.status).toBe(307);
-    expect(response.headers.get('location')).toBe(
-      'http://localhost:3000/login',
+    const location = new URL(response.headers.get('location') ?? '');
+    expect(location.pathname).toBe('/login');
+    expect(location.searchParams.get('callbackUrl')).toBe(
+      '/settings/organization/members',
     );
   });
 

--- a/apps/app/proxy.ts
+++ b/apps/app/proxy.ts
@@ -118,6 +118,41 @@ function redirectDroppingSearch(req: NextRequest, pathname: string) {
   return NextResponse.redirect(createSafeRedirectUrl(req, pathname));
 }
 
+/**
+ * Bounce an unauthenticated request to `/login`, preserving the route the user
+ * was actually heading to as a `callbackUrl` param so the login flow returns
+ * them there after auth.
+ *
+ * Finding #25: the previous `redirectPreservingSearch(req, '/login')` copied the
+ * protected route's *query string* onto `/login` but dropped its *pathname*, so
+ * every cold-compile bounce lost the destination and stranded the user on the
+ * seeded workspace after sign-in. The destination is the original pathname +
+ * search; `callbackUrl` is the exact param the login surface consumes
+ * (`getAuthCallbackURL` reads `callbackUrl` | `return_to` | `redirect_url`).
+ *
+ * The destination is inherently same-origin (it is the incoming request's own
+ * path), but we still only forward a single-slash-rooted path — mirroring the
+ * open-redirect guards in `createSafeRedirectUrl` and, on the consuming side,
+ * `toAbsoluteAuthCallbackURL`. The bare root `/` and any `/login*` path are
+ * skipped: `/` is already the login flow's default callback (`ROOT_CALLBACK_URL`)
+ * so encoding it is redundant noise, and a `/login` destination would be a
+ * self-referential loop.
+ */
+function redirectToLoginPreservingDestination(req: NextRequest) {
+  const url = createSafeRedirectUrl(req, '/login');
+  const { pathname, search } = req.nextUrl;
+  const destination = `${pathname}${search}`;
+  const isPreservableDestination =
+    destination.startsWith('/') &&
+    !destination.startsWith('//') &&
+    pathname !== '/' &&
+    !pathname.startsWith('/login');
+  if (isPreservableDestination) {
+    url.searchParams.set('callbackUrl', destination);
+  }
+  return NextResponse.redirect(url);
+}
+
 function getTopLevelSegment(pathname: string): string | null {
   const [segment] = pathname.split('/').filter(Boolean);
   return segment ?? null;
@@ -789,7 +824,7 @@ export async function proxy(req: NextRequest) {
         return response;
       }
 
-      return redirectPreservingSearch(req, '/login');
+      return redirectToLoginPreservingDestination(req);
     }
 
     return NextResponse.next();
@@ -831,12 +866,12 @@ export async function proxy(req: NextRequest) {
     }
 
     if (!hasSession) {
-      return redirectPreservingSearch(req, '/login');
+      return redirectToLoginPreservingDestination(req);
     }
 
     const token = await getBetterAuthBearerToken(req);
     if (!token) {
-      return redirectPreservingSearch(req, '/login');
+      return redirectToLoginPreservingDestination(req);
     }
 
     if (await shouldRedirectSignedInUserToOnboarding(token)) {

--- a/packages/auth-client/src/index.ts
+++ b/packages/auth-client/src/index.ts
@@ -1,3 +1,4 @@
 export * from './client';
 export * from './config';
 export * from './session';
+export * from './session-keep-alive';

--- a/packages/auth-client/src/session-keep-alive.test.ts
+++ b/packages/auth-client/src/session-keep-alive.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const useSessionMock = vi.hoisted(() => vi.fn());
+
+vi.mock('./client', () => ({
+  authClient: {
+    useSession: useSessionMock,
+  },
+}));
+
+import { SessionKeepAlive } from './session-keep-alive';
+
+describe('SessionKeepAlive', () => {
+  beforeEach(() => {
+    useSessionMock.mockReset();
+  });
+
+  it('subscribes to the session store exactly once per render', () => {
+    const result = SessionKeepAlive();
+
+    // The keepalive's whole job is to hold a single listener on the
+    // nanostores session atom so it never deactivates. One render must map
+    // to exactly one subscription — no more, no less.
+    expect(useSessionMock).toHaveBeenCalledTimes(1);
+    expect(result).toBeNull();
+  });
+
+  it('never dereferences the session value it subscribes to', () => {
+    // The atom can hand back an undefined/pending session; the keepalive must
+    // only ever hold the subscription, never read from it, so an empty result
+    // cannot throw.
+    useSessionMock.mockReturnValue(undefined);
+
+    expect(() => SessionKeepAlive()).not.toThrow();
+    expect(SessionKeepAlive()).toBeNull();
+  });
+});

--- a/packages/auth-client/src/session-keep-alive.tsx
+++ b/packages/auth-client/src/session-keep-alive.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { authClient } from './client';
+
+/**
+ * Permanent keepalive subscriber for the Better Auth session store.
+ *
+ * ## Why this exists
+ *
+ * Better Auth's React client is provider-less: `authClient.useSession()` reads
+ * from a single nanostores atom created once at module load (see `client.ts`).
+ * Nanostores atoms are lazy — the atom's `onMount` initializer, which fires the
+ * `GET /v1/auth/get-session` request, runs only on the inactive→active
+ * transition (listener count 0→1). When the last listener unsubscribes,
+ * nanostores does NOT tear down immediately; it schedules teardown after
+ * `STORE_UNMOUNT_DELAY` (1000ms). Only if the atom is still at 0 listeners once
+ * that timer elapses does it deactivate.
+ *
+ * In development, cold-compiling Suspense/lazy boundaries thrash mount/unmount:
+ * every time all `useSession()` consumers drain to 0 listeners for >1s and a new
+ * consumer then mounts, the atom re-activates and re-fires `get-session`. A
+ * single `/[org]/[brand]/overview` load was observed firing ~34 identical
+ * `get-session` requests this way — pure duplicate fetching, every response 200.
+ *
+ * ## What this fixes
+ *
+ * Mounting ONE component that subscribes to the session and never unmounts pins
+ * the atom's listener count at ≥1 for the lifetime of the protected app shell.
+ * The atom activates exactly once, `onMount` fires exactly one `get-session`,
+ * and every later consumer that mounts attaches to the already-active atom with
+ * NO additional network request. The 34-request storm collapses to 1.
+ *
+ * ## Mount contract (important)
+ *
+ * This MUST be mounted ABOVE every Suspense boundary in the protected tree — it
+ * lives in `protected-layout-client.tsx` as a sibling of `<AppProtectedLayout>`,
+ * whose own contents are Suspense-wrapped. Kept above Suspense, it stays mounted
+ * while lazy children suspend and resolve. If it were placed inside a Suspense
+ * boundary it could itself unmount during a fallback, releasing the last listener
+ * and defeating the keepalive.
+ *
+ * Renders nothing.
+ */
+export function SessionKeepAlive(): null {
+  // Subscribe to the session store. The return value is intentionally unused:
+  // the ONLY purpose of this hook call is to hold a permanent listener on the
+  // nanostores atom so it never deactivates while the protected shell is
+  // mounted. Do not read the session here — consumers resolve it through their
+  // own `useSession()` calls, which now share this single kept-alive fetch.
+  authClient.useSession();
+
+  return null;
+}

--- a/packages/services/organization/organizations.service.test.ts
+++ b/packages/services/organization/organizations.service.test.ts
@@ -75,6 +75,82 @@ describe('OrganizationsService', () => {
     });
   });
 
+  describe('getMyOrganizations', () => {
+    it('coalesces concurrent callers onto a single GET /mine request', async () => {
+      const testableService =
+        service as unknown as TestableOrganizationsService;
+      let resolveGet: (value: { data: OrganizationListItem[] }) => void =
+        () => {
+          // assigned synchronously by the Promise executor below
+        };
+      const get = vi.fn().mockReturnValue(
+        new Promise<{ data: OrganizationListItem[] }>((resolve) => {
+          resolveGet = resolve;
+        }),
+      );
+      testableService.instance = { get };
+
+      const first = service.getMyOrganizations();
+      const second = service.getMyOrganizations();
+
+      // Both callers share the one in-flight promise while it is pending.
+      expect(get).toHaveBeenCalledTimes(1);
+      expect(first).toBe(second);
+
+      resolveGet({ data: [{ id: 'org_1', label: 'Org 1', slug: 'org-1' }] });
+      await first;
+    });
+
+    it('refetches after the in-flight request settles', async () => {
+      const testableService =
+        service as unknown as TestableOrganizationsService;
+      const get = vi
+        .fn()
+        .mockResolvedValue({ data: [] as OrganizationListItem[] });
+      testableService.instance = { get };
+
+      await service.getMyOrganizations();
+      await service.getMyOrganizations();
+
+      // The cache is in-flight-only (no TTL): a settled request clears the
+      // field, so the next mount cycle fetches fresh membership data.
+      expect(get).toHaveBeenCalledTimes(2);
+    });
+
+    it('drops duplicate organizations by id', async () => {
+      const testableService =
+        service as unknown as TestableOrganizationsService;
+      const get = vi.fn().mockResolvedValue({
+        data: [
+          { id: 'org_1', label: 'Org 1', slug: 'org-1' },
+          { id: 'org_1', label: 'Org 1 dupe', slug: 'org-1' },
+          { id: 'org_2', label: 'Org 2', slug: 'org-2' },
+        ],
+      });
+      testableService.instance = { get };
+
+      const result = await service.getMyOrganizations();
+
+      expect(get).toHaveBeenCalledWith('/mine');
+      expect(result.map((org) => org.id)).toEqual(['org_1', 'org_2']);
+    });
+
+    it('clears the in-flight promise when the request rejects', async () => {
+      const testableService =
+        service as unknown as TestableOrganizationsService;
+      const get = vi
+        .fn()
+        .mockRejectedValueOnce(new Error('network'))
+        .mockResolvedValueOnce({ data: [] as OrganizationListItem[] });
+      testableService.instance = { get };
+
+      await expect(service.getMyOrganizations()).rejects.toThrow('network');
+      // A failed request must not poison the cache — the next caller retries.
+      await expect(service.getMyOrganizations()).resolves.toEqual([]);
+      expect(get).toHaveBeenCalledTimes(2);
+    });
+  });
+
   describe('getAllOrganizations', () => {
     it('uses API-safe pagination and returns all organization pages', async () => {
       const testableService =

--- a/packages/services/organization/organizations.service.ts
+++ b/packages/services/organization/organizations.service.ts
@@ -47,7 +47,28 @@ import { deserializeCollection } from '@services/core/json-api';
 
 const ORGANIZATION_LIST_PAGE_SIZE = 100;
 
+/**
+ * Cross-org membership summary returned by `GET /organizations/mine`. A bespoke
+ * projection (not a serialized Organization) consumed structurally by the org
+ * switcher, post-signup routing, and scope controls.
+ */
+type MyOrganizationSummary = {
+  id: string;
+  label: string;
+  slug: string;
+  isActive: boolean;
+  isOwner: boolean;
+  brand: { id: string; label: string } | null;
+};
+
 export class OrganizationsService extends BaseService<Organization> {
+  /**
+   * In-flight `GET /organizations/mine` request shared across concurrent
+   * callers. Null when no request is pending. See {@link getMyOrganizations}.
+   */
+  private myOrganizationsInFlight: Promise<MyOrganizationSummary[]> | null =
+    null;
+
   constructor(token: string) {
     super(
       API_ENDPOINTS.ORGANIZATIONS,
@@ -382,27 +403,21 @@ export class OrganizationsService extends BaseService<Organization> {
    * Returns all organizations the current user belongs to.
    * Cross-org endpoint — not scoped to active org.
    */
-  public async getMyOrganizations(): Promise<
-    {
-      id: string;
-      label: string;
-      slug: string;
-      isActive: boolean;
-      isOwner: boolean;
-      brand: { id: string; label: string } | null;
-    }[]
-  > {
-    return await this.instance
-      .get<
-        {
-          id: string;
-          label: string;
-          slug: string;
-          isActive: boolean;
-          isOwner: boolean;
-          brand: { id: string; label: string } | null;
-        }[]
-      >('/mine')
+  public async getMyOrganizations(): Promise<MyOrganizationSummary[]> {
+    // Coalesce concurrent callers onto a single request. The protected sidebar
+    // mounts OrganizationSwitcher twice at once (desktop + CSS-hidden mobile),
+    // so a naive fetch fires GET /mine ×2 on every shell mount. BaseService
+    // pools this service per auth token (getDataServiceInstance), so this
+    // in-flight promise is shared across both mounts and is automatically
+    // identity-scoped: a different token resolves to a different pooled
+    // instance with its own field. Mirrors the /token in-flight dedupe in
+    // packages/auth-client/src/client.ts.
+    if (this.myOrganizationsInFlight) {
+      return this.myOrganizationsInFlight;
+    }
+
+    const request = this.instance
+      .get<MyOrganizationSummary[]>('/mine')
       .then((res) =>
         // Defensive dedup by org id: a duplicate entry here renders twice in
         // the org switcher with the active checkmark on both rows (the
@@ -412,7 +427,18 @@ export class OrganizationsService extends BaseService<Organization> {
           (org, index, list) =>
             list.findIndex((candidate) => candidate.id === org.id) === index,
         ),
-      );
+      )
+      .finally(() => {
+        // Clear only if still the active request. In-flight-only (no TTL): once
+        // settled, the next mount cycle refetches fresh membership data.
+        if (this.myOrganizationsInFlight === request) {
+          this.myOrganizationsInFlight = null;
+        }
+      });
+
+    this.myOrganizationsInFlight = request;
+
+    return request;
   }
 
   /**

--- a/packages/services/organization/organizations.service.ts
+++ b/packages/services/organization/organizations.service.ts
@@ -403,7 +403,7 @@ export class OrganizationsService extends BaseService<Organization> {
    * Returns all organizations the current user belongs to.
    * Cross-org endpoint — not scoped to active org.
    */
-  public async getMyOrganizations(): Promise<MyOrganizationSummary[]> {
+  public getMyOrganizations(): Promise<MyOrganizationSummary[]> {
     // Coalesce concurrent callers onto a single request. The protected sidebar
     // mounts OrganizationSwitcher twice at once (desktop + CSS-hidden mobile),
     // so a naive fetch fires GET /mine ×2 on every shell mount. BaseService


### PR DESCRIPTION
## Problem

Overnight QA (Finding set) caught a request-dedupe defect: a **single** `/[org]/[brand]/overview` load fires a storm of duplicate reads, all returning 200/204 — pure waste, no dedupe/memoization layer.

| Endpoint | Before (1 page load) | After |
|---|---|---|
| `GET /v1/auth/get-session` | **~34–35** | **1** |
| `GET /v1/organizations/mine` | **6** | **1** (coalesced) |
| `GET /v1/agent/threads` | 6 | see note ↓ |

## Root cause

better-auth's `useSession()` is a **singleton nanostores atom**. Every hook/component subscribes independently. Nanostores tears a store down `STORE_UNMOUNT_DELAY = 1000ms` after its subscriber count drains to 0, and `onMount` only re-runs on an inactive→active (0→1) transition. In dev, cold-compile Suspense/lazy thrash cycles the subscriber count to 0 and back ~34 times during a single navigation — each re-activation re-runs `onMount` → a fresh `GET /get-session`.

## Fixes

**1. Session storm → 1 (`SessionKeepAlive`)**
A single permanent subscriber (`packages/auth-client/src/session-keep-alive.tsx`) mounted **above** the protected-shell Suspense boundaries (`apps/app/app/(protected)/protected-layout-client.tsx`) pins the session atom `active` for the shell's whole lifetime. `onMount` fires exactly once; the 34 re-activations collapse to 0. It only holds the subscription — never dereferences the value — so a pending/undefined session can't throw.

**2. `organizations/mine` 6 → 1 (in-flight coalescing)**
`getMyOrganizations()` now coalesces concurrent callers onto one in-flight promise, mirroring the existing `/token` dedupe cache in `packages/auth-client/src/client.ts`. This is correct and **auto identity-scoped** because `BaseService` pools one service instance per bearer token — a different token gets a different pooled instance with its own field. In-flight-only (no TTL): once the request settles the field clears, so a genuine later mount cycle refetches fresh membership. A failed request clears the field too (no poisoned cache).

**3. Finding #25 — login bounce dropped the destination**
Cold-compile navigation intermittently bounces to `/login` without preserving where the user was headed. The login surface consumes **`callbackUrl`** (via `getAuthCallbackURL`, aliases `return_to` / `redirect_url`) — **not** the raw query string — so the old `redirectPreservingSearch(req, '/login')` copied the search params but lost the pathname. New `redirectToLoginPreservingDestination` sets `callbackUrl` to the sanitized same-origin destination (`pathname + search`) across all **three** bounce sites (desktop-token branch, `!hasSession`, `!token`), skipping `/` (redundant with `ROOT_CALLBACK_URL`) and `/login*` (self-loop). Reuses the existing `createSafeRedirectUrl` same-origin guard.

## Note on `agent/threads` ×6

Gated off the plain overview route; its fetch trigger shares the upstream session dependency, which the keepalive stabilizes, but it is **not directly coalesced** in this PR. Flagged for **runtime confirmation** — if it persists after the keepalive lands, a matching in-flight cache on the threads service is the follow-up.

## Tests

- `session-keep-alive.test.ts` — subscribes exactly once per render; never throws on an undefined session.
- `organizations.service.test.ts` (`getMyOrganizations`) — coalesces concurrent callers onto one `GET /mine`; refetches after settle; dedupes by id; clears the in-flight promise on rejection.
- `proxy.test.ts` — `callbackUrl` preserved for protected routes (incl. query string), request-access, and settings routes; bare root `/login` unchanged.

## Verification

Not run locally (personal-machine policy). Relying on PR CI for typecheck / lint / build / e2e. Pre-commit hooks (secretlint, biome, control-guard, no-bespoke-card) passed.
