### PR TITLE
fix(webhooks): authenticate Leonardo.AI callbacks with a shared secret

### DIFF
--- a/apps/server/api/src/endpoints/webhooks/leonardoai/webhooks.leonardoai.constants.ts
+++ b/apps/server/api/src/endpoints/webhooks/leonardoai/webhooks.leonardoai.constants.ts
@@ -1,0 +1,33 @@
+/**
+ * Last-known Leonardo.AI egress addresses.
+ *
+ * Leonardo does not publish a stable CIDR range and rotates these without
+ * notice, so this list is only a fallback for deployments that have not yet
+ * provisioned `LEONARDO_WEBHOOK_SECRET`. Once a secret is configured the
+ * shared secret is the gate and the allowlist is opt-in via
+ * `LEONARDO_WEBHOOK_ALLOWED_IPS`, which is changeable without a deploy.
+ */
+export const LEONARDOAI_DEFAULT_ALLOWED_IPS: readonly string[] = [
+  '35.173.108.170',
+  '34.239.69.60',
+  '52.73.75.186',
+  '3.229.99.26',
+  '44.218.0.197',
+  '174.129.230.221',
+];
+
+/**
+ * Parse a comma-separated allowlist from config. Returns an empty array when
+ * the value is unset or contains no usable entries, which callers treat as
+ * "no explicit allowlist configured".
+ */
+export function parseAllowedIps(rawValue: string | undefined): string[] {
+  if (!rawValue) {
+    return [];
+  }
+
+  return rawValue
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}

--- a/apps/server/api/src/endpoints/webhooks/leonardoai/webhooks.leonardoai.controller.spec.ts
+++ b/apps/server/api/src/endpoints/webhooks/leonardoai/webhooks.leonardoai.controller.spec.ts
@@ -2,7 +2,9 @@ import { LeonardoaiWebhookController } from '@api/endpoints/webhooks/leonardoai/
 import { LeonardoaiWebhookService } from '@api/endpoints/webhooks/leonardoai/webhooks.leonardoai.service';
 import { WebhooksService } from '@api/endpoints/webhooks/webhooks.service';
 import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
+import { ConfigService } from '@libs/config/config.service';
 import { LoggerService } from '@libs/logger/logger.service';
+import { UnauthorizedException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import type { Request } from 'express';
 
@@ -12,21 +14,46 @@ vi.mock('@libs/utils/caller/caller.util', () => ({
   },
 }));
 
+const WEBHOOK_SECRET = 'leonardo-webhook-secret';
+
 describe('LeonardoaiWebhookController', () => {
   let controller: LeonardoaiWebhookController;
   let leonardoaiWebhookService: vi.Mocked<LeonardoaiWebhookService>;
   let loggerService: vi.Mocked<LoggerService>;
+  let webhooksService: vi.Mocked<WebhooksService>;
+  let configValues: Record<string, string | undefined>;
 
-  // Use a known allowed IP from the controller allowlist
-  const mockRequest = {
-    headers: { 'x-forwarded-for': '35.173.108.170' },
-    ip: '35.173.108.170',
-  } as unknown as Request;
+  function requestFrom(options: {
+    authorization?: string;
+    ip?: string;
+  }): Request {
+    return {
+      headers: options.authorization
+        ? { authorization: options.authorization }
+        : {},
+      ip: options.ip ?? '203.0.113.10',
+      query: {},
+    } as unknown as Request;
+  }
+
+  // Authenticated request from an address that is NOT on the shipped vendor
+  // list — the rotation case the previous hardcoded allowlist rejected.
+  const authenticatedRequest = requestFrom({
+    authorization: `Bearer ${WEBHOOK_SECRET}`,
+  });
 
   beforeEach(async () => {
+    configValues = { LEONARDO_WEBHOOK_SECRET: WEBHOOK_SECRET };
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [LeonardoaiWebhookController],
       providers: [
+        {
+          provide: ConfigService,
+          useValue: {
+            get: vi.fn((key: string) => configValues[key]),
+          },
+        },
         {
           provide: LeonardoaiWebhookService,
           useValue: {
@@ -58,6 +85,7 @@ describe('LeonardoaiWebhookController', () => {
     );
     leonardoaiWebhookService = module.get(LeonardoaiWebhookService);
     loggerService = module.get(LoggerService);
+    webhooksService = module.get(WebhooksService);
   });
 
   it('should be defined', () => {
@@ -65,7 +93,7 @@ describe('LeonardoaiWebhookController', () => {
   });
 
   describe('handleCallback', () => {
-    it('should handle callback successfully from allowed IP', async () => {
+    it('should handle callback successfully with a valid webhook token', async () => {
       const body = {
         customId: undefined,
         data: { object: { id: 'gen_123', images: [] } },
@@ -73,7 +101,10 @@ describe('LeonardoaiWebhookController', () => {
       };
       leonardoaiWebhookService.handleCallback.mockResolvedValue(undefined);
 
-      const result = await controller.handleCallback(mockRequest, body);
+      const result = await controller.handleCallback(
+        authenticatedRequest,
+        body,
+      );
 
       expect(loggerService.log).toHaveBeenCalledWith(
         'LeonardoaiWebhookController leonardoai callback received',
@@ -85,6 +116,31 @@ describe('LeonardoaiWebhookController', () => {
       });
     });
 
+    it('should reject a request with no webhook token', async () => {
+      const body = {
+        data: { object: { id: 'gen_123', images: [] } },
+        type: 'image-generation.complete',
+      };
+
+      await expect(
+        controller.handleCallback(requestFrom({}), body),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    it('should reject a request with a wrong webhook token', async () => {
+      const body = {
+        data: { object: { id: 'gen_123', images: [] } },
+        type: 'image-generation.complete',
+      };
+
+      await expect(
+        controller.handleCallback(
+          requestFrom({ authorization: 'Bearer not-the-secret' }),
+          body,
+        ),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
     it('should invoke leonardoaiWebhookService when customId is present', async () => {
       const body = {
         customId: 'custom_123',
@@ -93,18 +149,108 @@ describe('LeonardoaiWebhookController', () => {
       };
       leonardoaiWebhookService.handleCallback.mockResolvedValue(undefined);
 
-      await controller.handleCallback(mockRequest, body);
+      await controller.handleCallback(authenticatedRequest, body);
 
       expect(leonardoaiWebhookService.handleCallback).toHaveBeenCalledWith(
         body,
       );
     });
 
-    it('should throw when request comes from unauthorized IP', async () => {
-      const unauthorizedRequest = {
-        headers: {},
-        ip: '1.2.3.4',
-      } as unknown as Request;
+    it('should dispatch the matching generated image for download', async () => {
+      const body = {
+        data: {
+          object: {
+            id: 'gen_789',
+            images: [
+              {
+                generationId: 'other',
+                url: 'https://cdn.leonardo.ai/other.png',
+              },
+              {
+                generationId: 'gen_789',
+                url: 'https://cdn.leonardo.ai/hit.png',
+              },
+            ],
+          },
+        },
+        type: 'image-generation.complete',
+      };
+
+      await controller.handleCallback(authenticatedRequest, body);
+
+      expect(webhooksService.processMediaFromWebhook).toHaveBeenCalledWith(
+        'leonardoai',
+        expect.anything(),
+        'gen_789',
+        'https://cdn.leonardo.ai/hit.png',
+      );
+    });
+
+    it('should acknowledge a malformed payload without throwing', async () => {
+      const body = {
+        data: undefined,
+        type: 'image-generation.complete',
+      };
+
+      const result = await controller.handleCallback(
+        authenticatedRequest,
+        body,
+      );
+
+      expect(result).toEqual({
+        message: 'Webhook payload ignored',
+        success: false,
+      });
+      expect(loggerService.warn).toHaveBeenCalledWith(
+        'LeonardoaiWebhookController leonardoai callback payload missing data.object',
+        { type: 'image-generation.complete' },
+      );
+      expect(webhooksService.processMediaFromWebhook).not.toHaveBeenCalled();
+    });
+
+    it('should acknowledge a payload whose data envelope has no object', async () => {
+      const body = { data: {}, type: 'image-generation.complete' };
+
+      await expect(
+        controller.handleCallback(authenticatedRequest, body),
+      ).resolves.toEqual({
+        message: 'Webhook payload ignored',
+        success: false,
+      });
+    });
+
+    it('should enforce the configured IP allowlist as defence in depth', async () => {
+      configValues.LEONARDO_WEBHOOK_ALLOWED_IPS = '198.51.100.4, 198.51.100.5';
+
+      const body = {
+        data: { object: { id: 'gen_ip', images: [] } },
+        type: 'image-generation.complete',
+      };
+
+      await expect(
+        controller.handleCallback(authenticatedRequest, body),
+      ).rejects.toThrow('Unauthorized webhook request');
+
+      expect(loggerService.warn).toHaveBeenCalledWith(
+        'Unauthorized webhook request from IP: 203.0.113.10',
+      );
+
+      await expect(
+        controller.handleCallback(
+          requestFrom({
+            authorization: `Bearer ${WEBHOOK_SECRET}`,
+            ip: '198.51.100.5',
+          }),
+          body,
+        ),
+      ).resolves.toEqual({
+        message: 'Webhook processed successfully',
+        success: true,
+      });
+    });
+
+    it('should fall back to the vendor IP list when no secret is configured', async () => {
+      configValues.LEONARDO_WEBHOOK_SECRET = undefined;
 
       const body = {
         data: { object: { id: 'gen_789', images: [] } },
@@ -112,12 +258,19 @@ describe('LeonardoaiWebhookController', () => {
       };
 
       await expect(
-        controller.handleCallback(unauthorizedRequest, body),
+        controller.handleCallback(requestFrom({ ip: '1.2.3.4' }), body),
       ).rejects.toThrow('Unauthorized webhook request');
 
       expect(loggerService.warn).toHaveBeenCalledWith(
         'Unauthorized webhook request from IP: 1.2.3.4',
       );
+
+      await expect(
+        controller.handleCallback(requestFrom({ ip: '35.173.108.170' }), body),
+      ).resolves.toEqual({
+        message: 'Webhook processed successfully',
+        success: true,
+      });
     });
 
     it('should rethrow error when callback handling fails', async () => {
@@ -130,7 +283,7 @@ describe('LeonardoaiWebhookController', () => {
       leonardoaiWebhookService.handleCallback.mockRejectedValue(error);
 
       await expect(
-        controller.handleCallback(mockRequest, body),
+        controller.handleCallback(authenticatedRequest, body),
       ).rejects.toThrow('Generation processing failed');
 
       expect(loggerService.error).toHaveBeenCalledWith(

--- a/apps/server/api/src/endpoints/webhooks/leonardoai/webhooks.leonardoai.controller.ts
+++ b/apps/server/api/src/endpoints/webhooks/leonardoai/webhooks.leonardoai.controller.ts
@@ -1,7 +1,12 @@
+import {
+  LEONARDOAI_DEFAULT_ALLOWED_IPS,
+  parseAllowedIps,
+} from '@api/endpoints/webhooks/leonardoai/webhooks.leonardoai.constants';
 import { LeonardoaiWebhookService } from '@api/endpoints/webhooks/leonardoai/webhooks.leonardoai.service';
 import { WebhooksService } from '@api/endpoints/webhooks/webhooks.service';
 import { AutoSwagger } from '@api/helpers/decorators/swagger/auto-swagger.decorator';
 import { IngredientCategory } from '@genfeedai/enums';
+import { ConfigService } from '@libs/config/config.service';
 import { Public } from '@libs/decorators/public.decorator';
 import { LeonardoAIWebhookPayload } from '@libs/interfaces/webhook-payload.interface';
 import { LoggerService } from '@libs/logger/logger.service';
@@ -14,6 +19,7 @@ import {
   Req,
   UnauthorizedException,
 } from '@nestjs/common';
+import { assertWebhookToken } from '@server/webhooks/webhook-token.util';
 import type { Request } from 'express';
 
 @AutoSwagger()
@@ -23,6 +29,7 @@ export class LeonardoaiWebhookController {
   private readonly constructorName: string = String(this.constructor.name);
 
   constructor(
+    private readonly configService: ConfigService,
     private readonly loggerService: LoggerService,
     private readonly leonardoaiWebhookService: LeonardoaiWebhookService,
     private readonly webhooksService: WebhooksService,
@@ -36,30 +43,32 @@ export class LeonardoaiWebhookController {
   ) {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
 
+    const configuredSecret = this.configService.get(
+      'LEONARDO_WEBHOOK_SECRET',
+    ) as string | undefined;
+
+    // Leonardo.AI has no HMAC scheme; it presents the webhook callback API key
+    // registered against the production API key as `Authorization: Bearer`.
+    // @Public() short-circuits CombinedAuthGuard, so that header reaches us
+    // untouched.
+    assertWebhookToken({
+      acceptBearerHeader: true,
+      configuredSecret,
+      loggerService: this.loggerService,
+      request,
+      url,
+    });
+
+    // request.ip is derived safely by Express under `trust proxy 1`.
+    // Reading x-forwarded-for directly is spoofable: an attacker sends
+    // 'X-Forwarded-For: <allowed-ip>, <self>' and the first-token split
+    // yields the allowed IP.
+    const requestIp: string = request.ip || '';
+
+    this.assertAllowedIp(requestIp, Boolean(configuredSecret));
+
     try {
       this.loggerService.log(`${url} received`, payload);
-      // request.ip is derived safely by Express under `trust proxy 1`.
-      // Reading x-forwarded-for directly is spoofable: an attacker sends
-      // 'X-Forwarded-For: <allowed-ip>, <self>' and the first-token split
-      // yields the allowed IP.
-      const requestIp: string = request.ip || '';
-
-      // Verify that the request is coming from LeonardoAI's IP addresses
-      const allowedIps = [
-        '35.173.108.170',
-        '34.239.69.60',
-        '52.73.75.186',
-        '3.229.99.26',
-        '44.218.0.197',
-        '174.129.230.221',
-      ];
-
-      if (!allowedIps.includes(requestIp)) {
-        this.loggerService.warn(
-          `Unauthorized webhook request from IP: ${requestIp}`,
-        );
-        throw new UnauthorizedException('Unauthorized webhook request');
-      }
 
       // Handle metadata-based webhook processing if customId is present
       const customId = payload?.customId;
@@ -68,30 +77,31 @@ export class LeonardoaiWebhookController {
       }
 
       const type = payload.type;
-      // @ts-expect-error TS2571
-      const images = (
-        payload.data as Record<string, unknown> as Record<string, unknown>
-      ).object.images;
-      // @ts-expect-error TS2571
-      const generatedId = (
-        payload.data as Record<string, unknown> as Record<string, unknown>
-      ).object.id;
+      const generation = payload.data?.object;
+
+      // The vendor envelope is not contractual — a payload without
+      // `data.object` is logged and acknowledged rather than thrown, so a
+      // shape change never turns into a 500 and a vendor retry storm.
+      if (!generation) {
+        this.loggerService.warn(`${url} payload missing data.object`, { type });
+
+        return { message: 'Webhook payload ignored', success: false };
+      }
+
+      const generatedId = generation.id;
+      const images = Array.isArray(generation.images) ? generation.images : [];
 
       this.loggerService.log('Received webhook from LeonardoAI', {
         generatedId,
         type,
       });
 
-      if (type === 'image-generation.complete') {
+      if (type === 'image-generation.complete' && generatedId) {
         const generatedImage = images.find(
-          (image: unknown) =>
-            typeof image === 'object' &&
-            image !== null &&
-            'generationId' in image &&
-            image.generationId === generatedId,
+          (image) => image?.generationId === generatedId,
         );
 
-        if (generatedImage) {
+        if (generatedImage?.url) {
           await this.webhooksService.processMediaFromWebhook(
             'leonardoai',
             IngredientCategory.IMAGE,
@@ -106,5 +116,45 @@ export class LeonardoaiWebhookController {
       this.loggerService.error(`${url} failed`, error);
       throw error;
     }
+  }
+
+  /**
+   * Defence in depth on top of the shared secret. Leonardo rotates its egress
+   * addresses without notice, so the allowlist lives in config and is only
+   * enforced when a deployment opts in via `LEONARDO_WEBHOOK_ALLOWED_IPS`.
+   * While no secret is configured we still fall back to the last-known vendor
+   * list, so an un-provisioned deployment keeps today's posture instead of
+   * silently accepting anonymous callbacks.
+   */
+  private assertAllowedIp(
+    requestIp: string,
+    hasConfiguredSecret: boolean,
+  ): void {
+    const allowedIps = this.resolveAllowedIps(hasConfiguredSecret);
+
+    if (allowedIps.length === 0) {
+      return;
+    }
+
+    if (!allowedIps.includes(requestIp)) {
+      this.loggerService.warn(
+        `Unauthorized webhook request from IP: ${requestIp}`,
+      );
+      throw new UnauthorizedException('Unauthorized webhook request');
+    }
+  }
+
+  private resolveAllowedIps(hasConfiguredSecret: boolean): readonly string[] {
+    const configuredIps = parseAllowedIps(
+      this.configService.get('LEONARDO_WEBHOOK_ALLOWED_IPS') as
+        | string
+        | undefined,
+    );
+
+    if (configuredIps.length > 0) {
+      return configuredIps;
+    }
+
+    return hasConfiguredSecret ? [] : LEONARDOAI_DEFAULT_ALLOWED_IPS;
   }
 }

--- a/apps/server/api/src/endpoints/webhooks/leonardoai/webhooks.leonardoai.service.ts
+++ b/apps/server/api/src/endpoints/webhooks/leonardoai/webhooks.leonardoai.service.ts
@@ -45,11 +45,9 @@ export class LeonardoaiWebhookService {
     // Update metadata with callback response
     const updateData: Partial<Record<string, unknown>> = {};
 
-    // @ts-expect-error TS2339
     if (status === 'COMPLETE' && images && images.length > 0) {
       // Store the first image URL as result
-      // @ts-expect-error TS7053
-      updateData.result = images[0].url || JSON.stringify(images);
+      updateData.result = images[0]?.url || JSON.stringify(images);
     }
 
     if (status === 'FAILED') {

--- a/apps/server/api/src/endpoints/webhooks/webhook-token.util.spec.ts
+++ b/apps/server/api/src/endpoints/webhooks/webhook-token.util.spec.ts
@@ -10,13 +10,19 @@ describe('webhook-token.util', () => {
   const loggerService = { warn: vi.fn() } as unknown as LoggerService;
 
   function requestWith(options: {
+    authorization?: string;
     token?: string;
     headerToken?: string;
   }): Request {
     return {
-      headers: options.headerToken
-        ? { 'x-webhook-token': options.headerToken }
-        : {},
+      headers: {
+        ...(options.authorization
+          ? { authorization: options.authorization }
+          : {}),
+        ...(options.headerToken
+          ? { 'x-webhook-token': options.headerToken }
+          : {}),
+      },
       query: options.token ? { token: options.token } : {},
     } as unknown as Request;
   }
@@ -65,6 +71,53 @@ describe('webhook-token.util', () => {
           configuredSecret: 's3cret',
           loggerService,
           request: requestWith({ token: 'wrong-token' }),
+          url: 'test',
+        }),
+      ).toThrow(UnauthorizedException);
+    });
+
+    it('accepts a matching bearer token when opted in', () => {
+      expect(() =>
+        assertWebhookToken({
+          acceptBearerHeader: true,
+          configuredSecret: 's3cret',
+          loggerService,
+          request: requestWith({ authorization: 'Bearer s3cret' }),
+          url: 'test',
+        }),
+      ).not.toThrow();
+    });
+
+    it('ignores a bearer token when not opted in', () => {
+      expect(() =>
+        assertWebhookToken({
+          configuredSecret: 's3cret',
+          loggerService,
+          request: requestWith({ authorization: 'Bearer s3cret' }),
+          url: 'test',
+        }),
+      ).toThrow(UnauthorizedException);
+    });
+
+    it('ignores a non-bearer authorization scheme', () => {
+      expect(() =>
+        assertWebhookToken({
+          acceptBearerHeader: true,
+          configuredSecret: 's3cret',
+          loggerService,
+          request: requestWith({ authorization: 'Basic s3cret' }),
+          url: 'test',
+        }),
+      ).toThrow(UnauthorizedException);
+    });
+
+    it('rejects a wrong bearer token with 401', () => {
+      expect(() =>
+        assertWebhookToken({
+          acceptBearerHeader: true,
+          configuredSecret: 's3cret',
+          loggerService,
+          request: requestWith({ authorization: 'Bearer wrong-token' }),
           url: 'test',
         }),
       ).toThrow(UnauthorizedException);

--- a/apps/server/server/src/webhooks/webhook-token.util.ts
+++ b/apps/server/server/src/webhooks/webhook-token.util.ts
@@ -4,22 +4,52 @@ import { UnauthorizedException } from '@nestjs/common';
 import type { Request } from 'express';
 
 /**
+ * Extract the credential from an `Authorization: Bearer <token>` header.
+ * Returns undefined for any other scheme so a stray `Basic`/`Digest` header
+ * never gets compared against the webhook secret.
+ */
+function resolveBearerToken(
+  authorizationHeader: string | undefined,
+): string | undefined {
+  if (!authorizationHeader) {
+    return undefined;
+  }
+
+  const [scheme, token] = authorizationHeader.split(' ');
+
+  if (scheme?.toLowerCase() !== 'bearer') {
+    return undefined;
+  }
+
+  return token?.trim() || undefined;
+}
+
+/**
  * Shared-secret verification for provider webhooks whose vendors do not give
- * us a documented HMAC scheme (HeyGen, KlingAI, OpusPro). We control the
- * callback URL registered with each vendor, so the secret travels as a
- * `token` query parameter (or `x-webhook-token` header) and is compared in
- * constant time.
+ * us a documented HMAC scheme (HeyGen, KlingAI, OpusPro, Leonardo.Ai). We
+ * control the callback URL registered with each vendor, so the secret travels
+ * as a `token` query parameter (or `x-webhook-token` header) and is compared
+ * in constant time.
  *
  * When no secret is configured the callback is accepted with a warning so
  * existing deployments keep working until the secret is provisioned.
  */
 export function assertWebhookToken(options: {
+  /**
+   * Additionally accept the secret as `Authorization: Bearer <secret>`.
+   * Opt-in per vendor: only widen the accepted credential surface for
+   * providers that document that transport (Leonardo.Ai). Safe on `@Public()`
+   * routes, which short-circuit `CombinedAuthGuard` before it inspects the
+   * Authorization header.
+   */
+  acceptBearerHeader?: boolean;
   configuredSecret: string | undefined;
   loggerService: LoggerService;
   request: Request;
   url: string;
 }): void {
-  const { configuredSecret, loggerService, request, url } = options;
+  const { acceptBearerHeader, configuredSecret, loggerService, request, url } =
+    options;
 
   if (!configuredSecret) {
     loggerService.warn(
@@ -30,7 +60,10 @@ export function assertWebhookToken(options: {
 
   const provided =
     (request.query?.token as string | undefined) ??
-    (request.headers['x-webhook-token'] as string | undefined);
+    (request.headers['x-webhook-token'] as string | undefined) ??
+    (acceptBearerHeader
+      ? resolveBearerToken(request.headers?.authorization)
+      : undefined);
 
   if (!provided) {
     throw new UnauthorizedException('Missing webhook token');

--- a/packages/config/src/interfaces/env-config.interface.ts
+++ b/packages/config/src/interfaces/env-config.interface.ts
@@ -123,6 +123,8 @@ export interface IEnvConfig {
 
   // === Leonardo ===
   LEONARDO_KEY?: string;
+  LEONARDO_WEBHOOK_ALLOWED_IPS?: string;
+  LEONARDO_WEBHOOK_SECRET?: string;
 
   // === HeyGen ===
   HEYGEN_KEY?: string;

--- a/packages/config/src/schemas/ai.schema.ts
+++ b/packages/config/src/schemas/ai.schema.ts
@@ -68,6 +68,18 @@ export const elevenlabsSchema = {
  */
 export const leonardoSchema = {
   LEONARDO_KEY: conditionalRequired(),
+  LEONARDO_WEBHOOK_ALLOWED_IPS: Joi.string()
+    .optional()
+    .allow('')
+    .description(
+      'Comma-separated egress IPs allowed to call the Leonardo callback. Overrides the shipped vendor list so rotations do not need a deploy',
+    ),
+  LEONARDO_WEBHOOK_SECRET: Joi.string()
+    .optional()
+    .allow('')
+    .description(
+      'Webhook callback API key registered with Leonardo.Ai, presented as an Authorization: Bearer header and verified on inbound webhooks',
+    ),
 };
 
 /**

--- a/packages/libs/interfaces/webhook-payload.interface.ts
+++ b/packages/libs/interfaces/webhook-payload.interface.ts
@@ -81,12 +81,46 @@ export interface OpusProWebhookPayload extends WebhookPayload {
 }
 
 /**
+ * A single generated asset inside a Leonardo.AI webhook payload
+ */
+export interface LeonardoAIWebhookImage {
+  id?: string;
+  generationId?: string;
+  url?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * The generation record Leonardo.AI nests under `data.object`
+ */
+export interface LeonardoAIWebhookGeneration {
+  id?: string;
+  status?: string;
+  images?: LeonardoAIWebhookImage[];
+  [key: string]: unknown;
+}
+
+/**
+ * The `data` envelope of a Leonardo.AI webhook event. Every member is optional
+ * because the vendor is free to change the envelope; consumers must guard the
+ * shape at runtime rather than assume `data.object` exists.
+ */
+export interface LeonardoAIWebhookData {
+  object?: LeonardoAIWebhookGeneration;
+  [key: string]: unknown;
+}
+
+/**
  * Leonardo.AI webhook event payload
+ * @see https://docs.leonardo.ai/docs/webhooks
  */
 export interface LeonardoAIWebhookPayload extends WebhookPayload {
+  type?: string;
+  customId?: string;
   generationId?: string;
   status?: string;
-  data: unknown;
+  images?: LeonardoAIWebhookImage[];
+  data?: LeonardoAIWebhookData | null;
 }
 
 /**


### PR DESCRIPTION
## Problem

`webhooks/leonardoai/callback` was the only webhook in `apps/server/api/src/endpoints/webhooks/` authenticated purely by IP allowlist — and the six vendor IPs were hardcoded inline in `handleCallback`. When Leonardo rotates its egress addresses, every callback 401s, image generations silently never complete, and the only remedy is a deploy.

Two `@ts-expect-error TS2571` suppressions also wrapped `(payload.data as Record<string, unknown>).object.images` / `.object.id`, which throw a `TypeError` — a 500, then a vendor retry storm — the moment the envelope changes shape.

## Auth

Leonardo publishes **no HMAC scheme**. Their documented mechanism is a per-API-key *webhook callback API key* presented as `authorization: Bearer <key>`. The callback URL is registered in Leonardo's dashboard, not constructed in our code, so `appendWebhookToken` has no call site here — the header is the only practical transport.

So the controller now uses the same `assertWebhookToken` shared-secret path as the other unsigned-vendor webhooks (heygen, klingai, opuspro, fleet), and the util gains an **opt-in** `acceptBearerHeader` flag rather than forcing Leonardo into the repo's `?token=` convention. `resolveBearerToken` only accepts the `bearer` scheme, so a stray `Basic`/`Digest` header is never compared against the secret. `@Public()` short-circuits `CombinedAuthGuard`, so the header reaches the handler untouched.

## IP allowlist — kept as defence in depth, moved to config

Three states, so **no existing deployment regresses**:

1. `LEONARDO_WEBHOOK_ALLOWED_IPS` set → always enforced (rotations no longer need a deploy).
2. Else a secret is configured → token is the gate, IP check skipped.
3. Else → falls back to the shipped last-known vendor list, preserving today's posture instead of silently accepting anonymous callbacks.

The existing `request.ip` read under `trust proxy 1` is **unchanged** — deliberately not splitting `x-forwarded-for`, comment preserved.

## Payload typing

`LeonardoAIWebhookPayload` in `packages/libs/interfaces/webhook-payload.interface.ts` is now a real shape (`LeonardoAIWebhookData` / `LeonardoAIWebhookGeneration` / `LeonardoAIWebhookImage`), every member optional because the vendor envelope is not contractual. Both `@ts-expect-error` directives are gone; a payload missing `data.object` is logged and acknowledged (`success: false`) rather than throwing.

Typing the payload also made the two `@ts-expect-error` directives in `webhooks.leonardoai.service.ts` unused (TS2578), so they were removed in the same change — `images[0]?.url || JSON.stringify(images)` is behaviourally identical.

## Tests

- `webhooks.leonardoai.controller.spec.ts` — missing token rejected, wrong token rejected, valid bearer token accepted (from a non-vendor IP, i.e. the rotation case), malformed payload acknowledged without throwing, configured allowlist enforced, vendor-list fallback when no secret, rethrow on service failure.
- `webhook-token.util.spec.ts` — bearer accepted when opted in, ignored when not, non-bearer scheme ignored, wrong bearer 401s.

## Notes

- **No secret in the repo.** `LEONARDO_WEBHOOK_SECRET` and `LEONARDO_WEBHOOK_ALLOWED_IPS` are declared in `packages/config` (Joi schema + typed env interface), both optional, matching exactly how `HEYGEN_WEBHOOK_SECRET` / `KLINGAI_WEBHOOK_SECRET` / `OPUSPRO_WEBHOOK_SECRET` are declared. Deliberately **not** added to `scripts/env-spec.ts` — none of those three siblings are there either.
- **Follow-up (not fixed here):** `apps/server/api/src/shared/interfaces/webhooks/webhooks.interface.ts:33` holds a dead duplicate `LeonardoAIWebhookPayload`. Grep shows the whole file has zero importers — a deletion candidate, out of scope for this diff.
- Related context only, not addressed here: #474 (signature-verification secrets for HeyGen/KlingAI/OpusPro), #2029 (DNS-rebinding hardening for outbound delivery).

## Verification

Not run locally per machine policy — CI validates. Locally ran formatter/linters only: `biome check` clean, `check:di-value-imports` clean (2618 files), pre-commit secretlint + control-guard passed.