### PR TITLE
refactor(queues): extract idempotent-enqueue precheck into shared reserveIdempotentJob helper

### DIFF
--- a/apps/server/api/src/queues/agent-run/agent-run-queue.service.ts
+++ b/apps/server/api/src/queues/agent-run/agent-run-queue.service.ts
@@ -9,6 +9,7 @@
 import { ActionOrigin } from '@genfeedai/enums';
 import { AGENT_RUN_QUEUE, AgentRunJobData } from '@genfeedai/queue-contracts';
 import {
+  reserveIdempotentJob,
   resolveNestedActionOrigin,
   sanitizeActionOriginContext,
 } from '@genfeedai/server';
@@ -47,17 +48,13 @@ export class AgentRunQueueService implements OnModuleInit {
       ),
     };
 
-    // Check for existing job to prevent duplicates
-    const existingJob = await this.agentRunQueue.getJob(jobId);
-    if (existingJob) {
-      const state = await existingJob.getState();
-      if (['active', 'waiting', 'delayed'].includes(state)) {
-        this.logger.warn(
-          `${url} agent run ${data.runId} already queued (${state})`,
-        );
-        return jobId;
-      }
-      await existingJob.remove();
+    // Prevent duplicate runs sharing the deterministic job id.
+    const reservation = await reserveIdempotentJob(this.agentRunQueue, jobId);
+    if (reservation.alreadyQueued) {
+      this.logger.warn(
+        `${url} agent run ${data.runId} already queued (${reservation.state})`,
+      );
+      return jobId;
     }
 
     const job = await this.agentRunQueue.add('execute-agent-run', payload, {

--- a/apps/server/api/src/queues/campaign/campaign-queue.service.ts
+++ b/apps/server/api/src/queues/campaign/campaign-queue.service.ts
@@ -13,6 +13,7 @@ import {
   CAMPAIGN_PROCESSING_QUEUE,
   CampaignProcessingJobData,
 } from '@genfeedai/queue-contracts';
+import { reserveIdempotentJob } from '@genfeedai/server';
 import { LoggerService } from '@libs/logger/logger.service';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
 import { InjectQueue } from '@nestjs/bullmq';
@@ -106,19 +107,14 @@ export class CampaignQueueService implements OnModuleInit {
     const jobId = `campaign-${campaignId}`;
 
     try {
-      // Check if job already exists by trying to get it
-      const existingJob = await this.campaignQueue.getJob(jobId);
-      if (existingJob) {
-        const state = await existingJob.getState();
-        if (state === 'active' || state === 'waiting' || state === 'delayed') {
-          this.logger.log(
-            `${this.constructorName} skipping - job already queued`,
-            { campaignId, jobId, state },
-          );
-          return { id: undefined };
-        }
-        // Job exists but in completed/failed state - remove it to allow new job
-        await existingJob.remove();
+      // Check if job already exists to prevent duplicate processing.
+      const reservation = await reserveIdempotentJob(this.campaignQueue, jobId);
+      if (reservation.alreadyQueued) {
+        this.logger.log(
+          `${this.constructorName} skipping - job already queued`,
+          { campaignId, jobId, state: reservation.state },
+        );
+        return { id: undefined };
       }
 
       return this.campaignQueue.add(

--- a/apps/server/api/src/services/agent-campaign/campaign-memory-queue.service.ts
+++ b/apps/server/api/src/services/agent-campaign/campaign-memory-queue.service.ts
@@ -3,6 +3,7 @@ import {
   CAMPAIGN_MEMORY_EXTRACTION_QUEUE,
   CampaignMemoryExtractionJobData,
 } from '@genfeedai/queue-contracts';
+import { reserveIdempotentJob } from '@genfeedai/server';
 import { LoggerService } from '@libs/logger/logger.service';
 import { InjectQueue } from '@nestjs/bullmq';
 import { Injectable } from '@nestjs/common';
@@ -25,23 +26,20 @@ export class CampaignMemoryQueueService {
     scheduledAt?: Date;
   }): Promise<string> {
     const jobId = `campaign-memory-${data.campaignId}`;
-    const existingJob = await this.campaignMemoryQueue.getJob(jobId);
-
-    if (existingJob) {
-      const state = await existingJob.getState();
-      if (['active', 'waiting', 'delayed'].includes(state)) {
-        this.logger.warn(
-          `${this.logContext} campaign extraction already queued`,
-          {
-            campaignId: data.campaignId,
-            jobId,
-            state,
-          },
-        );
-        return jobId;
-      }
-
-      await existingJob.remove();
+    const reservation = await reserveIdempotentJob(
+      this.campaignMemoryQueue,
+      jobId,
+    );
+    if (reservation.alreadyQueued) {
+      this.logger.warn(
+        `${this.logContext} campaign extraction already queued`,
+        {
+          campaignId: data.campaignId,
+          jobId,
+          state: reservation.state,
+        },
+      );
+      return jobId;
     }
 
     const scheduledAt = data.scheduledAt ?? new Date();

--- a/apps/server/api/src/services/agent-campaign/orchestrator-queue.service.ts
+++ b/apps/server/api/src/services/agent-campaign/orchestrator-queue.service.ts
@@ -3,6 +3,7 @@ import {
   ORCHESTRATOR_RUN_QUEUE,
   OrchestratorRunJobData,
 } from '@genfeedai/queue-contracts';
+import { reserveIdempotentJob } from '@genfeedai/server';
 import { LoggerService } from '@libs/logger/logger.service';
 import { InjectQueue } from '@nestjs/bullmq';
 import { Injectable } from '@nestjs/common';
@@ -25,20 +26,17 @@ export class OrchestratorQueueService {
     scheduledAt?: Date;
   }): Promise<string> {
     const jobId = `orchestrator-run-${data.campaignId}`;
-    const existingJob = await this.orchestratorQueue.getJob(jobId);
-
-    if (existingJob) {
-      const state = await existingJob.getState();
-      if (['active', 'waiting', 'delayed'].includes(state)) {
-        this.logger.warn(`${this.logContext} campaign already queued`, {
-          campaignId: data.campaignId,
-          jobId,
-          state,
-        });
-        return jobId;
-      }
-
-      await existingJob.remove();
+    const reservation = await reserveIdempotentJob(
+      this.orchestratorQueue,
+      jobId,
+    );
+    if (reservation.alreadyQueued) {
+      this.logger.warn(`${this.logContext} campaign already queued`, {
+        campaignId: data.campaignId,
+        jobId,
+        state: reservation.state,
+      });
+      return jobId;
     }
 
     const scheduledAt = data.scheduledAt ?? new Date();

--- a/apps/server/api/src/services/agent-campaign/trigger-evaluator-queue.service.ts
+++ b/apps/server/api/src/services/agent-campaign/trigger-evaluator-queue.service.ts
@@ -3,6 +3,7 @@ import {
   TRIGGER_EVALUATION_QUEUE,
   TriggerEvaluationJobData,
 } from '@genfeedai/queue-contracts';
+import { reserveIdempotentJob } from '@genfeedai/server';
 import { LoggerService } from '@libs/logger/logger.service';
 import { InjectQueue } from '@nestjs/bullmq';
 import { Injectable } from '@nestjs/common';
@@ -25,20 +26,17 @@ export class TriggerEvaluatorQueueService {
     scheduledAt?: Date;
   }): Promise<string> {
     const jobId = `trigger-evaluation-${data.campaignId}`;
-    const existingJob = await this.triggerEvaluationQueue.getJob(jobId);
-
-    if (existingJob) {
-      const state = await existingJob.getState();
-      if (['active', 'waiting', 'delayed'].includes(state)) {
-        this.logger.warn(`${this.logContext} campaign already queued`, {
-          campaignId: data.campaignId,
-          jobId,
-          state,
-        });
-        return jobId;
-      }
-
-      await existingJob.remove();
+    const reservation = await reserveIdempotentJob(
+      this.triggerEvaluationQueue,
+      jobId,
+    );
+    if (reservation.alreadyQueued) {
+      this.logger.warn(`${this.logContext} campaign already queued`, {
+        campaignId: data.campaignId,
+        jobId,
+        state: reservation.state,
+      });
+      return jobId;
     }
 
     const scheduledAt = data.scheduledAt ?? new Date();

--- a/apps/server/api/src/services/task-orchestration/workspace-task-queue.service.ts
+++ b/apps/server/api/src/services/task-orchestration/workspace-task-queue.service.ts
@@ -2,6 +2,7 @@ import {
   WORKSPACE_TASK_QUEUE,
   WorkspaceTaskJobData,
 } from '@genfeedai/queue-contracts';
+import { reserveIdempotentJob } from '@genfeedai/server';
 import { LoggerService } from '@libs/logger/logger.service';
 import { InjectQueue } from '@nestjs/bullmq';
 import { Injectable } from '@nestjs/common';
@@ -24,17 +25,13 @@ export class WorkspaceTaskQueueService {
   async enqueue(data: WorkspaceTaskJobData): Promise<string> {
     const jobId = `workspace-task-${data.taskId}`;
 
-    // Prevent duplicate jobs
-    const existing = await this.queue.getJob(jobId);
-    if (existing) {
-      const state = await existing.getState();
-      if (['active', 'waiting', 'delayed'].includes(state)) {
-        this.logger.warn(
-          `${this.logContext}: Task ${data.taskId} already queued (${state})`,
-        );
-        return jobId;
-      }
-      await existing.remove();
+    // Prevent duplicate jobs sharing the deterministic job id.
+    const reservation = await reserveIdempotentJob(this.queue, jobId);
+    if (reservation.alreadyQueued) {
+      this.logger.warn(
+        `${this.logContext}: Task ${data.taskId} already queued (${reservation.state})`,
+      );
+      return jobId;
     }
 
     const job = await this.queue.add('orchestrate-task', data, {

--- a/apps/server/server/src/index.ts
+++ b/apps/server/server/src/index.ts
@@ -91,6 +91,10 @@ export {
   PublishApprovalsService,
   type PublishExecutionClaim,
 } from './publish-approvals/publish-approvals.service';
+export {
+  type IdempotentJobReservation,
+  reserveIdempotentJob,
+} from './queues/idempotent-job';
 export { PostPublishQueueService } from './queues/post-publish/post-publish-queue.service';
 export {
   SERVER_TOKENS,

--- a/apps/server/server/src/queues/idempotent-job.spec.ts
+++ b/apps/server/server/src/queues/idempotent-job.spec.ts
@@ -1,0 +1,62 @@
+import { reserveIdempotentJob } from './idempotent-job';
+
+interface FakeJob {
+  getState: () => Promise<string>;
+  remove: () => Promise<void>;
+}
+
+function fakeQueue(job: FakeJob | undefined) {
+  const removed: string[] = [];
+  const queue = {
+    getJob: async (id: string) => {
+      if (!job) return undefined;
+      return {
+        getState: job.getState,
+        remove: async () => {
+          removed.push(id);
+          await job.remove();
+        },
+      };
+    },
+    // biome-ignore lint/suspicious/noExplicitAny: minimal structural stub for the Queue surface used by the helper
+  } as any;
+  return { queue, removed };
+}
+
+describe('reserveIdempotentJob', () => {
+  it('allows enqueue when no job exists for the id', async () => {
+    const { queue } = fakeQueue(undefined);
+
+    const result = await reserveIdempotentJob(queue, 'job-1');
+
+    expect(result).toEqual({ alreadyQueued: false });
+  });
+
+  for (const state of ['active', 'waiting', 'delayed']) {
+    it(`refuses enqueue and preserves an in-flight job (${state})`, async () => {
+      const { queue, removed } = fakeQueue({
+        getState: async () => state,
+        remove: async () => undefined,
+      });
+
+      const result = await reserveIdempotentJob(queue, 'job-1');
+
+      expect(result).toEqual({ alreadyQueued: true, state });
+      expect(removed).toEqual([]);
+    });
+  }
+
+  for (const state of ['completed', 'failed', 'unknown']) {
+    it(`removes a stale job and allows enqueue (${state})`, async () => {
+      const { queue, removed } = fakeQueue({
+        getState: async () => state,
+        remove: async () => undefined,
+      });
+
+      const result = await reserveIdempotentJob(queue, 'job-1');
+
+      expect(result).toEqual({ alreadyQueued: false });
+      expect(removed).toEqual(['job-1']);
+    });
+  }
+});

--- a/apps/server/server/src/queues/idempotent-job.ts
+++ b/apps/server/server/src/queues/idempotent-job.ts
@@ -1,0 +1,48 @@
+import type { Queue } from 'bullmq';
+
+/**
+ * Job states that represent an in-flight job which must NOT be superseded by a
+ * duplicate enqueue under the same deterministic id. A job in any other state
+ * (completed/failed/etc.) is stale and gets removed so a fresh job can reclaim
+ * the id.
+ */
+const ACTIVE_JOB_STATES = new Set<string>(['active', 'waiting', 'delayed']);
+
+export type IdempotentJobReservation =
+  | { alreadyQueued: true; state: string }
+  | { alreadyQueued: false };
+
+/**
+ * Reserve a deterministic BullMQ job id.
+ *
+ * Looks up an existing job by id: if it is still in flight
+ * (active/waiting/delayed) the reservation is refused so the caller can skip the
+ * enqueue; if it exists in any terminal/stale state it is removed so the caller
+ * can re-add under the same id. Returns whether the caller should proceed to
+ * enqueue.
+ *
+ * Extracted from the byte-identical precheck that was copied across every
+ * deterministic-id queue service. Callers keep their own `queue.add(...)`
+ * options, log messages, and return values — this owns only the precheck.
+ */
+export async function reserveIdempotentJob<
+  DataType = unknown,
+  ResultType = unknown,
+  NameType extends string = string,
+>(
+  queue: Queue<DataType, ResultType, NameType>,
+  jobId: string,
+): Promise<IdempotentJobReservation> {
+  const existingJob = await queue.getJob(jobId);
+  if (!existingJob) {
+    return { alreadyQueued: false };
+  }
+
+  const state = await existingJob.getState();
+  if (ACTIVE_JOB_STATES.has(state)) {
+    return { alreadyQueued: true, state };
+  }
+
+  await existingJob.remove();
+  return { alreadyQueued: false };
+}


### PR DESCRIPTION
## What

Six API queue services each carried a **byte-identical** BullMQ precheck before enqueue:

```ts
const existing = await queue.getJob(jobId);
if (existing) {
  const state = await existing.getState();
  if (['active', 'waiting', 'delayed'].includes(state)) { /* already queued */ }
  else { await existing.remove(); }
}
```

This extracts that logic once into `reserveIdempotentJob` in `@genfeedai/server` (already an `api` dependency carrying `bullmq`) and rewires all six callers to it.

## Why

Pure DRY consolidation. The idempotent-enqueue idiom — reserve a deterministic job id, keep an in-flight job, evict a stale one — was copy-pasted across 6 services with only the log message differing. One helper, one place to reason about job-state semantics.

## Behavior preserved

Each caller keeps its **own** `.add()` options, log message, and return shape. The helper owns only the precheck and returns a discriminated result (`{ alreadyQueued: true; state }` | `{ alreadyQueued: false }`); callers decide what to log and return. No runtime behavior change.

## Callers rewired

- `queues/agent-run/agent-run-queue.service.ts`
- `queues/campaign/campaign-queue.service.ts`
- `services/agent-campaign/orchestrator-queue.service.ts`
- `services/agent-campaign/campaign-memory-queue.service.ts`
- `services/agent-campaign/trigger-evaluator-queue.service.ts`
- `services/task-orchestration/workspace-task-queue.service.ts`

## Tests

Adds `idempotent-job.spec.ts` covering the full state matrix: no job → allow; active/waiting/delayed → refuse + not removed; completed/failed/unknown → remove + allow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)