### PR TITLE
fix(email): allowlist link schemes in system email templates

### DIFF
--- a/apps/server/api/src/auth/better-auth/services/better-auth-mailer.service.ts
+++ b/apps/server/api/src/auth/better-auth/services/better-auth-mailer.service.ts
@@ -3,6 +3,7 @@ import {
   buildSystemEmailHtml,
   buildSystemEmailParagraph,
   escapeSystemEmailHtml,
+  sanitizeSystemEmailUrl,
 } from '@genfeedai/helpers';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Injectable } from '@nestjs/common';
@@ -78,11 +79,32 @@ export class BetterAuthMailerService {
     });
   }
 
+  /**
+   * Renders the "copy and paste this URL" fallback, but only for schemes we
+   * trust. Escaping alone closes attribute breakout while leaving a
+   * `javascript:` or `data:text/html` target perfectly functional inside the
+   * `href`, so the scheme check is what makes this raw interpolation safe.
+   * An untrusted target renders nothing rather than a poisoned link.
+   */
+  private buildUrlFallbackBlock(url: string): string {
+    const safeUrl = sanitizeSystemEmailUrl(url);
+
+    if (!safeUrl) {
+      return '';
+    }
+
+    const escapedUrl = escapeSystemEmailHtml(safeUrl);
+
+    return [
+      '<p style="margin:0 0 10px;color:#8c8c96;font-size:12px;line-height:18px;">If the button does not work, copy and paste this URL into your browser:</p>',
+      `<p style="background:#131518;border:1px solid #333538;border-radius:8px;color:#b4b4bc;font-size:12px;line-height:18px;margin:0 0 22px;padding:12px;word-break:break-all;"><a href="${escapedUrl}" style="color:#f4f4f5;text-decoration:underline;">${escapedUrl}</a></p>`,
+    ].join('');
+  }
+
   private buildMagicLinkHtml(
     url: string,
     purpose: 'sign-in' | 'sign-up',
   ): string {
-    const escapedUrl = escapeSystemEmailHtml(url);
     const isSignUp = purpose === 'sign-up';
 
     return buildSystemEmailHtml({
@@ -93,8 +115,7 @@ export class BetterAuthMailerService {
             ? 'Click the button below to create your account. This link expires shortly and can only be used once.'
             : 'Click the button below to sign in. This link expires shortly and can only be used once.',
         ),
-        '<p style="margin:0 0 10px;color:#8c8c96;font-size:12px;line-height:18px;">If the button does not work, copy and paste this URL into your browser:</p>',
-        `<p style="background:#131518;border:1px solid #333538;border-radius:8px;color:#b4b4bc;font-size:12px;line-height:18px;margin:0 0 22px;padding:12px;word-break:break-all;"><a href="${escapedUrl}" style="color:#f4f4f5;text-decoration:underline;">${escapedUrl}</a></p>`,
+        this.buildUrlFallbackBlock(url),
       ].join(''),
       footerNote: isSignUp
         ? 'If you did not create a Genfeed.ai account, you can safely ignore this email.'
@@ -109,16 +130,13 @@ export class BetterAuthMailerService {
   }
 
   private buildVerificationEmailHtml(url: string): string {
-    const escapedUrl = escapeSystemEmailHtml(url);
-
     return buildSystemEmailHtml({
       action: { label: 'Verify email', url },
       bodyHtml: [
         buildSystemEmailParagraph(
           'Click the button below to verify your email address and finish securing your Genfeed.ai account.',
         ),
-        '<p style="margin:0 0 10px;color:#8c8c96;font-size:12px;line-height:18px;">If the button does not work, copy and paste this URL into your browser:</p>',
-        `<p style="background:#131518;border:1px solid #333538;border-radius:8px;color:#b4b4bc;font-size:12px;line-height:18px;margin:0 0 22px;padding:12px;word-break:break-all;"><a href="${escapedUrl}" style="color:#f4f4f5;text-decoration:underline;">${escapedUrl}</a></p>`,
+        this.buildUrlFallbackBlock(url),
       ].join(''),
       footerNote:
         'If you did not create a Genfeed.ai account, you can safely ignore this email.',
@@ -128,16 +146,13 @@ export class BetterAuthMailerService {
   }
 
   private buildResetPasswordHtml(url: string): string {
-    const escapedUrl = escapeSystemEmailHtml(url);
-
     return buildSystemEmailHtml({
       action: { label: 'Reset password', url },
       bodyHtml: [
         buildSystemEmailParagraph(
           'Click the button below to choose a new Genfeed.ai password. This link expires shortly and can only be used once.',
         ),
-        '<p style="margin:0 0 10px;color:#8c8c96;font-size:12px;line-height:18px;">If the button does not work, copy and paste this URL into your browser:</p>',
-        `<p style="background:#131518;border:1px solid #333538;border-radius:8px;color:#b4b4bc;font-size:12px;line-height:18px;margin:0 0 22px;padding:12px;word-break:break-all;"><a href="${escapedUrl}" style="color:#f4f4f5;text-decoration:underline;">${escapedUrl}</a></p>`,
+        this.buildUrlFallbackBlock(url),
       ].join(''),
       footerNote:
         'If you did not request a Genfeed.ai password reset, you can safely ignore this email.',

--- a/apps/server/server/src/services/lifecycle-emails/lifecycle-email-delivery.service.ts
+++ b/apps/server/server/src/services/lifecycle-emails/lifecycle-email-delivery.service.ts
@@ -11,6 +11,7 @@ import {
   buildSystemEmailHtml,
   buildSystemEmailParagraph,
   escapeSystemEmailHtml,
+  sanitizeSystemEmailUrl,
 } from '@helpers/email/system-email.helper';
 import { Inject, Injectable } from '@nestjs/common';
 import {
@@ -344,12 +345,19 @@ export class LifecycleEmailDeliveryService {
   }
 
   private buildHtml(template: EmailTemplate, unsubscribeToken: string): string {
-    const unsubscribeUrl = this.unsubscribeUrl(unsubscribeToken);
+    // A misconfigured API url must never turn the unsubscribe anchor into an
+    // arbitrary scheme; keep the notice either way, drop only the link.
+    const unsubscribeUrl = sanitizeSystemEmailUrl(
+      this.unsubscribeUrl(unsubscribeToken),
+    );
+    const unsubscribeHtml = unsubscribeUrl
+      ? `No longer want lifecycle emails? <a href="${escapeSystemEmailHtml(unsubscribeUrl)}" style="color:#b4b4bc;text-decoration:underline;">Unsubscribe</a>.`
+      : 'No longer want lifecycle emails? Reply to this email to unsubscribe.';
     const bodyHtml = [
       ...template.paragraphs.map((paragraph) =>
         buildSystemEmailParagraph(paragraph),
       ),
-      `<p style="margin:8px 0 20px;color:#8c8c96;font-size:12px;line-height:18px;">No longer want lifecycle emails? <a href="${escapeSystemEmailHtml(unsubscribeUrl)}" style="color:#b4b4bc;text-decoration:underline;">Unsubscribe</a>.</p>`,
+      `<p style="margin:8px 0 20px;color:#8c8c96;font-size:12px;line-height:18px;">${unsubscribeHtml}</p>`,
     ].join('');
 
     return buildSystemEmailHtml({

--- a/packages/helpers/src/email/system-email.helper.test.ts
+++ b/packages/helpers/src/email/system-email.helper.test.ts
@@ -4,6 +4,7 @@ import {
   buildSystemEmailHtml,
   buildSystemEmailParagraph,
   escapeSystemEmailHtml,
+  sanitizeSystemEmailUrl,
 } from './system-email.helper';
 
 describe('system email helpers', () => {
@@ -29,5 +30,92 @@ describe('system email helpers', () => {
     expect(html).toContain('Secure Genfeed link');
     expect(html).toContain('https://app.genfeed.ai/settings');
     expect(html).toContain('Ignore this email if you did not request it.');
+  });
+});
+
+describe('sanitizeSystemEmailUrl', () => {
+  it('keeps http, https and mailto targets verbatim', () => {
+    expect(sanitizeSystemEmailUrl('https://app.genfeed.ai/settings')).toBe(
+      'https://app.genfeed.ai/settings',
+    );
+    expect(sanitizeSystemEmailUrl('http://localhost:3010/verify')).toBe(
+      'http://localhost:3010/verify',
+    );
+    expect(sanitizeSystemEmailUrl('mailto:support@genfeed.ai')).toBe(
+      'mailto:support@genfeed.ai',
+    );
+  });
+
+  it('trims surrounding whitespace before parsing', () => {
+    expect(sanitizeSystemEmailUrl('  https://app.genfeed.ai  ')).toBe(
+      'https://app.genfeed.ai',
+    );
+  });
+
+  it('rejects script-bearing schemes', () => {
+    expect(sanitizeSystemEmailUrl('javascript:alert(1)')).toBeNull();
+    expect(sanitizeSystemEmailUrl('JavaScript:alert(1)')).toBeNull();
+    expect(
+      sanitizeSystemEmailUrl('data:text/html;base64,PHNjcmlwdD4='),
+    ).toBeNull();
+    expect(sanitizeSystemEmailUrl('vbscript:msgbox(1)')).toBeNull();
+    expect(sanitizeSystemEmailUrl('file:///etc/passwd')).toBeNull();
+  });
+
+  it('rejects relative and empty targets', () => {
+    expect(sanitizeSystemEmailUrl('/settings')).toBeNull();
+    expect(sanitizeSystemEmailUrl('app.genfeed.ai')).toBeNull();
+    expect(sanitizeSystemEmailUrl('   ')).toBeNull();
+    expect(sanitizeSystemEmailUrl('')).toBeNull();
+  });
+});
+
+describe('buildSystemEmailHtml link safety', () => {
+  it('drops the action button when the target scheme is untrusted', () => {
+    const html = buildSystemEmailHtml({
+      action: {
+        label: 'Review post',
+        url: 'javascript:alert(document.cookie)',
+      },
+      bodyHtml: buildSystemEmailParagraph('A post is waiting for review.'),
+      title: 'Review required',
+    });
+
+    expect(html).not.toContain('javascript:');
+    expect(html).not.toContain('Review post');
+    expect(html).toContain('A post is waiting for review.');
+  });
+
+  it('renders the action button for a trusted target', () => {
+    const html = buildSystemEmailHtml({
+      action: { label: 'Review post', url: 'https://app.genfeed.ai/review/1' },
+      bodyHtml: buildSystemEmailParagraph('A post is waiting for review.'),
+      title: 'Review required',
+    });
+
+    expect(html).toContain('href="https://app.genfeed.ai/review/1"');
+    expect(html).toContain('Review post');
+  });
+
+  it('falls back to the default app url when appUrl is untrusted', () => {
+    const html = buildSystemEmailHtml({
+      appUrl: 'javascript:alert(1)',
+      bodyHtml: buildSystemEmailParagraph('Body.'),
+      title: 'Notice',
+    });
+
+    expect(html).not.toContain('javascript:');
+    expect(html).toContain('href="https://app.genfeed.ai"');
+  });
+
+  it('still renders an unlinked brand mark when appUrl is explicitly empty', () => {
+    const html = buildSystemEmailHtml({
+      appUrl: '',
+      bodyHtml: buildSystemEmailParagraph('Body.'),
+      title: 'Notice',
+    });
+
+    expect(html).not.toContain('Open Genfeed</a>');
+    expect(html).toContain('Genfeed.ai</span>');
   });
 });

--- a/packages/helpers/src/email/system-email.helper.ts
+++ b/packages/helpers/src/email/system-email.helper.ts
@@ -16,6 +16,31 @@ export interface SystemEmailOptions {
 const DEFAULT_APP_URL = 'https://app.genfeed.ai';
 const BRAND_NAME = 'Genfeed.ai';
 
+/** The only schemes an outbound email is allowed to link to. */
+const SAFE_EMAIL_URL_PROTOCOLS = new Set(['http:', 'https:', 'mailto:']);
+
+/**
+ * Escaping a URL only closes attribute breakout — it leaves `javascript:` and
+ * `data:text/html;…` payloads perfectly intact inside an `href`. Several link
+ * targets reaching these templates are caller-supplied (workflow review URLs,
+ * video job URLs, scraped trend links), so parse the value and keep only the
+ * schemes above. Anything else — including a relative or unparseable string —
+ * is rejected rather than rendered.
+ */
+export function sanitizeSystemEmailUrl(value: string): string | null {
+  const candidate = value.trim();
+  if (!candidate) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(candidate);
+    return SAFE_EMAIL_URL_PROTOCOLS.has(parsed.protocol) ? candidate : null;
+  } catch {
+    return null;
+  }
+}
+
 export function escapeSystemEmailHtml(value: string): string {
   return value
     .replaceAll('&', '&amp;')
@@ -30,7 +55,11 @@ export function buildSystemEmailParagraph(text: string): string {
 }
 
 export function buildSystemEmailHtml(input: SystemEmailOptions): string {
-  const appUrl = input.appUrl ?? DEFAULT_APP_URL;
+  const requestedAppUrl = input.appUrl ?? DEFAULT_APP_URL;
+  // An explicit empty string still means "render the brand without a link".
+  const appUrl = requestedAppUrl
+    ? (sanitizeSystemEmailUrl(requestedAppUrl) ?? DEFAULT_APP_URL)
+    : '';
   const brandMark = appUrl
     ? `<a href="${escapeSystemEmailHtml(appUrl)}" style="color:#f4f4f5;font-size:14px;font-weight:700;letter-spacing:0;text-decoration:none;">${BRAND_NAME}</a>`
     : `<span style="color:#f4f4f5;font-size:14px;font-weight:700;letter-spacing:0;">${BRAND_NAME}</span>`;
@@ -41,9 +70,15 @@ export function buildSystemEmailHtml(input: SystemEmailOptions): string {
     input.preheader ??
     `${input.title} - a secure notification from ${BRAND_NAME}.`;
   const eyebrow = input.eyebrow ?? BRAND_NAME;
-  const action = input.action
-    ? `<tr><td style="padding:8px 32px 24px;"><a href="${escapeSystemEmailHtml(input.action.url)}" style="background:#fafafa;border-radius:8px;color:#050607;display:inline-block;font-size:14px;font-weight:700;line-height:20px;padding:12px 18px;text-decoration:none;">${escapeSystemEmailHtml(input.action.label)}</a></td></tr>`
-    : '';
+  // Fail closed: an action pointing at a scheme we do not trust is dropped
+  // rather than rendered, so a poisoned link target cannot ship a button.
+  const actionUrl = input.action
+    ? sanitizeSystemEmailUrl(input.action.url)
+    : null;
+  const action =
+    input.action && actionUrl
+      ? `<tr><td style="padding:8px 32px 24px;"><a href="${escapeSystemEmailHtml(actionUrl)}" style="background:#fafafa;border-radius:8px;color:#050607;display:inline-block;font-size:14px;font-weight:700;line-height:20px;padding:12px 18px;text-decoration:none;">${escapeSystemEmailHtml(input.action.label)}</a></td></tr>`
+      : '';
   const footerNote = input.footerNote
     ? `<p style="margin:0 0 12px;color:#8c8c96;font-size:12px;line-height:18px;">${escapeSystemEmailHtml(input.footerNote)}</p>`
     : '';


### PR DESCRIPTION
Third of eight security branches from the whole-repo scan. Addresses **F3** (outbound email HTML sink family), scoped to what is actually still broken on `master`.

## What the scan flagged vs. what is actually wrong

The finding was recorded as "unescaped user content into outbound email HTML." Reading the code, **the text-escaping half is already correct on `master`** — every body interpolation in `notification-handler.service.ts` runs through `escapeSystemEmailHtml`, and every other email builder in the repo delegates to that same escaper.

The real, unfixed defect in the same sink family is the **`href` half**: `escapeSystemEmailHtml` is a *text* escaper. In attribute position it closes breakout, but it leaves a `javascript:` or `data:text/html;base64,…` target perfectly functional inside the `href`. Nothing anywhere checked the scheme.

Link targets reaching these templates that are not fully trusted:
- `reviewUrl` — built from workflow node config (user-controlled)
- `payload.url` — video job payload
- Better Auth links influenced by `callbackURL`
- trend-digest links originating from scraped external sources

## Fix

Central, so callers cannot forget it. New `sanitizeSystemEmailUrl` in `packages/helpers/src/email/system-email.helper.ts` parses the value and keeps only `http:`, `https:`, `mailto:`. Relative and unparseable strings are rejected — outbound email needs absolute links anyway.

Wired into `buildSystemEmailHtml`, which covers all 7 call sites at once:
- **`action.url` fails closed** — an untrusted target drops the whole button rather than rendering it
- **`appUrl` falls back** to `DEFAULT_APP_URL` when untrusted, so a misconfigured env cannot poison the brand mark or footer link
- **explicit `appUrl: ''` still means "brand mark, no link"** — that existing behaviour is preserved

Then the remaining raw-`href` sites, which build their own anchors and so bypass the central path:
- `better-auth-mailer.service.ts` — the three duplicated "copy and paste this URL" fallback blocks collapse into one shared `buildUrlFallbackBlock`, which renders nothing for an untrusted target
- `lifecycle-email-delivery.service.ts` — the unsubscribe anchor. Here the link is dropped but **the notice text is kept** ("Reply to this email to unsubscribe"); silently removing the unsubscribe sentence would be a compliance regression.

## Verified no regression

All 7 `buildSystemEmailHtml` call sites pass absolute `http(s)` URLs, so the fail-closed action path changes nothing in normal operation: the 3 Better Auth builders, `invitation.service.ts:598`, `lifecycle-email-delivery.service.ts:356`, `trend-digest.helper.ts:152`, and the two that pass no `action` at all (`trend-inspiration.processor.ts`, `email-digest.service.ts`).

## Deliberately left alone

`handleEmailAction`'s `send_email` case in `apps/server/notifications/src/services/notification-handler.service.ts` takes `html` **raw** from the Redis payload. That is an intentional internal contract — the API builds the HTML and the notifications service delivers it — and the API side is now covered centrally. Changing it would mean re-escaping already-escaped markup.

## Tests

8 new cases in `system-email.helper.test.ts`: scheme allowlist (accept `http`/`https`/`mailto`, reject `javascript:` in both casings, `data:`, `vbscript:`, `file:`), whitespace trimming, relative/empty rejection, and 4 end-to-end assertions on `buildSystemEmailHtml` covering the drop, the render, the `appUrl` fallback, and the explicit-empty case.

Local tests/typechecks not run per the repo's MacBook constraint — CI is the gate.