### PR TITLE
perf(api): drive reply-bot polling fan-out from active configs

### DIFF
--- a/apps/server/api/src/collections/reply-bot-configs/services/reply-bot-configs.service.ts
+++ b/apps/server/api/src/collections/reply-bot-configs/services/reply-bot-configs.service.ts
@@ -128,6 +128,23 @@ export class ReplyBotConfigsService extends BaseService<
   }
 
   /**
+   * Find every active config across all organizations.
+   *
+   * Platform-wide cron fan-out is driven by this scarce set instead of by the
+   * full tenant list — there are far fewer active reply bots than
+   * organizations, so one cross-org read replaces one query per tenant.
+   * Soft-deleted organizations are excluded in the same read so the result
+   * matches a scan that only ever visited live organizations.
+   */
+  findAllActive(): Promise<ReplyBotConfigDocument[]> {
+    return this.find({
+      isActive: true,
+      isDeleted: false,
+      organization: { is: { isDeleted: false } },
+    });
+  }
+
+  /**
    * Find all active configs by organization
    */
   findActiveByOrganization(

--- a/apps/server/api/src/queues/reply-bot/reply-bot-queue.service.spec.ts
+++ b/apps/server/api/src/queues/reply-bot/reply-bot-queue.service.spec.ts
@@ -1,5 +1,4 @@
 import { CredentialsService } from '@api/collections/credentials/services/credentials.service';
-import { OrganizationsService } from '@api/collections/organizations/services/organizations.service';
 import { ReplyBotConfigsService } from '@api/collections/reply-bot-configs/services/reply-bot-configs.service';
 import { ReplyBotQueueService } from '@api/queues/reply-bot/reply-bot-queue.service';
 import { CredentialPlatform } from '@genfeedai/enums';
@@ -17,24 +16,29 @@ interface MockQueue {
   resume: ReturnType<typeof vi.fn>;
 }
 
-interface MockOrgsService {
-  findAll: ReturnType<typeof vi.fn>;
-}
-
 interface MockReplyBotConfigsService {
   findActive: ReturnType<typeof vi.fn>;
+  findAllActive: ReturnType<typeof vi.fn>;
 }
 
 interface MockCredentialsService {
+  find: ReturnType<typeof vi.fn>;
   findOne: ReturnType<typeof vi.fn>;
+}
+
+interface MockLoggerService {
+  debug: ReturnType<typeof vi.fn>;
+  error: ReturnType<typeof vi.fn>;
+  log: ReturnType<typeof vi.fn>;
+  warn: ReturnType<typeof vi.fn>;
 }
 
 describe('ReplyBotQueueService', () => {
   let service: ReplyBotQueueService;
   let mockQueue: MockQueue;
-  let orgsService: MockOrgsService;
   let replyBotConfigsService: MockReplyBotConfigsService;
   let credentialsService: MockCredentialsService;
+  let logger: MockLoggerService;
 
   beforeEach(async () => {
     mockQueue = {
@@ -47,41 +51,37 @@ describe('ReplyBotQueueService', () => {
       resume: vi.fn().mockResolvedValue(undefined),
     };
 
-    const mockOrgs: MockOrgsService = {
-      findAll: vi.fn().mockResolvedValue({ docs: [] }),
-    };
-
     const mockReplyBotConfigs: MockReplyBotConfigsService = {
       findActive: vi.fn().mockResolvedValue([]),
+      findAllActive: vi.fn().mockResolvedValue([]),
     };
 
     const mockCredentials: MockCredentialsService = {
+      find: vi.fn().mockResolvedValue([]),
       findOne: vi.fn().mockResolvedValue(null),
+    };
+
+    const mockLogger: MockLoggerService = {
+      debug: vi.fn(),
+      error: vi.fn(),
+      log: vi.fn(),
+      warn: vi.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ReplyBotQueueService,
         { provide: getQueueToken('reply-bot-polling'), useValue: mockQueue },
-        { provide: OrganizationsService, useValue: mockOrgs },
         { provide: ReplyBotConfigsService, useValue: mockReplyBotConfigs },
         { provide: CredentialsService, useValue: mockCredentials },
-        {
-          provide: LoggerService,
-          useValue: {
-            debug: vi.fn(),
-            error: vi.fn(),
-            log: vi.fn(),
-            warn: vi.fn(),
-          },
-        },
+        { provide: LoggerService, useValue: mockLogger },
       ],
     }).compile();
 
     service = module.get<ReplyBotQueueService>(ReplyBotQueueService);
-    orgsService = module.get(OrganizationsService);
     replyBotConfigsService = module.get(ReplyBotConfigsService);
     credentialsService = module.get(CredentialsService);
+    logger = module.get(LoggerService);
 
     vi.clearAllMocks();
   });
@@ -129,30 +129,76 @@ describe('ReplyBotQueueService', () => {
   // ── scheduledPolling ─────────────────────────────────────────────────
 
   describe('scheduledPolling', () => {
-    it('does nothing when no organizations have active bots', async () => {
-      orgsService.findAll.mockResolvedValue({ docs: [] });
+    const ORG_WITH_CREDENTIAL = 'org-with-credential';
+    const ORG_WITHOUT_CREDENTIAL = 'org-without-credential';
+    const CREDENTIAL_ID = 'credential-1';
+
+    it('does nothing when no organization has an active bot', async () => {
+      replyBotConfigsService.findAllActive.mockResolvedValue([]);
 
       await service.scheduledPolling();
 
+      expect(credentialsService.find).not.toHaveBeenCalled();
       expect(mockQueue.add).not.toHaveBeenCalled();
     });
 
-    it('queues jobs for organizations with active bots and credentials', async () => {
-      const orgId1 = '507f191e810c19729de860ee';
-      const orgId2 = '507f191e810c19729de860ee';
-      const credId = '507f191e810c19729de860ee';
+    it('queues one job per organization that has an active bot and a Twitter credential, warns on a missing credential, and never reads credentials for organizations without an active bot', async () => {
+      replyBotConfigsService.findAllActive.mockResolvedValue([
+        { id: 'config-1', organizationId: ORG_WITH_CREDENTIAL },
+        // Second active config for the same org must not produce a second job.
+        { id: 'config-2', organizationId: ORG_WITH_CREDENTIAL },
+        { id: 'config-3', organizationId: ORG_WITHOUT_CREDENTIAL },
+      ]);
 
-      orgsService.findAll.mockResolvedValue({
-        docs: [{ id: orgId1 }, { id: orgId2 }],
+      credentialsService.find.mockResolvedValue([
+        { id: CREDENTIAL_ID, organizationId: ORG_WITH_CREDENTIAL },
+      ]);
+
+      await service.scheduledPolling();
+
+      // Two queries total for the whole tick, regardless of tenant count.
+      expect(replyBotConfigsService.findAllActive).toHaveBeenCalledTimes(1);
+      expect(credentialsService.find).toHaveBeenCalledTimes(1);
+      expect(replyBotConfigsService.findActive).not.toHaveBeenCalled();
+
+      // Only organizations with an active bot reach the credential read. The
+      // exact `in` list proves an organization without an active bot — which
+      // contributes no config here — is never queried for credentials.
+      expect(credentialsService.find).toHaveBeenCalledWith({
+        isDeleted: false,
+        organizationId: {
+          in: [ORG_WITH_CREDENTIAL, ORG_WITHOUT_CREDENTIAL],
+        },
+        platform: CredentialPlatform.TWITTER,
       });
 
-      replyBotConfigsService.findActive
-        .mockResolvedValueOnce([{ _id: 'config-1' }]) // org1 has active bots
-        .mockResolvedValueOnce([]); // org2 does not
+      // Included: active bot + credential.
+      expect(mockQueue.add).toHaveBeenCalledTimes(1);
+      expect(mockQueue.add).toHaveBeenCalledWith(
+        'poll',
+        {
+          credentialId: CREDENTIAL_ID,
+          organizationId: ORG_WITH_CREDENTIAL,
+        },
+        expect.any(Object),
+      );
 
-      credentialsService.findOne.mockResolvedValueOnce({
-        id: credId,
-      });
+      // Excluded + warned: active bot, no credential.
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `no Twitter credential found for org ${ORG_WITHOUT_CREDENTIAL}`,
+        ),
+      );
+    });
+
+    it('keeps the first credential when an organization has several', async () => {
+      replyBotConfigsService.findAllActive.mockResolvedValue([
+        { id: 'config-1', organizationId: ORG_WITH_CREDENTIAL },
+      ]);
+      credentialsService.find.mockResolvedValue([
+        { id: CREDENTIAL_ID, organizationId: ORG_WITH_CREDENTIAL },
+        { id: 'credential-2', organizationId: ORG_WITH_CREDENTIAL },
+      ]);
 
       await service.scheduledPolling();
 
@@ -160,45 +206,22 @@ describe('ReplyBotQueueService', () => {
       expect(mockQueue.add).toHaveBeenCalledWith(
         'poll',
         {
-          credentialId: credId.toString(),
-          organizationId: orgId1.toString(),
+          credentialId: CREDENTIAL_ID,
+          organizationId: ORG_WITH_CREDENTIAL,
         },
         expect.any(Object),
       );
     });
 
-    it('skips organizations without Twitter credentials', async () => {
-      const orgId1 = '507f191e810c19729de860ee';
-      orgsService.findAll.mockResolvedValue({
-        docs: [{ _id: orgId1 }],
-      });
-      replyBotConfigsService.findActive.mockResolvedValue([
-        { _id: 'config-1' },
-      ]);
-      credentialsService.findOne.mockResolvedValue(null);
+    it('queues nothing when the active-bot lookup fails', async () => {
+      replyBotConfigsService.findAllActive.mockRejectedValue(
+        new Error('Postgres down'),
+      );
 
-      await service.scheduledPolling();
+      await expect(service.scheduledPolling()).resolves.toBeUndefined();
 
       expect(mockQueue.add).not.toHaveBeenCalled();
-    });
-
-    it('looks up Twitter credentials specifically', async () => {
-      const orgId1 = '507f191e810c19729de860ee';
-      orgsService.findAll.mockResolvedValue({
-        docs: [{ id: orgId1 }],
-      });
-      replyBotConfigsService.findActive.mockResolvedValue([{ _id: 'c-1' }]);
-      credentialsService.findOne.mockResolvedValue(null);
-
-      await service.scheduledPolling();
-
-      expect(credentialsService.findOne).toHaveBeenCalledWith(
-        expect.objectContaining({
-          isDeleted: false,
-          organization: orgId1,
-          platform: CredentialPlatform.TWITTER,
-        }),
-      );
+      expect(logger.error).toHaveBeenCalled();
     });
   });
 

--- a/apps/server/api/src/queues/reply-bot/reply-bot-queue.service.ts
+++ b/apps/server/api/src/queues/reply-bot/reply-bot-queue.service.ts
@@ -1,5 +1,4 @@
 import { CredentialsService } from '@api/collections/credentials/services/credentials.service';
-import { OrganizationsService } from '@api/collections/organizations/services/organizations.service';
 import { ReplyBotConfigsService } from '@api/collections/reply-bot-configs/services/reply-bot-configs.service';
 import { CredentialPlatform } from '@genfeedai/enums';
 import {
@@ -19,7 +18,6 @@ export class ReplyBotQueueService implements OnModuleInit {
   constructor(
     @InjectQueue(REPLY_BOT_POLLING_QUEUE)
     private readonly pollingQueue: Queue<ReplyBotPollingJobData>,
-    @Optional() private readonly organizationsService: OrganizationsService,
     @Optional()
     private readonly replyBotConfigsService: ReplyBotConfigsService,
     @Optional() private readonly credentialsService: CredentialsService,
@@ -111,42 +109,61 @@ export class ReplyBotQueueService implements OnModuleInit {
     Array<{ organizationId: string; credentialId: string }>
   > {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
-    const results: Array<{ organizationId: string; credentialId: string }> = [];
 
     try {
-      // Get all organizations
-      const orgsResult = await this.organizationsService.findAll(
-        { where: { isDeleted: false } },
-        { pagination: false },
-        false,
-      );
-      const organizations = orgsResult.docs || [];
+      // Drive the fan-out from the scarce entity — active bot configs — rather
+      // than from every tenant. Scanning all organizations cost 2N+1 queries
+      // per tick and discarded almost every org immediately; this is 2 queries
+      // regardless of tenant count.
+      const activeConfigs = await this.replyBotConfigsService.findAllActive();
 
-      for (const org of organizations) {
-        const orgId = (org.id as string).toString();
+      const organizationIds = [
+        ...new Set(
+          activeConfigs
+            .map((config) => config.organizationId?.toString())
+            .filter(
+              (organizationId): organizationId is string => !!organizationId,
+            ),
+        ),
+      ];
 
-        // Check if org has active reply bot configs
-        const activeBots = await this.replyBotConfigsService.findActive(orgId);
+      if (organizationIds.length === 0) {
+        return [];
+      }
 
-        if (activeBots.length === 0) {
+      const credentials = await this.credentialsService.find({
+        isDeleted: false,
+        organizationId: { in: organizationIds },
+        platform: CredentialPlatform.TWITTER,
+      });
+
+      // First credential wins per organization, mirroring the `findOne` read
+      // this replaced.
+      const credentialIdByOrganizationId = new Map<string, string>();
+      for (const credential of credentials) {
+        const organizationId = credential.organizationId?.toString();
+        const credentialId = credential.id?.toString();
+
+        if (!organizationId || !credentialId) {
           continue;
         }
 
-        // Find a valid Twitter credential for this org
-        const credential = await this.credentialsService.findOne({
-          isDeleted: false,
-          organization: org.id,
-          platform: CredentialPlatform.TWITTER,
-        });
+        if (!credentialIdByOrganizationId.has(organizationId)) {
+          credentialIdByOrganizationId.set(organizationId, credentialId);
+        }
+      }
 
-        if (credential) {
-          results.push({
-            credentialId: (credential.id as string).toString(),
-            organizationId: orgId,
-          });
+      const results: Array<{ organizationId: string; credentialId: string }> =
+        [];
+
+      for (const organizationId of organizationIds) {
+        const credentialId = credentialIdByOrganizationId.get(organizationId);
+
+        if (credentialId) {
+          results.push({ credentialId, organizationId });
         } else {
           this.logger.warn(
-            `${url} no Twitter credential found for org ${orgId}`,
+            `${url} no Twitter credential found for org ${organizationId}`,
           );
         }
       }


### PR DESCRIPTION
## Problem

`ReplyBotQueueService.getOrganizationsWithActiveBots()` loaded **every** organization on the platform (`pagination: false`), then issued **2 sequential queries per organization**:

- `replyBotConfigsService.findActive(orgId)`
- `credentialsService.findOne({ ..., platform: TWITTER })`

That is **2N+1 queries per cron tick**, growing linearly with tenant count — and almost every organization is discarded immediately because it has no active reply bot.

## Fix

Invert the read so it is driven by the scarce entity (active bot configs) instead of by all tenants:

1. **`ReplyBotConfigsService.findAllActive()`** (new) — one cross-org read of active configs. Soft-deleted organizations are excluded in the same query (`organization: { is: { isDeleted: false } }`) so the result matches the previous live-organization scan without costing an extra round trip.
2. **One credential read** — `credentialsService.find({ organizationId: { in: [...] }, platform: TWITTER, isDeleted: false })`.
3. **In-memory join** producing the identical `Array<{ organizationId, credentialId }>`.

**2 queries per tick, regardless of tenant count.**

## Behavior preserved

- First credential wins per organization (mirrors the `findOne` it replaced).
- An organization with several active configs still yields exactly one job (`Set` dedupe).
- The `logger.warn` for an organization with an active bot but no Twitter credential is unchanged, including message text.
- The outer `try/catch` still returns `[]` on failure.
- `OrganizationsService` is no longer referenced, so its (already `@Optional()`, never provided by `queues.module.ts`) constructor injection is dropped.

## Tests

`reply-bot-queue.service.spec.ts` — `scheduledPolling` rewritten:

- no organization has an active bot → no credential read, no job
- **included**: active bot + credential → one job queued
- **warned + excluded**: active bot, no credential
- **never queried**: an organization with no active bot contributes no id to the `in` list (asserted on the exact query argument)
- exactly 2 queries per tick; per-org `findActive` is never called
- first credential wins when an organization has several
- active-bot lookup failure → no jobs, error logged

## Verification

Local builds/typechecks intentionally not run — relying on PR CI.