### PR TITLE
fix(api): scope GET /organizations/by-slug to the caller

### DIFF
--- a/apps/server/api/src/collections/organizations/controllers/organizations.controller.spec.ts
+++ b/apps/server/api/src/collections/organizations/controllers/organizations.controller.spec.ts
@@ -7,6 +7,19 @@ vi.mock('@genfeedai/config', async (importOriginal) => {
   };
 });
 
+// findBySlug is the only route in this suite that serializes. Keep the rest of
+// the response helpers real so nothing else changes shape.
+vi.mock('@api/helpers/utils/response/response.util', async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import('@api/helpers/utils/response/response.util')
+    >();
+  return {
+    ...actual,
+    serializeSingle: vi.fn((_request, _serializer, data) => data),
+  };
+});
+
 import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticated-user.interface';
 import { ActivitiesService } from '@api/collections/activities/services/activities.service';
 import { BrandsService } from '@api/collections/brands/services/brands.service';
@@ -24,9 +37,11 @@ import { VideosService } from '@api/collections/videos/services/videos.service';
 import { AccessBootstrapCacheService } from '@api/common/services/access-bootstrap-cache.service';
 import { BetterAuthIdentityCacheService } from '@api/common/services/better-auth-identity-cache.service';
 import { RequestContextCacheService } from '@api/common/services/request-context-cache.service';
+import { NotFoundException } from '@api/helpers/exceptions/http/not-found.exception';
 import { SubscriptionTier } from '@genfeedai/enums';
 import { SINGLE_ORGANIZATION_LIMIT } from '@genfeedai/pricing';
 import { LoggerService } from '@libs/logger/logger.service';
+import { HttpStatus } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 
 interface FindMineEntry {
@@ -58,6 +73,7 @@ describe('OrganizationsController', () => {
   const mockOrganizationsService = {
     count: vi.fn(),
     create: vi.fn(),
+    findBySlug: vi.fn(),
     findOne: vi.fn(),
     generateUniqueSlug: vi.fn(),
   };
@@ -516,6 +532,93 @@ describe('OrganizationsController', () => {
       );
 
       expect(result).toBe(false);
+    });
+  });
+
+  // GET /organizations/by-slug/:slug is bespoke, so the base findOne gate never
+  // runs for it. Without its own check any authenticated user could read any
+  // organization by guessing a slug.
+  describe('findBySlug', () => {
+    const mockRequest = {
+      originalUrl: '/api/organizations/by-slug/other-org',
+      query: {},
+    } as unknown as Parameters<OrganizationsController['findBySlug']>[0];
+
+    const NOT_FOUND_DETAIL = 'Organization with slug "other-org" not found';
+
+    const readSlug = (user: User = currentUser): Promise<unknown> =>
+      controller.findBySlug(mockRequest, 'other-org', user);
+
+    const expectNotFound = async (): Promise<void> => {
+      const error = await readSlug().catch((thrown: unknown) => thrown);
+
+      expect(error).toBeInstanceOf(NotFoundException);
+      expect((error as NotFoundException).getStatus()).toBe(
+        HttpStatus.NOT_FOUND,
+      );
+      expect((error as NotFoundException).getResponse()).toEqual({
+        detail: NOT_FOUND_DETAIL,
+        title: 'Resource Not Found',
+      });
+    };
+
+    it('returns the organization for a member reading their own org', async () => {
+      const org = { id: 'org_other', label: 'Other Org', userId: 'user_other' };
+      mockOrganizationsService.findBySlug.mockResolvedValue(org);
+      mockMembersService.findOne.mockResolvedValue({ id: 'member_1' });
+
+      const result = await readSlug();
+
+      expect(result).toBe(org);
+      expect(mockOrganizationsService.findBySlug).toHaveBeenCalledWith(
+        'other-org',
+      );
+    });
+
+    it('returns the active organization without a membership lookup', async () => {
+      const org = { id: 'org_active', label: 'Active Org', userId: 'user_x' };
+      mockOrganizationsService.findBySlug.mockResolvedValue(org);
+
+      const result = await readSlug();
+
+      expect(result).toBe(org);
+      expect(mockMembersService.findOne).not.toHaveBeenCalled();
+    });
+
+    it('404s when a non-member reads a foreign organization', async () => {
+      mockOrganizationsService.findBySlug.mockResolvedValue({
+        id: 'org_other',
+        label: 'Other Org',
+        userId: 'user_other',
+      });
+      mockMembersService.findOne.mockResolvedValue(null);
+
+      await expectNotFound();
+    });
+
+    // Same assertion as the denied read above: the two responses must be
+    // indistinguishable, or the slug becomes an existence oracle.
+    it('404s identically for an unknown slug', async () => {
+      mockOrganizationsService.findBySlug.mockResolvedValue(null);
+
+      await expectNotFound();
+    });
+
+    it('lets a super admin read a foreign organization', async () => {
+      const org = { id: 'org_other', label: 'Other Org', userId: 'user_other' };
+      mockOrganizationsService.findBySlug.mockResolvedValue(org);
+      mockMembersService.findOne.mockResolvedValue(null);
+
+      const superAdminUser = {
+        publicMetadata: {
+          ...(currentUser.publicMetadata as Record<string, unknown>),
+          isSuperAdmin: true,
+        },
+      } as unknown as User;
+
+      const result = await readSlug(superAdminUser);
+
+      expect(result).toBe(org);
     });
   });
 });

--- a/apps/server/api/src/collections/organizations/controllers/organizations.controller.ts
+++ b/apps/server/api/src/collections/organizations/controllers/organizations.controller.ts
@@ -194,19 +194,36 @@ export class OrganizationsController extends BaseCRUDController<
   /**
    * GET /organizations/by-slug/:slug
    * Resolve an organization by its URL-friendly slug.
+   *
+   * Bespoke route: the base findOne gate never runs for it, so it applies
+   * canUserReadEntity itself rather than defining a second access rule. A
+   * denied read and an unknown slug throw the identical 404 so a slug probe
+   * can't distinguish "exists, but not yours" from "does not exist".
    */
   @Get('by-slug/:slug')
   @LogMethod({ logEnd: false, logError: true, logStart: true })
   async findBySlug(
     @Req() request: Request,
     @Param('slug') slug: string,
+    @CurrentUser() user: User,
   ): Promise<unknown> {
     const org = await this.organizationsService.findBySlug(slug);
-    if (!org) {
-      throw new NotFoundException({
+    const notFound = (): NotFoundException =>
+      new NotFoundException({
         message: `Organization with slug "${slug}" not found`,
       });
+
+    if (!org) {
+      throw notFound();
     }
+
+    if (
+      !(await this.canUserReadEntity(user, org)) &&
+      !getIsSuperAdmin(user, request)
+    ) {
+      throw notFound();
+    }
+
     return serializeSingle(request, OrganizationSerializer, org);
   }
 


### PR DESCRIPTION
## Problem

`GET /organizations/by-slug/:slug` resolved an organization by slug and serialized it with **no scoping check**. Any authenticated user could read any organization — name, slug, prefix, settings — by guessing or knowing its slug.

Same IDOR class as the inherited single-record read fixed in #2050, but on a bespoke route that the base-controller gate never covers.

## Fix

`findBySlug` now applies the controller's existing `canUserReadEntity` (added in #2050) rather than defining a second access rule. Access resolves as: active org match **OR** organization ownership **OR** an active membership row. `getIsSuperAdmin(user, request)` bypass preserved.

A denied read throws the **identical 404** as an unknown slug — same `NotFoundException`, same detail string — so a slug probe can't distinguish "exists, but not yours" from "does not exist". No 403, matching repo convention.

## Consumer check

The sole client method is `packages/services/organization/organizations.service.ts:394`. Grepping `.findBySlug(` and `by-slug` across `apps/` and `packages/` found **zero call sites** — no onboarding or org-switch flow depends on a pre-membership read, so membership/ownership/active-org is the correct gate and no narrowed response is needed.

## Tests

New `describe('findBySlug')` in `organizations.controller.spec.ts`:
- member reads own org by slug -> ok
- active-org read short-circuits before the membership lookup
- non-member reads a foreign org -> 404
- unknown slug -> **identical** 404 body (asserted via `getResponse()`, not just the status) so the route is not an existence oracle
- super admin reads a foreign org -> ok

## Note on the base branch

Based on `fix/base-crud-cross-tenant-idor` (#2050), not `master`, because `canUserReadEntity` does not exist on `master` yet — reusing it required stacking. GitHub retargets this PR to `master` automatically once #2050 merges. **Merge #2050 first.**