### PR TITLE
refactor(seo): dedupe SEO scorer types into @genfeedai/interfaces

### DIFF
--- a/apps/server/api/src/services/seo/seo-scorer.types.ts
+++ b/apps/server/api/src/services/seo/seo-scorer.types.ts
@@ -1,62 +1,24 @@
 /**
- * Canonical SEO scorer contract (#758).
+ * SEO scorer types for the API.
  *
- * Mirrors the 7-dimension, 100-point rubric defined in
- * `skills/content-seo-optimizer/SKILL.md`. The scorer mixes deterministic
- * checks (computed in code, fully reproducible) with LLM qualitative
- * sub-scores for the criteria that cannot be derived from the content alone.
+ * The core scorecard contract is canonical in `@genfeedai/interfaces`
+ * (`content/seo-scorecard.interface.ts`) and re-exported here so the scorer
+ * service/util keep a single local import surface. Only the API-internal
+ * scoring types (input shape, LLM sub-scores, options) are defined here.
  */
 
-export const SEO_DIMENSIONS = [
-  'keywordPlacement',
-  'contentStructure',
-  'readability',
-  'metaOptimization',
-  'links',
-  'media',
-  'technicalSignals',
-] as const;
-
-export type SeoDimension = (typeof SEO_DIMENSIONS)[number];
-
-/** Per-dimension maximum points — sums to 100. */
-export const SEO_DIMENSION_MAX: Record<SeoDimension, number> = {
-  contentStructure: 20,
-  keywordPlacement: 20,
-  links: 10,
-  media: 10,
-  metaOptimization: 15,
-  readability: 15,
-  technicalSignals: 10,
-};
-
-/**
- * `deterministic` checks are computed purely in code (same input → same
- * points). `qualitative` checks carry a deterministic heuristic baseline but
- * may be refined by the LLM layer.
- */
-export type SeoCheckKind = 'deterministic' | 'qualitative';
-
-export interface SeoCheck {
-  /** Stable identifier (e.g. `kw_in_title`). */
-  id: string;
-  dimension: SeoDimension;
-  label: string;
-  kind: SeoCheckKind;
-  /** Maximum points this check contributes to its dimension. */
-  max: number;
-  /** Points earned (0..max). */
-  points: number;
-  /**
-   * `false` when the signal cannot be derived from the supplied input (e.g.
-   * canonical/OG tags live in <head>, page-speed needs a render environment).
-   * Unavailable checks still count 0 toward the raw score but are surfaced so
-   * the caller can renormalise against `maxAvailable`.
-   */
-  available: boolean;
-  /** Actionable, human-readable finding used to build suggestions. */
-  note: string;
-}
+export type {
+  SeoCheck,
+  SeoCheckKind,
+  SeoDimension,
+  SeoRating,
+  SeoScorecard,
+  SeoScorecardMeta,
+} from '@genfeedai/interfaces';
+export {
+  SEO_DIMENSION_MAX,
+  SEO_DIMENSIONS,
+} from '@genfeedai/interfaces';
 
 /**
  * Normalised, source-agnostic content the scorer operates on. Decoupled from
@@ -77,42 +39,6 @@ export interface SeoScorableContent {
   targetKeyword?: string | null;
   /** Supporting keywords audited in subheadings. */
   secondaryKeywords?: string[];
-}
-
-export type SeoRating =
-  | 'excellent'
-  | 'good'
-  | 'needs_work'
-  | 'poor'
-  | 'critical';
-
-export interface SeoScorecardMeta {
-  wordCount: number;
-  fleschReadingEase: number;
-  targetKeyword: string | null;
-  /**
-   * Word-coverage density: (occurrences × phrase_word_count) / total_words ×
-   * 100, or null when no keyword given.
-   */
-  keywordDensity: number | null;
-  /** Whether the LLM qualitative layer was applied. */
-  llmApplied: boolean;
-  /** Sum of `max` across available checks (for UI renormalisation). */
-  maxAvailable: number;
-  scoredAt: string;
-}
-
-export interface SeoScorecard {
-  /** Overall 0-100 score (sum of all checks, rounded). */
-  score: number;
-  rating: SeoRating;
-  /** Earned points per dimension. */
-  breakdown: Record<SeoDimension, number>;
-  /** Prioritised, actionable improvement suggestions. */
-  suggestions: string[];
-  /** Per-check detail (deterministic + qualitative). */
-  checks: SeoCheck[];
-  meta: SeoScorecardMeta;
 }
 
 /** Qualitative sub-scores returned by the LLM layer (each 0..check max). */

--- a/packages/interfaces/src/content/seo-scorecard.interface.ts
+++ b/packages/interfaces/src/content/seo-scorecard.interface.ts
@@ -1,3 +1,12 @@
+/**
+ * Canonical SEO scorer contract (#758).
+ *
+ * Mirrors the 7-dimension, 100-point rubric defined in
+ * `skills/content-seo-optimizer/SKILL.md`. The scorer mixes deterministic
+ * checks (computed in code, fully reproducible) with LLM qualitative
+ * sub-scores for the criteria that cannot be derived from the content alone.
+ */
+
 export const SEO_DIMENSIONS = [
   'keywordPlacement',
   'contentStructure',
@@ -10,6 +19,7 @@ export const SEO_DIMENSIONS = [
 
 export type SeoDimension = (typeof SEO_DIMENSIONS)[number];
 
+/** Per-dimension maximum points — sums to 100. */
 export const SEO_DIMENSION_MAX: Record<SeoDimension, number> = {
   contentStructure: 20,
   keywordPlacement: 20,
@@ -20,16 +30,31 @@ export const SEO_DIMENSION_MAX: Record<SeoDimension, number> = {
   technicalSignals: 10,
 };
 
+/**
+ * `deterministic` checks are computed purely in code (same input → same
+ * points). `qualitative` checks carry a deterministic heuristic baseline but
+ * may be refined by the LLM layer.
+ */
 export type SeoCheckKind = 'deterministic' | 'qualitative';
 
 export interface SeoCheck {
+  /** Stable identifier (e.g. `kw_in_title`). */
   id: string;
   dimension: SeoDimension;
   label: string;
   kind: SeoCheckKind;
+  /** Maximum points this check contributes to its dimension. */
   max: number;
+  /** Points earned (0..max). */
   points: number;
+  /**
+   * `false` when the signal cannot be derived from the supplied input (e.g.
+   * canonical/OG tags live in <head>, page-speed needs a render environment).
+   * Unavailable checks still count 0 toward the raw score but are surfaced so
+   * the caller can renormalise against `maxAvailable`.
+   */
   available: boolean;
+  /** Actionable, human-readable finding used to build suggestions. */
   note: string;
 }
 
@@ -44,25 +69,40 @@ export interface SeoScorecardMeta {
   wordCount: number;
   fleschReadingEase: number;
   targetKeyword: string | null;
+  /**
+   * Word-coverage density: (occurrences × phrase_word_count) / total_words ×
+   * 100, or null when no keyword given.
+   */
   keywordDensity: number | null;
+  /** Whether the LLM qualitative layer was applied. */
   llmApplied: boolean;
+  /** Sum of `max` across available checks (for UI renormalisation). */
   maxAvailable: number;
   scoredAt: string;
 }
 
 export interface SeoScorecard {
+  /** Overall 0-100 score (sum of all checks, rounded). */
   score: number;
   rating: SeoRating;
+  /** Earned points per dimension. */
   breakdown: Record<SeoDimension, number>;
+  /** Prioritised, actionable improvement suggestions. */
   suggestions: string[];
+  /** Per-check detail (deterministic + qualitative). */
   checks: SeoCheck[];
   meta: SeoScorecardMeta;
 }
 
+/**
+ * Persisted scorecard snapshot (e.g. `Article.seoBreakdown`,
+ * `Post.seoBreakdown`) where the overall `score` may not yet be computed.
+ */
 export type SeoScorecardSnapshot = Omit<SeoScorecard, 'score'> & {
   score?: number;
 };
 
+/** Request payload for the score-SEO action. */
 export interface ScoreSeoRequest {
   targetKeyword?: string;
 }


### PR DESCRIPTION
## What

The 8 shared SEO scorecard shapes were defined **identically** in two places:

- `packages/interfaces/src/content/seo-scorecard.interface.ts`
- `apps/server/api/src/services/seo/seo-scorer.types.ts`

Shapes: `SEO_DIMENSIONS`, `SEO_DIMENSION_MAX`, `SeoDimension`, `SeoCheckKind`, `SeoCheck`, `SeoRating`, `SeoScorecardMeta`, `SeoScorecard`.

## Change

- `packages/interfaces` is now the **single source of truth** — it was already the widely-consumed home (client models, frontend services, `Article`/`Post` interfaces via `SeoScorecardSnapshot`/`ScoreSeoRequest`).
- Carried the **richer JSDoc** from the API file across to the canonical file — no documentation lost.
- Re-pointed `seo-scorer.types.ts` to **re-export** the 8 shapes from `@genfeedai/interfaces`.
- The 4 API-internal types (`SeoScorableContent`, `SeoQualitativeLlmResult`, `ScoreContentOptions`, `SeoScorableType`) stay local.

## Blast radius

- The `./seo-scorer.types` import path is **unchanged** → the 3 co-located consumers (`seo-scorer.service.ts`, `seo-scorer.util.ts`, `seo-scorer.service.spec.ts`) need **no edits**.
- `apps/server/api` already depends on `@genfeedai/interfaces` (`workspace:*`).
- Net **−34 lines**; one contract, not two.

Part of the monorepo DRY / consolidation pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)