### PR TITLE
refactor(server): consolidate leaf-service bootstraps into runService()

### DIFF
--- a/apps/server/discord/src/main.ts
+++ b/apps/server/discord/src/main.ts
@@ -1,43 +1,14 @@
-import {
-  bootstrap,
-  setupGracefulShutdown,
-  setupServiceShell,
-} from '@libs/bootstrap';
+import { bootstrap } from '@libs/bootstrap';
 import '@discord/instrument';
 
 bootstrap({ app: 'discord' });
 
-import process from 'node:process';
 import { AppModule } from '@discord/app.module';
 import { ConfigService } from '@discord/config/config.service';
-import { LoggerService } from '@libs/logger/logger.service';
-import { NestFactory } from '@nestjs/core';
-import type { NestExpressApplication } from '@nestjs/platform-express';
+import { runService } from '@libs/bootstrap/run-service';
 
-async function main() {
-  const app = await NestFactory.create<NestExpressApplication>(AppModule, {
-    abortOnError: false,
-    logger: ['error'],
-    snapshot: true,
-  });
-
-  const configService = app.get(ConfigService);
-  const logger = app.get<LoggerService>(LoggerService);
-  const port = configService.get('PORT');
-
-  try {
-    setupServiceShell(app, { redirectTarget: '/v1/health' });
-
-    app.setGlobalPrefix('v1');
-
-    await app.listen(port);
-    logger.debug(`Discord service is running on port ${port}`);
-
-    setupGracefulShutdown();
-  } catch (error: unknown) {
-    logger.error('Failed to start discord service:', error);
-    process.exit(1);
-  }
-}
-
-void main();
+void runService({
+  configService: ConfigService,
+  module: AppModule,
+  serviceName: 'discord',
+});

--- a/apps/server/images/src/main.ts
+++ b/apps/server/images/src/main.ts
@@ -1,42 +1,14 @@
 import '@images/instrument';
-import {
-  bootstrap,
-  setupGracefulShutdown,
-  setupServiceShell,
-} from '@libs/bootstrap';
+import { bootstrap } from '@libs/bootstrap';
 
 bootstrap({ app: 'images' });
 
 import { AppModule } from '@images/app.module';
 import { ConfigService } from '@images/config/config.service';
-import { LoggerService } from '@libs/logger/logger.service';
-import { NestFactory } from '@nestjs/core';
-import type { NestExpressApplication } from '@nestjs/platform-express';
+import { runService } from '@libs/bootstrap/run-service';
 
-async function main() {
-  const app = await NestFactory.create<NestExpressApplication>(AppModule, {
-    abortOnError: false,
-    logger: ['error'],
-    snapshot: true,
-  });
-
-  const configService = app.get(ConfigService);
-  const logger = app.get<LoggerService>(LoggerService);
-  const port = configService.get('PORT');
-
-  try {
-    setupServiceShell(app, { redirectTarget: '/v1/health' });
-
-    app.setGlobalPrefix('v1');
-
-    await app.listen(port);
-    logger.debug(`Images service is running on port ${port}`);
-
-    setupGracefulShutdown();
-  } catch (error: unknown) {
-    logger.error('Failed to start images service:', error);
-    process.exit(1);
-  }
-}
-
-main();
+void runService({
+  configService: ConfigService,
+  module: AppModule,
+  serviceName: 'images',
+});

--- a/apps/server/slack/src/main.ts
+++ b/apps/server/slack/src/main.ts
@@ -1,43 +1,14 @@
-import {
-  bootstrap,
-  setupGracefulShutdown,
-  setupServiceShell,
-} from '@libs/bootstrap';
+import { bootstrap } from '@libs/bootstrap';
 import '@slack/instrument';
 
 bootstrap({ app: 'slack' });
 
-import process from 'node:process';
-import { LoggerService } from '@libs/logger/logger.service';
-import { NestFactory } from '@nestjs/core';
-import type { NestExpressApplication } from '@nestjs/platform-express';
+import { runService } from '@libs/bootstrap/run-service';
 import { AppModule } from '@slack/app.module';
 import { ConfigService } from '@slack/config/config.service';
 
-async function main() {
-  const app = await NestFactory.create<NestExpressApplication>(AppModule, {
-    abortOnError: false,
-    logger: ['error'],
-    snapshot: true,
-  });
-
-  const configService = app.get(ConfigService);
-  const logger = app.get<LoggerService>(LoggerService);
-  const port = configService.get('PORT');
-
-  try {
-    setupServiceShell(app, { redirectTarget: '/v1/health' });
-
-    app.setGlobalPrefix('v1');
-
-    await app.listen(port);
-    logger.debug(`Slack service is running on port ${port}`);
-
-    setupGracefulShutdown();
-  } catch (error: unknown) {
-    logger.error('Failed to start slack service:', error);
-    process.exit(1);
-  }
-}
-
-main();
+void runService({
+  configService: ConfigService,
+  module: AppModule,
+  serviceName: 'slack',
+});

--- a/apps/server/telegram/src/main.ts
+++ b/apps/server/telegram/src/main.ts
@@ -1,45 +1,18 @@
-import {
-  bootstrap,
-  setupGracefulShutdown,
-  setupServiceShell,
-} from '@libs/bootstrap';
+import { bootstrap } from '@libs/bootstrap';
 import '@telegram/instrument';
 
 bootstrap({ app: 'telegram' });
 
-import { LoggerService } from '@libs/logger/logger.service';
-import { NestFactory } from '@nestjs/core';
-import type { NestExpressApplication } from '@nestjs/platform-express';
+import { runService } from '@libs/bootstrap/run-service';
 import { AppModule } from '@telegram/app.module';
 import { ConfigService } from '@telegram/config/config.service';
 
-async function main() {
-  const app = await NestFactory.create<NestExpressApplication>(AppModule, {
-    abortOnError: false,
-    logger: ['error'],
-    snapshot: true,
-  });
-
-  const configService = app.get(ConfigService);
-  const logger = app.get<LoggerService>(LoggerService);
-  const port = configService.get('PORT');
-
-  try {
-    setupServiceShell(app, {
-      redirectPaths: ['/', '/docs'],
-      redirectTarget: '/v1/health',
-    });
-
-    app.setGlobalPrefix('v1');
-
-    await app.listen(port);
-    logger.debug(`Telegram service is running on port ${port}`);
-
-    setupGracefulShutdown();
-  } catch (error: unknown) {
-    logger.error('Failed to start telegram service:', error);
-    process.exit(1);
-  }
-}
-
-void main();
+void runService({
+  configService: ConfigService,
+  module: AppModule,
+  serviceName: 'telegram',
+  shell: {
+    redirectPaths: ['/', '/docs'],
+    redirectTarget: '/v1/health',
+  },
+});

--- a/apps/server/videos/src/main.ts
+++ b/apps/server/videos/src/main.ts
@@ -1,45 +1,18 @@
-import {
-  bootstrap,
-  setupGracefulShutdown,
-  setupServiceShell,
-} from '@libs/bootstrap';
+import { bootstrap } from '@libs/bootstrap';
 import '@videos/instrument';
 
 bootstrap({ app: 'videos' });
 
-import { LoggerService } from '@libs/logger/logger.service';
-import { NestFactory } from '@nestjs/core';
-import type { NestExpressApplication } from '@nestjs/platform-express';
+import { runService } from '@libs/bootstrap/run-service';
 import { AppModule } from '@videos/app.module';
 import { ConfigService } from '@videos/config/config.service';
 
-async function main() {
-  const app = await NestFactory.create<NestExpressApplication>(AppModule, {
-    abortOnError: false,
-    logger: ['error'],
-    snapshot: true,
-  });
-
-  const configService = app.get(ConfigService);
-  const logger = app.get<LoggerService>(LoggerService);
-  const port = configService.get('PORT');
-
-  try {
-    setupServiceShell(app, {
-      redirectPaths: ['/', '/docs'],
-      redirectTarget: '/v1/health',
-    });
-
-    app.setGlobalPrefix('v1');
-
-    await app.listen(port);
-    logger.debug(`Videos service is running on port ${port}`);
-
-    setupGracefulShutdown();
-  } catch (error: unknown) {
-    logger.error('Failed to start videos service:', error);
-    process.exit(1);
-  }
-}
-
-main();
+void runService({
+  configService: ConfigService,
+  module: AppModule,
+  serviceName: 'videos',
+  shell: {
+    redirectPaths: ['/', '/docs'],
+    redirectTarget: '/v1/health',
+  },
+});

--- a/apps/server/voices/src/main.ts
+++ b/apps/server/voices/src/main.ts
@@ -1,45 +1,18 @@
-import {
-  bootstrap,
-  setupGracefulShutdown,
-  setupServiceShell,
-} from '@libs/bootstrap';
+import { bootstrap } from '@libs/bootstrap';
 import '@voices/instrument';
 
 bootstrap({ app: 'voices' });
 
-import { LoggerService } from '@libs/logger/logger.service';
-import { NestFactory } from '@nestjs/core';
-import type { NestExpressApplication } from '@nestjs/platform-express';
+import { runService } from '@libs/bootstrap/run-service';
 import { AppModule } from '@voices/app.module';
 import { ConfigService } from '@voices/config/config.service';
 
-async function main() {
-  const app = await NestFactory.create<NestExpressApplication>(AppModule, {
-    abortOnError: false,
-    logger: ['error'],
-    snapshot: true,
-  });
-
-  const configService = app.get(ConfigService);
-  const logger = app.get<LoggerService>(LoggerService);
-  const port = configService.get('PORT');
-
-  try {
-    setupServiceShell(app, {
-      redirectPaths: ['/', '/docs'],
-      redirectTarget: '/v1/health',
-    });
-
-    app.setGlobalPrefix('v1');
-
-    await app.listen(port);
-    logger.debug(`Voices service is running on port ${port}`);
-
-    setupGracefulShutdown();
-  } catch (error: unknown) {
-    logger.error('Failed to start voices service:', error);
-    process.exit(1);
-  }
-}
-
-main();
+void runService({
+  configService: ConfigService,
+  module: AppModule,
+  serviceName: 'voices',
+  shell: {
+    redirectPaths: ['/', '/docs'],
+    redirectTarget: '/v1/health',
+  },
+});

--- a/packages/libs/bootstrap/run-service.ts
+++ b/packages/libs/bootstrap/run-service.ts
@@ -1,0 +1,74 @@
+import { LoggerService } from '@libs/logger/logger.service';
+import type { Type } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+import type { NestExpressApplication } from '@nestjs/platform-express';
+import {
+  type ServiceShellOptions,
+  setupGracefulShutdown,
+  setupServiceShell,
+} from './env-loader';
+
+/** Minimal ConfigService shape the runner needs — just the `PORT` lookup. */
+interface PortConfigService {
+  get(key: string): string;
+}
+
+export interface RunServiceOptions {
+  /** Root application module to instantiate. */
+  module: Type;
+  /** Service `ConfigService` class; resolved from the DI container to read `PORT`. */
+  configService: Type<PortConfigService>;
+  /** Lowercase service id used in startup/error log lines (e.g. `images`). */
+  serviceName: string;
+  /**
+   * Service shell (trust-proxy + root health redirect) options. Defaults to a
+   * single `/` → `/v1/health` redirect; pass explicit `redirectPaths` for
+   * services that also redirect `/docs`.
+   */
+  shell?: ServiceShellOptions;
+  /** Global route prefix (default `v1`). */
+  globalPrefix?: string;
+}
+
+/**
+ * Standard Nest HTTP-service bootstrap shared by the leaf backend services
+ * (images, discord, slack, telegram, videos, voices).
+ *
+ * Each `main.ts` still owns its Sentry `instrument` import and
+ * `bootstrap({ app })` env call — those must run before this module and the
+ * AppModule are imported — then delegates the otherwise-identical
+ * NestFactory → listen → graceful-shutdown flow here.
+ */
+export async function runService(options: RunServiceOptions): Promise<void> {
+  const {
+    module,
+    configService,
+    serviceName,
+    shell = { redirectTarget: '/v1/health' },
+    globalPrefix = 'v1',
+  } = options;
+
+  const app = await NestFactory.create<NestExpressApplication>(module, {
+    abortOnError: false,
+    logger: ['error'],
+    snapshot: true,
+  });
+
+  const config = app.get(configService);
+  const logger = app.get(LoggerService);
+  const port = config.get('PORT');
+
+  try {
+    setupServiceShell(app, shell);
+
+    app.setGlobalPrefix(globalPrefix);
+
+    await app.listen(port);
+    logger.debug(`${serviceName} service is running on port ${port}`);
+
+    setupGracefulShutdown();
+  } catch (error: unknown) {
+    logger.error(`Failed to start ${serviceName} service:`, error);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## What

The six leaf backend HTTP services — **images, discord, slack, telegram, videos, voices** — had byte-identical `main()` bodies. This extracts that flow into a single `runService()` helper in `@libs/bootstrap`.

Net: **-221 / +128** across 7 files; each entrypoint drops from ~44 lines to ~14.

## Why

`main()` in all six was the same `NestFactory.create` (same options) → `PORT` lookup → `setupServiceShell` → `setGlobalPrefix('v1')` → `listen` → startup log → `setupGracefulShutdown`, with identical `catch → logger.error → process.exit(1)`. The only real variation points are the module, the config class, the service name, and (for 3 of them) the redirect paths.

## How

- New `runService(RunServiceOptions)` in `packages/libs/bootstrap/run-service.ts`.
- Each `main.ts` **keeps its own `instrument` import and `bootstrap({ app })` env call** — these must run before the `AppModule` is imported (Sentry init + env load ordering). `runService` is imported from the `@libs/bootstrap/run-service` **subpath**, placed *after* `bootstrap()` — the same position the `AppModule` import held — so module load ordering is unchanged. It is deliberately **not** re-exported from the `@libs/bootstrap` barrel, to keep the pre-`bootstrap()` `import { bootstrap }` free of `NestFactory`.

## Behavior preservation

- `shell` defaults to a single `/` → `/v1/health` redirect (images/discord/slack). **telegram/videos/voices** pass explicit `redirectPaths: ['/', '/docs']` — preserved exactly.
- **One intentional cosmetic change:** the startup debug log now uses the lowercase service id for all six (e.g. `images service is running` instead of `Images service is running`). The error line was already lowercase; this just makes the pair consistent. Log text is not a contract.
- Dropped now-unused imports from the six entrypoints: `node:process`, `LoggerService`, `NestFactory`, `NestExpressApplication`.

## Notes

- `@nestjs/core` (for `NestFactory`) resolves via workspace hoisting, matching how `@nestjs/common` is already used in `@libs/logger/logger.service` without a `libs` `package.json` dep entry — so no manifest change.
- Not touched: `notifications`, `files`, `workers`, `mcp`, `api` — these have custom bootstraps (Redis adapter, CORS, custom health routes) and don't fit the shared shape.

Part of the monorepo DRY consolidation pass.