### PR TITLE
fix(api): read scalar FKs instead of Prisma relation aliases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,7 +272,7 @@ jobs:
           bun run check:runtime-complexity -- --base "$BASE"
       - name: Architecture Guard Fixtures
         run: |
-          bunx vitest run --config scripts/architecture/vitest.config.ts check-runtime-complexity.test.ts check-deterministic-locale.test.ts
+          bunx vitest run --config scripts/architecture/vitest.config.ts check-runtime-complexity.test.ts check-deterministic-locale.test.ts check-relation-alias-reads.test.ts
           bunx vitest run --config scripts/ci/vitest.config.ts feature-test-coverage.test.ts nightly-test-workspace-inventory.test.ts nightly-unit-matrix.test.ts pr-validation-telemetry.test.ts
       - name: Require tests for feature source changes
         if: github.event_name == 'pull_request'
@@ -281,6 +281,8 @@ jobs:
         run: bun run scripts/ci/feature-test-coverage.ts --base "${{ github.event.pull_request.base.sha }}" | tee -a "$GITHUB_STEP_SUMMARY"
       - name: DI Value Imports
         run: bun run check:di-value-imports
+      - name: Relation Alias Reads
+        run: bun run check:relation-alias-reads
       - name: Desktop Schema Drift
         run: bun run check:desktop-schema-drift
       - name: Serializer Drift Regression Tests

--- a/apps/server/api/src/collections/agent-runs/controllers/agent-runs.controller.ts
+++ b/apps/server/api/src/collections/agent-runs/controllers/agent-runs.controller.ts
@@ -19,6 +19,7 @@ import {
 } from '@api/helpers/utils/response/response.util';
 import { handleQuerySort } from '@api/helpers/utils/sort/sort.util';
 import { BaseCRUDController } from '@api/shared/controllers/base-crud/base-crud.controller';
+import { resolveRelationId } from '@api/shared/utils/relation-id/relation-id.util';
 import { AgentExecutionStatus } from '@genfeedai/enums';
 import type { JsonApiSingleResponse } from '@genfeedai/interfaces';
 import {
@@ -217,12 +218,14 @@ export class AgentRunsController extends BaseCRUDController<
       return true;
     }
 
-    const entityOrganizationId =
-      (entity.organization as unknown as { id: string })?.id?.toString() ||
-      entity.organization?.toString();
-    const entityBrandId =
-      (entity.brand as unknown as { id?: string })?.id?.toString() ||
-      entity.brand?.toString();
+    // Scalar FKs first — the relations are only present when the row was
+    // loaded with a populate, so reading the aliases alone denied legitimate
+    // owners and skipped the brand check entirely.
+    const entityOrganizationId = resolveRelationId(
+      entity.organizationId,
+      entity.organization,
+    );
+    const entityBrandId = resolveRelationId(entity.brandId, entity.brand);
 
     if (
       publicMetadata.brand &&

--- a/apps/server/api/src/collections/agent-strategies/controllers/agent-strategies.controller.ts
+++ b/apps/server/api/src/collections/agent-strategies/controllers/agent-strategies.controller.ts
@@ -13,6 +13,7 @@ import { getPublicMetadata } from '@api/helpers/utils/auth/auth.util';
 import { serializeSingle } from '@api/helpers/utils/response/response.util';
 import { handleQuerySort } from '@api/helpers/utils/sort/sort.util';
 import { BaseCRUDController } from '@api/shared/controllers/base-crud/base-crud.controller';
+import { resolveRelationId } from '@api/shared/utils/relation-id/relation-id.util';
 import type { JsonApiSingleResponse } from '@genfeedai/interfaces';
 import { AgentStrategySerializer } from '@genfeedai/serializers';
 import { LoggerService } from '@libs/logger/logger.service';
@@ -93,9 +94,12 @@ export class AgentStrategiesController extends BaseCRUDController<
   ): boolean {
     const publicMetadata = getPublicMetadata(user);
 
-    const entityOrganizationId =
-      (entity.organization as unknown as { id: string })?.id?.toString() ||
-      entity.organization?.toString();
+    // Scalar FK first — the relation is only present when the row was loaded
+    // with a populate, so reading the alias alone denied legitimate owners.
+    const entityOrganizationId = resolveRelationId(
+      entity.organizationId,
+      entity.organization,
+    );
 
     if (
       entityOrganizationId &&

--- a/apps/server/api/src/collections/credentials/services/credentials.service.spec.ts
+++ b/apps/server/api/src/collections/credentials/services/credentials.service.spec.ts
@@ -242,6 +242,41 @@ describe('CredentialsService', () => {
       expect(data.accessToken).toMatch(CIPHERTEXT_PATTERN);
       expect(crypto.decrypt(data.accessToken)).toBe('save-raw');
     });
+
+    it('writes real foreign keys when the brand carries legacy relation aliases', async () => {
+      await service.saveCredentials(
+        { _id: brandId, organization: { id: orgId }, user: 'u1' } as never,
+        'twitter' as never,
+        { accessToken: 'save-raw' },
+      );
+
+      const data = prisma.credential.create.mock.calls[0][0].data as Record<
+        string,
+        string
+      >;
+
+      // `String(brand.organization)` used to write "[object Object]" and
+      // `String(undefined)` the literal "undefined" — both rejected by
+      // Postgres with a P2003 foreign-key violation.
+      expect(data.brandId).toBe(brandId);
+      expect(data.organizationId).toBe(orgId);
+      expect(data.userId).toBe('u1');
+
+      for (const key of ['brandId', 'organizationId', 'userId'] as const) {
+        expect(data[key]).not.toBe('undefined');
+        expect(data[key]).not.toBe('[object Object]');
+      }
+    });
+
+    it('fails closed rather than writing an unresolvable foreign key', async () => {
+      await expect(
+        service.saveCredentials({ id: brandId } as never, 'twitter' as never, {
+          accessToken: 'save-raw',
+        }),
+      ).rejects.toThrow(/organization/);
+
+      expect(prisma.credential.create).not.toHaveBeenCalled();
+    });
   });
 
   describe('updateExternalProfile', () => {

--- a/apps/server/api/src/collections/credentials/services/credentials.service.ts
+++ b/apps/server/api/src/collections/credentials/services/credentials.service.ts
@@ -6,6 +6,7 @@ import { CredentialCryptoService } from '@api/collections/credentials/services/c
 import { assertUrlNotPrivate } from '@api/helpers/utils/ssrf/ssrf.util';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { BaseService } from '@api/shared/services/base/base.service';
+import { requireRelationId } from '@api/shared/utils/relation-id/relation-id.util';
 import { CredentialPlatform, FileInputType } from '@genfeedai/enums';
 import type { PopulateOption } from '@genfeedai/interfaces';
 import { LoggerService } from '@libs/logger/logger.service';
@@ -118,9 +119,23 @@ export class CredentialsService extends BaseService<
     platform: CredentialPlatform,
     fields: Partial<Record<string, unknown>>,
   ): Promise<CredentialDocument> {
-    const brandId = String(brand.id);
-    const organizationId = String(brand.organizationId ?? brand.organization);
-    const userId = String(brand.userId ?? brand.user);
+    // `String(undefined)` wrote the literal "undefined" into a foreign key,
+    // which Postgres rejects with P2003 — and `String(<populated relation>)`
+    // wrote "[object Object]". Resolve scalar-first and fail closed instead.
+    const brandRef = 'Brand';
+    const brandId = requireRelationId(brand.id, brand._id, 'brand', brandRef);
+    const organizationId = requireRelationId(
+      brand.organizationId,
+      brand.organization,
+      'organization',
+      brandRef,
+    );
+    const userId = requireRelationId(
+      brand.userId,
+      brand.user,
+      'user',
+      brandRef,
+    );
 
     const existing = await this.findOne({
       brandId,

--- a/apps/server/api/src/collections/posts/controllers/analytics/posts-analytics.controller.spec.ts
+++ b/apps/server/api/src/collections/posts/controllers/analytics/posts-analytics.controller.spec.ts
@@ -194,5 +194,67 @@ describe('PostsAnalyticsController', () => {
 
       expect(result).toHaveProperty('statusCode', 404);
     });
+
+    it('keeps the credential lookup scoped to the brand and organization', async () => {
+      mockPostsService.findOne.mockResolvedValue(mockPost);
+      mockCredentialsService.findOne.mockResolvedValue(mockCredential);
+      mockPostAnalyticsService.getPostAnalyticsSummary.mockResolvedValue(
+        mockAnalyticsSummary,
+      );
+
+      await controller.refreshAnalytics(mockUser, postId);
+
+      // Exact match: an extra/missing key here is the whole defect. Filter
+      // values of `undefined` are dropped by `normalizeWhere`, so a lookup
+      // built from unpopulated relation aliases silently loses its tenant
+      // scoping and can return another organization's credential.
+      expect(mockCredentialsService.findOne).toHaveBeenCalledWith({
+        _id: '507f1f77bcf86cd799439016',
+        brandId: '507f1f77bcf86cd799439013',
+        organizationId: '507f1f77bcf86cd799439012',
+      });
+    });
+
+    it('resolves scalar foreign keys ahead of populated relation objects', async () => {
+      mockPostsService.findOne.mockResolvedValue({
+        ...mockPost,
+        // What the row actually looks like when the relations are included.
+        brand: { id: '507f1f77bcf86cd799439013', label: 'Acme' },
+        brandId: '507f1f77bcf86cd799439013',
+        credentialId: '507f1f77bcf86cd799439016',
+        organization: { id: '507f1f77bcf86cd799439012' },
+        organizationId: '507f1f77bcf86cd799439012',
+      });
+      mockCredentialsService.findOne.mockResolvedValue(mockCredential);
+      mockPostAnalyticsService.getPostAnalyticsSummary.mockResolvedValue(
+        mockAnalyticsSummary,
+      );
+
+      await controller.refreshAnalytics(mockUser, postId);
+
+      expect(mockCredentialsService.findOne).toHaveBeenCalledWith({
+        _id: '507f1f77bcf86cd799439016',
+        brandId: '507f1f77bcf86cd799439013',
+        organizationId: '507f1f77bcf86cd799439012',
+      });
+    });
+
+    it('fails closed instead of querying unscoped when the organization is unresolvable', async () => {
+      mockPostsService.findOne.mockResolvedValue({
+        _id: '507f1f77bcf86cd799439014',
+        brandId: '507f1f77bcf86cd799439013',
+        credentialId: '507f1f77bcf86cd799439016',
+        isDeleted: false,
+      });
+
+      await expect(
+        controller.refreshAnalytics(mockUser, postId),
+      ).rejects.toThrow(/organization/);
+
+      expect(mockCredentialsService.findOne).not.toHaveBeenCalled();
+      expect(
+        mockPostAnalyticsService.trackPostAnalytics,
+      ).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/server/api/src/collections/posts/controllers/analytics/posts-analytics.controller.ts
+++ b/apps/server/api/src/collections/posts/controllers/analytics/posts-analytics.controller.ts
@@ -10,6 +10,10 @@ import { RolesGuard } from '@api/helpers/guards/roles/roles.guard';
 import { getPublicMetadata } from '@api/helpers/utils/auth/auth.util';
 import { customLabels } from '@api/helpers/utils/pagination/pagination.util';
 import { returnNotFound } from '@api/helpers/utils/response/response.util';
+import {
+  requireRelationId,
+  resolveRelationId,
+} from '@api/shared/utils/relation-id/relation-id.util';
 import { MemberRole, PostStatus, PublishStatus } from '@genfeedai/enums';
 import type { JsonApiSingleResponse } from '@genfeedai/interfaces';
 import { LoggerService } from '@libs/logger/logger.service';
@@ -172,11 +176,39 @@ export class PostsAnalyticsController {
       }
     }
 
-    // Get credential for the post
+    // Get credential for the post.
+    //
+    // Scalar FKs only. `post.credential` is never back-filled by
+    // `BaseService.normalizeDocument`, and `post.brand` / `post.organization`
+    // are populated relation objects on this call path — so the previous
+    // `{ _id: post.credential, brand: post.brand, organization: post.organization }`
+    // filter had `undefined` and object values that `normalizeWhere` drops,
+    // silently unscoping the lookup from both the brand and the organization.
+    // `requireRelationId` fails closed instead: no id, no query.
+    const postRef = `Post ${postId}`;
+    const credentialId = requireRelationId(
+      post.credentialId,
+      post.credential,
+      'credential',
+      postRef,
+    );
+    const brandId = requireRelationId(
+      post.brandId,
+      post.brand,
+      'brand',
+      postRef,
+    );
+    const organizationId = requireRelationId(
+      post.organizationId,
+      post.organization,
+      'organization',
+      postRef,
+    );
+
     const credential = await this.credentialsService.findOne({
-      _id: post.credential,
-      brand: post.brand,
-      organization: post.organization,
+      _id: credentialId,
+      brandId,
+      organizationId,
     });
 
     if (!credential) {
@@ -274,12 +306,49 @@ export class PostsAnalyticsController {
       let successCount = 0;
       let errorCount = 0;
 
+      // `findAll` loads no relations, so `post.credential` was always
+      // `undefined` here — every post in the batch reached the analytics
+      // service without a credential. Resolve it from the scalar FK instead,
+      // memoized per credential id so one connected account is fetched once
+      // rather than once per post.
+      const credentialCache = new Map<string, CredentialEntity | null>();
+
       for (const post of posts.docs || []) {
         try {
+          const credentialId = resolveRelationId(
+            post.credentialId,
+            post.credential,
+          );
+
+          if (!credentialId) {
+            errorCount++;
+            this.loggerService.error(
+              `Post ${post.id} has no resolvable credential id`,
+            );
+            continue;
+          }
+
+          let credential = credentialCache.get(credentialId);
+          if (credential === undefined) {
+            credential = (await this.credentialsService.findOne({
+              _id: credentialId,
+              organizationId: publicMetadata.organization,
+            })) as unknown as CredentialEntity | null;
+            credentialCache.set(credentialId, credential);
+          }
+
+          if (!credential) {
+            errorCount++;
+            this.loggerService.error(
+              `Credential ${credentialId} is not available for post ${post.id}`,
+            );
+            continue;
+          }
+
           const trackUrl = `${url} trackPostAnalytics:${post.id}`;
           await this.postAnalyticsService.trackPostAnalytics(
             post,
-            post.credential as unknown as CredentialEntity,
+            credential,
             trackUrl,
           );
           successCount++;

--- a/apps/server/api/src/collections/posts/services/post-analytics.service.spec.ts
+++ b/apps/server/api/src/collections/posts/services/post-analytics.service.spec.ts
@@ -1,0 +1,127 @@
+import type { PostDocument } from '@api/collections/posts/schemas/post.schema';
+import { PostAnalyticsService } from '@api/collections/posts/services/post-analytics.service';
+import { PostsService } from '@api/collections/posts/services/posts.service';
+import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import type { LoggerService } from '@libs/logger/logger.service';
+
+const TWITTER = 'TWITTER' as never;
+
+function createHarness(post: unknown) {
+  const upsert = vi.fn().mockResolvedValue({ id: 'analytics_1' });
+  const findFirst = vi.fn().mockResolvedValue(null);
+  const logger = {
+    error: vi.fn(),
+    log: vi.fn(),
+    warn: vi.fn(),
+  } as unknown as LoggerService;
+
+  const service = new PostAnalyticsService(
+    {
+      postAnalytics: { findFirst, upsert },
+    } as unknown as PrismaService,
+    logger,
+    {
+      findOne: vi.fn().mockResolvedValue(post),
+    } as unknown as PostsService,
+  );
+
+  return { findFirst, logger, service, upsert };
+}
+
+const metrics = {
+  totalComments: 3,
+  totalLikes: 20,
+  totalShares: 1,
+  totalViews: 100,
+};
+
+describe('PostAnalyticsService.updateTodayAnalytics', () => {
+  it('writes scalar foreign keys when the post carries populated relations', async () => {
+    // `PostsService.findOne` populates brand/user, so the legacy aliases hold
+    // objects — `String(post.brand)` used to write "[object Object]" into a
+    // foreign key column and Postgres rejected the upsert with P2003.
+    const { service, upsert } = createHarness({
+      brand: { id: 'brand_1', label: 'Acme' },
+      id: 'post_1',
+      organization: { id: 'org_1' },
+      user: { id: 'user_1' },
+    } as unknown as PostDocument);
+
+    await service.updateTodayAnalytics('post_1', TWITTER, metrics);
+
+    const create = upsert.mock.calls[0][0].create;
+
+    expect(create).toMatchObject({
+      brandId: 'brand_1',
+      organizationId: 'org_1',
+      postId: 'post_1',
+      userId: 'user_1',
+    });
+
+    for (const key of ['brandId', 'organizationId', 'userId'] as const) {
+      expect(create[key]).not.toBe('undefined');
+      expect(create[key]).not.toBe('[object Object]');
+    }
+  });
+
+  it('prefers the scalar foreign key over the legacy alias', async () => {
+    const { service, upsert } = createHarness({
+      brand: 'stale_brand',
+      brandId: 'brand_1',
+      id: 'post_1',
+      organization: 'stale_org',
+      organizationId: 'org_1',
+      user: 'stale_user',
+      userId: 'user_1',
+    } as unknown as PostDocument);
+
+    await service.updateTodayAnalytics('post_1', TWITTER, metrics);
+
+    expect(upsert.mock.calls[0][0].create).toMatchObject({
+      brandId: 'brand_1',
+      organizationId: 'org_1',
+      userId: 'user_1',
+    });
+  });
+
+  it('skips the upsert when an owner id cannot be resolved', async () => {
+    const { logger, service, upsert } = createHarness({
+      brandId: 'brand_1',
+      id: 'post_1',
+      organizationId: 'org_1',
+    } as unknown as PostDocument);
+
+    const result = await service.updateTodayAnalytics('post_1', TWITTER, {
+      totalComments: 0,
+      totalLikes: 0,
+      totalViews: 0,
+    });
+
+    expect(result).toBeNull();
+    expect(upsert).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalled();
+  });
+});
+
+describe('PostAnalyticsService.trackPostAnalytics', () => {
+  it('returns early instead of throwing when the credential is missing', async () => {
+    const { logger, service, upsert } = createHarness(null);
+
+    await service.trackPostAnalytics(
+      {
+        brandId: 'brand_1',
+        externalId: 'ext_1',
+        id: 'post_1',
+        organizationId: 'org_1',
+        userId: 'user_1',
+      } as unknown as PostDocument,
+      undefined,
+      'test',
+    );
+
+    expect(upsert).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('Missing credential'),
+    );
+  });
+});

--- a/apps/server/api/src/collections/posts/services/post-analytics.service.ts
+++ b/apps/server/api/src/collections/posts/services/post-analytics.service.ts
@@ -13,6 +13,7 @@ import { TwitterService } from '@api/services/integrations/twitter/services/twit
 import { YoutubeService } from '@api/services/integrations/youtube/services/youtube.service';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { BaseService } from '@api/shared/services/base/base.service';
+import { resolveRelationId } from '@api/shared/utils/relation-id/relation-id.util';
 import type { CredentialPlatform } from '@genfeedai/prisma';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable, Optional } from '@nestjs/common';
@@ -145,15 +146,23 @@ export class PostAnalyticsService extends BaseService<
       return null;
     }
 
+    // Scalar FKs only. The relation aliases are populated objects on this call
+    // path (PostsService.findOne populates brand + user), so `String(post.brand)`
+    // wrote "[object Object]" and every upsert failed with a P2003 FK violation.
+    const owner = this.resolvePostOwner(post);
+    if (!owner) {
+      return null;
+    }
+
     const result = await this.prisma.postAnalytics.upsert({
       create: {
-        brandId: String(post.brand),
+        brandId: owner.brandId,
         date: today,
         engagementRate,
-        organizationId: String(post.organization),
+        organizationId: owner.organizationId,
         platform,
         postId,
-        userId: String(post.user),
+        userId: owner.userId,
         ...metrics,
         ...increments,
       } as never,
@@ -320,10 +329,20 @@ export class PostAnalyticsService extends BaseService<
 
   async trackPostAnalytics(
     post: PostDocument,
-    credential: CredentialEntity,
+    credential: CredentialEntity | null | undefined,
     url: string,
   ) {
     try {
+      const postId = post.id?.toString() || String(post.id);
+
+      // `credential` is undefined whenever the post was loaded without a
+      // populate (BaseService never back-fills the credential alias), which
+      // used to blow up on `credential.platform` and get swallowed below.
+      if (!credential?.platform) {
+        this.logger.error(`${url} Missing credential for post ${postId}`);
+        return;
+      }
+
       const platform = credential.platform;
       let analytics: {
         totalViews: number;
@@ -333,62 +352,76 @@ export class PostAnalyticsService extends BaseService<
         totalSaves: number;
       } | null = null;
 
-      const postId = post.id?.toString() || String(post.id);
       if (!post.externalId) {
         this.logger.warn(`${url} No external ID for post ${postId}`);
         return;
       }
 
+      // `PostDocument` types `externalId` through its index signature, so the
+      // truthiness guard above narrows it to `{}` rather than `string`.
+      const externalId = String(post.externalId);
+
+      // Scalar FKs, never the relation aliases: depending on the caller's
+      // populate those aliases are objects, id strings, or undefined, so
+      // `post.brand.toString()` silently produced "[object Object]" and
+      // queried the wrong brand's analytics.
+      const owner = this.resolvePostOwner(post);
+      if (!owner) {
+        return;
+      }
+
+      const { brandId, organizationId, userId } = owner;
+
       switch (platform) {
         case CREDENTIAL_PLATFORM.YOUTUBE:
           analytics = await this.getYoutubeAnalytics(
-            post.organization.toString(),
-            post.brand.toString(),
-            post.externalId,
+            organizationId,
+            brandId,
+            externalId,
           );
           break;
 
         case CREDENTIAL_PLATFORM.TIKTOK:
           analytics = await this.getTiktokAnalytics(
-            post.organization.toString(),
-            post.brand.toString(),
-            post.externalId,
+            organizationId,
+            brandId,
+            externalId,
           );
           break;
 
         case CREDENTIAL_PLATFORM.INSTAGRAM:
           analytics = await this.getInstagramAnalytics(
-            post.organization.toString(),
-            post.brand.toString(),
-            post.externalId,
+            organizationId,
+            brandId,
+            externalId,
           );
           break;
 
         case CREDENTIAL_PLATFORM.TWITTER:
-          analytics = await this.getTwitterAnalytics(post.externalId);
+          analytics = await this.getTwitterAnalytics(externalId);
           break;
 
         case CREDENTIAL_PLATFORM.PINTEREST:
           analytics = await this.getPinterestAnalytics(
-            post.organization.toString(),
-            post.brand.toString(),
-            post.externalId,
+            organizationId,
+            brandId,
+            externalId,
           );
           break;
 
         case CREDENTIAL_PLATFORM.LINKEDIN:
           analytics = await this.getLinkedInAnalytics(
-            post.organization.toString(),
-            post.brand.toString(),
-            post.externalId,
+            organizationId,
+            brandId,
+            externalId,
           );
           break;
 
         case CREDENTIAL_PLATFORM.MASTODON:
           analytics = await this.getMastodonAnalytics(
-            post.organization.toString(),
-            post.brand.toString(),
-            post.externalId,
+            organizationId,
+            brandId,
+            externalId,
           );
           break;
         default:
@@ -400,7 +433,7 @@ export class PostAnalyticsService extends BaseService<
         const postIngredients = Array.isArray(post.ingredients)
           ? post.ingredients
           : [];
-        if (!post.id || postIngredients.length === 0 || !post.user) {
+        if (!post.id || postIngredients.length === 0) {
           this.logger.error(`${url} Missing required post fields`, {
             postId: postId,
           });
@@ -411,10 +444,10 @@ export class PostAnalyticsService extends BaseService<
         today.setHours(0, 0, 0, 0);
 
         await this.findOrCreateTodayAnalytics(postId, platform, {
-          brandId: post.brand.toString(),
+          brandId,
           date: today,
           engagementRate: 0,
-          organizationId: post.organization.toString(),
+          organizationId,
           platform,
           postId,
           totalComments: 0,
@@ -427,7 +460,7 @@ export class PostAnalyticsService extends BaseService<
           totalSharesIncrement: 0,
           totalViews: 0,
           totalViewsIncrement: 0,
-          userId: post.user.toString(),
+          userId,
         } as never);
 
         await this.updateTodayAnalytics(postId, platform, analytics);
@@ -448,6 +481,41 @@ export class PostAnalyticsService extends BaseService<
         error,
       );
     }
+  }
+
+  /**
+   * Resolves the post's owning brand/organization/user from its scalar foreign
+   * keys, falling back to the legacy relation aliases only when they carry a
+   * usable id. Returns null (and logs) rather than letting an unresolvable id
+   * reach a non-nullable FK column or a platform analytics lookup.
+   *
+   * @see .agents/memory/rules/prisma_legacy_alias_fields.md
+   */
+  private resolvePostOwner(post: PostDocument): {
+    brandId: string;
+    organizationId: string;
+    userId: string;
+  } | null {
+    const brandId = resolveRelationId(post.brandId, post.brand);
+    const organizationId = resolveRelationId(
+      post.organizationId,
+      post.organization,
+    );
+    const userId = resolveRelationId(post.userId, post.user);
+
+    if (!brandId || !organizationId || !userId) {
+      this.logger.error(
+        `Post ${post.id ?? 'unknown'} is missing resolvable owner ids for analytics`,
+        {
+          hasBrandId: Boolean(brandId),
+          hasOrganizationId: Boolean(organizationId),
+          hasUserId: Boolean(userId),
+        },
+      );
+      return null;
+    }
+
+    return { brandId, organizationId, userId };
   }
 
   private async getYoutubeAnalytics(

--- a/apps/server/api/src/collections/posts/services/post-analytics.service.ts
+++ b/apps/server/api/src/collections/posts/services/post-analytics.service.ts
@@ -14,6 +14,7 @@ import { YoutubeService } from '@api/services/integrations/youtube/services/yout
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { BaseService } from '@api/shared/services/base/base.service';
 import { resolveRelationId } from '@api/shared/utils/relation-id/relation-id.util';
+import type { IPlatformAnalyticsTotals } from '@genfeedai/interfaces';
 import type { CredentialPlatform } from '@genfeedai/prisma';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable, Optional } from '@nestjs/common';
@@ -344,13 +345,6 @@ export class PostAnalyticsService extends BaseService<
       }
 
       const platform = credential.platform;
-      let analytics: {
-        totalViews: number;
-        totalLikes: number;
-        totalComments: number;
-        totalShares: number;
-        totalSaves: number;
-      } | null = null;
 
       if (!post.externalId) {
         this.logger.warn(`${url} No external ID for post ${postId}`);
@@ -372,62 +366,13 @@ export class PostAnalyticsService extends BaseService<
 
       const { brandId, organizationId, userId } = owner;
 
-      switch (platform) {
-        case CREDENTIAL_PLATFORM.YOUTUBE:
-          analytics = await this.getYoutubeAnalytics(
-            organizationId,
-            brandId,
-            externalId,
-          );
-          break;
-
-        case CREDENTIAL_PLATFORM.TIKTOK:
-          analytics = await this.getTiktokAnalytics(
-            organizationId,
-            brandId,
-            externalId,
-          );
-          break;
-
-        case CREDENTIAL_PLATFORM.INSTAGRAM:
-          analytics = await this.getInstagramAnalytics(
-            organizationId,
-            brandId,
-            externalId,
-          );
-          break;
-
-        case CREDENTIAL_PLATFORM.TWITTER:
-          analytics = await this.getTwitterAnalytics(externalId);
-          break;
-
-        case CREDENTIAL_PLATFORM.PINTEREST:
-          analytics = await this.getPinterestAnalytics(
-            organizationId,
-            brandId,
-            externalId,
-          );
-          break;
-
-        case CREDENTIAL_PLATFORM.LINKEDIN:
-          analytics = await this.getLinkedInAnalytics(
-            organizationId,
-            brandId,
-            externalId,
-          );
-          break;
-
-        case CREDENTIAL_PLATFORM.MASTODON:
-          analytics = await this.getMastodonAnalytics(
-            organizationId,
-            brandId,
-            externalId,
-          );
-          break;
-        default:
-          this.logger.warn(`${url} unsupported platform: ${platform}`);
-          return;
-      }
+      const analytics = await this.fetchPlatformAnalytics(
+        platform,
+        organizationId,
+        brandId,
+        externalId,
+        url,
+      );
 
       if (analytics) {
         const postIngredients = Array.isArray(post.ingredients)
@@ -518,17 +463,40 @@ export class PostAnalyticsService extends BaseService<
     return { brandId, organizationId, userId };
   }
 
+  /** Routes a post to its platform fetcher; null when unsupported. */
+  private fetchPlatformAnalytics(
+    platform: CredentialPlatform,
+    organizationId: string,
+    brandId: string,
+    externalId: string,
+    url: string,
+  ): Promise<IPlatformAnalyticsTotals | null> {
+    switch (platform) {
+      case CREDENTIAL_PLATFORM.YOUTUBE:
+        return this.getYoutubeAnalytics(organizationId, brandId, externalId);
+      case CREDENTIAL_PLATFORM.TIKTOK:
+        return this.getTiktokAnalytics(organizationId, brandId, externalId);
+      case CREDENTIAL_PLATFORM.INSTAGRAM:
+        return this.getInstagramAnalytics(organizationId, brandId, externalId);
+      case CREDENTIAL_PLATFORM.TWITTER:
+        return this.getTwitterAnalytics(externalId);
+      case CREDENTIAL_PLATFORM.PINTEREST:
+        return this.getPinterestAnalytics(organizationId, brandId, externalId);
+      case CREDENTIAL_PLATFORM.LINKEDIN:
+        return this.getLinkedInAnalytics(organizationId, brandId, externalId);
+      case CREDENTIAL_PLATFORM.MASTODON:
+        return this.getMastodonAnalytics(organizationId, brandId, externalId);
+      default:
+        this.logger.warn(`${url} unsupported platform: ${platform}`);
+        return Promise.resolve(null);
+    }
+  }
+
   private async getYoutubeAnalytics(
     organizationId: string,
     brandId: string,
     videoId: string,
-  ): Promise<{
-    totalViews: number;
-    totalLikes: number;
-    totalComments: number;
-    totalShares: number;
-    totalSaves: number;
-  } | null> {
+  ): Promise<IPlatformAnalyticsTotals | null> {
     try {
       // @ts-expect-error TS2532
       const stats = await this.youtubeService.getMediaAnalytics(
@@ -553,13 +521,7 @@ export class PostAnalyticsService extends BaseService<
     organizationId: string,
     brandId: string,
     videoId: string,
-  ): Promise<{
-    totalViews: number;
-    totalLikes: number;
-    totalComments: number;
-    totalShares: number;
-    totalSaves: number;
-  } | null> {
+  ): Promise<IPlatformAnalyticsTotals | null> {
     try {
       // @ts-expect-error TS2532
       const stats = await this.tiktokService.getMediaAnalytics(
@@ -584,13 +546,7 @@ export class PostAnalyticsService extends BaseService<
     organizationId: string,
     brandId: string,
     mediaId: string,
-  ): Promise<{
-    totalViews: number;
-    totalLikes: number;
-    totalComments: number;
-    totalShares: number;
-    totalSaves: number;
-  } | null> {
+  ): Promise<IPlatformAnalyticsTotals | null> {
     try {
       // @ts-expect-error TS2532
       const stats = await this.instagramService.getMediaAnalytics(
@@ -612,13 +568,9 @@ export class PostAnalyticsService extends BaseService<
     }
   }
 
-  private async getTwitterAnalytics(tweetId: string): Promise<{
-    totalViews: number;
-    totalLikes: number;
-    totalComments: number;
-    totalShares: number;
-    totalSaves: number;
-  } | null> {
+  private async getTwitterAnalytics(
+    tweetId: string,
+  ): Promise<IPlatformAnalyticsTotals | null> {
     try {
       // @ts-expect-error TS2532
       const stats = await this.twitterService.getMediaAnalytics(tweetId);
@@ -640,13 +592,7 @@ export class PostAnalyticsService extends BaseService<
     organizationId: string,
     brandId: string,
     pinId: string,
-  ): Promise<{
-    totalViews: number;
-    totalLikes: number;
-    totalComments: number;
-    totalShares: number;
-    totalSaves: number;
-  } | null> {
+  ): Promise<IPlatformAnalyticsTotals | null> {
     try {
       // @ts-expect-error TS2532
       const stats = await this.pinterestService.getMediaAnalytics(
@@ -982,13 +928,7 @@ export class PostAnalyticsService extends BaseService<
     organizationId: string,
     brandId: string,
     shareId: string,
-  ): Promise<{
-    totalViews: number;
-    totalLikes: number;
-    totalComments: number;
-    totalShares: number;
-    totalSaves: number;
-  } | null> {
+  ): Promise<IPlatformAnalyticsTotals | null> {
     try {
       if (!this.linkedInService) {
         this.logger.warn('LinkedInService not available');
@@ -1016,13 +956,7 @@ export class PostAnalyticsService extends BaseService<
     organizationId: string,
     brandId: string,
     statusId: string,
-  ): Promise<{
-    totalViews: number;
-    totalLikes: number;
-    totalComments: number;
-    totalShares: number;
-    totalSaves: number;
-  } | null> {
+  ): Promise<IPlatformAnalyticsTotals | null> {
     try {
       if (!this.mastodonService) {
         this.logger.warn('MastodonService not available');

--- a/apps/server/api/src/collections/posts/services/posts.service.ts
+++ b/apps/server/api/src/collections/posts/services/posts.service.ts
@@ -14,6 +14,10 @@ import { FileQueueService } from '@api/services/files-microservice/queue/file-qu
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { BaseService } from '@api/shared/services/base/base.service';
 import { PopulatePatterns } from '@api/shared/utils/populate/populate.util';
+import {
+  requireRelationId,
+  resolveRelationId,
+} from '@api/shared/utils/relation-id/relation-id.util';
 import { TimezoneUtil } from '@api/shared/utils/timezone/timezone.util';
 import { CredentialPlatform, PostStatus } from '@genfeedai/enums';
 import type {
@@ -379,13 +383,20 @@ export class PostsService extends BaseService<
   }
 
   private async completePublishFirstPostMission(
-    post: Pick<PostDocument, 'organization'>,
+    post: Pick<PostDocument, 'organization'> & { organizationId?: unknown },
   ): Promise<void> {
     if (!this.organizationSettingsService || !this.creditsUtilsService) {
       return;
     }
 
-    const organizationId = String(post.organization);
+    // `String(post.organization)` yielded the literal "undefined" (truthy, so
+    // the guard below never fired) whenever the patched post carried no
+    // populated organization — which then looked up settings for a
+    // non-existent organization id.
+    const organizationId = resolveRelationId(
+      post.organizationId,
+      post.organization,
+    );
     if (!organizationId) {
       return;
     }
@@ -490,13 +501,33 @@ export class PostsService extends BaseService<
           ? user.authProviderId
           : undefined;
 
+      // Scalar FKs first. `post.user` is a populated relation object on this
+      // call path (needed above for `authProviderId`), so `post.user.toString()`
+      // produced "[object Object]"; `post.brand` / `post.organization` are
+      // whatever the caller's populate happened to load. Fail closed rather
+      // than enqueueing a job with an unusable owner id.
+      const postRef = `Post ${postId}`;
+      const brandId = requireRelationId(
+        post.brandId,
+        post.brand,
+        'brand',
+        postRef,
+      );
+      const organizationId = requireRelationId(
+        post.organizationId,
+        post.organization,
+        'organization',
+        postRef,
+      );
+      const userId = requireRelationId(post.userId, post.user, 'user', postRef);
+
       await this.fileQueueService?.uploadYoutube({
-        brandId: post.brand.toString(),
+        brandId,
         authProviderUserId,
         credentialId: credential.id.toString(),
         description: post.description || '',
         ingredientId: ingredient.id.toString(),
-        organizationId: post.organization.toString(),
+        organizationId,
         postId,
         room: authProviderUserId
           ? getUserRoomName(authProviderUserId)
@@ -509,7 +540,7 @@ export class PostsService extends BaseService<
               typeof tag === 'object' && tag?.name ? tag.name : String(tag),
           ) || [],
         title: post.label || 'Untitled',
-        userId: post.user.toString(),
+        userId,
         websocketUrl: process.env.WEBSOCKET_URL,
       });
 

--- a/apps/server/api/src/collections/tasks/controllers/tasks.controller.ts
+++ b/apps/server/api/src/collections/tasks/controllers/tasks.controller.ts
@@ -236,19 +236,11 @@ export class TasksController extends BaseCRUDController<
     user: User,
     entity: TaskDocument,
   ): boolean {
-    const publicMetadata = getPublicMetadata(user);
-    // Scalar FK first, and both sides must be present: comparing two absent
-    // ids (`undefined === undefined`) previously granted write access.
-    const entityOrganizationId = resolveRelationId(
-      entity.organizationId,
-      entity.organization,
-    );
-
-    if (!entityOrganizationId || !publicMetadata.organization) {
-      return false;
-    }
-
-    return entityOrganizationId === publicMetadata.organization;
+    // Both ids must exist: `undefined === undefined` granted write access.
+    const { organization: userOrgId } = getPublicMetadata(user);
+    const { organization, organizationId } = entity;
+    const entityOrgId = resolveRelationId(organizationId, organization);
+    return Boolean(userOrgId) && entityOrgId === userOrgId;
   }
 
   @Get('by-identifier/:identifier')

--- a/apps/server/api/src/collections/tasks/controllers/tasks.controller.ts
+++ b/apps/server/api/src/collections/tasks/controllers/tasks.controller.ts
@@ -22,6 +22,7 @@ import { handleQuerySort } from '@api/helpers/utils/sort/sort.util';
 import { AgentOrchestratorService } from '@api/services/agent-orchestrator/agent-orchestrator.service';
 import { WorkspaceTaskQueueService } from '@api/services/task-orchestration/workspace-task-queue.service';
 import { BaseCRUDController } from '@api/shared/controllers/base-crud/base-crud.controller';
+import { resolveRelationId } from '@api/shared/utils/relation-id/relation-id.util';
 import type {
   JsonApiCollectionResponse,
   JsonApiSingleResponse,
@@ -236,9 +237,16 @@ export class TasksController extends BaseCRUDController<
     entity: TaskDocument,
   ): boolean {
     const publicMetadata = getPublicMetadata(user);
-    const entityOrganizationId =
-      (entity.organization as unknown as { id?: string })?.id?.toString() ||
-      entity.organization?.toString();
+    // Scalar FK first, and both sides must be present: comparing two absent
+    // ids (`undefined === undefined`) previously granted write access.
+    const entityOrganizationId = resolveRelationId(
+      entity.organizationId,
+      entity.organization,
+    );
+
+    if (!entityOrganizationId || !publicMetadata.organization) {
+      return false;
+    }
 
     return entityOrganizationId === publicMetadata.organization;
   }

--- a/apps/server/api/src/shared/controllers/base-integration/base-integration.controller.spec.ts
+++ b/apps/server/api/src/shared/controllers/base-integration/base-integration.controller.spec.ts
@@ -71,7 +71,12 @@ class TestIntegrationController extends BaseIntegrationController {
   }
 
   async testGetOrCreateCredential(
-    brand: { id: string; organization: string },
+    brand: {
+      id?: unknown;
+      _id?: unknown;
+      organization?: unknown;
+      organizationId?: unknown;
+    },
     initialData?: Record<string, unknown>,
   ) {
     return this.getOrCreateCredential(brand, initialData);
@@ -207,13 +212,14 @@ describe('BaseIntegrationController', () => {
 
       const result = await controller.testGetOrCreateCredential(brand);
 
-      expect(credentialsService.findOne).toHaveBeenCalledWith(
-        expect.objectContaining({
-          brand: expect.any(String),
-          organization: expect.any(String),
-          platform: CredentialPlatform.YOUTUBE,
-        }),
-      );
+      // Scalar foreign keys — an `organization` alias filter is dropped by
+      // `normalizeWhere` when the relation was not populated, which would
+      // unscope the credential lookup.
+      expect(credentialsService.findOne).toHaveBeenCalledWith({
+        brandId,
+        organizationId: orgId,
+        platform: CredentialPlatform.YOUTUBE,
+      });
       expect(credentialsService.saveCredentials).not.toHaveBeenCalled();
       expect(result).toHaveProperty('_id');
     });
@@ -239,6 +245,15 @@ describe('BaseIntegrationController', () => {
         expect.objectContaining({ isConnected: false }),
       );
       expect(result).toHaveProperty('_id');
+    });
+
+    it('fails closed instead of querying unscoped when the organization is unresolvable', async () => {
+      await expect(
+        controller.testGetOrCreateCredential({ id: brandId }),
+      ).rejects.toThrow(/organization/);
+
+      expect(credentialsService.findOne).not.toHaveBeenCalled();
+      expect(credentialsService.saveCredentials).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/server/api/src/shared/controllers/base-integration/base-integration.controller.ts
+++ b/apps/server/api/src/shared/controllers/base-integration/base-integration.controller.ts
@@ -4,14 +4,17 @@ import { CreateCredentialDto } from '@api/collections/credentials/dto/create-cre
 import { CredentialsService } from '@api/collections/credentials/services/credentials.service';
 import { getPublicMetadata } from '@api/helpers/utils/auth/auth.util';
 import { IAuthPublicMetadata } from '@api/shared/interfaces/auth/auth-public-metadata.interface';
+import { requireRelationId } from '@api/shared/utils/relation-id/relation-id.util';
 import { CredentialPlatform } from '@genfeedai/enums';
 import { LoggerService } from '@libs/logger/logger.service';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
 import { HttpException, HttpStatus } from '@nestjs/common';
 
 type IntegrationBrand = {
-  id: string;
-  organization: string;
+  id?: unknown;
+  _id?: unknown;
+  organization?: unknown;
+  organizationId?: unknown;
 };
 
 /**
@@ -147,14 +150,30 @@ export abstract class BaseIntegrationController {
    * @returns The credential (existing or newly created)
    */
   protected async getOrCreateCredential(
-    brand: { id: string; organization: string },
+    brand: IntegrationBrand,
     initialData: Record<string, unknown> = {},
   ) {
-    const existingCredential = await this.credentialsService.findOne({
-      brand: brand.id,
-      organization: brand.organization,
+    // Scalar FK first: `brand.organization` is only present when the brand was
+    // loaded with the relation included, and an `undefined` filter value is
+    // dropped by `normalizeWhere` — which would look up (and hand back) a
+    // credential belonging to another organization.
+    const brandRef = `Brand ${String(brand.id ?? brand._id)}`;
+    const brandId = requireRelationId(brand.id, brand._id, 'brand', brandRef);
+    const organizationId = requireRelationId(
+      brand.organizationId,
+      brand.organization,
+      'organization',
+      brandRef,
+    );
+
+    const credentialFilter = {
+      brandId,
+      organizationId,
       platform: this.platform,
-    });
+    };
+
+    const existingCredential =
+      await this.credentialsService.findOne(credentialFilter);
 
     if (existingCredential) {
       return existingCredential;
@@ -165,11 +184,7 @@ export abstract class BaseIntegrationController {
       ...initialData,
     });
 
-    return this.credentialsService.findOne({
-      brand: brand.id,
-      organization: brand.organization,
-      platform: this.platform,
-    });
+    return this.credentialsService.findOne(credentialFilter);
   }
 
   /**
@@ -206,7 +221,12 @@ export abstract class BaseIntegrationController {
 
       // Generate OAuth URL
       const oauthResult = await this.generateOAuthUrl(
-        brand.id.toString(),
+        requireRelationId(
+          brand.id,
+          brand._id,
+          'brand',
+          `Brand ${createCredentialDto.brand}`,
+        ),
         publicMetadata,
       );
 

--- a/apps/server/api/src/shared/utils/relation-id/relation-id.util.spec.ts
+++ b/apps/server/api/src/shared/utils/relation-id/relation-id.util.spec.ts
@@ -1,0 +1,59 @@
+import {
+  requireRelationId,
+  resolveRelationId,
+} from '@api/shared/utils/relation-id/relation-id.util';
+import { BadRequestException } from '@nestjs/common';
+
+describe('resolveRelationId', () => {
+  it('prefers the scalar foreign key over the legacy alias', () => {
+    expect(resolveRelationId('org_scalar', 'org_alias')).toBe('org_scalar');
+  });
+
+  it('falls back to the alias when it is a back-filled id string', () => {
+    expect(resolveRelationId(undefined, 'org_alias')).toBe('org_alias');
+  });
+
+  it('reads the id off a populated relation object', () => {
+    expect(resolveRelationId(undefined, { id: 'brand_1', label: 'Acme' })).toBe(
+      'brand_1',
+    );
+  });
+
+  it('reads the legacy _id off a populated relation object', () => {
+    expect(resolveRelationId(undefined, { _id: 'brand_legacy' })).toBe(
+      'brand_legacy',
+    );
+  });
+
+  it('never stringifies a populated relation object', () => {
+    // `String(post.brand)` produced "[object Object]" — a bogus foreign key.
+    expect(resolveRelationId(undefined, { label: 'Acme' })).toBeUndefined();
+  });
+
+  it('returns undefined for missing, empty, or non-id values', () => {
+    expect(resolveRelationId(undefined, undefined)).toBeUndefined();
+    expect(resolveRelationId('', '')).toBeUndefined();
+    expect(resolveRelationId(null, null)).toBeUndefined();
+    expect(resolveRelationId(undefined, 42)).toBeUndefined();
+  });
+});
+
+describe('requireRelationId', () => {
+  it('returns the resolved id', () => {
+    expect(requireRelationId('org_1', undefined, 'organization', 'Post')).toBe(
+      'org_1',
+    );
+  });
+
+  it('fails closed when no id can be resolved', () => {
+    expect(() =>
+      requireRelationId(undefined, undefined, 'organization', 'Post p_1'),
+    ).toThrow(BadRequestException);
+  });
+
+  it('names the field and context in the error', () => {
+    expect(() =>
+      requireRelationId(undefined, { label: 'Acme' }, 'brand', 'Post p_1'),
+    ).toThrow("Post p_1 is missing a resolvable 'brand' id");
+  });
+});

--- a/apps/server/api/src/shared/utils/relation-id/relation-id.util.ts
+++ b/apps/server/api/src/shared/utils/relation-id/relation-id.util.ts
@@ -1,0 +1,89 @@
+import { BadRequestException } from '@nestjs/common';
+
+/**
+ * Resolves the id of a Prisma relation without trusting the Mongo-era alias.
+ *
+ * Prisma rows always carry the scalar foreign key (`organizationId`, `brandId`,
+ * `userId`, `credentialId`). The legacy `*Document` types additionally declare
+ * relation aliases (`organization`, `brand`, `user`, `credential`) typed as
+ * `string`, but at runtime that alias is one of three different things
+ * depending on how the row was loaded:
+ *
+ * - a **populated relation object** — the query passed a populate/include
+ *   (e.g. `PostsService.findOne` defaults to populating brand/user/credential),
+ * - an **id string** — back-filled by `BaseService.normalizeDocument` from the
+ *   scalar FK when no relation was included,
+ * - **`undefined`** — neither happened (`credential` is never back-filled).
+ *
+ * Reading the alias directly therefore type-checks but silently produces
+ * `"[object Object]"` or `"undefined"` when stringified, which reaches Postgres
+ * as a bogus foreign key (P2003), and — worse — produces `undefined` filter
+ * values that `normalizeWhere` drops, silently widening a tenant-scoped query.
+ *
+ * Always prefer the scalar FK. This helper is the single implementation of the
+ * scalar-first read that was previously hand-rolled per call site.
+ *
+ * @see .agents/memory/rules/prisma_legacy_alias_fields.md
+ */
+export function resolveRelationId(
+  scalarId: unknown,
+  alias?: unknown,
+): string | undefined {
+  const fromScalar = toIdString(scalarId);
+  if (fromScalar) {
+    return fromScalar;
+  }
+
+  return toIdString(alias);
+}
+
+/**
+ * Same as {@link resolveRelationId}, but fails closed: callers that use the
+ * result to scope a tenant query or to write a non-nullable foreign key must
+ * never proceed with a missing id, because an absent filter value widens the
+ * query instead of narrowing it.
+ *
+ * @throws BadRequestException when neither the scalar FK nor the alias yields an id.
+ */
+export function requireRelationId(
+  scalarId: unknown,
+  alias: unknown,
+  field: string,
+  context: string,
+): string {
+  const id = resolveRelationId(scalarId, alias);
+
+  if (!id) {
+    throw new BadRequestException(
+      `${context} is missing a resolvable '${field}' id`,
+    );
+  }
+
+  return id;
+}
+
+/**
+ * Narrows the three runtime shapes to a non-empty id string.
+ * Populated relations expose `id` (Prisma) and/or `_id` (legacy alias).
+ */
+function toIdString(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    return value.length > 0 ? value : undefined;
+  }
+
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+
+  const record = value as { id?: unknown; _id?: unknown };
+
+  if (typeof record.id === 'string' && record.id.length > 0) {
+    return record.id;
+  }
+
+  if (typeof record._id === 'string' && record._id.length > 0) {
+    return record._id;
+  }
+
+  return undefined;
+}

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "check:deterministic-locale": "bun run scripts/architecture/check-deterministic-locale.ts",
     "check:di-value-imports": "bun run scripts/check-di-value-imports.ts",
     "check:import-cycles": "bun run scripts/check-import-cycles.ts",
+    "check:relation-alias-reads": "bun run scripts/architecture/check-relation-alias-reads.ts",
     "check:ui-guards": "bun run scripts/ui/check-ui-guards.ts",
     "publish:package": "./scripts/publish-package.sh",
     "check:nightly-test-inventory": "bun run scripts/ci/nightly-test-workspace-inventory.ts",

--- a/packages/interfaces/src/analytics/analytics.interface.ts
+++ b/packages/interfaces/src/analytics/analytics.interface.ts
@@ -65,6 +65,15 @@ export interface IPostAnalyticsSummary {
   platforms: Record<string, IPlatformStats>;
 }
 
+/** Raw per-post totals returned by a platform's analytics fetcher. */
+export interface IPlatformAnalyticsTotals {
+  totalViews: number;
+  totalLikes: number;
+  totalComments: number;
+  totalShares: number;
+  totalSaves: number;
+}
+
 export interface IPlatformStats {
   totalViews: number;
   totalLikes: number;

--- a/scripts/architecture/check-relation-alias-reads.test.ts
+++ b/scripts/architecture/check-relation-alias-reads.test.ts
@@ -1,0 +1,299 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  collectRelationAliases,
+  countByFile,
+  diffAgainstBaseline,
+  runCheckRelationAliasReads,
+} from './check-relation-alias-reads';
+
+/**
+ * Two models, mirroring the shape that makes the real schema tricky:
+ * `organization`/`brand`/`credential` are relations everywhere, while
+ * `metadata` is a relation on Post and a plain `Json?` column on Ingredient.
+ */
+const SCHEMA = [
+  'model Post {',
+  '  id             String        @id',
+  '  organizationId String',
+  '  organization   Organization  @relation(fields: [organizationId], references: [id])',
+  '  brandId        String?',
+  '  brand          Brand?        @relation(fields: [brandId], references: [id])',
+  '  credentialId   String?',
+  '  credential     Credential?   @relation(fields: [credentialId], references: [id])',
+  '  metadataId     String?',
+  '  metadata       Metadata?     @relation(fields: [metadataId], references: [id])',
+  '}',
+  '',
+  'model Ingredient {',
+  '  id       String  @id',
+  '  metadata Json?',
+  '}',
+].join('\n');
+
+describe('check-relation-alias-reads', () => {
+  let originalCwd = '';
+  let testDir = '';
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    testDir = mkdtempSync(path.join(tmpdir(), 'relation-alias-check-'));
+    process.chdir(testDir);
+    writeFixture('packages/prisma/prisma/schema.prisma', SCHEMA);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(testDir, { force: true, recursive: true });
+  });
+
+  describe('collectRelationAliases', () => {
+    it('pairs each relation alias with its scalar foreign key', () => {
+      const aliases = collectRelationAliases(SCHEMA);
+
+      expect(aliases.get('organization')).toBe('organizationId');
+      expect(aliases.get('brand')).toBe('brandId');
+      expect(aliases.get('credential')).toBe('credentialId');
+    });
+
+    it('drops names that are a plain column on any other model', () => {
+      // `metadata` is a relation on Post but `Json?` on Ingredient. Without a
+      // type checker the guard cannot tell which model a receiver came from,
+      // so the name is unusable and must not be flagged anywhere.
+      expect(collectRelationAliases(SCHEMA).has('metadata')).toBe(false);
+    });
+
+    it('handles compound foreign-key lists', () => {
+      const aliases = collectRelationAliases(
+        [
+          'model Snapshot {',
+          '  sourceId       String',
+          '  organizationId String',
+          '  source         Source @relation(fields: [sourceId, organizationId], references: [id, organizationId])',
+          '}',
+        ].join('\n'),
+      );
+
+      expect(aliases.get('source')).toBe('sourceId');
+    });
+  });
+
+  describe('id-coercion rule', () => {
+    it('flags String(row.alias)', () => {
+      writeFixture(
+        'apps/server/api/src/posts/posts.service.ts',
+        [
+          "import type { PostDocument } from './post.schema';",
+          '',
+          'export function track(post: PostDocument) {',
+          '  return { organizationId: String(post.organization) };',
+          '}',
+        ].join('\n'),
+      );
+
+      expect(runCheckRelationAliasReads().violations).toEqual([
+        expect.objectContaining({
+          alias: 'organization',
+          receiver: 'post',
+          rule: 'id-coercion',
+          scalar: 'organizationId',
+        }),
+      ]);
+    });
+
+    it('flags row.alias.toString()', () => {
+      writeFixture(
+        'apps/server/api/src/posts/posts.service.ts',
+        [
+          "import type { PostDocument } from './post.schema';",
+          '',
+          'export function track(post: PostDocument) {',
+          '  return post.brand.toString();',
+          '}',
+        ].join('\n'),
+      );
+
+      expect(runCheckRelationAliasReads().violations).toEqual([
+        expect.objectContaining({ alias: 'brand', rule: 'id-coercion' }),
+      ]);
+    });
+
+    it('flags a relation alias interpolated into a template literal', () => {
+      writeFixture(
+        'apps/server/api/src/posts/posts.service.ts',
+        [
+          "import type { PostDocument } from './post.schema';",
+          '',
+          'export function cacheKey(post: PostDocument) {',
+          `  return \`posts:\${post.organization}\`;`,
+          '}',
+        ].join('\n'),
+      );
+
+      expect(runCheckRelationAliasReads().violations).toEqual([
+        expect.objectContaining({ alias: 'organization', rule: 'id-coercion' }),
+      ]);
+    });
+  });
+
+  describe('filter-value rule', () => {
+    it('flags relation aliases used as id-shaped filter values', () => {
+      writeFixture(
+        'apps/server/api/src/posts/posts.controller.ts',
+        [
+          'export async function refresh(service, credentials) {',
+          '  const post = await service.findOne({ _id: id });',
+          '  return credentials.findOne({',
+          '    _id: post.credential,',
+          '    brand: post.brand,',
+          '    organization: post.organization,',
+          '  });',
+          '}',
+        ].join('\n'),
+      );
+
+      const { violations } = runCheckRelationAliasReads();
+
+      // The security-relevant half: `normalizeWhere` drops undefined values, so
+      // this lookup silently loses its tenant scoping.
+      expect(violations.map((entry) => entry.alias).sort()).toEqual([
+        'brand',
+        'credential',
+        'organization',
+      ]);
+      expect(violations.every((entry) => entry.rule === 'filter-value')).toBe(
+        true,
+      );
+    });
+
+    it('ignores alias filter keys whose value did not come from a row', () => {
+      // `processSearchParams` maps alias keys to scalars, and these values come
+      // from auth metadata rather than an unpopulated row — legitimate, and the
+      // single largest source of false positives if the rule keyed on the name.
+      writeFixture(
+        'apps/server/api/src/runs/runs.controller.ts',
+        [
+          'export async function findOne(service, publicMetadata, id) {',
+          '  return service.findOne({',
+          '    _id: id,',
+          '    organization: publicMetadata.organization,',
+          '  });',
+          '}',
+        ].join('\n'),
+      );
+
+      expect(runCheckRelationAliasReads().violations).toEqual([]);
+    });
+  });
+
+  describe('non-violations', () => {
+    it('ignores sub-property reads, which only work when the relation is populated', () => {
+      writeFixture(
+        'apps/server/api/src/posts/posts.service.ts',
+        [
+          "import type { PostDocument } from './post.schema';",
+          '',
+          'export function label(post: PostDocument) {',
+          '  return post.brand.label;',
+          '}',
+        ].join('\n'),
+      );
+
+      expect(runCheckRelationAliasReads().violations).toEqual([]);
+    });
+
+    it('ignores receivers that are not row bindings', () => {
+      // A job DTO that declares `organization`/`brand` as plain strings is a
+      // different type with the same property names.
+      writeFixture(
+        'apps/server/api/src/analytics/analytics-job.service.ts',
+        [
+          'export function run(job: AnalyticsJob, client) {',
+          '  return client.getMediaAnalytics(String(job.organization));',
+          '}',
+        ].join('\n'),
+      );
+
+      expect(runCheckRelationAliasReads().violations).toEqual([]);
+    });
+
+    it('honours a relation-alias-ok annotation', () => {
+      writeFixture(
+        'apps/server/api/src/posts/posts.service.ts',
+        [
+          "import type { PostDocument } from './post.schema';",
+          '',
+          'export function track(post: PostDocument) {',
+          '  // relation-alias-ok: findOne populates organization on this path',
+          '  return String(post.organization);',
+          '}',
+        ].join('\n'),
+      );
+
+      expect(runCheckRelationAliasReads().violations).toEqual([]);
+    });
+
+    it('skips test files', () => {
+      writeFixture(
+        'apps/server/api/src/posts/posts.service.spec.ts',
+        [
+          "import type { PostDocument } from './post.schema';",
+          '',
+          'const post = { organization: { id: 1 } } as unknown as PostDocument;',
+          'expect(String(post.organization)).toBeDefined();',
+        ].join('\n'),
+      );
+
+      expect(runCheckRelationAliasReads().violations).toEqual([]);
+    });
+  });
+
+  describe('ratchet', () => {
+    const violation = (file: string) => ({
+      alias: 'organization',
+      file,
+      line: 1,
+      receiver: 'post',
+      rule: 'id-coercion' as const,
+      scalar: 'organizationId',
+    });
+
+    it('counts violations per file', () => {
+      expect(
+        countByFile([violation('a.ts'), violation('a.ts'), violation('b.ts')]),
+      ).toEqual({
+        'a.ts': 2,
+        'b.ts': 1,
+      });
+    });
+
+    it('reports a file over its baseline as a regression', () => {
+      expect(diffAgainstBaseline({ 'a.ts': 3 }, { 'a.ts': 2 })).toEqual({
+        regressions: [{ actual: 3, baseline: 2, file: 'a.ts' }],
+        stale: [],
+      });
+    });
+
+    it('reports a file under its baseline as stale so the entry gets pruned', () => {
+      expect(diffAgainstBaseline({}, { 'a.ts': 2 })).toEqual({
+        regressions: [],
+        stale: [{ actual: 0, baseline: 2, file: 'a.ts' }],
+      });
+    });
+
+    it('passes a file that exactly matches its baseline', () => {
+      expect(diffAgainstBaseline({ 'a.ts': 2 }, { 'a.ts': 2 })).toEqual({
+        regressions: [],
+        stale: [],
+      });
+    });
+  });
+});
+
+function writeFixture(relativePath: string, content: string): void {
+  const absolute = path.join(process.cwd(), relativePath);
+  mkdirSync(path.dirname(absolute), { recursive: true });
+  writeFileSync(absolute, content);
+}

--- a/scripts/architecture/check-relation-alias-reads.ts
+++ b/scripts/architecture/check-relation-alias-reads.ts
@@ -1,0 +1,553 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { globSync } from 'glob';
+import ts from 'typescript';
+import { RELATION_ALIAS_READ_BASELINE } from './relation-alias-reads.baseline';
+
+/**
+ * Guard: forbid reading Mongo-era relation aliases off Prisma rows in the
+ * server apps.
+ *
+ * `schema.prisma` splits scalar foreign keys (`organizationId`, `brandId`, …)
+ * from relation fields (`organization`, `brand`, …). The scalar is always on
+ * the row; the relation is present only when the query explicitly `include`d
+ * it, and `BaseService.findOne` defaults to no populate. The legacy
+ * `*Document` types still declare the relation props as optional, so reading
+ * one type-checks while its runtime value is call-path dependent — a populated
+ * object, a back-filled id string, or `undefined`.
+ *
+ * Every failure mode is silent:
+ *   - `String(post.organization)` writes "[object Object]" or the literal
+ *     "undefined" into a foreign key column (Postgres P2003).
+ *   - `post.brand.toString()` throws a TypeError that a surrounding catch eats.
+ *   - `{ organization: post.organization }` as a filter has its `undefined`
+ *     value dropped by `normalizeWhere`, silently unscoping a tenant query.
+ *
+ * Fix: read the scalar FK, via `resolveRelationId` / `requireRelationId`
+ * (apps/server/api/src/shared/utils/relation-id/relation-id.util.ts). Those two
+ * are the sanctioned readers and are exempt here.
+ *
+ * Scope: only the two shapes where reading the alias is broken under every
+ * call path — coercing it to a string id, and using it as the value of an
+ * id-shaped filter key. Plain reads are left alone: plenty of call sites do
+ * pass a populate and legitimately walk into the relation object
+ * (`ingredient.metadata.duration`), and this guard has no type checker to tell
+ * the two apart.
+ *
+ * @see .agents/memory/rules/prisma_legacy_alias_fields.md
+ */
+
+const INCLUDE_GLOBS = ['apps/server/**/*.ts'];
+
+const IGNORE_GLOBS = [
+  '**/*.spec.ts',
+  '**/*.test.ts',
+  '**/__fixtures__/**',
+  '**/node_modules/**',
+  '**/dist/**',
+  '**/.next/**',
+  '**/.turbo/**',
+  '**/coverage/**',
+  '**/fixtures/**',
+  '**/generated/**',
+];
+
+const SCHEMA_PATH = 'packages/prisma/prisma/schema.prisma';
+
+const BASELINE_PATH = 'scripts/architecture/relation-alias-reads.baseline.ts';
+
+const BASELINE_HEADER = `/**
+ * Ratchet baseline for check-relation-alias-reads.ts.
+ *
+ * Per-file counts of pre-existing relation-alias reads, captured 2026-07-24.
+ * Counts may ONLY go down — the guard fails on a file that gains one, and also
+ * on a file that drops below its entry, so whoever fixes a site prunes the
+ * number in the same PR. Regenerate with:
+ *
+ *   bun run check:relation-alias-reads --update-baseline
+ *
+ * When this map is empty, delete it and flip the guard to a plain ban.
+ *
+ * Every entry is a real instance of the defect fixed in #2033, not a false
+ * positive — the backlog is large because the hazard is systemic, not because
+ * the guard is noisy.
+ */
+`;
+
+/**
+ * A row binding is only recognised when the code says so syntactically: an
+ * explicit `*Document` / `*Entity` annotation, or a binding initialised from a
+ * `BaseService` read. Anything the guard cannot classify is left alone — this
+ * check is deliberately conservative, because the alias names double as plain
+ * declared string fields on job DTOs and auth metadata.
+ */
+const ROW_TYPE_PATTERN = /(?:Document|Entity)$/;
+
+const ROW_READ_METHODS = new Set([
+  'findAll',
+  'findById',
+  'findFirst',
+  'findMany',
+  'findOne',
+  'findOneById',
+]);
+
+const SUPPRESSION_COMMENT = 'relation-alias-ok';
+
+export type RelationAliasRule = 'filter-value' | 'id-coercion';
+
+export type RelationAliasViolation = {
+  alias: string;
+  file: string;
+  line: number;
+  receiver: string;
+  rule: RelationAliasRule;
+  scalar: string;
+};
+
+export type RelationAliasCheckOptions = {
+  ignoreGlobs?: string[];
+  includeGlobs?: string[];
+  schemaPath?: string;
+};
+
+export type RelationAliasCheckResult = {
+  aliasCount: number;
+  filesScanned: number;
+  violations: RelationAliasViolation[];
+};
+
+/**
+ * Ground truth comes from the schema, not a hand-maintained list: every
+ * relation field declared with `@relation(fields: [<scalar>])` whose scalar is
+ * named `<field>Id`. That pairing is exactly the hazard — an alias that has a
+ * scalar twin the code should have read instead.
+ */
+export function collectRelationAliases(
+  schemaSource: string,
+): Map<string, string> {
+  const aliases = new Map<string, string>();
+  const ambiguous = new Set<string>();
+
+  for (const line of schemaSource.split('\n')) {
+    const field = /^[ \t]+(\w+)[ \t]+\S+/.exec(line);
+    if (!field) {
+      continue;
+    }
+
+    const name = field[1];
+    const fkList = /@relation\([^)]*fields:\s*\[([^\]]*)\]/.exec(line);
+    const isAliasDeclaration =
+      fkList?.[1]
+        .split(',')
+        .map((entry) => entry.trim())
+        .includes(`${name}Id`) ?? false;
+
+    if (isAliasDeclaration) {
+      aliases.set(name, `${name}Id`);
+    } else {
+      ambiguous.add(name);
+    }
+  }
+
+  // A name that is *also* declared as something else somewhere in the schema
+  // can't be classified from the property access alone. `metadata` is a
+  // `Metadata?` relation on one model and a plain `Json?` column on a dozen
+  // others; `source`, `content` and `plan` are the same story. With no
+  // type checker the guard cannot tell which model a receiver came from, so
+  // those names are dropped entirely. What survives — `organization`, `brand`,
+  // `user`, `credential` and friends — means "relation" everywhere in the
+  // schema, which is what makes a read of it unambiguously wrong.
+  for (const name of ambiguous) {
+    aliases.delete(name);
+  }
+
+  return aliases;
+}
+
+function annotationTypeName(node: ts.TypeNode | undefined): string | null {
+  if (!node) {
+    return null;
+  }
+  if (ts.isTypeReferenceNode(node)) {
+    let name: ts.EntityName = node.typeName;
+    while (ts.isQualifiedName(name)) {
+      name = name.right;
+    }
+    return name.text;
+  }
+  // `post: PostDocument | null` — a nullable row is still a row.
+  if (ts.isUnionTypeNode(node)) {
+    for (const member of node.types) {
+      const inner = annotationTypeName(member);
+      if (inner && ROW_TYPE_PATTERN.test(inner)) {
+        return inner;
+      }
+    }
+  }
+  return null;
+}
+
+function isRowAnnotation(node: ts.TypeNode | undefined): boolean {
+  const name = annotationTypeName(node);
+  return name !== null && ROW_TYPE_PATTERN.test(name);
+}
+
+function unwrapAwait(expression: ts.Expression): ts.Expression {
+  return ts.isAwaitExpression(expression) ? expression.expression : expression;
+}
+
+/** `await this.postsService.findOne(...)` and friends yield a Prisma row. */
+function isRowReadCall(expression: ts.Expression | undefined): boolean {
+  if (!expression) {
+    return false;
+  }
+  const call = unwrapAwait(expression);
+  if (!ts.isCallExpression(call)) {
+    return false;
+  }
+  const callee = call.expression;
+  return (
+    ts.isPropertyAccessExpression(callee) &&
+    ROW_READ_METHODS.has(callee.name.text)
+  );
+}
+
+/**
+ * Collects identifiers that hold a Prisma row, per file. Scope is ignored on
+ * purpose: a name bound to a row anywhere in a file is treated as a row
+ * everywhere in it. Shadowing the same identifier with a non-row value in the
+ * same file is not a pattern this codebase uses, and erring toward reporting
+ * keeps the guard from going quiet on a real defect.
+ */
+function collectRowBindings(sourceFile: ts.SourceFile): Set<string> {
+  const bindings = new Set<string>();
+
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isParameter(node) &&
+      ts.isIdentifier(node.name) &&
+      isRowAnnotation(node.type)
+    ) {
+      bindings.add(node.name.text);
+    }
+
+    if (ts.isPropertyDeclaration(node) && ts.isIdentifier(node.name)) {
+      if (isRowAnnotation(node.type)) {
+        bindings.add(node.name.text);
+      }
+    }
+
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) {
+      if (isRowAnnotation(node.type) || isRowReadCall(node.initializer)) {
+        bindings.add(node.name.text);
+      }
+    }
+
+    // `for (const post of posts.docs)` / `for (const post of rows)` where the
+    // iterated value already traces back to a row read.
+    if (ts.isForOfStatement(node)) {
+      const declaration = ts.isVariableDeclarationList(node.initializer)
+        ? node.initializer.declarations[0]
+        : undefined;
+      if (declaration && ts.isIdentifier(declaration.name)) {
+        const source = node.expression;
+        const root = ts.isPropertyAccessExpression(source)
+          ? source.expression
+          : source;
+        if (
+          (ts.isIdentifier(root) && bindings.has(root.text)) ||
+          isRowReadCall(source)
+        ) {
+          bindings.add(declaration.name.text);
+        }
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  // Two passes: a `for...of` may iterate a binding declared earlier in source
+  // order but visited later through nesting.
+  visit(sourceFile);
+  visit(sourceFile);
+
+  return bindings;
+}
+
+/**
+ * `String(post.brand)`, `post.brand.toString()`, `` `${post.brand}` `` — every
+ * one of these produces "[object Object]" when the relation is populated and
+ * the literal "undefined" when it is not. Neither is ever a valid foreign key.
+ */
+function isIdCoercion(access: ts.PropertyAccessExpression): boolean {
+  const parent = access.parent;
+  if (!parent) {
+    return false;
+  }
+
+  if (
+    ts.isCallExpression(parent) &&
+    ts.isIdentifier(parent.expression) &&
+    parent.expression.text === 'String'
+  ) {
+    return parent.arguments.includes(access);
+  }
+
+  if (
+    ts.isPropertyAccessExpression(parent) &&
+    parent.expression === access &&
+    parent.name.text === 'toString' &&
+    parent.parent &&
+    ts.isCallExpression(parent.parent)
+  ) {
+    return true;
+  }
+
+  return ts.isTemplateSpan(parent);
+}
+
+/**
+ * `{ _id: post.credential, organization: post.organization }` — an id-shaped
+ * key fed from a relation alias. `normalizeWhere` drops `undefined` values, so
+ * the tenant filter silently disappears instead of failing.
+ */
+function isIdShapedFilterValue(
+  access: ts.PropertyAccessExpression,
+  alias: string,
+): boolean {
+  const parent = access.parent;
+  if (
+    !parent ||
+    !ts.isPropertyAssignment(parent) ||
+    parent.initializer !== access
+  ) {
+    return false;
+  }
+
+  const key = ts.isIdentifier(parent.name)
+    ? parent.name.text
+    : ts.isStringLiteral(parent.name)
+      ? parent.name.text
+      : null;
+
+  return key === '_id' || key === 'id' || key === alias || key === `${alias}Id`;
+}
+
+function isSuppressed(sourceFile: ts.SourceFile, position: number): boolean {
+  const { line } = sourceFile.getLineAndCharacterOfPosition(position);
+  const lines = sourceFile.getFullText().split('\n');
+  const current = lines[line] ?? '';
+  const previous = line > 0 ? (lines[line - 1] ?? '') : '';
+  return (
+    current.includes(SUPPRESSION_COMMENT) ||
+    previous.includes(SUPPRESSION_COMMENT)
+  );
+}
+
+function checkFile(
+  file: string,
+  aliases: Map<string, string>,
+): RelationAliasViolation[] {
+  const content = readFileSync(file, 'utf8');
+  const sourceFile = ts.createSourceFile(
+    file,
+    content,
+    ts.ScriptTarget.Latest,
+    true,
+  );
+
+  const rowBindings = collectRowBindings(sourceFile);
+  if (rowBindings.size === 0) {
+    return [];
+  }
+
+  const violations: RelationAliasViolation[] = [];
+
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isPropertyAccessExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      rowBindings.has(node.expression.text)
+    ) {
+      const alias = node.name.text;
+      const scalar = aliases.get(alias);
+      const rule: RelationAliasRule | null = !scalar
+        ? null
+        : isIdCoercion(node)
+          ? 'id-coercion'
+          : isIdShapedFilterValue(node, alias)
+            ? 'filter-value'
+            : null;
+
+      if (scalar && rule && !isSuppressed(sourceFile, node.getStart())) {
+        violations.push({
+          alias,
+          file,
+          line:
+            sourceFile.getLineAndCharacterOfPosition(node.getStart()).line + 1,
+          receiver: node.expression.text,
+          rule,
+          scalar,
+        });
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  return violations;
+}
+
+export function runCheckRelationAliasReads(
+  options: RelationAliasCheckOptions = {},
+): RelationAliasCheckResult {
+  const aliases = collectRelationAliases(
+    readFileSync(options.schemaPath ?? SCHEMA_PATH, 'utf8'),
+  );
+
+  const files = globSync(options.includeGlobs ?? INCLUDE_GLOBS, {
+    ignore: options.ignoreGlobs ?? IGNORE_GLOBS,
+    nodir: true,
+  });
+
+  return {
+    aliasCount: aliases.size,
+    filesScanned: files.length,
+    violations: files.flatMap((file) => checkFile(file, aliases)),
+  };
+}
+
+export function countByFile(
+  violations: readonly RelationAliasViolation[],
+): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const violation of violations) {
+    counts[violation.file] = (counts[violation.file] ?? 0) + 1;
+  }
+  return counts;
+}
+
+export type RatchetDrift = {
+  actual: number;
+  baseline: number;
+  file: string;
+};
+
+/**
+ * Exact-match ratchet, same contract as `workers-api-imports.baseline.ts`: a
+ * file over its baseline is a regression, and a file under it is a stale entry
+ * that must be pruned in the PR that fixed it. Anything else lets the baseline
+ * rot into a number nobody trusts.
+ */
+export function diffAgainstBaseline(
+  counts: Record<string, number>,
+  baseline: Readonly<Record<string, number>>,
+): { regressions: RatchetDrift[]; stale: RatchetDrift[] } {
+  const regressions: RatchetDrift[] = [];
+  const stale: RatchetDrift[] = [];
+
+  for (const file of new Set([
+    ...Object.keys(counts),
+    ...Object.keys(baseline),
+  ])) {
+    const actual = counts[file] ?? 0;
+    const allowed = baseline[file] ?? 0;
+    if (actual > allowed) {
+      regressions.push({ actual, baseline: allowed, file });
+    } else if (actual < allowed) {
+      stale.push({ actual, baseline: allowed, file });
+    }
+  }
+
+  return {
+    regressions: regressions.sort((a, b) => a.file.localeCompare(b.file)),
+    stale: stale.sort((a, b) => a.file.localeCompare(b.file)),
+  };
+}
+
+function describe(violation: RelationAliasViolation): string {
+  const consequence =
+    violation.rule === 'id-coercion'
+      ? 'coerces a relation alias to a string id — that is "[object Object]" when populated and "undefined" when not'
+      : 'feeds a relation alias into an id-shaped filter key — an undefined value is dropped by normalizeWhere, silently unscoping the query';
+  return (
+    `  ${violation.file}:${violation.line} — '${violation.receiver}.${violation.alias}' ${consequence}. ` +
+    `Read '${violation.receiver}.${violation.scalar}' instead, or route it through ` +
+    'resolveRelationId()/requireRelationId(). If the alias really is populated here, annotate the ' +
+    `line with '// ${SUPPRESSION_COMMENT}: <reason>'.`
+  );
+}
+
+function writeBaseline(counts: Record<string, number>): void {
+  const entries = Object.entries(counts).sort(([a], [b]) => a.localeCompare(b));
+  const total = entries.reduce((sum, [, count]) => sum + count, 0);
+  const body = entries
+    .map(([file, count]) => `  '${file}': ${count},`)
+    .join('\n');
+
+  writeFileSync(
+    BASELINE_PATH,
+    `${BASELINE_HEADER}\nexport const RELATION_ALIAS_READ_BASELINE: Readonly<Record<string, number>> = {\n${body}\n};\n`,
+  );
+  console.log(
+    `check:relation-alias-reads — baseline rewritten: ${entries.length} file(s), ${total} violation(s).`,
+  );
+}
+
+function main(): void {
+  const { aliasCount, filesScanned, violations } = runCheckRelationAliasReads();
+  const counts = countByFile(violations);
+
+  if (process.argv.includes('--update-baseline')) {
+    writeBaseline(counts);
+    return;
+  }
+
+  const { regressions, stale } = diffAgainstBaseline(
+    counts,
+    RELATION_ALIAS_READ_BASELINE,
+  );
+
+  if (regressions.length === 0 && stale.length === 0) {
+    console.log(
+      `check:relation-alias-reads — ${filesScanned} files scanned against ` +
+        `${aliasCount} schema relation aliases; ${violations.length} baselined ` +
+        'violation(s), no new ones.',
+    );
+    return;
+  }
+
+  if (regressions.length > 0) {
+    console.error(
+      'check:relation-alias-reads — new relation-alias read(s). Prisma relation fields are only ' +
+        'present when a query explicitly includes them, so reading one yields a populated object, a ' +
+        'back-filled id, or undefined depending on the call path — silently corrupting foreign keys ' +
+        'and dropping tenant filters while type-check passes.',
+    );
+    const regressed = new Set(regressions.map((entry) => entry.file));
+    for (const violation of violations.filter((entry) =>
+      regressed.has(entry.file),
+    )) {
+      console.error(describe(violation));
+    }
+  }
+
+  if (stale.length > 0) {
+    console.error(
+      '\ncheck:relation-alias-reads — the baseline is stale. These files improved; lower them in ' +
+        'scripts/architecture/relation-alias-reads.baseline.ts (or run with --update-baseline) so the ' +
+        'ratchet cannot slip back:',
+    );
+    for (const entry of stale) {
+      console.error(
+        `  ${entry.file} — baseline ${entry.baseline}, actual ${entry.actual}`,
+      );
+    }
+  }
+
+  process.exit(1);
+}
+
+if (import.meta.main) {
+  main();
+}

--- a/scripts/architecture/relation-alias-reads.baseline.ts
+++ b/scripts/architecture/relation-alias-reads.baseline.ts
@@ -1,0 +1,78 @@
+/**
+ * Ratchet baseline for check-relation-alias-reads.ts.
+ *
+ * Per-file counts of pre-existing relation-alias reads, captured 2026-07-24.
+ * Counts may ONLY go down — the guard fails on a file that gains one, and also
+ * on a file that drops below its entry, so whoever fixes a site prunes the
+ * number in the same PR. Regenerate with:
+ *
+ *   bun run check:relation-alias-reads --update-baseline
+ *
+ * When this map is empty, delete it and flip the guard to a plain ban.
+ *
+ * Every entry is a real instance of the defect fixed in #2033, not a false
+ * positive — the backlog is large because the hazard is systemic, not because
+ * the guard is noisy.
+ */
+
+export const RELATION_ALIAS_READ_BASELINE: Readonly<Record<string, number>> = {
+  'apps/server/api/src/collections/agent-campaigns/controllers/agent-campaigns.controller.ts': 1,
+  'apps/server/api/src/collections/agent-strategies/services/agent-strategy-autopilot-execution.service.ts': 1,
+  'apps/server/api/src/collections/agent-strategies/services/agent-strategy-autopilot-performance.service.ts': 2,
+  'apps/server/api/src/collections/articles/controllers/articles.controller.ts': 2,
+  'apps/server/api/src/collections/articles/services/articles-content.service.ts': 1,
+  'apps/server/api/src/collections/bots/services/bots-livestream-delivery.service.ts': 1,
+  'apps/server/api/src/collections/content-plan-items/services/content-plan-items.service.ts': 3,
+  'apps/server/api/src/collections/images/controllers/operations/images-operations.controller.ts': 1,
+  'apps/server/api/src/collections/ingredients/controllers/ingredients-relationships.controller.ts': 1,
+  'apps/server/api/src/collections/outreach-campaigns/controllers/outreach-campaigns.controller.ts': 3,
+  'apps/server/api/src/collections/posts/controllers/operations/posts-operations.controller.ts': 5,
+  'apps/server/api/src/collections/posts/services/posts.service.ts': 1,
+  'apps/server/api/src/collections/prompts/controllers/prompts-operations.controller.ts': 7,
+  'apps/server/api/src/collections/runs/services/runs.service.ts': 2,
+  'apps/server/api/src/collections/streaks/services/streaks.service.ts': 2,
+  'apps/server/api/src/collections/trainings/controllers/trainings.controller.ts': 2,
+  'apps/server/api/src/collections/users/services/user-setup.service.ts': 1,
+  'apps/server/api/src/collections/videos/controllers/batch-interpolation.controller.ts': 1,
+  'apps/server/api/src/collections/videos/controllers/transformations/edits/videos-edits.controller.ts': 2,
+  'apps/server/api/src/collections/videos/controllers/transformations/effects/videos-effects.controller.ts': 2,
+  'apps/server/api/src/collections/videos/services/video-generation.service.ts': 3,
+  'apps/server/api/src/collections/workflow-executions/controllers/internal-workflow-executions.controller.ts': 1,
+  'apps/server/api/src/collections/workflows/services/workflow-webhook.service.ts': 2,
+  'apps/server/api/src/endpoints/dev/dev.controller.ts': 1,
+  'apps/server/api/src/endpoints/webhooks/replicate/webhooks.replicate.controller.ts': 1,
+  'apps/server/api/src/endpoints/webhooks/services/post-processing-orchestrator.service.ts': 3,
+  'apps/server/api/src/endpoints/webhooks/stripe/handlers/stripe-invoice-webhook.handler.ts': 2,
+  'apps/server/api/src/endpoints/webhooks/stripe/handlers/stripe-subscription-webhook.handler.ts': 10,
+  'apps/server/api/src/endpoints/webhooks/webhooks.service.ts': 2,
+  'apps/server/api/src/services/agent-campaign/campaign-winner-extraction.service.ts': 5,
+  'apps/server/api/src/services/agent-campaign/content-engine.service.ts': 10,
+  'apps/server/api/src/services/agent-campaign/trigger-evaluator.service.ts': 10,
+  'apps/server/api/src/services/agent-orchestrator/agent-stream-publisher.service.ts': 1,
+  'apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts': 3,
+  'apps/server/api/src/services/agent-threading/services/agent-thread-projector.service.ts': 4,
+  'apps/server/api/src/services/ai-influencer/ai-influencer.service.ts': 3,
+  'apps/server/api/src/services/batch-content/batch-content.service.ts': 1,
+  'apps/server/api/src/services/campaign/campaign-discovery.service.ts': 1,
+  'apps/server/api/src/services/campaign/campaign-executor.service.ts': 7,
+  'apps/server/api/src/services/campaign/dm-campaign-executor.service.ts': 7,
+  'apps/server/api/src/services/distribution/telegram/telegram-distribution.service.ts': 1,
+  'apps/server/api/src/services/integrations/facebook/controllers/facebook.controller.ts': 1,
+  'apps/server/api/src/services/integrations/fanvue/controllers/fanvue.controller.ts': 1,
+  'apps/server/api/src/services/integrations/google-ads/controllers/google-ads.controller.ts': 1,
+  'apps/server/api/src/services/integrations/google-search-console/controllers/google-search-console.controller.ts': 1,
+  'apps/server/api/src/services/integrations/instagram/controllers/instagram.controller.ts': 1,
+  'apps/server/api/src/services/integrations/linkedin/controllers/linkedin.controller.ts': 1,
+  'apps/server/api/src/services/integrations/medium/controllers/medium.controller.ts': 1,
+  'apps/server/api/src/services/integrations/reddit/controllers/reddit.controller.ts': 2,
+  'apps/server/api/src/services/integrations/threads/controllers/threads.controller.ts': 1,
+  'apps/server/api/src/services/integrations/tiktok/controllers/tiktok.controller.ts': 1,
+  'apps/server/api/src/services/integrations/twitter/controllers/twitter.controller.ts': 1,
+  'apps/server/api/src/services/integrations/twitter/services/twitter.service.ts': 1,
+  'apps/server/api/src/services/integrations/youtube/controllers/youtube.controller.ts': 2,
+  'apps/server/api/src/services/reply-bot/reply-bot-orchestrator.service.ts': 5,
+  'apps/server/api/src/services/workflow-executor/processors/trend-inspiration.processor.ts': 1,
+  'apps/server/workers/src/crons/ad-sync/cron.ad-sync-meta.service.ts': 2,
+  'apps/server/workers/src/crons/credentials/cron.credentials.service.ts': 2,
+  'apps/server/workers/src/crons/youtube/cron.youtube-status.service.ts': 4,
+};


### PR DESCRIPTION
## Problem

`packages/prisma/prisma/schema.prisma` splits **scalar FKs** (`organizationId`, `brandId`, `userId`, `credentialId` — always present on a row) from **relation fields** (`organization`, `brand`, `user`, `credential` — present only when explicitly `include`d). `BaseService.findOne(params, populate: PopulateInput = [])` defaults to an empty populate and `populateToInclude([])` returns `undefined`, so relations are usually **not** loaded.

Mongo-era `*Document` types still declare those relation props as optional, so reading them **type-checks** but at runtime the value is call-path dependent: a populated object, a back-filled id string, or `undefined`.

Per [`.agents/memory/rules/prisma_legacy_alias_fields.md`](.agents/memory/rules/prisma_legacy_alias_fields.md).

## Confirmed failures fixed

### 1. Analytics upsert wrote garbage foreign keys — P2003 on every write

`post-analytics.service.ts` fetched the post with no populate and wrote `String(post.brand)` / `String(post.organization)` / `String(post.user)` into the upsert `create` block. `PostsService.findOne` **does** populate brand + user, so those stringified to `"[object Object]"`; on paths without the populate they stringified to the literal `"undefined"`. Postgres rejected both with a **P2003 foreign-key violation** — post analytics never persisted.

### 2. `trackPostAnalytics` — TypeError / wrong-brand lookups

The YOUTUBE / TIKTOK / INSTAGRAM / PINTEREST / LINKEDIN / MASTODON branches called `post.organization.toString()` and `post.brand.toString()`: TypeError on unpopulated rows, `"[object Object]"` lookups on populated ones. The `credential` argument was also `undefined` from `refreshAllAnalytics` (see #3), so `credential.platform` threw before any of that — and the throw was swallowed by the surrounding try/catch.

### 3. Credential lookup silently lost tenant scoping — **security-relevant**

`posts-analytics.controller.ts` built:

```ts
{ _id: post.credential, brand: post.brand, organization: post.organization }
```

`normalizeWhere` **drops `undefined` values**, and `credential` is never back-filled by `BaseService.normalizeDocument` (it is not in the alias list). So the filter collapsed to an unscoped-by-tenant lookup that could return **another organization's credential**. `refreshAllAnalytics` also passed `post.credential as unknown as CredentialEntity` — always `undefined`, since `findAll` loads no relations.

## Approach

New shared resolver at [`apps/server/api/src/shared/utils/relation-id/relation-id.util.ts`](apps/server/api/src/shared/utils/relation-id/relation-id.util.ts):

- **`resolveRelationId(scalarId, alias)`** — scalar FK first; falls back to the legacy alias only when it carries a usable id (string, or `.id` / `._id` off a populated object). Never `String()`s an object. Returns `undefined` when nothing resolves.
- **`requireRelationId(scalarId, alias, field, context)`** — same, but throws `BadRequestException` when unresolvable. Used wherever a missing id would otherwise **silently widen a tenant-scoped query or write a bad FK**. Fails closed: no id, no query.

This follows the rule's prescription (read scalar FKs) rather than adding populate calls, matching the reference fallback at `organizations.controller.ts:471`.

## Also fixed (same root cause)

| File | Issue |
|---|---|
| `credentials.service.ts` → `saveCredentials` | `String(brand.id)` / `String(brand.organizationId ?? brand.organization)` wrote `"undefined"` / `"[object Object]"` into credential FKs |
| `base-integration.controller.ts` → `getOrCreateCredential` | `{ brand, organization }` alias filter dropped by `normalizeWhere` → unscoped credential lookup, shared across both `findOne` calls now |
| `posts.service.ts` → `handleYoutubePost` | `post.user` is a populated object on this path; `post.user.toString()` enqueued `"[object Object]"` as `userId` |
| `posts.service.ts` → `completePublishFirstPostMission` | `String(post.organization)` produced the truthy literal `"undefined"`, so the `if (!organizationId) return` guard never fired |
| `agent-runs.controller.ts` → `canUserModifyEntity` | alias-only reads **denied legitimate owners** and skipped the brand check entirely |
| `agent-strategies.controller.ts` → `canUserModifyEntity` | same, org check |
| `tasks.controller.ts` → `canUserModifyEntity` | **fail-open**: both sides resolved to `undefined`, and `undefined === undefined` **granted write access**. Now requires both sides present. |

`credential.id.toString()` and `ingredient.id.toString()` in `handleYoutubePost` are deliberately left alone — those are genuinely populated entities, not relation aliases.

## Investigated — false positives, unchanged

- **`apps/server/server/src/collections/ad-optimization-recommendations/services/ad-optimization-recommendations.service.ts:157`** — inside `toDocument()`, which *explicitly* sets `organization: doc.organizationId`. That is the alias being **written from** the scalar FK, which is correct.
- **`apps/server/server/src/analytics/services/analytics-social-job.service.ts:128,175,208,241,281`** — `organization` / `brand` there are declared **`string` fields on the job DTO** (`packages/queue-contracts/src/job-data/analytics-social-job.interface.ts`), not Prisma relation aliases.

## Tests

- **`relation-id.util.spec.ts`** (new, 9 tests) — scalar preferred over alias, `.id` / `._id` extraction, never stringifies a populated object, `undefined` / `''` / `null` / non-id objects → `undefined`, and `requireRelationId`'s throw + message.
- **`post-analytics.service.spec.ts`** (new, 4 tests) — the upsert writes **real** FK values, asserted `not.toBe('undefined')` and `not.toBe('[object Object]')`, for both a populated-relation post and a scalar-FK post; skips the upsert and returns `null` when an owner id is unresolvable; `trackPostAnalytics` returns early instead of throwing on a missing credential.
- **`posts-analytics.controller.spec.ts`** (+3) — `credentialsService.findOne` is called with **exactly** `{ _id, brandId, organizationId }` (an exact-match assertion, since a missing key *is* the defect); scalar FKs win over populated objects; the controller **throws rather than querying unscoped** when the organization is unresolvable.
- **`credentials.service.spec.ts`** (+2) — same root cause one frame down: real FKs from a legacy-alias brand, and fail-closed when unresolvable.
- **`base-integration.controller.spec.ts`** — assertion tightened from `expect.objectContaining({ brand: expect.any(String) })` to an exact scalar-FK match, plus a fail-closed case.

## Follow-up proposal (not in this PR)

A repo-wide AST guard — `scripts/check-relation-alias-reads.ts`, modeled on the existing `scripts/check-di-value-imports.ts` and wired into the CI `guards` job — could catch this class of bug statically. It would flag, over `apps/server/**/*.ts`:

1. `String(x.<alias>)` / `x.<alias>.toString()` where `<alias>` ∈ `{organization, brand, user, credential}` and a sibling `<alias>Id` exists on the same Prisma model;
2. object literals passed to `findOne` / `findFirst` / `findMany` / `where:` containing a bare alias key alongside no scalar-FK key.

Rule (2) is the security-relevant half and is the cheaper of the two to implement — the alias key set is finite and greppable. Happy to build it as a separate PR if wanted.

## Verification

Not run locally (MacBook constraint). Biome + secretlint + control-guard passed via the pre-commit hook; the 9 remaining biome warnings in the touched directories are **pre-existing on `master`** (verified by stashing and re-running) and were left alone. Type-check and tests run in PR CI.
