### PR TITLE
fix(api): scope members findOne to the caller organization

### DIFF
--- a/apps/server/api/src/collections/members/controllers/members.controller.spec.ts
+++ b/apps/server/api/src/collections/members/controllers/members.controller.spec.ts
@@ -1,0 +1,146 @@
+// Stub only the serializer hop — `returnNotFound` stays real so the 404
+// convention this suite asserts is the production one, not a test double.
+vi.mock(
+  '@api/helpers/utils/response/response.util',
+  async (importOriginal) => ({
+    ...(await importOriginal<
+      typeof import('@api/helpers/utils/response/response.util')
+    >()),
+    serializeSingle: vi.fn((_req, _serializer, data) => data),
+  }),
+);
+
+import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticated-user.interface';
+import { MembersController } from '@api/collections/members/controllers/members.controller';
+import type { InvitationService } from '@api/collections/members/services/invitation.service';
+import type { MembersService } from '@api/collections/members/services/members.service';
+import type { LoggerService } from '@libs/logger/logger.service';
+import { HttpException, HttpStatus } from '@nestjs/common';
+import type { Request } from 'express';
+
+const callerOrgId = 'clr1a2b3c4d5e6f7g8h9i0jk';
+const otherOrgId = 'clr9z8y7x6w5v4u3t2s1r0qp';
+const callerUserId = 'clu1a2b3c4d5e6f7g8h9i0jk';
+// A member of the caller's own organization.
+const memberId = 'clm1a2b3c4d5e6f7g8h9i0jk';
+// A real, well-formed member id that belongs to `otherOrgId`.
+const foreignMemberId = 'clm9z8y7x6w5v4u3t2s1r0qp';
+
+const makeUser = (overrides: Record<string, unknown> = {}): User =>
+  ({
+    id: 'authProvider-user-1',
+    publicMetadata: {
+      brand: '',
+      isSuperAdmin: false,
+      organization: callerOrgId,
+      user: callerUserId,
+      ...overrides,
+    },
+  }) as unknown as User;
+
+const makeRequest = (): Request =>
+  ({ originalUrl: `/members/${memberId}` }) as unknown as Request;
+
+const mockMembersService = {
+  findAll: vi.fn(),
+  findOne: vi.fn(),
+} as unknown as MembersService;
+
+const mockInvitationService = {
+  listInvitations: vi.fn(),
+  resendInvitation: vi.fn(),
+  revokeInvitation: vi.fn(),
+} as unknown as InvitationService;
+
+const mockLoggerService = {
+  debug: vi.fn(),
+  error: vi.fn(),
+  log: vi.fn(),
+  warn: vi.fn(),
+} as unknown as LoggerService;
+
+function buildController() {
+  return new MembersController(
+    mockMembersService,
+    mockInvitationService,
+    mockLoggerService,
+  );
+}
+
+async function expectNotFound(promise: Promise<unknown>): Promise<void> {
+  await expect(promise).rejects.toThrow(HttpException);
+  await promise.catch((error: HttpException) => {
+    expect(error.getStatus()).toBe(HttpStatus.NOT_FOUND);
+  });
+}
+
+describe('MembersController.findOne — cross-tenant scoping', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('scopes the lookup to the caller organization and excludes soft-deleted rows', async () => {
+    const controller = buildController();
+    vi.mocked(mockMembersService.findOne).mockResolvedValue({
+      id: memberId,
+      isActive: true,
+      isDeleted: false,
+      organizationId: callerOrgId,
+      userId: callerUserId,
+    } as never);
+
+    await controller.findOne(makeRequest(), makeUser(), memberId);
+
+    expect(mockMembersService.findOne).toHaveBeenCalledWith({
+      _id: memberId,
+      isDeleted: false,
+      organizationId: callerOrgId,
+    });
+  });
+
+  it('returns 404 for a member id belonging to another organization', async () => {
+    const controller = buildController();
+    // `foreignMemberId` exists, but in `otherOrgId`. The caller's org-scoped
+    // filter matches nothing, so the service resolves null and the controller
+    // must 404 — never leak the foreign roster row, and never report 403,
+    // which would confirm the id exists elsewhere.
+    vi.mocked(mockMembersService.findOne).mockResolvedValue(null);
+
+    await expectNotFound(
+      controller.findOne(makeRequest(), makeUser(), foreignMemberId),
+    );
+
+    expect(mockMembersService.findOne).toHaveBeenCalledWith({
+      _id: foreignMemberId,
+      isDeleted: false,
+      organizationId: callerOrgId,
+    });
+    expect(mockMembersService.findOne).not.toHaveBeenCalledWith(
+      expect.objectContaining({ organizationId: otherOrgId }),
+    );
+  });
+
+  it('never issues an unscoped read when the session carries no organization', async () => {
+    const controller = buildController();
+
+    await expectNotFound(
+      controller.findOne(
+        makeRequest(),
+        makeUser({ organization: '' }),
+        memberId,
+      ),
+    );
+
+    expect(mockMembersService.findOne).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 for a malformed member id without querying', async () => {
+    const controller = buildController();
+
+    await expectNotFound(
+      controller.findOne(makeRequest(), makeUser(), 'not-an-entity-id'),
+    );
+
+    expect(mockMembersService.findOne).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/api/src/collections/members/controllers/members.controller.ts
+++ b/apps/server/api/src/collections/members/controllers/members.controller.ts
@@ -17,6 +17,7 @@ import {
   serializeSingle,
 } from '@api/helpers/utils/response/response.util';
 import { handleQuerySort } from '@api/helpers/utils/sort/sort.util';
+import { isEntityId } from '@api/helpers/validation/entity-id.validator';
 import type { JsonApiCollectionResponse } from '@genfeedai/interfaces';
 import { MemberSerializer } from '@genfeedai/serializers';
 import { LoggerService } from '@libs/logger/logger.service';
@@ -83,8 +84,30 @@ export class MembersController {
 
   @Get(':memberId')
   @LogMethod({ logEnd: false, logError: true, logStart: true })
-  async findOne(@Req() request: Request, @Param('memberId') memberId: string) {
-    const data = await this.membersService.findOne({ _id: memberId });
+  async findOne(
+    @Req() request: Request,
+    @CurrentUser() user: User,
+    @Param('memberId') memberId: string,
+  ) {
+    const publicMetadata = getPublicMetadata(user);
+    const organizationId = publicMetadata.organization;
+
+    // Tenant scoping has to live here: RolesGuard only proves the CALLER is an
+    // active member of their OWN organization — it never inspects the requested
+    // member. Without this filter any authenticated user could read another
+    // org's roster, role assignments and brand assignments by id.
+    // A missing/invalid org context is fail-closed (404), never an unscoped read.
+    if (!isEntityId(memberId) || !isEntityId(organizationId)) {
+      return returnNotFound(this.constructorName, memberId);
+    }
+
+    const data = await this.membersService.findOne({
+      _id: memberId,
+      isDeleted: false,
+      organizationId,
+    });
+    // 404 (not 403) on a cross-org miss, matching base-crud.controller.ts — the
+    // response must not confirm that the id exists in another organization.
     return data
       ? serializeSingle(request, MemberSerializer, data)
       : returnNotFound(this.constructorName, memberId);


### PR DESCRIPTION
## Summary

Fixes a **cross-tenant IDOR** on `GET /members/:memberId`.

`MembersController.findOne` called:

```ts
const data = await this.membersService.findOne({ _id: memberId });
```

No organization filter, no `isDeleted` filter. Any authenticated user could read **any** member row in the database by id.

The class-level `@UseGuards(RolesGuard)` does not close this. [`roles.guard.ts:107`](https://github.com/genfeedai/genfeed.ai/blob/master/apps/server/api/src/helpers/guards/roles/roles.guard.ts#L107) resolves the organization from the **caller's** session and verifies the caller is an active member of their **own** org — it never inspects the requested resource.

`memberAttributes` exposes `organization`, `user`, `role`, `brands`, `isActive`, so a successful cross-org read leaks another tenant's **roster, role assignments and brand assignments**.

## The fix

`apps/server/api/src/collections/members/controllers/members.controller.ts`

- Derives `organizationId` from `getPublicMetadata(user)`, the same way the sibling `findAll` in this controller and the other org-scoped controllers do.
- Filters on `{ _id, isDeleted: false, organizationId }`. `BaseService.processSearchParams` expands `_id` into `OR: [{ id }, { mongoId }]` and ANDs it with the scalar columns, so the query is backed by the existing `members_org_user_deleted_idx` (`@@index([organizationId, userId, isDeleted])`).
- **Fail-closed on missing org context.** `getPublicMetadata` defaults `organization` to `''` when absent, and `RolesGuard` lets requests through without org context when no `@Roles` are declared. Rather than rely on `''` matching nothing, the handler explicitly 404s when either `memberId` or `organizationId` is not a valid entity id — an unscoped read can never regress back in.
- **404, not 403**, on a cross-org miss, per the convention in `base-crud.controller.ts` (`// Return 404 instead of 403 for security`). A 403 would confirm the id exists in another organization.

No superadmin bypass was added — the sibling `findAll` has none, and adding one would widen exactly the surface this PR closes.

No frontend call sites for this endpoint exist (`apps/app`, `packages/services` both clean), so nothing breaks downstream.

## Regression tests

New `members.controller.spec.ts`, 4 cases:

1. Scopes the lookup to the caller org and excludes soft-deleted rows — asserts the exact filter `{ _id, isDeleted: false, organizationId: callerOrgId }`.
2. **A member id belonging to another organization returns 404** — and the emitted filter carries the caller's org, never the foreign one.
3. A session with no organization returns 404 and **never calls the service** (no unscoped read).
4. A malformed member id returns 404 without querying.

The spec partially mocks `response.util` — only `serializeSingle` is stubbed, via `importOriginal`, so `returnNotFound` stays the real implementation and the 404 assertions test production behaviour rather than a test double.

## Out of scope — flagged for follow-up

`@Get(':memberId')` is declared **before** `@Get('invitations')` in this controller, so Nest matches `GET /members/invitations` against the `:memberId` route and `listInvitations` is effectively dead. Pre-existing, unrelated to the security fix, not touched here.

## Verification

Not run locally (MacBook constraint) — relying on PR CI. Biome, the secretlint pre-commit hook, and the UI control guard all passed on the staged diff.
