### PR TITLE
chore(guards): add relation-alias read guard with ratchet baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,7 +272,7 @@ jobs:
           bun run check:runtime-complexity -- --base "$BASE"
       - name: Architecture Guard Fixtures
         run: |
-          bunx vitest run --config scripts/architecture/vitest.config.ts check-runtime-complexity.test.ts check-deterministic-locale.test.ts
+          bunx vitest run --config scripts/architecture/vitest.config.ts check-runtime-complexity.test.ts check-deterministic-locale.test.ts check-relation-alias-reads.test.ts
           bunx vitest run --config scripts/ci/vitest.config.ts feature-test-coverage.test.ts nightly-test-workspace-inventory.test.ts nightly-unit-matrix.test.ts pr-validation-telemetry.test.ts
       - name: Require tests for feature source changes
         if: github.event_name == 'pull_request'
@@ -281,6 +281,8 @@ jobs:
         run: bun run scripts/ci/feature-test-coverage.ts --base "${{ github.event.pull_request.base.sha }}" | tee -a "$GITHUB_STEP_SUMMARY"
       - name: DI Value Imports
         run: bun run check:di-value-imports
+      - name: Relation Alias Reads
+        run: bun run check:relation-alias-reads
       - name: Desktop Schema Drift
         run: bun run check:desktop-schema-drift
       - name: Serializer Drift Regression Tests

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "check:deterministic-locale": "bun run scripts/architecture/check-deterministic-locale.ts",
     "check:di-value-imports": "bun run scripts/check-di-value-imports.ts",
     "check:import-cycles": "bun run scripts/check-import-cycles.ts",
+    "check:relation-alias-reads": "bun run scripts/architecture/check-relation-alias-reads.ts",
     "check:ui-guards": "bun run scripts/ui/check-ui-guards.ts",
     "publish:package": "./scripts/publish-package.sh",
     "check:nightly-test-inventory": "bun run scripts/ci/nightly-test-workspace-inventory.ts",

--- a/scripts/architecture/check-relation-alias-reads.test.ts
+++ b/scripts/architecture/check-relation-alias-reads.test.ts
@@ -1,0 +1,299 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  collectRelationAliases,
+  countByFile,
+  diffAgainstBaseline,
+  runCheckRelationAliasReads,
+} from './check-relation-alias-reads';
+
+/**
+ * Two models, mirroring the shape that makes the real schema tricky:
+ * `organization`/`brand`/`credential` are relations everywhere, while
+ * `metadata` is a relation on Post and a plain `Json?` column on Ingredient.
+ */
+const SCHEMA = [
+  'model Post {',
+  '  id             String        @id',
+  '  organizationId String',
+  '  organization   Organization  @relation(fields: [organizationId], references: [id])',
+  '  brandId        String?',
+  '  brand          Brand?        @relation(fields: [brandId], references: [id])',
+  '  credentialId   String?',
+  '  credential     Credential?   @relation(fields: [credentialId], references: [id])',
+  '  metadataId     String?',
+  '  metadata       Metadata?     @relation(fields: [metadataId], references: [id])',
+  '}',
+  '',
+  'model Ingredient {',
+  '  id       String  @id',
+  '  metadata Json?',
+  '}',
+].join('\n');
+
+describe('check-relation-alias-reads', () => {
+  let originalCwd = '';
+  let testDir = '';
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    testDir = mkdtempSync(path.join(tmpdir(), 'relation-alias-check-'));
+    process.chdir(testDir);
+    writeFixture('packages/prisma/prisma/schema.prisma', SCHEMA);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(testDir, { force: true, recursive: true });
+  });
+
+  describe('collectRelationAliases', () => {
+    it('pairs each relation alias with its scalar foreign key', () => {
+      const aliases = collectRelationAliases(SCHEMA);
+
+      expect(aliases.get('organization')).toBe('organizationId');
+      expect(aliases.get('brand')).toBe('brandId');
+      expect(aliases.get('credential')).toBe('credentialId');
+    });
+
+    it('drops names that are a plain column on any other model', () => {
+      // `metadata` is a relation on Post but `Json?` on Ingredient. Without a
+      // type checker the guard cannot tell which model a receiver came from,
+      // so the name is unusable and must not be flagged anywhere.
+      expect(collectRelationAliases(SCHEMA).has('metadata')).toBe(false);
+    });
+
+    it('handles compound foreign-key lists', () => {
+      const aliases = collectRelationAliases(
+        [
+          'model Snapshot {',
+          '  sourceId       String',
+          '  organizationId String',
+          '  source         Source @relation(fields: [sourceId, organizationId], references: [id, organizationId])',
+          '}',
+        ].join('\n'),
+      );
+
+      expect(aliases.get('source')).toBe('sourceId');
+    });
+  });
+
+  describe('id-coercion rule', () => {
+    it('flags String(row.alias)', () => {
+      writeFixture(
+        'apps/server/api/src/posts/posts.service.ts',
+        [
+          "import type { PostDocument } from './post.schema';",
+          '',
+          'export function track(post: PostDocument) {',
+          '  return { organizationId: String(post.organization) };',
+          '}',
+        ].join('\n'),
+      );
+
+      expect(runCheckRelationAliasReads().violations).toEqual([
+        expect.objectContaining({
+          alias: 'organization',
+          receiver: 'post',
+          rule: 'id-coercion',
+          scalar: 'organizationId',
+        }),
+      ]);
+    });
+
+    it('flags row.alias.toString()', () => {
+      writeFixture(
+        'apps/server/api/src/posts/posts.service.ts',
+        [
+          "import type { PostDocument } from './post.schema';",
+          '',
+          'export function track(post: PostDocument) {',
+          '  return post.brand.toString();',
+          '}',
+        ].join('\n'),
+      );
+
+      expect(runCheckRelationAliasReads().violations).toEqual([
+        expect.objectContaining({ alias: 'brand', rule: 'id-coercion' }),
+      ]);
+    });
+
+    it('flags a relation alias interpolated into a template literal', () => {
+      writeFixture(
+        'apps/server/api/src/posts/posts.service.ts',
+        [
+          "import type { PostDocument } from './post.schema';",
+          '',
+          'export function cacheKey(post: PostDocument) {',
+          `  return \`posts:\${post.organization}\`;`,
+          '}',
+        ].join('\n'),
+      );
+
+      expect(runCheckRelationAliasReads().violations).toEqual([
+        expect.objectContaining({ alias: 'organization', rule: 'id-coercion' }),
+      ]);
+    });
+  });
+
+  describe('filter-value rule', () => {
+    it('flags relation aliases used as id-shaped filter values', () => {
+      writeFixture(
+        'apps/server/api/src/posts/posts.controller.ts',
+        [
+          'export async function refresh(service, credentials) {',
+          '  const post = await service.findOne({ _id: id });',
+          '  return credentials.findOne({',
+          '    _id: post.credential,',
+          '    brand: post.brand,',
+          '    organization: post.organization,',
+          '  });',
+          '}',
+        ].join('\n'),
+      );
+
+      const { violations } = runCheckRelationAliasReads();
+
+      // The security-relevant half: `normalizeWhere` drops undefined values, so
+      // this lookup silently loses its tenant scoping.
+      expect(violations.map((entry) => entry.alias).sort()).toEqual([
+        'brand',
+        'credential',
+        'organization',
+      ]);
+      expect(violations.every((entry) => entry.rule === 'filter-value')).toBe(
+        true,
+      );
+    });
+
+    it('ignores alias filter keys whose value did not come from a row', () => {
+      // `processSearchParams` maps alias keys to scalars, and these values come
+      // from auth metadata rather than an unpopulated row — legitimate, and the
+      // single largest source of false positives if the rule keyed on the name.
+      writeFixture(
+        'apps/server/api/src/runs/runs.controller.ts',
+        [
+          'export async function findOne(service, publicMetadata, id) {',
+          '  return service.findOne({',
+          '    _id: id,',
+          '    organization: publicMetadata.organization,',
+          '  });',
+          '}',
+        ].join('\n'),
+      );
+
+      expect(runCheckRelationAliasReads().violations).toEqual([]);
+    });
+  });
+
+  describe('non-violations', () => {
+    it('ignores sub-property reads, which only work when the relation is populated', () => {
+      writeFixture(
+        'apps/server/api/src/posts/posts.service.ts',
+        [
+          "import type { PostDocument } from './post.schema';",
+          '',
+          'export function label(post: PostDocument) {',
+          '  return post.brand.label;',
+          '}',
+        ].join('\n'),
+      );
+
+      expect(runCheckRelationAliasReads().violations).toEqual([]);
+    });
+
+    it('ignores receivers that are not row bindings', () => {
+      // A job DTO that declares `organization`/`brand` as plain strings is a
+      // different type with the same property names.
+      writeFixture(
+        'apps/server/api/src/analytics/analytics-job.service.ts',
+        [
+          'export function run(job: AnalyticsJob, client) {',
+          '  return client.getMediaAnalytics(String(job.organization));',
+          '}',
+        ].join('\n'),
+      );
+
+      expect(runCheckRelationAliasReads().violations).toEqual([]);
+    });
+
+    it('honours a relation-alias-ok annotation', () => {
+      writeFixture(
+        'apps/server/api/src/posts/posts.service.ts',
+        [
+          "import type { PostDocument } from './post.schema';",
+          '',
+          'export function track(post: PostDocument) {',
+          '  // relation-alias-ok: findOne populates organization on this path',
+          '  return String(post.organization);',
+          '}',
+        ].join('\n'),
+      );
+
+      expect(runCheckRelationAliasReads().violations).toEqual([]);
+    });
+
+    it('skips test files', () => {
+      writeFixture(
+        'apps/server/api/src/posts/posts.service.spec.ts',
+        [
+          "import type { PostDocument } from './post.schema';",
+          '',
+          'const post = { organization: { id: 1 } } as unknown as PostDocument;',
+          'expect(String(post.organization)).toBeDefined();',
+        ].join('\n'),
+      );
+
+      expect(runCheckRelationAliasReads().violations).toEqual([]);
+    });
+  });
+
+  describe('ratchet', () => {
+    const violation = (file: string) => ({
+      alias: 'organization',
+      file,
+      line: 1,
+      receiver: 'post',
+      rule: 'id-coercion' as const,
+      scalar: 'organizationId',
+    });
+
+    it('counts violations per file', () => {
+      expect(
+        countByFile([violation('a.ts'), violation('a.ts'), violation('b.ts')]),
+      ).toEqual({
+        'a.ts': 2,
+        'b.ts': 1,
+      });
+    });
+
+    it('reports a file over its baseline as a regression', () => {
+      expect(diffAgainstBaseline({ 'a.ts': 3 }, { 'a.ts': 2 })).toEqual({
+        regressions: [{ actual: 3, baseline: 2, file: 'a.ts' }],
+        stale: [],
+      });
+    });
+
+    it('reports a file under its baseline as stale so the entry gets pruned', () => {
+      expect(diffAgainstBaseline({}, { 'a.ts': 2 })).toEqual({
+        regressions: [],
+        stale: [{ actual: 0, baseline: 2, file: 'a.ts' }],
+      });
+    });
+
+    it('passes a file that exactly matches its baseline', () => {
+      expect(diffAgainstBaseline({ 'a.ts': 2 }, { 'a.ts': 2 })).toEqual({
+        regressions: [],
+        stale: [],
+      });
+    });
+  });
+});
+
+function writeFixture(relativePath: string, content: string): void {
+  const absolute = path.join(process.cwd(), relativePath);
+  mkdirSync(path.dirname(absolute), { recursive: true });
+  writeFileSync(absolute, content);
+}

--- a/scripts/architecture/check-relation-alias-reads.ts
+++ b/scripts/architecture/check-relation-alias-reads.ts
@@ -1,0 +1,553 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { globSync } from 'glob';
+import ts from 'typescript';
+import { RELATION_ALIAS_READ_BASELINE } from './relation-alias-reads.baseline';
+
+/**
+ * Guard: forbid reading Mongo-era relation aliases off Prisma rows in the
+ * server apps.
+ *
+ * `schema.prisma` splits scalar foreign keys (`organizationId`, `brandId`, …)
+ * from relation fields (`organization`, `brand`, …). The scalar is always on
+ * the row; the relation is present only when the query explicitly `include`d
+ * it, and `BaseService.findOne` defaults to no populate. The legacy
+ * `*Document` types still declare the relation props as optional, so reading
+ * one type-checks while its runtime value is call-path dependent — a populated
+ * object, a back-filled id string, or `undefined`.
+ *
+ * Every failure mode is silent:
+ *   - `String(post.organization)` writes "[object Object]" or the literal
+ *     "undefined" into a foreign key column (Postgres P2003).
+ *   - `post.brand.toString()` throws a TypeError that a surrounding catch eats.
+ *   - `{ organization: post.organization }` as a filter has its `undefined`
+ *     value dropped by `normalizeWhere`, silently unscoping a tenant query.
+ *
+ * Fix: read the scalar FK, via `resolveRelationId` / `requireRelationId`
+ * (apps/server/api/src/shared/utils/relation-id/relation-id.util.ts). Those two
+ * are the sanctioned readers and are exempt here.
+ *
+ * Scope: only the two shapes where reading the alias is broken under every
+ * call path — coercing it to a string id, and using it as the value of an
+ * id-shaped filter key. Plain reads are left alone: plenty of call sites do
+ * pass a populate and legitimately walk into the relation object
+ * (`ingredient.metadata.duration`), and this guard has no type checker to tell
+ * the two apart.
+ *
+ * @see .agents/memory/rules/prisma_legacy_alias_fields.md
+ */
+
+const INCLUDE_GLOBS = ['apps/server/**/*.ts'];
+
+const IGNORE_GLOBS = [
+  '**/*.spec.ts',
+  '**/*.test.ts',
+  '**/__fixtures__/**',
+  '**/node_modules/**',
+  '**/dist/**',
+  '**/.next/**',
+  '**/.turbo/**',
+  '**/coverage/**',
+  '**/fixtures/**',
+  '**/generated/**',
+];
+
+const SCHEMA_PATH = 'packages/prisma/prisma/schema.prisma';
+
+const BASELINE_PATH = 'scripts/architecture/relation-alias-reads.baseline.ts';
+
+const BASELINE_HEADER = `/**
+ * Ratchet baseline for check-relation-alias-reads.ts.
+ *
+ * Per-file counts of pre-existing relation-alias reads, captured 2026-07-24.
+ * Counts may ONLY go down — the guard fails on a file that gains one, and also
+ * on a file that drops below its entry, so whoever fixes a site prunes the
+ * number in the same PR. Regenerate with:
+ *
+ *   bun run check:relation-alias-reads --update-baseline
+ *
+ * When this map is empty, delete it and flip the guard to a plain ban.
+ *
+ * Every entry is a real instance of the defect fixed in #2033, not a false
+ * positive — the backlog is large because the hazard is systemic, not because
+ * the guard is noisy.
+ */
+`;
+
+/**
+ * A row binding is only recognised when the code says so syntactically: an
+ * explicit `*Document` / `*Entity` annotation, or a binding initialised from a
+ * `BaseService` read. Anything the guard cannot classify is left alone — this
+ * check is deliberately conservative, because the alias names double as plain
+ * declared string fields on job DTOs and auth metadata.
+ */
+const ROW_TYPE_PATTERN = /(?:Document|Entity)$/;
+
+const ROW_READ_METHODS = new Set([
+  'findAll',
+  'findById',
+  'findFirst',
+  'findMany',
+  'findOne',
+  'findOneById',
+]);
+
+const SUPPRESSION_COMMENT = 'relation-alias-ok';
+
+export type RelationAliasRule = 'filter-value' | 'id-coercion';
+
+export type RelationAliasViolation = {
+  alias: string;
+  file: string;
+  line: number;
+  receiver: string;
+  rule: RelationAliasRule;
+  scalar: string;
+};
+
+export type RelationAliasCheckOptions = {
+  ignoreGlobs?: string[];
+  includeGlobs?: string[];
+  schemaPath?: string;
+};
+
+export type RelationAliasCheckResult = {
+  aliasCount: number;
+  filesScanned: number;
+  violations: RelationAliasViolation[];
+};
+
+/**
+ * Ground truth comes from the schema, not a hand-maintained list: every
+ * relation field declared with `@relation(fields: [<scalar>])` whose scalar is
+ * named `<field>Id`. That pairing is exactly the hazard — an alias that has a
+ * scalar twin the code should have read instead.
+ */
+export function collectRelationAliases(
+  schemaSource: string,
+): Map<string, string> {
+  const aliases = new Map<string, string>();
+  const ambiguous = new Set<string>();
+
+  for (const line of schemaSource.split('\n')) {
+    const field = /^[ \t]+(\w+)[ \t]+\S+/.exec(line);
+    if (!field) {
+      continue;
+    }
+
+    const name = field[1];
+    const fkList = /@relation\([^)]*fields:\s*\[([^\]]*)\]/.exec(line);
+    const isAliasDeclaration =
+      fkList?.[1]
+        .split(',')
+        .map((entry) => entry.trim())
+        .includes(`${name}Id`) ?? false;
+
+    if (isAliasDeclaration) {
+      aliases.set(name, `${name}Id`);
+    } else {
+      ambiguous.add(name);
+    }
+  }
+
+  // A name that is *also* declared as something else somewhere in the schema
+  // can't be classified from the property access alone. `metadata` is a
+  // `Metadata?` relation on one model and a plain `Json?` column on a dozen
+  // others; `source`, `content` and `plan` are the same story. With no
+  // type checker the guard cannot tell which model a receiver came from, so
+  // those names are dropped entirely. What survives — `organization`, `brand`,
+  // `user`, `credential` and friends — means "relation" everywhere in the
+  // schema, which is what makes a read of it unambiguously wrong.
+  for (const name of ambiguous) {
+    aliases.delete(name);
+  }
+
+  return aliases;
+}
+
+function annotationTypeName(node: ts.TypeNode | undefined): string | null {
+  if (!node) {
+    return null;
+  }
+  if (ts.isTypeReferenceNode(node)) {
+    let name: ts.EntityName = node.typeName;
+    while (ts.isQualifiedName(name)) {
+      name = name.right;
+    }
+    return name.text;
+  }
+  // `post: PostDocument | null` — a nullable row is still a row.
+  if (ts.isUnionTypeNode(node)) {
+    for (const member of node.types) {
+      const inner = annotationTypeName(member);
+      if (inner && ROW_TYPE_PATTERN.test(inner)) {
+        return inner;
+      }
+    }
+  }
+  return null;
+}
+
+function isRowAnnotation(node: ts.TypeNode | undefined): boolean {
+  const name = annotationTypeName(node);
+  return name !== null && ROW_TYPE_PATTERN.test(name);
+}
+
+function unwrapAwait(expression: ts.Expression): ts.Expression {
+  return ts.isAwaitExpression(expression) ? expression.expression : expression;
+}
+
+/** `await this.postsService.findOne(...)` and friends yield a Prisma row. */
+function isRowReadCall(expression: ts.Expression | undefined): boolean {
+  if (!expression) {
+    return false;
+  }
+  const call = unwrapAwait(expression);
+  if (!ts.isCallExpression(call)) {
+    return false;
+  }
+  const callee = call.expression;
+  return (
+    ts.isPropertyAccessExpression(callee) &&
+    ROW_READ_METHODS.has(callee.name.text)
+  );
+}
+
+/**
+ * Collects identifiers that hold a Prisma row, per file. Scope is ignored on
+ * purpose: a name bound to a row anywhere in a file is treated as a row
+ * everywhere in it. Shadowing the same identifier with a non-row value in the
+ * same file is not a pattern this codebase uses, and erring toward reporting
+ * keeps the guard from going quiet on a real defect.
+ */
+function collectRowBindings(sourceFile: ts.SourceFile): Set<string> {
+  const bindings = new Set<string>();
+
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isParameter(node) &&
+      ts.isIdentifier(node.name) &&
+      isRowAnnotation(node.type)
+    ) {
+      bindings.add(node.name.text);
+    }
+
+    if (ts.isPropertyDeclaration(node) && ts.isIdentifier(node.name)) {
+      if (isRowAnnotation(node.type)) {
+        bindings.add(node.name.text);
+      }
+    }
+
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) {
+      if (isRowAnnotation(node.type) || isRowReadCall(node.initializer)) {
+        bindings.add(node.name.text);
+      }
+    }
+
+    // `for (const post of posts.docs)` / `for (const post of rows)` where the
+    // iterated value already traces back to a row read.
+    if (ts.isForOfStatement(node)) {
+      const declaration = ts.isVariableDeclarationList(node.initializer)
+        ? node.initializer.declarations[0]
+        : undefined;
+      if (declaration && ts.isIdentifier(declaration.name)) {
+        const source = node.expression;
+        const root = ts.isPropertyAccessExpression(source)
+          ? source.expression
+          : source;
+        if (
+          (ts.isIdentifier(root) && bindings.has(root.text)) ||
+          isRowReadCall(source)
+        ) {
+          bindings.add(declaration.name.text);
+        }
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  };
+
+  // Two passes: a `for...of` may iterate a binding declared earlier in source
+  // order but visited later through nesting.
+  visit(sourceFile);
+  visit(sourceFile);
+
+  return bindings;
+}
+
+/**
+ * `String(post.brand)`, `post.brand.toString()`, `` `${post.brand}` `` — every
+ * one of these produces "[object Object]" when the relation is populated and
+ * the literal "undefined" when it is not. Neither is ever a valid foreign key.
+ */
+function isIdCoercion(access: ts.PropertyAccessExpression): boolean {
+  const parent = access.parent;
+  if (!parent) {
+    return false;
+  }
+
+  if (
+    ts.isCallExpression(parent) &&
+    ts.isIdentifier(parent.expression) &&
+    parent.expression.text === 'String'
+  ) {
+    return parent.arguments.includes(access);
+  }
+
+  if (
+    ts.isPropertyAccessExpression(parent) &&
+    parent.expression === access &&
+    parent.name.text === 'toString' &&
+    parent.parent &&
+    ts.isCallExpression(parent.parent)
+  ) {
+    return true;
+  }
+
+  return ts.isTemplateSpan(parent);
+}
+
+/**
+ * `{ _id: post.credential, organization: post.organization }` — an id-shaped
+ * key fed from a relation alias. `normalizeWhere` drops `undefined` values, so
+ * the tenant filter silently disappears instead of failing.
+ */
+function isIdShapedFilterValue(
+  access: ts.PropertyAccessExpression,
+  alias: string,
+): boolean {
+  const parent = access.parent;
+  if (
+    !parent ||
+    !ts.isPropertyAssignment(parent) ||
+    parent.initializer !== access
+  ) {
+    return false;
+  }
+
+  const key = ts.isIdentifier(parent.name)
+    ? parent.name.text
+    : ts.isStringLiteral(parent.name)
+      ? parent.name.text
+      : null;
+
+  return key === '_id' || key === 'id' || key === alias || key === `${alias}Id`;
+}
+
+function isSuppressed(sourceFile: ts.SourceFile, position: number): boolean {
+  const { line } = sourceFile.getLineAndCharacterOfPosition(position);
+  const lines = sourceFile.getFullText().split('\n');
+  const current = lines[line] ?? '';
+  const previous = line > 0 ? (lines[line - 1] ?? '') : '';
+  return (
+    current.includes(SUPPRESSION_COMMENT) ||
+    previous.includes(SUPPRESSION_COMMENT)
+  );
+}
+
+function checkFile(
+  file: string,
+  aliases: Map<string, string>,
+): RelationAliasViolation[] {
+  const content = readFileSync(file, 'utf8');
+  const sourceFile = ts.createSourceFile(
+    file,
+    content,
+    ts.ScriptTarget.Latest,
+    true,
+  );
+
+  const rowBindings = collectRowBindings(sourceFile);
+  if (rowBindings.size === 0) {
+    return [];
+  }
+
+  const violations: RelationAliasViolation[] = [];
+
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isPropertyAccessExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      rowBindings.has(node.expression.text)
+    ) {
+      const alias = node.name.text;
+      const scalar = aliases.get(alias);
+      const rule: RelationAliasRule | null = !scalar
+        ? null
+        : isIdCoercion(node)
+          ? 'id-coercion'
+          : isIdShapedFilterValue(node, alias)
+            ? 'filter-value'
+            : null;
+
+      if (scalar && rule && !isSuppressed(sourceFile, node.getStart())) {
+        violations.push({
+          alias,
+          file,
+          line:
+            sourceFile.getLineAndCharacterOfPosition(node.getStart()).line + 1,
+          receiver: node.expression.text,
+          rule,
+          scalar,
+        });
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+  return violations;
+}
+
+export function runCheckRelationAliasReads(
+  options: RelationAliasCheckOptions = {},
+): RelationAliasCheckResult {
+  const aliases = collectRelationAliases(
+    readFileSync(options.schemaPath ?? SCHEMA_PATH, 'utf8'),
+  );
+
+  const files = globSync(options.includeGlobs ?? INCLUDE_GLOBS, {
+    ignore: options.ignoreGlobs ?? IGNORE_GLOBS,
+    nodir: true,
+  });
+
+  return {
+    aliasCount: aliases.size,
+    filesScanned: files.length,
+    violations: files.flatMap((file) => checkFile(file, aliases)),
+  };
+}
+
+export function countByFile(
+  violations: readonly RelationAliasViolation[],
+): Record<string, number> {
+  const counts: Record<string, number> = {};
+  for (const violation of violations) {
+    counts[violation.file] = (counts[violation.file] ?? 0) + 1;
+  }
+  return counts;
+}
+
+export type RatchetDrift = {
+  actual: number;
+  baseline: number;
+  file: string;
+};
+
+/**
+ * Exact-match ratchet, same contract as `workers-api-imports.baseline.ts`: a
+ * file over its baseline is a regression, and a file under it is a stale entry
+ * that must be pruned in the PR that fixed it. Anything else lets the baseline
+ * rot into a number nobody trusts.
+ */
+export function diffAgainstBaseline(
+  counts: Record<string, number>,
+  baseline: Readonly<Record<string, number>>,
+): { regressions: RatchetDrift[]; stale: RatchetDrift[] } {
+  const regressions: RatchetDrift[] = [];
+  const stale: RatchetDrift[] = [];
+
+  for (const file of new Set([
+    ...Object.keys(counts),
+    ...Object.keys(baseline),
+  ])) {
+    const actual = counts[file] ?? 0;
+    const allowed = baseline[file] ?? 0;
+    if (actual > allowed) {
+      regressions.push({ actual, baseline: allowed, file });
+    } else if (actual < allowed) {
+      stale.push({ actual, baseline: allowed, file });
+    }
+  }
+
+  return {
+    regressions: regressions.sort((a, b) => a.file.localeCompare(b.file)),
+    stale: stale.sort((a, b) => a.file.localeCompare(b.file)),
+  };
+}
+
+function describe(violation: RelationAliasViolation): string {
+  const consequence =
+    violation.rule === 'id-coercion'
+      ? 'coerces a relation alias to a string id — that is "[object Object]" when populated and "undefined" when not'
+      : 'feeds a relation alias into an id-shaped filter key — an undefined value is dropped by normalizeWhere, silently unscoping the query';
+  return (
+    `  ${violation.file}:${violation.line} — '${violation.receiver}.${violation.alias}' ${consequence}. ` +
+    `Read '${violation.receiver}.${violation.scalar}' instead, or route it through ` +
+    'resolveRelationId()/requireRelationId(). If the alias really is populated here, annotate the ' +
+    `line with '// ${SUPPRESSION_COMMENT}: <reason>'.`
+  );
+}
+
+function writeBaseline(counts: Record<string, number>): void {
+  const entries = Object.entries(counts).sort(([a], [b]) => a.localeCompare(b));
+  const total = entries.reduce((sum, [, count]) => sum + count, 0);
+  const body = entries
+    .map(([file, count]) => `  '${file}': ${count},`)
+    .join('\n');
+
+  writeFileSync(
+    BASELINE_PATH,
+    `${BASELINE_HEADER}\nexport const RELATION_ALIAS_READ_BASELINE: Readonly<Record<string, number>> = {\n${body}\n};\n`,
+  );
+  console.log(
+    `check:relation-alias-reads — baseline rewritten: ${entries.length} file(s), ${total} violation(s).`,
+  );
+}
+
+function main(): void {
+  const { aliasCount, filesScanned, violations } = runCheckRelationAliasReads();
+  const counts = countByFile(violations);
+
+  if (process.argv.includes('--update-baseline')) {
+    writeBaseline(counts);
+    return;
+  }
+
+  const { regressions, stale } = diffAgainstBaseline(
+    counts,
+    RELATION_ALIAS_READ_BASELINE,
+  );
+
+  if (regressions.length === 0 && stale.length === 0) {
+    console.log(
+      `check:relation-alias-reads — ${filesScanned} files scanned against ` +
+        `${aliasCount} schema relation aliases; ${violations.length} baselined ` +
+        'violation(s), no new ones.',
+    );
+    return;
+  }
+
+  if (regressions.length > 0) {
+    console.error(
+      'check:relation-alias-reads — new relation-alias read(s). Prisma relation fields are only ' +
+        'present when a query explicitly includes them, so reading one yields a populated object, a ' +
+        'back-filled id, or undefined depending on the call path — silently corrupting foreign keys ' +
+        'and dropping tenant filters while type-check passes.',
+    );
+    const regressed = new Set(regressions.map((entry) => entry.file));
+    for (const violation of violations.filter((entry) =>
+      regressed.has(entry.file),
+    )) {
+      console.error(describe(violation));
+    }
+  }
+
+  if (stale.length > 0) {
+    console.error(
+      '\ncheck:relation-alias-reads — the baseline is stale. These files improved; lower them in ' +
+        'scripts/architecture/relation-alias-reads.baseline.ts (or run with --update-baseline) so the ' +
+        'ratchet cannot slip back:',
+    );
+    for (const entry of stale) {
+      console.error(
+        `  ${entry.file} — baseline ${entry.baseline}, actual ${entry.actual}`,
+      );
+    }
+  }
+
+  process.exit(1);
+}
+
+if (import.meta.main) {
+  main();
+}

--- a/scripts/architecture/relation-alias-reads.baseline.ts
+++ b/scripts/architecture/relation-alias-reads.baseline.ts
@@ -1,0 +1,78 @@
+/**
+ * Ratchet baseline for check-relation-alias-reads.ts.
+ *
+ * Per-file counts of pre-existing relation-alias reads, captured 2026-07-24.
+ * Counts may ONLY go down — the guard fails on a file that gains one, and also
+ * on a file that drops below its entry, so whoever fixes a site prunes the
+ * number in the same PR. Regenerate with:
+ *
+ *   bun run check:relation-alias-reads --update-baseline
+ *
+ * When this map is empty, delete it and flip the guard to a plain ban.
+ *
+ * Every entry is a real instance of the defect fixed in #2033, not a false
+ * positive — the backlog is large because the hazard is systemic, not because
+ * the guard is noisy.
+ */
+
+export const RELATION_ALIAS_READ_BASELINE: Readonly<Record<string, number>> = {
+  'apps/server/api/src/collections/agent-campaigns/controllers/agent-campaigns.controller.ts': 1,
+  'apps/server/api/src/collections/agent-strategies/services/agent-strategy-autopilot-execution.service.ts': 1,
+  'apps/server/api/src/collections/agent-strategies/services/agent-strategy-autopilot-performance.service.ts': 2,
+  'apps/server/api/src/collections/articles/controllers/articles.controller.ts': 2,
+  'apps/server/api/src/collections/articles/services/articles-content.service.ts': 1,
+  'apps/server/api/src/collections/bots/services/bots-livestream-delivery.service.ts': 1,
+  'apps/server/api/src/collections/content-plan-items/services/content-plan-items.service.ts': 3,
+  'apps/server/api/src/collections/images/controllers/operations/images-operations.controller.ts': 1,
+  'apps/server/api/src/collections/ingredients/controllers/ingredients-relationships.controller.ts': 1,
+  'apps/server/api/src/collections/outreach-campaigns/controllers/outreach-campaigns.controller.ts': 3,
+  'apps/server/api/src/collections/posts/controllers/operations/posts-operations.controller.ts': 5,
+  'apps/server/api/src/collections/posts/services/posts.service.ts': 1,
+  'apps/server/api/src/collections/prompts/controllers/prompts-operations.controller.ts': 7,
+  'apps/server/api/src/collections/runs/services/runs.service.ts': 2,
+  'apps/server/api/src/collections/streaks/services/streaks.service.ts': 2,
+  'apps/server/api/src/collections/trainings/controllers/trainings.controller.ts': 2,
+  'apps/server/api/src/collections/users/services/user-setup.service.ts': 1,
+  'apps/server/api/src/collections/videos/controllers/batch-interpolation.controller.ts': 1,
+  'apps/server/api/src/collections/videos/controllers/transformations/edits/videos-edits.controller.ts': 2,
+  'apps/server/api/src/collections/videos/controllers/transformations/effects/videos-effects.controller.ts': 2,
+  'apps/server/api/src/collections/videos/services/video-generation.service.ts': 3,
+  'apps/server/api/src/collections/workflow-executions/controllers/internal-workflow-executions.controller.ts': 1,
+  'apps/server/api/src/collections/workflows/services/workflow-webhook.service.ts': 2,
+  'apps/server/api/src/endpoints/dev/dev.controller.ts': 1,
+  'apps/server/api/src/endpoints/webhooks/replicate/webhooks.replicate.controller.ts': 1,
+  'apps/server/api/src/endpoints/webhooks/services/post-processing-orchestrator.service.ts': 3,
+  'apps/server/api/src/endpoints/webhooks/stripe/handlers/stripe-invoice-webhook.handler.ts': 2,
+  'apps/server/api/src/endpoints/webhooks/stripe/handlers/stripe-subscription-webhook.handler.ts': 10,
+  'apps/server/api/src/endpoints/webhooks/webhooks.service.ts': 2,
+  'apps/server/api/src/services/agent-campaign/campaign-winner-extraction.service.ts': 5,
+  'apps/server/api/src/services/agent-campaign/content-engine.service.ts': 10,
+  'apps/server/api/src/services/agent-campaign/trigger-evaluator.service.ts': 10,
+  'apps/server/api/src/services/agent-orchestrator/agent-stream-publisher.service.ts': 1,
+  'apps/server/api/src/services/agent-orchestrator/tools/agent-tool-executor.service.ts': 3,
+  'apps/server/api/src/services/agent-threading/services/agent-thread-projector.service.ts': 4,
+  'apps/server/api/src/services/ai-influencer/ai-influencer.service.ts': 3,
+  'apps/server/api/src/services/batch-content/batch-content.service.ts': 1,
+  'apps/server/api/src/services/campaign/campaign-discovery.service.ts': 1,
+  'apps/server/api/src/services/campaign/campaign-executor.service.ts': 7,
+  'apps/server/api/src/services/campaign/dm-campaign-executor.service.ts': 7,
+  'apps/server/api/src/services/distribution/telegram/telegram-distribution.service.ts': 1,
+  'apps/server/api/src/services/integrations/facebook/controllers/facebook.controller.ts': 1,
+  'apps/server/api/src/services/integrations/fanvue/controllers/fanvue.controller.ts': 1,
+  'apps/server/api/src/services/integrations/google-ads/controllers/google-ads.controller.ts': 1,
+  'apps/server/api/src/services/integrations/google-search-console/controllers/google-search-console.controller.ts': 1,
+  'apps/server/api/src/services/integrations/instagram/controllers/instagram.controller.ts': 1,
+  'apps/server/api/src/services/integrations/linkedin/controllers/linkedin.controller.ts': 1,
+  'apps/server/api/src/services/integrations/medium/controllers/medium.controller.ts': 1,
+  'apps/server/api/src/services/integrations/reddit/controllers/reddit.controller.ts': 2,
+  'apps/server/api/src/services/integrations/threads/controllers/threads.controller.ts': 1,
+  'apps/server/api/src/services/integrations/tiktok/controllers/tiktok.controller.ts': 1,
+  'apps/server/api/src/services/integrations/twitter/controllers/twitter.controller.ts': 1,
+  'apps/server/api/src/services/integrations/twitter/services/twitter.service.ts': 1,
+  'apps/server/api/src/services/integrations/youtube/controllers/youtube.controller.ts': 2,
+  'apps/server/api/src/services/reply-bot/reply-bot-orchestrator.service.ts': 5,
+  'apps/server/api/src/services/workflow-executor/processors/trend-inspiration.processor.ts': 1,
+  'apps/server/workers/src/crons/ad-sync/cron.ad-sync-meta.service.ts': 2,
+  'apps/server/workers/src/crons/credentials/cron.credentials.service.ts': 2,
+  'apps/server/workers/src/crons/youtube/cron.youtube-status.service.ts': 4,
+};


### PR DESCRIPTION
Follow-up to #2033. That PR fixed one instance of a defect class; this one makes the class detectable repo-wide.

**Stacked on #2033** — base is `fix/prisma-relation-alias-analytics`, not `master`. The baseline was captured with #2033's fix applied; against bare `master` the guard correctly reports 21 extra violations. GitHub will retarget to `master` when #2033 merges.

## The hazard

`schema.prisma` splits scalar FKs (`organizationId`, always on the row) from relation fields (`organization`, present only when explicitly `include`d). `BaseService.findOne(params, populate = [])` defaults to an empty populate, so the relation is normally absent. Mongo-era `*Document` types still declare the relation prop as optional — reading it type-checks and is `undefined` at runtime. Documented in `.agents/memory/rules/prisma_legacy_alias_fields.md`.

## What the guard does

`scripts/architecture/check-relation-alias-reads.ts` — syntax-only AST pass (no type checker) over `apps/server/**`.

1. Derives the alias → scalar-FK map from `schema.prisma` (74 aliases).
2. Drops names that are a relation on one model and a plain column on another — `metadata`, `source`, `content`, `plan`. Without a type checker there is no way to tell which model a receiver came from, so ambiguous names go wholesale.
3. Classifies local bindings produced by `findOne`/`findAll`/`findMany`-style calls annotated with a `*Document`/`*Entity` type. Only those receivers are checked, which keeps DTOs and plain objects out.
4. Flags two rules:

| rule | shape | failure |
|---|---|---|
| `id-coercion` | `String(post.organization)`, `post.brand.toString()`, `` `posts:${post.organization}` `` | writes `"undefined"` / `"[object Object]"` into an FK column → Postgres P2003 |
| `filter-value` | alias as the value of an id-shaped filter key | `normalizeWhere` drops `undefined` and silently widens the query — the multi-tenancy half |

Rule 2 checks alias **values**, not alias **keys**. `processSearchParams` legitimately maps alias keys to scalar FKs, so a key-based rule would flood on correct code (`agent-runs.controller.ts:97-105,337-342`). Both of those sites, and `canUserModifyEntity`'s correct `resolveRelationId` use, are clean under the narrowed rule.

## Ratchet, not a ban

The sweep found **148 pre-existing real instances across 59 files** — every one a genuine occurrence of the defect, not guard noise. So it ships as a ratchet: `relation-alias-reads.baseline.ts` pins per-file counts and fails **both** ways. A file that gains one regresses; a file that drops below its entry is stale, so whoever fixes a site prunes the number in the same PR. Same pattern as `workers-api-imports.baseline.ts`. When the map empties, delete it and flip to a plain ban.

`// relation-alias-ok` escapes a reviewed site. Regenerate with `bun run check:relation-alias-reads --update-baseline`.

Worst concentrations: `stripe-subscription-webhook.handler.ts` (10), `content-engine.service.ts` (10), `trigger-evaluator.service.ts` (10), `campaign-executor.service.ts` (7), `dm-campaign-executor.service.ts` (7), `prompts-operations.controller.ts` (7).

## Regression proof

Restoring the two pre-#2033 files from `64054595d` makes the guard emit exactly the 21 violations that PR fixed — 18 `id-coercion` in `post-analytics.service.ts`, 3 `filter-value` in `posts-analytics.controller.ts` — and exit 1. Restored clean afterwards.

## CI wiring

- `guards` job: new `Relation Alias Reads` step running `bun run check:relation-alias-reads`.
- `Architecture Guard Fixtures` step: added `check-relation-alias-reads.test.ts`.

The test lives in `scripts/architecture/` on purpose — the root `vitest.config.ts` globs `scripts/*/vitest.config.ts`, **subdirectories only**, so a test placed beside the guard at `scripts/` would never run. (`scripts/check-di-value-imports.test.ts` is currently in that dead zone; out of scope here.)

## Verification

Per the MacBook constraint no tests/typechecks/builds were run locally. The guard itself is a linter and was run: clean from its new path, and correctly failing under the regression restore. Every test-file assertion was additionally validated by building a synthetic fixture tree and running the guard against it — all ten expected behaviors matched. Vitest and type-check run in CI.
