### PR TITLE
perf(api): hoist per-iteration findMany reads out of trend and forecast loops

### DIFF
--- a/apps/server/api/src/collections/insights/services/insights.service.spec.ts
+++ b/apps/server/api/src/collections/insights/services/insights.service.spec.ts
@@ -2,6 +2,7 @@ import { InsightsService } from '@api/collections/insights/services/insights.ser
 import type { ModelsService } from '@api/collections/models/services/models.service';
 import type { LlmDispatcherService } from '@api/services/integrations/llm/llm-dispatcher.service';
 import type { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import { Timeframe } from '@genfeedai/enums';
 import type { LoggerService } from '@libs/logger/logger.service';
 
 type MockInsightDelegate = {
@@ -14,6 +15,7 @@ type MockInsightDelegate = {
 describe('InsightsService', () => {
   let service: InsightsService;
   let delegate: MockInsightDelegate;
+  let forecastDelegate: { findMany: ReturnType<typeof vi.fn> };
   let llmDispatcherService: {
     chatCompletion: ReturnType<typeof vi.fn>;
   };
@@ -68,6 +70,9 @@ describe('InsightsService', () => {
         ],
       }),
     };
+    forecastDelegate = {
+      findMany: vi.fn().mockResolvedValue([]),
+    };
     logger = {
       debug: vi.fn(),
       error: vi.fn(),
@@ -76,7 +81,10 @@ describe('InsightsService', () => {
     };
 
     service = new InsightsService(
-      { insight: delegate } as unknown as PrismaService,
+      {
+        forecast: forecastDelegate,
+        insight: delegate,
+      } as unknown as PrismaService,
       logger as unknown as LoggerService,
       {} as unknown as ModelsService,
       llmDispatcherService as unknown as LlmDispatcherService,
@@ -202,6 +210,112 @@ describe('InsightsService', () => {
       await expect(
         service.update('missing', 'org-1', { isRead: true }),
       ).rejects.toThrow('Insight not found');
+    });
+  });
+
+  describe('getForecast', () => {
+    const futureDate = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    const pastDate = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+
+    const makeForecastRow = (
+      id: string,
+      data: Record<string, unknown>,
+    ): Record<string, unknown> => ({
+      createdAt: new Date('2026-07-15T00:00:00.000Z'),
+      data,
+      id,
+      isDeleted: false,
+      organizationId: 'org-1',
+    });
+
+    it('reads the forecast table once for all requested metrics', async () => {
+      forecastDelegate.findMany.mockResolvedValue([
+        makeForecastRow('forecast-engagement', {
+          data: { value: 1 },
+          metric: 'engagement',
+          period: Timeframe.D30,
+          validUntil: futureDate,
+        }),
+        makeForecastRow('forecast-followers', {
+          data: { value: 2 },
+          metric: 'followers',
+          period: Timeframe.D30,
+          validUntil: futureDate,
+        }),
+      ]);
+
+      const result = await service.getForecast(
+        { metrics: ['engagement', 'followers'], period: Timeframe.D30 },
+        'org-1',
+      );
+
+      expect(forecastDelegate.findMany).toHaveBeenCalledTimes(1);
+      expect(forecastDelegate.findMany).toHaveBeenCalledWith({
+        where: { isDeleted: false, organizationId: 'org-1' },
+      });
+      expect(result).toHaveLength(2);
+      expect(result.map((forecast) => forecast.id)).toEqual([
+        'forecast-engagement',
+        'forecast-followers',
+      ]);
+    });
+
+    it('keeps the first stored row when a metric has duplicates', async () => {
+      forecastDelegate.findMany.mockResolvedValue([
+        makeForecastRow('forecast-first', {
+          metric: 'engagement',
+          period: Timeframe.D30,
+          validUntil: futureDate,
+        }),
+        makeForecastRow('forecast-second', {
+          metric: 'engagement',
+          period: Timeframe.D30,
+          validUntil: futureDate,
+        }),
+      ]);
+
+      const result = await service.getForecast(
+        { metrics: ['engagement'], period: Timeframe.D30 },
+        'org-1',
+      );
+
+      expect(result.map((forecast) => forecast.id)).toEqual(['forecast-first']);
+    });
+
+    it('ignores rows from another period and rows that already expired', async () => {
+      forecastDelegate.findMany.mockResolvedValue([
+        makeForecastRow('forecast-other-period', {
+          metric: 'engagement',
+          period: Timeframe.D90,
+          validUntil: futureDate,
+        }),
+        makeForecastRow('forecast-expired', {
+          metric: 'followers',
+          period: Timeframe.D30,
+          validUntil: pastDate,
+        }),
+      ]);
+
+      await expect(
+        service.getForecast(
+          { metrics: ['engagement'], period: Timeframe.D30 },
+          'org-1',
+        ),
+      ).rejects.toThrow('Insufficient data');
+      expect(forecastDelegate.findMany).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls through to generation when no stored forecast matches', async () => {
+      forecastDelegate.findMany.mockResolvedValue([]);
+
+      await expect(
+        service.getForecast(
+          { metrics: ['engagement'], period: Timeframe.D30 },
+          'org-1',
+        ),
+      ).rejects.toThrow(
+        'Insufficient data: real value for metric "engagement"',
+      );
     });
   });
 });

--- a/apps/server/api/src/collections/insights/services/insights.service.ts
+++ b/apps/server/api/src/collections/insights/services/insights.service.ts
@@ -182,21 +182,38 @@ export class InsightsService {
 
     const forecasts: Forecast[] = [];
 
-    for (const metric of dto.metrics) {
-      // Check for recent forecast in data JSON
-      const allForecasts = await this.prisma.forecast.findMany({
-        where: { isDeleted: false, organizationId },
-      });
+    // `dto.metrics` is user-controlled, so reading inside the loop was an O(N)
+    // sequence of org-wide scans. Read once and index the still-valid rows by
+    // metric; the period filter is loop-invariant.
+    const now = new Date();
+    const allForecasts = await this.prisma.forecast.findMany({
+      where: { isDeleted: false, organizationId },
+    });
 
-      const existingForecast = allForecasts.find((f) => {
-        const data = f.data as ForecastData;
-        return (
-          data?.metric === metric &&
-          data?.period === dto.period &&
-          data?.validUntil &&
-          new Date(data.validUntil) > new Date()
-        );
-      });
+    const validForecastsByMetric = new Map<
+      string,
+      (typeof allForecasts)[number]
+    >();
+    for (const candidate of allForecasts) {
+      const data = candidate.data as ForecastData;
+
+      if (
+        typeof data?.metric !== 'string' ||
+        data.period !== dto.period ||
+        !data.validUntil ||
+        new Date(data.validUntil) <= now
+      ) {
+        continue;
+      }
+
+      // `.find()` returned the first match, so keep the first row per metric.
+      if (!validForecastsByMetric.has(data.metric)) {
+        validForecastsByMetric.set(data.metric, candidate);
+      }
+    }
+
+    for (const metric of dto.metrics) {
+      const existingForecast = validForecastsByMetric.get(metric);
 
       if (existingForecast) {
         forecasts.push(existingForecast as unknown as Forecast);

--- a/apps/server/api/src/collections/trends/services/modules/trend-video.service.spec.ts
+++ b/apps/server/api/src/collections/trends/services/modules/trend-video.service.spec.ts
@@ -23,14 +23,16 @@ describe('TrendVideoService', () => {
     getYouTubeVideos: vi.fn(),
   };
 
+  type MockTrendDelegate = {
+    create: ReturnType<typeof vi.fn>;
+    findMany: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+  };
+
   let mockPrisma: {
-    trendingHashtag: { findMany: ReturnType<typeof vi.fn> };
-    trendingSound: { findMany: ReturnType<typeof vi.fn> };
-    trendingVideo: {
-      create: ReturnType<typeof vi.fn>;
-      findMany: ReturnType<typeof vi.fn>;
-      update: ReturnType<typeof vi.fn>;
-    };
+    trendingHashtag: MockTrendDelegate;
+    trendingSound: MockTrendDelegate;
+    trendingVideo: MockTrendDelegate;
   };
   let service: TrendVideoService;
 
@@ -79,13 +81,17 @@ describe('TrendVideoService', () => {
 
     mockPrisma = {
       trendingHashtag: {
+        create: vi.fn().mockResolvedValue({ id: 'created-hashtag' }),
         findMany: vi.fn().mockResolvedValue([]),
+        update: vi.fn().mockResolvedValue({}),
       },
       trendingSound: {
+        create: vi.fn().mockResolvedValue({ id: 'created-sound' }),
         findMany: vi.fn().mockResolvedValue([]),
+        update: vi.fn().mockResolvedValue({}),
       },
       trendingVideo: {
-        create: vi.fn().mockResolvedValue({}),
+        create: vi.fn().mockResolvedValue({ id: 'created-video' }),
         findMany: vi.fn().mockResolvedValue([]),
         update: vi.fn().mockResolvedValue({}),
       },
@@ -197,5 +203,188 @@ describe('TrendVideoService', () => {
     });
 
     expect(result).toHaveLength(0);
+  });
+
+  describe('fetchAndCacheViralVideos', () => {
+    it('reads existing videos once for the whole batch and updates the match', async () => {
+      mockApifyService.getTikTokVideos.mockResolvedValue([
+        { externalId: 'a', title: 'A' },
+        { externalId: 'b', title: 'B' },
+        { externalId: 'c', title: 'C' },
+      ]);
+      mockPrisma.trendingVideo.findMany.mockResolvedValue([
+        {
+          ...makeVideoDoc({ externalId: 'b', platform: 'tiktok' }),
+          id: 'video-b',
+        },
+      ]);
+
+      await service.fetchAndCacheViralVideos('tiktok', 3);
+
+      expect(mockPrisma.trendingVideo.findMany).toHaveBeenCalledTimes(1);
+      expect(mockPrisma.trendingVideo.update).toHaveBeenCalledTimes(1);
+      expect(mockPrisma.trendingVideo.update).toHaveBeenCalledWith({
+        data: { data: expect.objectContaining({ externalId: 'b' }) },
+        where: { id: 'video-b' },
+      });
+      expect(mockPrisma.trendingVideo.create).toHaveBeenCalledTimes(2);
+      expect(mockLoggerService.error).not.toHaveBeenCalled();
+    });
+
+    it('creates a new video when no existing record matches', async () => {
+      mockApifyService.getTikTokVideos.mockResolvedValue([
+        { externalId: 'a', title: 'A' },
+      ]);
+      mockPrisma.trendingVideo.findMany.mockResolvedValue([]);
+
+      await service.fetchAndCacheViralVideos('tiktok', 1);
+
+      expect(mockPrisma.trendingVideo.update).not.toHaveBeenCalled();
+      expect(mockPrisma.trendingVideo.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not match the same externalId on another platform', async () => {
+      mockApifyService.getTikTokVideos.mockResolvedValue([
+        { externalId: 'a', title: 'A' },
+      ]);
+      mockPrisma.trendingVideo.findMany.mockResolvedValue([
+        {
+          ...makeVideoDoc({ externalId: 'a', platform: 'instagram' }),
+          id: 'video-instagram',
+        },
+      ]);
+
+      await service.fetchAndCacheViralVideos('tiktok', 1);
+
+      expect(mockPrisma.trendingVideo.update).not.toHaveBeenCalled();
+      expect(mockPrisma.trendingVideo.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps the newest row per key when duplicates exist', async () => {
+      mockApifyService.getTikTokVideos.mockResolvedValue([
+        { externalId: 'a', title: 'A' },
+      ]);
+      // Rows arrive `createdAt desc`, so the first duplicate is the newest.
+      mockPrisma.trendingVideo.findMany.mockResolvedValue([
+        {
+          ...makeVideoDoc({ externalId: 'a', platform: 'tiktok' }),
+          id: 'video-newest',
+        },
+        {
+          ...makeVideoDoc({ externalId: 'a', platform: 'tiktok' }),
+          id: 'video-oldest',
+        },
+      ]);
+
+      await service.fetchAndCacheViralVideos('tiktok', 1);
+
+      expect(mockPrisma.trendingVideo.update).toHaveBeenCalledWith({
+        data: { data: expect.objectContaining({ externalId: 'a' }) },
+        where: { id: 'video-newest' },
+      });
+    });
+
+    it('updates the row it just created when a key repeats inside one batch', async () => {
+      mockApifyService.getTikTokVideos.mockResolvedValue([
+        { externalId: 'a', title: 'first' },
+        { externalId: 'a', title: 'second' },
+      ]);
+      mockPrisma.trendingVideo.findMany.mockResolvedValue([]);
+
+      await service.fetchAndCacheViralVideos('tiktok', 2);
+
+      expect(mockPrisma.trendingVideo.create).toHaveBeenCalledTimes(1);
+      expect(mockPrisma.trendingVideo.update).toHaveBeenCalledWith({
+        data: { data: expect.objectContaining({ title: 'second' }) },
+        where: { id: 'created-video' },
+      });
+    });
+
+    it('skips the read entirely when the provider returns nothing', async () => {
+      mockApifyService.getTikTokVideos.mockResolvedValue([]);
+
+      await service.fetchAndCacheViralVideos('tiktok', 5);
+
+      expect(mockPrisma.trendingVideo.findMany).not.toHaveBeenCalled();
+      expect(mockPrisma.trendingVideo.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('fetchAndCacheHashtags', () => {
+    it('reads existing hashtags once for the whole batch and updates the match', async () => {
+      mockApifyService.getTrendingHashtags.mockResolvedValue([
+        { hashtag: '#one' },
+        { hashtag: '#two' },
+        { hashtag: '#three' },
+      ]);
+      mockPrisma.trendingHashtag.findMany.mockResolvedValue([
+        {
+          ...makeHashtagDoc({ hashtag: '#two', platform: 'tiktok' }),
+          id: 'hashtag-two',
+        },
+      ]);
+
+      await service.fetchAndCacheHashtags('tiktok', 3);
+
+      expect(mockPrisma.trendingHashtag.findMany).toHaveBeenCalledTimes(1);
+      expect(mockPrisma.trendingHashtag.update).toHaveBeenCalledTimes(1);
+      expect(mockPrisma.trendingHashtag.update).toHaveBeenCalledWith({
+        data: { data: expect.objectContaining({ hashtag: '#two' }) },
+        where: { id: 'hashtag-two' },
+      });
+      expect(mockPrisma.trendingHashtag.create).toHaveBeenCalledTimes(2);
+      expect(mockLoggerService.error).not.toHaveBeenCalled();
+    });
+
+    it('creates a new hashtag when no existing record matches', async () => {
+      mockApifyService.getTrendingHashtags.mockResolvedValue([
+        { hashtag: '#one' },
+      ]);
+      mockPrisma.trendingHashtag.findMany.mockResolvedValue([
+        {
+          ...makeHashtagDoc({ hashtag: '#one', platform: 'instagram' }),
+          id: 'hashtag-instagram',
+        },
+      ]);
+
+      await service.fetchAndCacheHashtags('tiktok', 1);
+
+      expect(mockPrisma.trendingHashtag.update).not.toHaveBeenCalled();
+      expect(mockPrisma.trendingHashtag.create).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('fetchAndCacheSounds', () => {
+    it('reads existing sounds once for the whole batch and updates the match', async () => {
+      mockApifyService.getTikTokSounds.mockResolvedValue([
+        { soundId: 's1' },
+        { soundId: 's2' },
+        { soundId: 's3' },
+      ]);
+      mockPrisma.trendingSound.findMany.mockResolvedValue([
+        { ...makeSoundDoc({ soundId: 's2' }), id: 'sound-two' },
+      ]);
+
+      await service.fetchAndCacheSounds(3);
+
+      expect(mockPrisma.trendingSound.findMany).toHaveBeenCalledTimes(1);
+      expect(mockPrisma.trendingSound.update).toHaveBeenCalledTimes(1);
+      expect(mockPrisma.trendingSound.update).toHaveBeenCalledWith({
+        data: { data: expect.objectContaining({ soundId: 's2' }) },
+        where: { id: 'sound-two' },
+      });
+      expect(mockPrisma.trendingSound.create).toHaveBeenCalledTimes(2);
+      expect(mockLoggerService.error).not.toHaveBeenCalled();
+    });
+
+    it('creates a new sound when no existing record matches', async () => {
+      mockApifyService.getTikTokSounds.mockResolvedValue([{ soundId: 's1' }]);
+      mockPrisma.trendingSound.findMany.mockResolvedValue([]);
+
+      await service.fetchAndCacheSounds(1);
+
+      expect(mockPrisma.trendingSound.update).not.toHaveBeenCalled();
+      expect(mockPrisma.trendingSound.create).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/apps/server/api/src/collections/trends/services/modules/trend-video.service.ts
+++ b/apps/server/api/src/collections/trends/services/modules/trend-video.service.ts
@@ -12,6 +12,13 @@ import { Timeframe } from '@genfeedai/enums';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
 
+/** Separator that cannot appear in a platform id or external id. */
+const TREND_KEY_SEPARATOR = '\u0000';
+
+function trendKey(...parts: string[]): string {
+  return parts.join(TREND_KEY_SEPARATOR);
+}
+
 @Injectable()
 export class TrendVideoService {
   private readonly CACHE_PREFIX = 'trends';
@@ -24,6 +31,36 @@ export class TrendVideoService {
     private readonly cacheService: CacheService,
     private readonly apifyService: ApifyService,
   ) {}
+
+  /**
+   * Index trend rows by their in-JSON match key so a batch upsert needs a single
+   * read instead of one full scan per item.
+   *
+   * Callers pass rows ordered `createdAt desc`, matching the previous
+   * per-iteration `.find()`; keeping the first row per key therefore preserves
+   * the "newest match wins" semantics.
+   */
+  private indexTrendDocsByKey(
+    docs: Array<{ id: string; data: unknown }>,
+    keyOf: (data: Record<string, unknown>) => string | null,
+  ): Map<string, string> {
+    const index = new Map<string, string>();
+
+    for (const doc of docs) {
+      if (typeof doc.data !== 'object' || doc.data === null) {
+        continue;
+      }
+
+      const key = keyOf(doc.data as Record<string, unknown>);
+      if (key === null || index.has(key)) {
+        continue;
+      }
+
+      index.set(key, doc.id);
+    }
+
+    return index;
+  }
 
   /**
    * Get viral videos from all platforms or a specific platform
@@ -123,21 +160,32 @@ export class TrendVideoService {
         Date.now() + this.TREND_SIGNAL_DOCUMENT_TTL_SECONDS * 1000,
       );
 
+      // Existing records match on externalId + platform inside the JSON `data`
+      // blob, so index the table once for the whole batch instead of re-scanning
+      // it on every iteration.
+      const existingVideoDocs =
+        videos.length > 0
+          ? await this.prisma.trendingVideo.findMany({
+              orderBy: { createdAt: 'desc' },
+              take: 1000,
+              where: { isDeleted: false },
+            })
+          : [];
+      const existingVideoIds = this.indexTrendDocsByKey(
+        existingVideoDocs,
+        (d) =>
+          typeof d.externalId === 'string' && typeof d.platform === 'string'
+            ? trendKey(d.platform, d.externalId)
+            : null,
+      );
+
       for (const video of videos) {
         const externalId = video.externalId as string | undefined;
 
         // Find existing record by externalId + platform in data (in-memory match)
         if (externalId) {
-          // Find the actual match via in-memory check
-          const allDocs = await this.prisma.trendingVideo.findMany({
-            orderBy: { createdAt: 'desc' },
-            take: 1000,
-            where: { isDeleted: false },
-          });
-          const match = allDocs.find((doc) => {
-            const d = doc.data as unknown as Record<string, unknown>;
-            return d.externalId === externalId && d.platform === platform;
-          });
+          const videoKey = trendKey(platform, externalId);
+          const matchId = existingVideoIds.get(videoKey);
 
           const dataPayload = {
             ...video,
@@ -147,15 +195,20 @@ export class TrendVideoService {
             lastSeenAt: new Date(),
           };
 
-          if (match) {
+          if (matchId) {
             await this.prisma.trendingVideo.update({
               data: { data: dataPayload as never },
-              where: { id: match.id },
+              where: { id: matchId },
             });
           } else {
-            await this.prisma.trendingVideo.create({
+            const created = await this.prisma.trendingVideo.create({
               data: { data: dataPayload as never, isDeleted: false },
             });
+            // Keep the index authoritative so a key repeated inside this batch
+            // updates the row we just created instead of duplicating it.
+            if (created.id) {
+              existingVideoIds.set(videoKey, created.id);
+            }
           }
         } else {
           await this.prisma.trendingVideo.create({
@@ -266,21 +319,26 @@ export class TrendVideoService {
         Date.now() + this.TREND_SIGNAL_DOCUMENT_TTL_SECONDS * 1000,
       );
 
+      // One indexed read for the whole batch instead of one full scan per item.
+      const existingHashtagDocs = await this.prisma.trendingHashtag.findMany({
+        orderBy: { createdAt: 'desc' },
+        take: 1000,
+        where: { isDeleted: false },
+      });
+      const existingHashtagIds = this.indexTrendDocsByKey(
+        existingHashtagDocs,
+        (d) =>
+          typeof d.hashtag === 'string' && typeof d.platform === 'string'
+            ? trendKey(d.platform, d.hashtag)
+            : null,
+      );
+
       for (const hashtag of hashtags) {
         const hashtagKey = (hashtag as unknown as Record<string, unknown>)
           .hashtag as string | undefined;
 
-        const allDocs = await this.prisma.trendingHashtag.findMany({
-          orderBy: { createdAt: 'desc' },
-          take: 1000,
-          where: { isDeleted: false },
-        });
-        const match = hashtagKey
-          ? allDocs.find((doc) => {
-              const d = doc.data as unknown as Record<string, unknown>;
-              return d.hashtag === hashtagKey && d.platform === platform;
-            })
-          : undefined;
+        const indexKey = hashtagKey ? trendKey(platform, hashtagKey) : null;
+        const matchId = indexKey ? existingHashtagIds.get(indexKey) : undefined;
 
         const dataPayload = {
           ...hashtag,
@@ -290,15 +348,19 @@ export class TrendVideoService {
           lastSeenAt: new Date(),
         };
 
-        if (match) {
+        if (matchId) {
           await this.prisma.trendingHashtag.update({
             data: { data: dataPayload as never },
-            where: { id: match.id },
+            where: { id: matchId },
           });
         } else {
-          await this.prisma.trendingHashtag.create({
+          const created = await this.prisma.trendingHashtag.create({
             data: { data: dataPayload as never, isDeleted: false },
           });
+          // Keep the index authoritative for keys repeated inside this batch.
+          if (indexKey && created.id) {
+            existingHashtagIds.set(indexKey, created.id);
+          }
         }
       }
 
@@ -382,22 +444,23 @@ export class TrendVideoService {
         Date.now() + this.TREND_SIGNAL_DOCUMENT_TTL_SECONDS * 1000,
       );
 
+      // One indexed read for the whole batch instead of one full scan per item.
+      const existingSoundDocs = await this.prisma.trendingSound.findMany({
+        orderBy: { createdAt: 'desc' },
+        take: 1000,
+        where: { isDeleted: false },
+      });
+      const existingSoundIds = this.indexTrendDocsByKey(
+        existingSoundDocs,
+        (d) => (typeof d.soundId === 'string' ? d.soundId : null),
+      );
+
       for (const sound of sounds) {
         const soundId = (sound as unknown as Record<string, unknown>).soundId as
           | string
           | undefined;
 
-        const allDocs = await this.prisma.trendingSound.findMany({
-          orderBy: { createdAt: 'desc' },
-          take: 1000,
-          where: { isDeleted: false },
-        });
-        const match = soundId
-          ? allDocs.find((doc) => {
-              const d = doc.data as unknown as Record<string, unknown>;
-              return d.soundId === soundId;
-            })
-          : undefined;
+        const matchId = soundId ? existingSoundIds.get(soundId) : undefined;
 
         const dataPayload = {
           ...sound,
@@ -407,15 +470,19 @@ export class TrendVideoService {
           lastSeenAt: new Date(),
         };
 
-        if (match) {
+        if (matchId) {
           await this.prisma.trendingSound.update({
             data: { data: dataPayload as never },
-            where: { id: match.id },
+            where: { id: matchId },
           });
         } else {
-          await this.prisma.trendingSound.create({
+          const created = await this.prisma.trendingSound.create({
             data: { data: dataPayload as never, isDeleted: false },
           });
+          // Keep the index authoritative for ids repeated inside this batch.
+          if (soundId && created.id) {
+            existingSoundIds.set(soundId, created.id);
+          }
         }
       }
 


### PR DESCRIPTION
## Problem

Four batch loops in `apps/server` issued a bulk `findMany` on **every iteration** and then matched in memory — each batch was an O(N) sequence of large table scans.

| Site | Read per iteration |
|---|---|
| `insights.service.ts` `getForecast` | all non-deleted forecasts for the org, once per user-supplied metric |
| `trend-video.service.ts` `fetchAndCacheViralVideos` | `trendingVideo` — up to 1000 rows, **not org-scoped** |
| `trend-video.service.ts` `fetchAndCacheHashtags` | `trendingHashtag` — same |
| `trend-video.service.ts` `fetchAndCacheSounds` | `trendingSound` — same |

`dto.metrics` on the insights path is user-controlled, so request size directly multiplied the scan count.

## Fix

Each site reads **once before the loop** and indexes rows by the match key that lives inside the JSON `data` blob:

- videos → `platform + externalId`
- hashtags → `platform + hashtag`
- sounds → `soundId`
- forecasts → `metric` (the `period`/`validUntil` filters are loop-invariant, so they're applied while building the index)

## Behavior preservation

- Rows are still fetched `orderBy createdAt desc`; the index keeps the **first** row per key, so the previous "newest match wins" `.find()` semantics are unchanged.
- Match keys are only indexed when the JSON field is a `string`, preserving the original strict-equality comparison.
- The three trend loops `create` inside the loop, so a newly created id is written back into the index. A key repeated within one batch still **updates the row just created** instead of inserting a duplicate — the old code would have found it via the re-read.
- Videos have no early return on an empty batch, so the hoisted read is guarded on `videos.length > 0` to avoid adding a query on that path. Hashtags and sounds already return early.
- The index helper skips rows whose `data` is JSON `null`; the previous inline `.find()` would have thrown a `TypeError`.
- `generateForecast` currently always throws and never persists, so nothing inside the insights loop can invalidate the hoisted snapshot.

## Tests

`trend-video.service.spec.ts` — new `fetchAndCache*` coverage: match found → `update` with the matched id, no match → `create`, one `findMany` for an N-item batch, same `externalId` on a different platform does not match, newest duplicate wins, and a key repeated within one batch creates once then updates.

`insights.service.spec.ts` — new `getForecast` coverage: single read for multiple metrics, first stored row wins per metric, wrong-period/expired rows ignored, and fall-through to generation when nothing matches.

## Verification

Not run locally by request — relying on PR CI.