### PR TITLE
fix(codex): correct frontend agent path aliases for apps/app

### DIFF
--- a/.codex/agents/frontend.toml
+++ b/.codex/agents/frontend.toml
@@ -144,19 +144,45 @@ useEffect(() => {
 
 ## Path Aliases (apps/app)
 
+Source of truth: `apps/app/tsconfig.json` `compilerOptions.paths`. It declares its
+own full `paths` map, which replaces (does not merge with) the one in
+`packages/tsconfig/base.json` — so aliases that exist repo-wide are not
+automatically available here.
+
 ```
-@components/*    -> packages-components
-@hooks/*         -> packages/hooks/src
-@contexts/*      -> packages/contexts/src
-@services/*      -> packages/services/src
-@ui/*            -> packages/ui/src
-@ui/primitives/* -> packages/ui/src/primitives/*
-@helpers/*       -> packages/helpers/src
-@constants/*     -> packages/constants/src
-@enums/*         -> packages/enums/src
-@interfaces/*    -> packages/interfaces/src
-@props/*         -> packages/props/src
+@ui/*            -> packages/ui/src/*  |  packages/ui/src/components/*
+@ui-constants/*  -> packages/ui/src/components/constants/*
+@app-components/* -> apps/app/packages/components/*
+@protected/*     -> apps/app/app/(protected)/admin/*
+@app/*           -> apps/app/app/*
+@hooks/*         -> packages/hooks/*
+@contexts/*      -> packages/contexts/*
+@providers/*     -> packages/contexts/providers/*
+@services/*      -> packages/services/*
+@props/*         -> packages/props/*
+@helpers/*       -> packages/helpers/src/*
+@serializers/*   -> packages/serializers/src/*
+@models/*        -> packages/models/*
+@pages/*         -> packages/pages/*
+@utils/*         -> packages/utils/*
+@styles/*        -> packages/styles/*
+@config/*        -> packages/config/src/*
+@api-types/*     -> packages/api-types/src/*
 ```
+
+- `@components/` is **not** a wildcard in `apps/app` — `tsconfig.json` lists a
+  closed allowlist of individual file mappings (e.g.
+  `@components/loading/fallback/LazyLoadingFallback`,
+  `@components/modals/modal/Modal`, `@components/cards/KpiCard`). A new
+  `@components/<anything-else>` import will not resolve. Import shared UI via
+  `@ui/*` and app-local components via `@app-components/*`.
+- `@ui/primitives/*` is covered by the `@ui/*` mapping
+  (`packages/ui/src/primitives/*`); it is not a separate entry.
+- There is no `@constants/*`, `@enums/*`, or `@interfaces/*` alias here — use the
+  package specifiers `@genfeedai/constants`, `@genfeedai/enums`, and
+  `@genfeedai/interfaces`.
+- Alias targets have no `src` segment unless shown above (`packages/hooks/*`, not
+  `packages/hooks/src`).
 
 ## Hard Rules
 


### PR DESCRIPTION
Closes #1723.

## Problem

`.codex/agents/frontend.toml` documented `@components/* -> packages-components` — a target that does not exist anywhere in the repo. Six more entries were also wrong, so any frontend work delegated to the Codex agent that followed this table produced unresolvable imports.

Audited every documented alias against `apps/app/tsconfig.json`:

| documented | actual |
|---|---|
| `@components/* -> packages-components` | no such target; `@components/` is a **closed allowlist** of 11 individual file mappings, not a wildcard |
| `@hooks/* -> packages/hooks/src` | `packages/hooks/*` (no `src`) |
| `@contexts/* -> packages/contexts/src` | `packages/contexts/*` (no `src`) |
| `@services/* -> packages/services/src` | `packages/services/*` (no `src`) |
| `@helpers/* -> packages/helpers/src` | `packages/helpers/src/*` ✅ |
| `@props/* -> packages/props/src` | `packages/props/*` (no `src`) |
| `@ui/* -> packages/ui/src` | `packages/ui/src/*` **and** `packages/ui/src/components/*` |
| `@ui/primitives/*` | not a separate entry — covered by `@ui/*` |
| `@constants/*`, `@enums/*`, `@interfaces/*` | **do not exist** in apps/app; use `@genfeedai/constants` / `@genfeedai/enums` / `@genfeedai/interfaces` |

A key subtlety the old table missed: `apps/app/tsconfig.json` declares its own full `compilerOptions.paths`, which **replaces** rather than merges with `packages/tsconfig/base.json`. `base.json` does define `@components/* -> ../ui/src/components/*`, but apps/app overrides it away — which is why the wildcard silently doesn't work there.

## Change

Rewrote the Path Aliases section from the real tsconfig, added the aliases that were missing (`@app-components/*`, `@protected/*`, `@providers/*`, `@serializers/*`, `@models/*`, `@pages/*`, `@utils/*`, `@styles/*`, `@config/*`, `@api-types/*`, `@ui-constants/*`, `@app/*`), and documented the override/allowlist behaviour explicitly.

## Verification

- `python3 -c "import tomllib; tomllib.load(...)"` — file still parses; keys unchanged (`name`, `description`, `developer_instructions`).
- Every `@components/` specifier actually used in `apps/app` (8 distinct, 80 occurrences) matches an explicit tsconfig entry — confirming the allowlist framing.
- Grepped `apps/app` for `@constants/`, `@enums/`, `@interfaces/` imports: **0 hits**, consistent with those aliases not existing.
- Non-alias claims in the file spot-checked and left alone (`packages/contexts/user/brand-context/`, `packages/hooks/auth/use-auth-identity/`, `packages/hooks/data`, `packages/services/<domain>/` all exist).

Docs/config only — no runtime code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)