### PR TITLE
fix(api): make task counter allocation a single atomic upsert

### DIFF
--- a/apps/server/api/src/collections/task-counters/services/task-counters.service.spec.ts
+++ b/apps/server/api/src/collections/task-counters/services/task-counters.service.spec.ts
@@ -1,0 +1,101 @@
+import { TaskCountersService } from '@api/collections/task-counters/services/task-counters.service';
+import type { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import type { LoggerService } from '@libs/logger/logger.service';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type MockTaskCounterDelegate = {
+  create: ReturnType<typeof vi.fn>;
+  findFirst: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+  upsert: ReturnType<typeof vi.fn>;
+};
+
+describe('TaskCountersService', () => {
+  const organizationId = 'org-1';
+
+  let taskCounter: MockTaskCounterDelegate;
+  let logger: { error: ReturnType<typeof vi.fn> };
+  let service: TaskCountersService;
+
+  beforeEach(() => {
+    taskCounter = {
+      create: vi.fn(),
+      findFirst: vi.fn(),
+      update: vi.fn(),
+      upsert: vi.fn(),
+    };
+    logger = { error: vi.fn() };
+    service = new TaskCountersService(
+      { taskCounter } as unknown as PrismaService,
+      logger as unknown as LoggerService,
+    );
+  });
+
+  describe('getNextNumber', () => {
+    it('issues a single atomic upsert keyed on the unique organizationId', async () => {
+      taskCounter.upsert.mockResolvedValue({ counter: 1, organizationId });
+
+      const result = await service.getNextNumber(organizationId);
+
+      expect(result).toBe(1);
+      expect(taskCounter.upsert).toHaveBeenCalledTimes(1);
+      expect(taskCounter.upsert).toHaveBeenCalledWith({
+        create: { counter: 1, organizationId },
+        update: { counter: { increment: 1 } },
+        where: { organizationId },
+      });
+    });
+
+    it('never falls back to a read-then-create race', async () => {
+      taskCounter.upsert.mockResolvedValue({ counter: 1, organizationId });
+
+      await service.getNextNumber(organizationId);
+
+      expect(taskCounter.findFirst).not.toHaveBeenCalled();
+      expect(taskCounter.create).not.toHaveBeenCalled();
+      expect(taskCounter.update).not.toHaveBeenCalled();
+    });
+
+    it('returns the incremented counter on repeated calls', async () => {
+      let counter = 0;
+      taskCounter.upsert.mockImplementation(async () => {
+        counter += 1;
+        return { counter, organizationId };
+      });
+
+      await expect(service.getNextNumber(organizationId)).resolves.toBe(1);
+      await expect(service.getNextNumber(organizationId)).resolves.toBe(2);
+      await expect(service.getNextNumber(organizationId)).resolves.toBe(3);
+      expect(taskCounter.upsert).toHaveBeenCalledTimes(3);
+    });
+
+    it('serves concurrent callers for the same org distinct numbers', async () => {
+      let counter = 0;
+      taskCounter.upsert.mockImplementation(async () => {
+        counter += 1;
+        return { counter, organizationId };
+      });
+
+      const numbers = await Promise.all([
+        service.getNextNumber(organizationId),
+        service.getNextNumber(organizationId),
+        service.getNextNumber(organizationId),
+      ]);
+
+      expect(new Set(numbers).size).toBe(3);
+      expect(taskCounter.create).not.toHaveBeenCalled();
+    });
+
+    it('throws and logs when the upsert yields no record', async () => {
+      taskCounter.upsert.mockResolvedValue(null);
+
+      await expect(service.getNextNumber(organizationId)).rejects.toThrow(
+        'Failed to generate next task number',
+      );
+      expect(logger.error).toHaveBeenCalledWith(
+        'Failed to get next task number',
+        { organizationId },
+      );
+    });
+  });
+});

--- a/apps/server/api/src/collections/task-counters/services/task-counters.service.ts
+++ b/apps/server/api/src/collections/task-counters/services/task-counters.service.ts
@@ -15,23 +15,15 @@ export class TaskCountersService {
    * Creates the counter document if it doesn't exist.
    */
   async getNextNumber(organizationId: string): Promise<number> {
-    // Prisma upsert: find by organizationId, increment counter if exists, create with counter=1 if not
-    const existing = await this.prisma.taskCounter.findFirst({
+    // Single atomic upsert against the unique `organizationId` column. A
+    // read-then-create would race: concurrent first-ever calls for the same
+    // organization (e.g. Promise.all over follow-up plan steps) all miss the
+    // read and then collide on the unique constraint with P2002.
+    const result = (await this.prisma.taskCounter.upsert({
+      create: { counter: 1, organizationId },
+      update: { counter: { increment: 1 } },
       where: { organizationId },
-    });
-
-    let result: TaskCounterDocument;
-
-    if (existing) {
-      result = (await this.prisma.taskCounter.update({
-        data: { counter: { increment: 1 } },
-        where: { id: existing.id },
-      })) as unknown as TaskCounterDocument;
-    } else {
-      result = (await this.prisma.taskCounter.create({
-        data: { counter: 1, organizationId },
-      })) as unknown as TaskCounterDocument;
-    }
+    })) as unknown as TaskCounterDocument;
 
     if (!result) {
       this.logger.error('Failed to get next task number', { organizationId });


### PR DESCRIPTION
## Problem

`TaskCountersService.getNextNumber` claimed to be atomic, but only half of it was. It read the counter row with `findFirst`, then branched:

- **update branch** — genuinely atomic (`data: { counter: { increment: 1 } }`)
- **create branch** — a read-then-create race

`TaskCounter.organizationId` is declared `@unique` (`packages/prisma/prisma/schema.prisma:3439`), so concurrent first-ever calls for the same org don't duplicate rows — the losers throw Prisma **P2002**, which surfaces as an unhandled **500**.

## Reachability

`TaskPlanningService.createFollowUpTasks` (`apps/server/api/src/collections/tasks/services/task-planning.service.ts:142`) fires N concurrent `getNextNumber` calls:

```ts
Promise.all(followUpSteps.map(async (step) => {
  const taskNumber = await this.taskCountersService.getNextNumber(taskOrgId);
  ...
}))
```

For a brand-new organization's first approved plan, all N miss the `findFirst` and N-1 land in the create branch simultaneously.

## Fix

One atomic upsert keyed on the unique column:

```ts
const result = await this.prisma.taskCounter.upsert({
  create: { counter: 1, organizationId },
  update: { counter: { increment: 1 } },
  where: { organizationId },
});
```

Return shape (`result.counter`) and the existing failure logging are unchanged.

## Verification

Per repo policy this branch relies on PR CI for typecheck/build — no local builds were run. The `where: { organizationId }` unique-input form was verified statically against an existing shipped precedent rather than by compiling:

- `MoodBoard.brandId String @unique` (`schema.prisma:959`) → `MoodBoardsService` upserts with `where: { brandId }` (`mood-boards.service.ts:48`)

Same single-`@unique`-scalar shape, already green on the Prisma 7 client. CI typecheck is the real gate.

## Tests

New `task-counters.service.spec.ts` asserts:

- exactly one `upsert` call, with the exact `create`/`update`/`where` payload
- `findFirst`, `create`, and `update` are **never** called (the race path is gone)
- repeated calls return incrementing numbers
- concurrent callers for the same org get distinct numbers and never hit `create`
- a null upsert result still logs and throws `Failed to generate next task number`