### PR TITLE
ci(e2e): reopen the nightly-failure tracker instead of filing duplicates

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -493,6 +493,11 @@ jobs:
   # Nightly-only failure reporter. The scheduled E2E run is the flake alarm; when
   # it goes red, open (or update) ONE tracking issue so a broken nightly can't rot
   # unseen — the whole reason the authed job could sit red for 5+ June nightlies.
+  # Dedup order: comment on the open labelled issue; else REOPEN the most recently
+  # updated labelled issue closed within REOPEN_WINDOW_DAYS and comment on that;
+  # else create. Reopening matters because closing the tracker while the suite is
+  # still red used to spawn a fresh duplicate on the next red nightly (#1448,
+  # #1626, #1891). Only a genuinely absent/stale tracker creates a new issue.
   # Runs ONLY on the standalone cron: a workflow_call from the deploy path inherits
   # the caller's event, so github.event_name is 'schedule' solely for the nightly.
   # Deploy gating is untouched. Keys off the aggregated gate AND the authed job
@@ -510,7 +515,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - name: Open or update the nightly-failure issue
+      - name: Open, reopen, or update the nightly-failure issue
         uses: actions/github-script@v8
         env:
           GATE_RESULT: ${{ needs.e2e-gate.result }}
@@ -563,6 +568,42 @@ jobs:
                 issue_number: existing.data[0].number,
                 body,
               });
-            } else {
-              await github.rest.issues.create({ owner, repo, title, body, labels: [label] });
+              return;
             }
+            // No open tracker. Closing the issue while the suite is still red must
+            // not spawn a duplicate — reopen the most recent recently-closed one
+            // instead, and only create when there is genuinely nothing to revive.
+            const reopenWindowDays = 30;
+            const cutoff = Date.now() - reopenWindowDays * 24 * 60 * 60 * 1000;
+            const closed = await github.rest.issues.listForRepo({
+              owner,
+              repo,
+              state: 'closed',
+              labels: label,
+              sort: 'updated',
+              direction: 'desc',
+              per_page: 20,
+            });
+            const revivable = closed.data.find((issue) => {
+              if (issue.pull_request) {
+                return false;
+              }
+              const closedAt = issue.closed_at || issue.updated_at;
+              return Boolean(closedAt) && Date.parse(closedAt) >= cutoff;
+            });
+            if (revivable) {
+              await github.rest.issues.update({
+                owner,
+                repo,
+                issue_number: revivable.number,
+                state: 'open',
+              });
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: revivable.number,
+                body: `${body}\n\nReopened automatically: this issue was closed, but the nightly is red again.`,
+              });
+              return;
+            }
+            await github.rest.issues.create({ owner, repo, title, body, labels: [label] });


### PR DESCRIPTION
## Problem

The nightly E2E failure reporter (`nightly-failure-report` in [.github/workflows/e2e.yml](.github/workflows/e2e.yml), added in `f9905cf9e` / #1294) deduped **only against open issues**:

```js
const existing = await github.rest.issues.listForRepo({ state: 'open', labels: 'nightly-e2e-failure' });
existing.data.length > 0 ? createComment(...) : issues.create(...);
```

That is correct while the tracker is open. The defect is the closed case: if someone closes the tracker while the suite is still red, the next red nightly finds nothing open and files a **fresh duplicate**.

Observed three times in this repo:

- #1448 — created 2026-07-07
- #1626 — created 2026-07-12, closed 2026-07-16, reopened 2026-07-23 (the single open tracker now)
- #1891 — created 2026-07-19, since closed as a duplicate

The 2026-07-25 scheduled run failed, so this is live.

## Change

New dedup order in the `github-script` step:

1. **Open** labelled issue → comment on it (unchanged).
2. Otherwise list **closed** labelled issues (`sort: 'updated'`, `direction: 'desc'`, `per_page: 20`), skip anything that is a PR, and pick the first one closed within a **30-day window** (`closed_at`, falling back to `updated_at`).
3. If found → `issues.update({ state: 'open' })`, then post the failure comment with an extra line: *"Reopened automatically: this issue was closed, but the nightly is red again."*
4. Only when there is genuinely no such issue → `issues.create(...)`.

The job's leading comment block now documents the reopen behaviour.

## Unchanged

- Label auto-provisioning (`getLabel` / `createLabel`) block — verbatim.
- Comment body — verbatim; the reopen path appends one line to it.
- Job trigger: still `always() && github.event_name == 'schedule' && (gate failure || authed failure)`.
- No other job in `e2e.yml`; deploy gating untouched (44 insertions / 3 deletions, all inside `nightly-failure-report`).

## Verification

No local tests, typechecks, or builds were run — relying on PR CI.

Local read-only sanity checks only:

- `yaml.safe_load` parses the workflow; only `nightly-failure-report` differs.
- The extracted `script:` body passes `node --check` when wrapped in an async function (`actions/github-script` runs it as an `AsyncFunction`, so the top-level `return`s are valid).

Behaviour itself is exercised by the next red scheduled run: with #1626 open it takes the comment path; close #1626 while red and it should reopen rather than create.