### PR TITLE
chore(website): remove em dashes from marketing copy

### DIFF
--- a/apps/website/app/(public)/pricing/page.tsx
+++ b/apps/website/app/(public)/pricing/page.tsx
@@ -4,7 +4,7 @@ import PricingContent from '@public/pricing/pricing-content';
 
 export const generateMetadata = createPageMetadataWithCanonical(
   'Pricing',
-  'Free to sign up — credits buy the output you generate. Subscriptions from $49/mo include monthly credits at a better rate, paid API access, and unlimited team seats; Scale adds multi-organization workflows.',
+  'Free to sign up. Credits buy the output you generate. Subscriptions from $49/mo include monthly credits at a better rate, paid API access, and unlimited team seats; Scale adds multi-organization workflows.',
   '/pricing',
 );
 

--- a/apps/website/app/(public)/pricing/pricing-content.tsx
+++ b/apps/website/app/(public)/pricing/pricing-content.tsx
@@ -60,7 +60,7 @@ const FAQ_ITEMS = [
   },
   {
     answer:
-      'Yes. API access is included on every paid plan at the same credit price — generate in the studio or via code, and it draws from the same credit balance. Pro gets standard rate limits, Scale higher limits, and Enterprise custom limits with an SLA.',
+      'Yes. API access is included on every paid plan at the same credit price. Generate in the studio or via code, and it draws from the same credit balance. Pro gets standard rate limits, Scale higher limits, and Enterprise custom limits with an SLA.',
     question: 'Is there an API?',
   },
   {
@@ -295,8 +295,8 @@ export default function PricingContent() {
           </NeuralGrid>
 
           <p className="mt-6 text-center text-sm text-surface/50">
-            Every paid plan includes API access at the same credit price —
-            create in the studio or via code, and it draws from the same credit
+            Every paid plan includes API access at the same credit price. Create
+            in the studio or via code, and it draws from the same credit
             balance. Higher plans get higher rate limits.
           </p>
 
@@ -367,8 +367,8 @@ export default function PricingContent() {
           </div>
 
           <p className="mt-8 mb-2 text-sm font-medium text-surface/70">
-            Top up any amount from $10 — pay-as-you-go, no subscription. 1
-            credit = $0.01.
+            Top up any amount from $10. Pay-as-you-go, no subscription. 1 credit
+            = $0.01.
           </p>
           <div className="grid gap-px bg-edge/5 sm:grid-cols-3">
             {WEBSITE_CREDIT_PACKS.map((pack) => (

--- a/apps/website/app/(public)/self-hosted/page.tsx
+++ b/apps/website/app/(public)/self-hosted/page.tsx
@@ -3,7 +3,7 @@ import SelfHostedContent from '@public/self-hosted/self-hosted-content';
 
 export const generateMetadata = createPageMetadataWithCanonical(
   'Self-Host Genfeed',
-  'Genfeed is open source. Self-host the full content OS on your own infrastructure with Docker — or skip the ops and start free on managed cloud.',
+  'Genfeed is open source. Self-host the full content OS on your own infrastructure with Docker, or skip the ops and start free on managed cloud.',
   '/self-hosted',
 );
 

--- a/apps/website/app/(public)/self-hosted/self-hosted-content.tsx
+++ b/apps/website/app/(public)/self-hosted/self-hosted-content.tsx
@@ -28,7 +28,7 @@ const DOCS_URL = 'https://docs.genfeed.ai';
 const WHY_SELF_HOST = [
   {
     description:
-      'Deploy the full content OS on your own servers with Docker. Your models, your storage, your network — no vendor lock-in.',
+      'Deploy the full content OS on your own servers with Docker. Your models, your storage, your network. No vendor lock-in.',
     icon: LuServer,
     title: 'Own Your Infrastructure',
   },
@@ -57,7 +57,7 @@ const QUICKSTART = [
     step: 'Configure',
   },
   {
-    description: 'Bring it up with Docker Compose — API, workers, and app.',
+    description: 'Bring it up with Docker Compose: API, workers, and app.',
     step: 'Deploy',
   },
   {
@@ -69,7 +69,7 @@ const QUICKSTART = [
 const FAQ_ITEMS = [
   {
     answer:
-      'Yes. The core is open source under AGPL-3.0. Clone it, run it on your own infrastructure, and use it for free — you cover your own hosting and model costs.',
+      'Yes. The core is open source under AGPL-3.0. Clone it, run it on your own infrastructure, and use it for free. You cover your own hosting and model costs.',
     question: 'Is self-hosting really free?',
   },
   {
@@ -79,17 +79,17 @@ const FAQ_ITEMS = [
   },
   {
     answer:
-      'Self-host gives you full control and zero platform fees, but you run the infrastructure, updates, and models yourself. Managed cloud handles all of that, adds managed credits and support, and starts free — most teams self-host to evaluate, then move to cloud to skip the ops.',
+      'Self-host gives you full control and zero platform fees, but you run the infrastructure, updates, and models yourself. Managed cloud handles all of that, adds managed credits and support, and starts free. Most teams self-host to evaluate, then move to cloud to skip the ops.',
     question: 'Self-host or managed cloud?',
   },
   {
     answer:
-      'Community support lives on GitHub — issues, discussions, and the docs. Managed cloud plans add direct support and SLAs.',
+      'Community support lives on GitHub: issues, discussions, and the docs. Managed cloud plans add direct support and SLAs.',
     question: 'Do I get support?',
   },
   {
     answer:
-      'Anytime. Start self-hosted, then move to managed cloud whenever the operational overhead outweighs the control — your workflows and content model carry over.',
+      'Anytime. Start self-hosted, then move to managed cloud whenever the operational overhead outweighs the control. Your workflows and content model carry over.',
     question: 'Can I move to cloud later?',
   },
 ];
@@ -110,7 +110,7 @@ export default function SelfHostedContent() {
             <span className="italic font-light">your own infra</span>.
           </>
         }
-        description="The full Genfeed content OS is open source. Clone it, run it with Docker, and own your stack end to end — or skip the ops and start free on managed cloud."
+        description="The full Genfeed content OS is open source. Clone it, run it with Docker, and own your stack end to end, or skip the ops and start free on managed cloud."
       >
         <WebSection maxWidth="lg" py="md">
           <div className="flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
@@ -142,7 +142,7 @@ export default function SelfHostedContent() {
         <WebSection maxWidth="xl" className="gsap-section">
           <SectionHeader
             title="Why self-host"
-            description="Full control over your infrastructure, data, and models — with no platform fees and no lock-in."
+            description="Full control over your infrastructure, data, and models, with no platform fees and no lock-in."
             className="[&_h2]:text-5xl"
           />
 
@@ -237,7 +237,7 @@ export default function SelfHostedContent() {
               <ul className="space-y-3">
                 {[
                   'We run the infrastructure and updates',
-                  'Managed credits — pay only for output',
+                  'Managed credits: pay only for output',
                   'No ops, no scaling to manage',
                   'Direct support and SLAs on paid plans',
                   'Start free on Pay As You Go',

--- a/apps/website/packages/components/landing/ServiceLandingPage.tsx
+++ b/apps/website/packages/components/landing/ServiceLandingPage.tsx
@@ -59,7 +59,7 @@ export default function ServiceLandingPage({
 
               <div className="flex flex-wrap items-center gap-3 text-sm text-surface/65">
                 <span className="border border-edge/10 px-3 py-2 text-surface/70">
-                  {config.priceLabel ?? 'Custom — scoped on a call'}
+                  {config.priceLabel ?? 'Custom, scoped on a call'}
                 </span>
                 {config.priceNote ? (
                   <span className="border border-edge/10 px-3 py-2">

--- a/apps/website/packages/components/landing/pitch-pages.data.ts
+++ b/apps/website/packages/components/landing/pitch-pages.data.ts
@@ -59,7 +59,7 @@ export const pitchLandingConfigs: ServiceLandingConfig[] = [
       },
     ],
     deliverablesDescription:
-      'A full content operation run on Genfeed — strategy, production, and publishing handled end to end so your brand ships consistently.',
+      'A full content operation run on Genfeed: strategy, production, and publishing handled end to end so your brand ships consistently.',
     deliverablesTitle: 'What The Retainer Covers',
     faqDescription: 'Straight answers before the call.',
     faqs: [
@@ -98,7 +98,7 @@ export const pitchLandingConfigs: ServiceLandingConfig[] = [
     ],
     heroAccent: 'content operation',
     heroDescription:
-      'A high-touch content retainer for founders and high-end SMBs — strategy, production, and publishing run for you on Genfeed.',
+      'A high-touch content retainer for founders and high-end SMBs. Strategy, production, and publishing run for you on Genfeed.',
     heroTitle: 'We run your',
     includes: [
       'Content strategy and monthly planning',
@@ -111,7 +111,7 @@ export const pitchLandingConfigs: ServiceLandingConfig[] = [
       'Dedicated operator',
     ],
     intro:
-      'You bring the expertise, context, and final approvals. We handle strategy, production, and publishing so your brand shows up consistently — without another internal function to manage.',
+      'You bring the expertise, context, and final approvals. We handle strategy, production, and publishing so your brand shows up consistently, without another internal function to manage.',
     metaDescription:
       'High-touch content retainer for founders and high-end SMBs. $5,000 setup, then $2,000/month. Strategy, production, and publishing run for you on Genfeed.',
     metaTitle: 'Content Retainer | Genfeed.ai',
@@ -154,7 +154,7 @@ export const pitchLandingConfigs: ServiceLandingConfig[] = [
       },
       {
         description:
-          'Monthly execution — production, publishing, and revisions on a clear operating rhythm.',
+          'Monthly execution: production, publishing, and revisions on a clear operating rhythm.',
         step: 'Run',
       },
       {
@@ -206,7 +206,7 @@ export const pitchLandingConfigs: ServiceLandingConfig[] = [
       },
     ],
     deliverablesDescription:
-      'A lighter done-for-you content service: we plan, produce, and publish a focused stream of content for you — without the full retainer commitment.',
+      'A lighter done-for-you content service: we plan, produce, and publish a focused stream of content for you, without the full retainer commitment.',
     deliverablesTitle: 'What You Get',
     faqDescription: 'Straight answers before the call.',
     faqs: [
@@ -217,7 +217,7 @@ export const pitchLandingConfigs: ServiceLandingConfig[] = [
       },
       {
         answer:
-          'Pricing is custom and sits below the full retainer — it scales with how many channels and how much output you need. We size it on the call.',
+          'Pricing is custom and sits below the full retainer. It scales with how many channels and how much output you need. We size it on the call.',
         question: 'How is it priced?',
       },
       {
@@ -227,12 +227,12 @@ export const pitchLandingConfigs: ServiceLandingConfig[] = [
       },
       {
         answer:
-          'No. You stay at the direction and approval level — we handle production and publishing so content is off your plate.',
+          'No. You stay at the direction and approval level. We handle production and publishing so content is off your plate.',
         question: 'Do I have to be involved every week?',
       },
       {
         answer:
-          'Yes. When output outgrows this scope, it rolls straight into the full retainer — same team, no restart.',
+          'Yes. When output outgrows this scope, it rolls straight into the full retainer: same team, no restart.',
         question: 'Can we scale up later?',
       },
     ],
@@ -245,7 +245,7 @@ export const pitchLandingConfigs: ServiceLandingConfig[] = [
     ],
     heroAccent: 'content',
     heroDescription:
-      'A lighter done-for-you content service — we plan, produce, and publish for you, sized for smaller budgets and earlier-stage teams.',
+      'A lighter done-for-you content service. We plan, produce, and publish for you, sized for smaller budgets and earlier-stage teams.',
     heroTitle: 'We run your',
     includes: [
       'Content planning',
@@ -260,7 +260,7 @@ export const pitchLandingConfigs: ServiceLandingConfig[] = [
     intro:
       'Not every team needs a full content operation yet. Done-For-You is the lighter version: we handle a focused stream of content end to end, so you show up consistently without the retainer-level commitment.',
     metaDescription:
-      'Lighter done-for-you content service. We plan, produce, and publish a focused content stream for you — sized for smaller budgets. Custom scope.',
+      'Lighter done-for-you content service. We plan, produce, and publish a focused content stream for you, sized for smaller budgets. Custom scope.',
     metaTitle: 'Done-For-You Content | Genfeed.ai',
     outcomes: [
       {
@@ -271,7 +271,7 @@ export const pitchLandingConfigs: ServiceLandingConfig[] = [
       },
       {
         description:
-          'A commitment sized to where you are now — real output without full-operation overhead.',
+          'A commitment sized to where you are now: real output without full-operation overhead.',
         icon: LuGauge,
         title: 'Right-Sized Commitment',
       },
@@ -305,7 +305,7 @@ export const pitchLandingConfigs: ServiceLandingConfig[] = [
       },
       {
         description:
-          'Review what lands and adjust — scale into the full retainer whenever you are ready.',
+          'Review what lands and adjust. Scale into the full retainer whenever you are ready.',
         step: 'Iterate',
       },
     ],
@@ -351,13 +351,13 @@ export const pitchLandingConfigs: ServiceLandingConfig[] = [
       },
     ],
     deliverablesDescription:
-      'A managed model fleet: custom LoRAs, AI influencers, and dedicated inference — designed, trained, and run for you on our GPU estate.',
+      'A managed model fleet: custom LoRAs, AI influencers, and dedicated inference, designed, trained, and run for you on our GPU estate.',
     deliverablesTitle: 'What The Fleet Delivers',
     faqDescription: 'For operators running owned models at scale.',
     faqs: [
       {
         answer:
-          'Creators, agencies, and brands that want owned models and AI influencers — custom LoRAs, consistent characters, and dedicated generation — without operating GPU infrastructure themselves.',
+          'Creators, agencies, and brands that want owned models and AI influencers: custom LoRAs, consistent characters, and dedicated generation, without operating GPU infrastructure themselves.',
         question: 'Who is this for?',
       },
       {
@@ -390,7 +390,7 @@ export const pitchLandingConfigs: ServiceLandingConfig[] = [
     ],
     heroAccent: 'model fleet',
     heroDescription:
-      'Custom LoRAs, AI influencers, and dedicated inference — designed, trained, and operated for you on our GPU fleet.',
+      'Custom LoRAs, AI influencers, and dedicated inference, designed, trained, and operated for you on our GPU fleet.',
     heroTitle: 'We run your',
     includes: [
       'Custom LoRA training',
@@ -403,9 +403,9 @@ export const pitchLandingConfigs: ServiceLandingConfig[] = [
       'Managed operation',
     ],
     intro:
-      'Generic models drift and credits meter every frame. A fleet is different: your own trained models, consistent identities, and dedicated capacity — built and run so you can produce at scale without touching infrastructure.',
+      'Generic models drift and credits meter every frame. A fleet is different: your own trained models, consistent identities, and dedicated capacity, built and run so you can produce at scale without touching infrastructure.',
     metaDescription:
-      'Managed model fleet: custom LoRAs, AI influencers, and dedicated inference — trained and operated for you on GPU infrastructure. Custom scope.',
+      'Managed model fleet: custom LoRAs, AI influencers, and dedicated inference, trained and operated for you on GPU infrastructure. Custom scope.',
     metaTitle: 'Model Fleet | Genfeed.ai',
     outcomes: [
       {
@@ -422,7 +422,7 @@ export const pitchLandingConfigs: ServiceLandingConfig[] = [
       },
       {
         description:
-          'Dedicated GPU capacity and a managed delivery pipeline — output at volume without running infrastructure.',
+          'Dedicated GPU capacity and a managed delivery pipeline: output at volume without running infrastructure.',
         icon: LuServer,
         title: 'Dedicated, Managed Inference',
       },
@@ -450,7 +450,7 @@ export const pitchLandingConfigs: ServiceLandingConfig[] = [
       },
       {
         description:
-          'Operate and update the fleet over time — new models, refreshed styles, and scaling as you grow.',
+          'Operate and update the fleet over time: new models, refreshed styles, and scaling as you grow.',
         step: 'Operate',
       },
     ],

--- a/apps/website/packages/data/faq.data.ts
+++ b/apps/website/packages/data/faq.data.ts
@@ -81,7 +81,7 @@ export const FAQ_CATEGORIES: Omit<FAQCategory, 'icon'>[] = [
       },
       {
         answer:
-          'Yes. API access is included on every paid plan at the same credit price — generate in the studio or via code, drawing from the same credit balance. Creator gets standard rate limits, Teams higher limits, and Enterprise custom limits with an SLA.',
+          'Yes. API access is included on every paid plan at the same credit price. Generate in the studio or via code, drawing from the same credit balance. Creator gets standard rate limits, Teams higher limits, and Enterprise custom limits with an SLA.',
         question: 'Is there an API?',
       },
       {


### PR DESCRIPTION
## Summary

Removes every em dash from rendered marketing-site copy. Pitch pages, self-hosted, pricing, shared FAQ data, and the service landing price label.

Each line was rewritten individually, not mechanically substituted:
- **colon** when the clause defines what precedes it
- **sentence split** when the clause stands alone
- **comma** when the clause is a subordinate qualifier

## Scope

- 7 files, 37 lines, rendered copy strings only.
- Code comments, JSDoc, and CI script console output are untouched (10 remaining instances in `apps/website`, all comments).
- No spec asserts on any changed string, verified before commit.

## Not in this PR

Product microcopy outside the marketing site still carries em dashes: `apps/app` (65 files), `packages/ui` (35), `apps/desktop` (5), `apps/docs` (4), `packages/constants` (2). Separate decision.