### PR TITLE
test(api): use Prisma scalar ids in autopilot spec fixtures

### DIFF
--- a/apps/server/api/src/collections/agent-strategies/services/agent-strategy-autopilot.service.spec.ts
+++ b/apps/server/api/src/collections/agent-strategies/services/agent-strategy-autopilot.service.spec.ts
@@ -4,12 +4,22 @@ import { AgentStrategyAutopilotPerformanceService } from '@api/collections/agent
 import { AgentStrategyAutopilotPlanningService } from '@api/collections/agent-strategies/services/agent-strategy-autopilot-planning.service';
 
 describe('AgentStrategyAutopilotService', () => {
-  const strategyId = 'test-object-id';
-  const organizationId = 'test-object-id';
-  const brandId = 'test-object-id';
+  // Distinct ids per entity: the autopilot helpers read the Prisma scalar `id`,
+  // so every assertion below can pin the exact value it expects instead of
+  // matching any string.
+  const strategyId = 'strategy-id';
+  const organizationId = 'organization-id';
+  const brandId = 'brand-id';
+  const userId = 'user-id';
+  const opportunityId = 'opportunity-id';
+  const draftId = 'draft-id';
+  const credentialId = 'credential-id';
+  const postId = 'post-id';
+  const reviewItemId = 'review-item-id';
+  const reviewPostId = 'review-post-id';
 
   const baseStrategy = {
-    _id: strategyId,
+    id: strategyId,
     agentType: 'general',
     autonomyMode: 'auto_publish',
     brand: brandId,
@@ -72,11 +82,11 @@ describe('AgentStrategyAutopilotService', () => {
       updateStatus: vi.fn().mockResolvedValue(undefined),
     };
     const reportsService = {
-      createReport: vi.fn().mockResolvedValue({ _id: 'test-object-id' }),
+      createReport: vi.fn().mockResolvedValue({ id: 'report-id' }),
       listByStrategy: vi.fn().mockResolvedValue([]),
     };
     const activitiesService = {
-      create: vi.fn().mockResolvedValue({ _id: 'test-object-id' }),
+      create: vi.fn().mockResolvedValue({ id: 'activity-id' }),
     };
     const trendsService = {
       getTrends: vi.fn().mockResolvedValue([]),
@@ -99,20 +109,20 @@ describe('AgentStrategyAutopilotService', () => {
     };
     const credentialsService = {
       findOne: vi.fn().mockResolvedValue({
-        _id: 'test-object-id',
+        id: credentialId,
         platform: 'twitter',
       }),
     };
     const postsService = {
-      create: vi.fn().mockResolvedValue({ _id: 'test-object-id' }),
+      create: vi.fn().mockResolvedValue({ id: postId }),
     };
     const batchGenerationService = {
       createManualReviewBatch: vi.fn().mockResolvedValue({
         id: 'batch-1',
         items: [
           {
-            id: 'test-object-id',
-            postId: 'test-object-id',
+            id: reviewItemId,
+            postId: reviewPostId,
           },
         ],
       }),
@@ -192,7 +202,7 @@ describe('AgentStrategyAutopilotService', () => {
     });
     deps.opportunitiesService.listOpenByStrategy.mockResolvedValue([
       {
-        _id: 'test-object-id',
+        id: opportunityId,
         estimatedCreditCost: 10,
         formatCandidates: ['text'],
         platformCandidates: ['twitter'],
@@ -204,10 +214,10 @@ describe('AgentStrategyAutopilotService', () => {
     ]);
 
     const result = await deps.service.executeQueuedRun({
-      organizationId: organizationId.toString(),
+      organizationId,
       runId: 'run-1',
-      strategyId: strategyId.toString(),
-      userId: 'test-object-id',
+      strategyId,
+      userId,
     });
 
     expect(result.creditsUsed).toBe(0);
@@ -218,11 +228,10 @@ describe('AgentStrategyAutopilotService', () => {
 
   it('revises a weak post once and discards it when the revised version still fails', async () => {
     const deps = createService();
-    const opportunityId = 'test-object-id';
 
     deps.opportunitiesService.listOpenByStrategy.mockResolvedValue([
       {
-        _id: opportunityId,
+        id: opportunityId,
         estimatedCreditCost: 10,
         formatCandidates: ['text'],
         platformCandidates: ['twitter'],
@@ -236,7 +245,7 @@ describe('AgentStrategyAutopilotService', () => {
     deps.contentGatewayService.processManualRequest.mockResolvedValue({
       drafts: [
         {
-          _id: 'test-object-id',
+          id: draftId,
           content: 'Weak draft',
           mediaUrls: [],
           metadata: {},
@@ -275,15 +284,38 @@ describe('AgentStrategyAutopilotService', () => {
     });
 
     const result = await deps.service.executeQueuedRun({
-      organizationId: organizationId.toString(),
+      organizationId,
       runId: 'run-1',
-      strategyId: strategyId.toString(),
-      userId: 'test-object-id',
+      strategyId,
+      userId,
     });
 
     expect(result.contentGenerated).toBe(1);
     expect(deps.optimizersService.optimizeContent).toHaveBeenCalledTimes(1);
+    expect(deps.contentDraftsService.patch).toHaveBeenCalledWith(
+      draftId,
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          autopilotOpportunityId: opportunityId,
+          autopilotStrategyId: strategyId,
+        }),
+      }),
+    );
     expect(deps.contentDraftsService.reject).toHaveBeenCalledTimes(1);
+    expect(deps.contentDraftsService.reject).toHaveBeenCalledWith(
+      draftId,
+      organizationId,
+      expect.any(String),
+    );
+    expect(deps.opportunitiesService.updateStatus).toHaveBeenCalledWith(
+      opportunityId,
+      organizationId,
+      'discarded',
+      expect.objectContaining({ decisionReason: expect.any(String) }),
+    );
+    expect(deps.reportsService.createReport).toHaveBeenCalledWith(
+      expect.objectContaining({ organizationId, strategyId }),
+    );
     expect(deps.postsService.create).not.toHaveBeenCalled();
   });
 
@@ -292,7 +324,7 @@ describe('AgentStrategyAutopilotService', () => {
 
     deps.opportunitiesService.listOpenByStrategy.mockResolvedValue([
       {
-        _id: 'test-object-id',
+        id: opportunityId,
         estimatedCreditCost: 24,
         formatCandidates: ['image'],
         platformCandidates: ['instagram'],
@@ -306,7 +338,7 @@ describe('AgentStrategyAutopilotService', () => {
     deps.contentGatewayService.processManualRequest.mockResolvedValue({
       drafts: [
         {
-          _id: 'test-object-id',
+          id: draftId,
           content: 'Generated image',
           mediaUrls: ['https://cdn.example.com/image.png'],
           metadata: {},
@@ -326,13 +358,24 @@ describe('AgentStrategyAutopilotService', () => {
     });
 
     await deps.service.executeQueuedRun({
-      organizationId: organizationId.toString(),
+      organizationId,
       runId: 'run-1',
-      strategyId: strategyId.toString(),
-      userId: 'test-object-id',
+      strategyId,
+      userId,
     });
 
     expect(deps.contentDraftsService.reject).toHaveBeenCalledTimes(1);
+    expect(deps.contentDraftsService.reject).toHaveBeenCalledWith(
+      draftId,
+      organizationId,
+      expect.any(String),
+    );
+    expect(deps.opportunitiesService.updateStatus).toHaveBeenCalledWith(
+      opportunityId,
+      organizationId,
+      'held',
+      expect.objectContaining({ decisionReason: expect.any(String) }),
+    );
     expect(deps.postsService.create).not.toHaveBeenCalled();
   });
 
@@ -341,7 +384,7 @@ describe('AgentStrategyAutopilotService', () => {
 
     deps.opportunitiesService.listOpenByStrategy.mockResolvedValue([
       {
-        _id: 'test-object-id',
+        id: opportunityId,
         estimatedCreditCost: 24,
         formatCandidates: ['image'],
         platformCandidates: ['instagram'],
@@ -355,7 +398,7 @@ describe('AgentStrategyAutopilotService', () => {
     deps.contentGatewayService.processManualRequest.mockResolvedValue({
       drafts: [
         {
-          _id: 'test-object-id',
+          id: draftId,
           content: 'Generated image',
           mediaUrls: ['https://cdn.example.com/image.png'],
           metadata: {},
@@ -375,35 +418,56 @@ describe('AgentStrategyAutopilotService', () => {
     });
 
     await deps.service.executeQueuedRun({
-      organizationId: organizationId.toString(),
+      organizationId,
       runId: 'run-1',
-      strategyId: strategyId.toString(),
-      userId: 'test-object-id',
+      strategyId,
+      userId,
     });
 
     expect(deps.contentDraftsService.approve).toHaveBeenCalledTimes(1);
+    expect(deps.contentDraftsService.approve).toHaveBeenCalledWith(
+      draftId,
+      organizationId,
+      userId,
+    );
     expect(
       deps.batchGenerationService.createManualReviewBatch,
     ).toHaveBeenCalledTimes(1);
     expect(
       deps.batchGenerationService.createManualReviewBatch,
     ).toHaveBeenCalledWith(
-      expect.objectContaining({
+      {
+        brandId,
         items: [
           expect.objectContaining({
             gateOverallScore: 91,
             gateReasons: ['Image cleared the autopilot quality gate.'],
             opportunitySourceType: 'trend',
             opportunityTopic: 'Product hero',
-            sourceActionId: expect.any(String),
-            sourceWorkflowId: expect.any(String),
+            sourceActionId: opportunityId,
+            sourceWorkflowId: strategyId,
           }),
         ],
-      }),
-      expect.any(String),
-      expect.any(String),
+      },
+      userId,
+      organizationId,
     );
+    expect(deps.contentDraftsService.patch).toHaveBeenCalledWith(draftId, {
+      metadata: {
+        reviewBatchId: 'batch-1',
+        reviewItemId,
+        reviewPostId,
+      },
+    });
     expect(deps.activitiesService.create).toHaveBeenCalledTimes(1);
+    expect(deps.activitiesService.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        brandId,
+        entityId: reviewPostId,
+        organizationId,
+        userId,
+      }),
+    );
     expect(deps.postsService.create).not.toHaveBeenCalled();
   });
 
@@ -420,7 +484,7 @@ describe('AgentStrategyAutopilotService', () => {
     });
     deps.opportunitiesService.listOpenByStrategy.mockResolvedValue([
       {
-        _id: 'test-object-id',
+        id: opportunityId,
         estimatedCreditCost: 10,
         formatCandidates: ['text'],
         platformCandidates: ['twitter'],
@@ -434,7 +498,7 @@ describe('AgentStrategyAutopilotService', () => {
     deps.contentGatewayService.processManualRequest.mockResolvedValue({
       drafts: [
         {
-          _id: 'test-object-id',
+          id: draftId,
           content: 'Strong post draft',
           mediaUrls: [],
           metadata: {},
@@ -456,20 +520,26 @@ describe('AgentStrategyAutopilotService', () => {
     });
 
     await deps.service.executeQueuedRun({
-      organizationId: organizationId.toString(),
+      organizationId,
       runId: 'run-1',
-      strategyId: strategyId.toString(),
-      userId: 'test-object-id',
+      strategyId,
+      userId,
     });
 
     expect(deps.contentDraftsService.approve).toHaveBeenCalledTimes(1);
+    expect(deps.contentDraftsService.approve).toHaveBeenCalledWith(
+      draftId,
+      organizationId,
+      userId,
+    );
     expect(
       deps.batchGenerationService.createManualReviewBatch,
     ).toHaveBeenCalledTimes(1);
     expect(
       deps.batchGenerationService.createManualReviewBatch,
     ).toHaveBeenCalledWith(
-      expect.objectContaining({
+      {
+        brandId,
         items: [
           expect.objectContaining({
             gateOverallScore: 88,
@@ -479,15 +549,30 @@ describe('AgentStrategyAutopilotService', () => {
             ],
             opportunitySourceType: 'evergreen',
             opportunityTopic: 'AI hooks',
-            sourceActionId: expect.any(String),
-            sourceWorkflowId: expect.any(String),
+            sourceActionId: opportunityId,
+            sourceWorkflowId: strategyId,
           }),
         ],
-      }),
-      expect.any(String),
-      expect.any(String),
+      },
+      userId,
+      organizationId,
     );
+    expect(deps.contentDraftsService.patch).toHaveBeenCalledWith(draftId, {
+      metadata: {
+        reviewBatchId: 'batch-1',
+        reviewItemId,
+        reviewPostId,
+      },
+    });
     expect(deps.activitiesService.create).toHaveBeenCalledTimes(1);
+    expect(deps.activitiesService.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        brandId,
+        entityId: reviewPostId,
+        organizationId,
+        userId,
+      }),
+    );
     expect(deps.postsService.create).not.toHaveBeenCalled();
   });
 
@@ -497,7 +582,7 @@ describe('AgentStrategyAutopilotService', () => {
     deps.credentialsService.findOne.mockResolvedValue(null);
     deps.opportunitiesService.listOpenByStrategy.mockResolvedValue([
       {
-        _id: 'test-object-id',
+        id: opportunityId,
         estimatedCreditCost: 10,
         formatCandidates: ['text'],
         platformCandidates: ['twitter'],
@@ -511,7 +596,7 @@ describe('AgentStrategyAutopilotService', () => {
     deps.contentGatewayService.processManualRequest.mockResolvedValue({
       drafts: [
         {
-          _id: 'test-object-id',
+          id: draftId,
           content: 'Strong post draft',
           mediaUrls: [],
           metadata: {},
@@ -533,20 +618,26 @@ describe('AgentStrategyAutopilotService', () => {
     });
 
     await deps.service.executeQueuedRun({
-      organizationId: organizationId.toString(),
+      organizationId,
       runId: 'run-1',
-      strategyId: strategyId.toString(),
-      userId: 'test-object-id',
+      strategyId,
+      userId,
     });
 
     expect(deps.contentDraftsService.approve).toHaveBeenCalledTimes(1);
+    expect(deps.contentDraftsService.approve).toHaveBeenCalledWith(
+      draftId,
+      organizationId,
+      userId,
+    );
     expect(
       deps.batchGenerationService.createManualReviewBatch,
     ).toHaveBeenCalledTimes(1);
     expect(
       deps.batchGenerationService.createManualReviewBatch,
     ).toHaveBeenCalledWith(
-      expect.objectContaining({
+      {
+        brandId,
         items: [
           expect.objectContaining({
             gateOverallScore: 88,
@@ -556,15 +647,116 @@ describe('AgentStrategyAutopilotService', () => {
             ],
             opportunitySourceType: 'evergreen',
             opportunityTopic: 'AI hooks',
-            sourceActionId: expect.any(String),
-            sourceWorkflowId: expect.any(String),
+            sourceActionId: opportunityId,
+            sourceWorkflowId: strategyId,
           }),
         ],
-      }),
-      expect.any(String),
-      expect.any(String),
+      },
+      userId,
+      organizationId,
     );
+    expect(deps.contentDraftsService.patch).toHaveBeenCalledWith(draftId, {
+      metadata: {
+        reviewBatchId: 'batch-1',
+        reviewItemId,
+        reviewPostId,
+      },
+    });
     expect(deps.activitiesService.create).toHaveBeenCalledTimes(1);
+    expect(deps.activitiesService.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        brandId,
+        entityId: reviewPostId,
+        organizationId,
+        userId,
+      }),
+    );
     expect(deps.postsService.create).not.toHaveBeenCalled();
+  });
+
+  it('auto-publishes a strong text draft when a connected credential exists', async () => {
+    const deps = createService();
+
+    deps.opportunitiesService.listOpenByStrategy.mockResolvedValue([
+      {
+        id: opportunityId,
+        estimatedCreditCost: 10,
+        formatCandidates: ['text'],
+        platformCandidates: ['twitter'],
+        priorityScore: 90,
+        sourceType: 'evergreen',
+        status: 'queued',
+        topic: 'AI hooks',
+      },
+    ]);
+
+    deps.contentGatewayService.processManualRequest.mockResolvedValue({
+      drafts: [
+        {
+          id: draftId,
+          content: 'Strong post draft',
+          mediaUrls: [],
+          metadata: {},
+          status: 'pending',
+        },
+      ],
+      runs: ['run-1'],
+    });
+
+    deps.optimizersService.analyzeContent.mockResolvedValue({
+      breakdown: {
+        clarity: 85,
+        engagement: 84,
+        platformOptimization: 82,
+        readability: 86,
+      },
+      metadata: { hasCallToAction: true },
+      overallScore: 88,
+    });
+
+    const result = await deps.service.executeQueuedRun({
+      organizationId,
+      runId: 'run-1',
+      strategyId,
+      userId,
+    });
+
+    expect(result.contentGenerated).toBe(1);
+    expect(deps.credentialsService.findOne).toHaveBeenCalledWith(
+      expect.objectContaining({
+        brandId,
+        isConnected: true,
+        isDeleted: false,
+        organizationId,
+        platform: 'twitter',
+      }),
+    );
+    expect(deps.postsService.create).toHaveBeenCalledTimes(1);
+    expect(deps.postsService.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        brandId,
+        credentialId,
+        description: 'Strong post draft',
+        organizationId,
+        platform: 'twitter',
+        userId,
+      }),
+    );
+    expect(deps.contentDraftsService.patch).toHaveBeenCalledWith(
+      draftId,
+      expect.objectContaining({
+        metadata: { publishedPostIds: [postId] },
+      }),
+    );
+    expect(deps.opportunitiesService.updateStatus).toHaveBeenCalledWith(
+      opportunityId,
+      organizationId,
+      'published',
+      expect.objectContaining({ decisionReason: expect.any(String) }),
+    );
+    expect(deps.contentDraftsService.approve).not.toHaveBeenCalled();
+    expect(
+      deps.batchGenerationService.createManualReviewBatch,
+    ).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Problem

`agent-strategy-autopilot.helpers.ts` resolves identity from the Prisma scalar column:

```ts
export function documentId(entity: unknown): string {
  return String((entity as Record<string, unknown>).id);
}
```

`opportunityId()`, `draftId()` and `strategyId()` all delegate to it. But the fixtures in `agent-strategy-autopilot.service.spec.ts` still carried the Mongo-era `_id` key, so every id that flowed through the autopilot execution path resolved to the literal string `"undefined"`.

The assertions were written as `expect.any(String)` — which matches `"undefined"` — so the suite went green while proving nothing about the identity plumbing it was supposed to cover.

## Change

- Rename `_id` → `id` across the strategy, opportunity, draft, credential, post and review-batch item fixtures, and give each entity a **distinct** id (`strategy-id`, `opportunity-id`, `draft-id`, …) so a mixed-up argument can no longer pass.
- Replace the `expect.any(String)` id matchers with the exact expected ids.
- Pin `createManualReviewBatch` to its full first-argument shape (`{ brandId, items }`) plus the positional `userId, organizationId` arguments.
- Add assertions that were previously impossible: the autopilot metadata patch (`autopilotOpportunityId` / `autopilotStrategyId`), the review-handoff patch (`reviewBatchId` / `reviewItemId` / `reviewPostId`), the publishing-inbox activity (`entityId`), `approve(draftId, organizationId, userId)`, `reject(draftId, organizationId, …)`, `updateStatus(opportunityId, organizationId, …)` and `createReport({ organizationId, strategyId })`.
- New test for the **auto-publish success path**, which had no coverage at all: post created with the resolved `credentialId`, draft patched with `{ publishedPostIds: [postId] }`, opportunity moved to `published`, and no manual-review handoff.

## Scope notes

- Test-only change. No production code touched.
- Verified no production code under `apps/server/api/src/collections/agent-strategies/` **reads** `._id` for identity — the only occurrences are two `normalize*` **writes** and one `Omit<>` type-union member.
- The `organization` / `brand` / `user` relation aliases on `baseStrategy` are left as-is: `strategyOrganizationId()` and `strategyBrandId()` still fall back to them. That is the separate alias family handled in #2046 and is deliberately out of scope here.

## Verification

Left to PR CI (no local test/typecheck/build runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)