### PR TITLE
test(e2e): stop clip-factory polling test racing the review-step project read

### DIFF
--- a/playwright/e2e/tests/studio/clips.spec.ts
+++ b/playwright/e2e/tests/studio/clips.spec.ts
@@ -19,6 +19,15 @@ const API_CLIP_RESULTS = '**/clip-results**';
 const MOCK_PROJECT_ID = '67d3d7a5e61f9c29b72d1234';
 const MOCK_YOUTUBE_URL = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ';
 
+/**
+ * Mirrors the clip-results poll interval in the progress-step effect of
+ * `apps/app/app/(protected)/[orgSlug]/[brandSlug]/studio/clips/useStudioClipsPage.ts`.
+ * Waits below are derived from it with headroom so a loaded CI runner cannot
+ * turn "the app is a little slow" into a test failure.
+ */
+const CLIP_POLL_INTERVAL_MS = 3_000;
+const CLIP_POLL_WAIT_MS = CLIP_POLL_INTERVAL_MS * 5;
+
 const mockHighlights = [
   {
     clip_type: 'hook',
@@ -249,6 +258,10 @@ test.describe('Clip Factory', () => {
   test('should keep polling in progress view until clips are actually completed', async ({
     authenticatedPage,
   }) => {
+    // The backend stays "generating" until the test releases it, so the
+    // in-progress assertions below can never race the app's poll interval.
+    let hasReleasedCompletion = false;
+    let hasRequestedGeneration = false;
     let projectPollCount = 0;
     let clipPollCount = 0;
 
@@ -256,6 +269,7 @@ test.describe('Clip Factory', () => {
     await mockHighlightsPolling(authenticatedPage);
 
     await authenticatedPage.route(API_GENERATE, async (route) => {
+      hasRequestedGeneration = true;
       await route.fulfill({
         body: JSON.stringify({
           clipCount: 3,
@@ -273,14 +287,26 @@ test.describe('Clip Factory', () => {
         return;
       }
 
+      // The review step also reads the project (for reference frames), so only
+      // reads issued after generation started count as progress-step polls.
+      if (!hasRequestedGeneration) {
+        await route.fulfill({
+          body: JSON.stringify({
+            data: { _id: MOCK_PROJECT_ID, status: 'analyzed' },
+          }),
+          contentType: 'application/json',
+          status: 200,
+        });
+        return;
+      }
+
       projectPollCount += 1;
-      const status = projectPollCount >= 2 ? 'completed' : 'generating';
 
       await route.fulfill({
         body: JSON.stringify({
           data: {
             _id: MOCK_PROJECT_ID,
-            status,
+            status: hasReleasedCompletion ? 'completed' : 'generating',
           },
         }),
         contentType: 'application/json',
@@ -290,15 +316,14 @@ test.describe('Clip Factory', () => {
 
     await authenticatedPage.route(API_CLIP_RESULTS, async (route) => {
       clipPollCount += 1;
-      const data =
-        clipPollCount >= 2
-          ? [
-              {
-                attributes: mockCompletedClipResult,
-                id: 'clip-1',
-              },
-            ]
-          : [];
+      const data = hasReleasedCompletion
+        ? [
+            {
+              attributes: mockCompletedClipResult,
+              id: 'clip-1',
+            },
+          ]
+        : [];
 
       await route.fulfill({
         body: JSON.stringify({ data }),
@@ -323,15 +348,28 @@ test.describe('Clip Factory', () => {
     await expect(
       authenticatedPage.getByText(/generating 3 avatar clips/i),
     ).toBeVisible();
+
+    // Polling must continue while the backend still reports `generating`.
     await expect
-      .poll(() => projectPollCount, { timeout: 7000 })
+      .poll(() => projectPollCount, { timeout: CLIP_POLL_WAIT_MS })
       .toBeGreaterThan(1);
     await expect
-      .poll(() => clipPollCount, { timeout: 7000 })
+      .poll(() => clipPollCount, { timeout: CLIP_POLL_WAIT_MS })
       .toBeGreaterThan(1);
+
+    // ...and the view must still be in progress, never a premature done state.
+    // Completion is gated on `hasReleasedCompletion`, not on elapsed time, so
+    // this cannot flake by the app simply polling faster than expected.
+    await expect(
+      authenticatedPage.getByText(/generating 3 avatar clips/i),
+    ).toBeVisible();
+    await expect(authenticatedPage.getByText(/done —/i)).toHaveCount(0);
+
+    hasReleasedCompletion = true;
+
     await expect(
       authenticatedPage.getByText(/done — 1 clip generated/i),
-    ).toBeVisible({ timeout: 8000 });
+    ).toBeVisible({ timeout: CLIP_POLL_WAIT_MS });
     await expect(
       authenticatedPage.getByRole('button', { name: /^edit$/i }),
     ).toBeVisible();


### PR DESCRIPTION
## Verdict: real regression, not flake

The nightly `Frontend E2E (Shard 4/4)` failure in `clips.spec.ts` →
`should keep polling in progress view until clips are actually completed`
is a **deterministic test regression introduced by #2003**, not timing flake.

### Evidence

**The earlier red nightlies were a different job.** Per-job forensics:

| Nightly | Failing job | Head SHA |
|---|---|---|
| 07-21 (`29804130336`) | `API E2E Full` | — |
| 07-23 (`29982477503`) | `API E2E Full` | — |
| 07-24 (success) | — | `173b3eb0e` |
| 07-25 (`30145682989`) | `Frontend E2E (Shard 4/4)` + gate; `API E2E Full` **green** | `64054595d` |

So 07-25 is this test's **first** failure ever, and `64054595d` is
`feat(clips): review and select reference frames` (#2003). The
intermittent-green history belongs to a different failure mode.

**No product interval regression.** `git show <sha>:useStudioClipsPage.ts` across
`efe3cb044` (07-09), `ca017bc00` (07-23), `3a5655a27` (07-24) and `64054595d`
shows the poll intervals unchanged throughout: `2_000` ms analysis poll,
`3_000` ms clip poll. **No product fix was needed.**

**What actually broke.** #2003 added a *second* `clipsService.getProject(...)`
call site — inside `pollAnalysis`, purely to read `referenceFrames` for the
review step. The test's `API_PROJECT` mock counted every project GET and
flipped `status` to `completed` at count ≥ 2. The new review-step read now
consumes count 1, so the **first progress-step poll** returns `completed` →
`TERMINAL_PROJECT_STATUSES` short-circuits → `clearPendingPoll()` → polling
stops at exactly one iteration. `clipPollCount` stays at `1`, both
`toBeGreaterThan(1)` assertions fail, and the UI renders
`Done — 0 clips generated`. The product behaviour is correct; the mock's
"count requests" contract was the fragile part.

### The fix

Gate completion on **explicit test state** rather than on a request counter:

- Mocks return `generating` / empty clip results until the test sets
  `hasReleasedCompletion = true`. Every assertion is then either a bounded
  wait for a state that *will* arrive, or an assertion about a state that
  *cannot* change yet — no assertion depends on how many requests the app
  happened to make.
- A `hasRequestedGeneration` gate keeps `projectPollCount` / `clipPollCount`
  meaning "progress-step polls only", so the `> 1` assertions stay as strong
  as before and don't silently pass on review-step traffic.
- Added an explicit `await expect(page.getByText(/done —/i)).toHaveCount(0)`
  while the backend is still generating — the "does not prematurely show
  done" half of the intent is now asserted directly instead of being implied.
- Timeouts derive from `CLIP_POLL_INTERVAL_MS = 3_000` (the app's real
  interval) with 5× headroom, replacing hardcoded `7000` / `8000`. The old
  7s budget left ~1s of slack for two 3s polls — genuine secondary
  fragility, also fixed.

No assertion was deleted and the test is not skipped.

### Sibling tests (checked)

The only other hardcoded timeout in the file is `timeout: 15000` on
`unauthenticatedPage.waitForURL(/\/sign-in|\/login/)` in the auth-redirect
test. That's a navigation budget, not a poll-interval race — it has no
coupling to a mocked request count and shard 4 was green until #2003.
Deliberately left alone.

### Reported, not fixed: `403` on `cdn.genfeed.ai/avatars/default.png`

The 403 in the run logs comes from mock avatar URLs in
`playwright/e2e/utils/api-interceptor.ts:119,134` and
`playwright/e2e/fixtures/test-data.fixture.ts:90`, fetched by the **Next.js
image optimizer server-side** via `/_next/image?url=...`. `page.route()` only
intercepts browser-issued requests, and `network-guard.ts` allowlists the host
for the same reason — so this is **not a one-line stub** in existing test
setup. Out of scope per the task constraint; worth its own issue (point the
mocks at a local fixture asset, or add the host to `images.remotePatterns`
with a stubbed origin).

### Verification

Per repo policy no E2E/typecheck/build was run locally — **this needs a CI run
on the PR** to confirm shard 4 goes green. Biome/lint-staged/secretlint passed
on the staged file.

Refs #1626
