### PR TITLE
fix(security): validate training spawn args and contain storage paths

### DIFF
--- a/apps/server/images/src/services/training.service.spec.ts
+++ b/apps/server/images/src/services/training.service.spec.ts
@@ -164,6 +164,133 @@ describe('TrainingService', () => {
     });
   });
 
+  describe('argument and path guards', () => {
+    const VALID_REQUEST = {
+      loraName: 'test-lora',
+      personaSlug: 'test-persona',
+      triggerWord: 'ohwx',
+    };
+
+    // `personaSlug` and `loraName` are interpolated into filesystem paths and
+    // then handed to `spawn`. No shell is involved, so the hazards are `../`
+    // traversal and a value the trainer re-reads as a flag because it starts
+    // with `-`.
+    it.each([
+      '../evil',
+      '../../etc/passwd',
+      'nested/name',
+      '/absolute/persona',
+      '-o',
+      '--config_file=/etc/shadow',
+      '.hidden',
+      'name with space',
+      '$(whoami)',
+      'a;b',
+    ])('rejects the personaSlug %s without spawning', async (personaSlug) => {
+      await expect(
+        service.startTraining({ ...VALID_REQUEST, personaSlug }),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(mockSpawn).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      '../evil',
+      'nested/name',
+      '/absolute/lora',
+      '--output_dir',
+      '.hidden',
+      'a;b',
+    ])('rejects the loraName %s without spawning', async (loraName) => {
+      await expect(
+        service.startTraining({ ...VALID_REQUEST, loraName }),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(mockSpawn).not.toHaveBeenCalled();
+    });
+
+    // `triggerWord` is free text rather than a path segment, so spaces are
+    // fine — a leading `-` is not.
+    it.each([
+      '--config_file=/etc/shadow',
+      '-o',
+      '-',
+      '../evil',
+      '$(whoami)',
+      'a\nb',
+    ])('rejects the triggerWord %s without spawning', async (triggerWord) => {
+      await expect(
+        service.startTraining({ ...VALID_REQUEST, triggerWord }),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(mockSpawn).not.toHaveBeenCalled();
+    });
+
+    it('accepts a trigger word containing spaces', async () => {
+      const mockChild = createMockChildProcess();
+      mockSpawn.mockReturnValue(mockChild);
+
+      await expect(
+        service.startTraining({ ...VALID_REQUEST, triggerWord: 'ohwx person' }),
+      ).resolves.toMatchObject({ jobId: expect.any(String) });
+    });
+
+    // Fields typed `number` in TypeScript are still arbitrary JSON at runtime.
+    it.each([
+      ['steps', { steps: 0 }],
+      ['steps', { steps: 1.5 }],
+      ['steps', { steps: 10_000_000 }],
+      ['steps', { steps: '1e999' as unknown as number }],
+      ['loraRank', { loraRank: 0 }],
+      ['loraRank', { loraRank: 512 }],
+      ['loraRank', { loraRank: Number.NaN }],
+      ['learningRate', { learningRate: 0 }],
+      ['learningRate', { learningRate: 5 }],
+      ['learningRate', { learningRate: '1e-4' as unknown as number }],
+      ['learningRate', { learningRate: Number.POSITIVE_INFINITY }],
+    ])('rejects an out-of-contract %s without spawning', async (_field, overrides) => {
+      await expect(
+        service.startTraining({ ...VALID_REQUEST, ...overrides }),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(mockSpawn).not.toHaveBeenCalled();
+    });
+
+    it('does not record a job when a request is rejected', async () => {
+      await expect(
+        service.startTraining({ ...VALID_REQUEST, personaSlug: '../evil' }),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(await service.listTrainingJobs()).toEqual([]);
+    });
+
+    // `buildTrainingCommand` is public, so it re-asserts rather than trusting
+    // that `startTraining` already validated the params it was handed.
+    it('re-validates params handed straight to buildTrainingCommand', () => {
+      expect(() =>
+        service.buildTrainingCommand({
+          learningRate: 1e-4,
+          loraName: '../../etc/passwd',
+          loraRank: 16,
+          personaSlug: 'test-persona',
+          steps: 1500,
+          triggerWord: 'ohwx',
+        }),
+      ).toThrow(BadRequestException);
+
+      expect(() =>
+        service.buildTrainingCommand({
+          learningRate: 1e-4,
+          loraName: 'my-lora',
+          loraRank: 16,
+          personaSlug: '../../etc',
+          steps: 1500,
+          triggerWord: 'ohwx',
+        }),
+      ).toThrow(BadRequestException);
+    });
+  });
+
   describe('getTrainingJob', () => {
     it('should return a training job by jobId', async () => {
       const mockChild = createMockChildProcess();

--- a/apps/server/images/src/services/training.service.ts
+++ b/apps/server/images/src/services/training.service.ts
@@ -15,6 +15,13 @@ import { LoggerService } from '@libs/logger/logger.service';
 // biome-ignore lint/style/useImportType: NestJS DI requires runtime imports
 import { RedisService } from '@libs/redis/redis.service';
 import { S3Service } from '@libs/s3/s3.service';
+import {
+  assertBoundedInteger,
+  assertBoundedNumber,
+  assertSafeArgValue,
+  assertSafeSegment,
+  resolveContainedPath,
+} from '@libs/security';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
 import {
   BadRequestException,
@@ -27,6 +34,15 @@ import {
 const DEFAULT_LORA_RANK = 16;
 const DEFAULT_STEPS = 1500;
 const DEFAULT_LEARNING_RATE = 1e-4;
+
+const LORA_RANK_BOUNDS = { max: 256, min: 1 };
+const STEPS_BOUNDS = { max: 100_000, min: 1 };
+const LEARNING_RATE_BOUNDS = { max: 1, min: 1e-8 };
+
+const SAFETENSORS_EXT = '.safetensors';
+
+const createBadRequest = (message: string): Error =>
+  new BadRequestException(message);
 
 @Injectable()
 export class TrainingService implements OnModuleInit {
@@ -90,17 +106,48 @@ export class TrainingService implements OnModuleInit {
       );
     }
 
+    // Every field below becomes an argv element of the trainer process, or is
+    // interpolated into a filesystem path. `spawn` runs without a shell, so the
+    // risk is not `;` but a value that starts with `-` (the child reads it as a
+    // flag, not as the previous flag's value) and `../` in the path segments.
+    const params: TrainingParams = {
+      learningRate: assertBoundedNumber(
+        request.learningRate ?? DEFAULT_LEARNING_RATE,
+        'learningRate',
+        LEARNING_RATE_BOUNDS,
+        createBadRequest,
+      ),
+      loraName: assertSafeSegment(
+        request.loraName,
+        'loraName',
+        createBadRequest,
+      ),
+      loraRank: assertBoundedInteger(
+        request.loraRank ?? DEFAULT_LORA_RANK,
+        'loraRank',
+        LORA_RANK_BOUNDS,
+        createBadRequest,
+      ),
+      personaSlug: assertSafeSegment(
+        request.personaSlug,
+        'personaSlug',
+        createBadRequest,
+      ),
+      steps: assertBoundedInteger(
+        request.steps ?? DEFAULT_STEPS,
+        'steps',
+        STEPS_BOUNDS,
+        createBadRequest,
+      ),
+      triggerWord: assertSafeArgValue(
+        request.triggerWord,
+        'triggerWord',
+        createBadRequest,
+      ),
+    };
+
     const jobId = randomUUID();
     const now = new Date().toISOString();
-
-    const params: TrainingParams = {
-      learningRate: request.learningRate ?? DEFAULT_LEARNING_RATE,
-      loraName: request.loraName,
-      loraRank: request.loraRank ?? DEFAULT_LORA_RANK,
-      personaSlug: request.personaSlug,
-      steps: request.steps ?? DEFAULT_STEPS,
-      triggerWord: request.triggerWord,
-    };
 
     const job: TrainingJob = {
       createdAt: now,
@@ -188,7 +235,37 @@ export class TrainingService implements OnModuleInit {
     const datasetsPath = this.configService.DATASETS_PATH;
     const lorasPath = this.configService.COMFYUI_LORAS_PATH;
 
-    const datasetDir = `${datasetsPath}/${params.personaSlug}`;
+    // Re-asserted here rather than trusted from `startTraining`: this method is
+    // public, and it is the last place before the values become argv.
+    const loraName = assertSafeSegment(
+      params.loraName,
+      'loraName',
+      createBadRequest,
+    );
+    const steps = assertBoundedInteger(
+      params.steps,
+      'steps',
+      STEPS_BOUNDS,
+      createBadRequest,
+    );
+    const loraRank = assertBoundedInteger(
+      params.loraRank,
+      'loraRank',
+      LORA_RANK_BOUNDS,
+      createBadRequest,
+    );
+    const learningRate = assertBoundedNumber(
+      params.learningRate,
+      'learningRate',
+      LEARNING_RATE_BOUNDS,
+      createBadRequest,
+    );
+
+    const datasetDir = resolveContainedPath(
+      datasetsPath,
+      assertSafeSegment(params.personaSlug, 'personaSlug', createBadRequest),
+      createBadRequest,
+    );
 
     const args: string[] = [
       '--pretrained_model_name_or_path',
@@ -198,21 +275,21 @@ export class TrainingService implements OnModuleInit {
       '--output_dir',
       lorasPath,
       '--output_name',
-      params.loraName,
+      loraName,
       '--resolution',
       '1024',
       '--train_batch_size',
       '1',
       '--max_train_steps',
-      String(params.steps),
+      String(steps),
       '--learning_rate',
-      String(params.learningRate),
+      String(learningRate),
       '--network_module',
       'networks.lora',
       '--network_dim',
-      String(params.loraRank),
+      String(loraRank),
       '--network_alpha',
-      String(Math.floor(params.loraRank / 2)),
+      String(Math.floor(loraRank / 2)),
       '--caption_extension',
       '.txt',
       '--mixed_precision',
@@ -365,14 +442,23 @@ export class TrainingService implements OnModuleInit {
   ): Promise<void> {
     const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
     const lorasPath = this.configService.COMFYUI_LORAS_PATH;
-    const localPath = `${lorasPath}/${params.loraName}.safetensors`;
+    const loraName = assertSafeSegment(
+      params.loraName,
+      'loraName',
+      createBadRequest,
+    );
+    const localPath = resolveContainedPath(
+      lorasPath,
+      `${loraName}${SAFETENSORS_EXT}`,
+      createBadRequest,
+    );
 
     await this.updateJob(jobId, { progress: 96, stage: 'uploading' });
 
     this.loggerService.log(caller, {
       jobId,
       localPath,
-      loraName: params.loraName,
+      loraName,
       message: 'Uploading trained LoRA to S3',
     });
 
@@ -381,13 +467,13 @@ export class TrainingService implements OnModuleInit {
     if (bucket) {
       const { s3Key, sizeBytes } = await this.s3Service.uploadSafetensors(
         bucket,
-        params.loraName,
+        loraName,
         localPath,
       );
 
       this.loggerService.log(caller, {
         jobId,
-        loraName: params.loraName,
+        loraName,
         message: 'LoRA uploaded to S3',
         s3Key,
         sizeBytes,

--- a/apps/server/voices/src/services/voice-training.service.spec.ts
+++ b/apps/server/voices/src/services/voice-training.service.spec.ts
@@ -151,6 +151,71 @@ describe('VoiceTrainingService', () => {
     });
   });
 
+  describe('argument and path guards', () => {
+    // `voiceId` lands in argv and in two filesystem paths. `spawn` runs without
+    // a shell, so the hazards are traversal (`../`) and a value the trainer
+    // re-reads as a flag because it starts with `-`.
+    it.each([
+      '../evil',
+      '../../etc/passwd',
+      'nested/name',
+      '/absolute/voice',
+      '-o',
+      '--config_file=/etc/shadow',
+      '.hidden',
+      'name with space',
+      '$(whoami)',
+      'a;b',
+    ])('rejects the voiceId %s without spawning', async (voiceId) => {
+      await expect(service.startTraining({ voiceId })).rejects.toThrow(
+        BadRequestException,
+      );
+
+      expect(mockSpawn).not.toHaveBeenCalled();
+    });
+
+    // Fields typed `number` in TypeScript are still arbitrary JSON at runtime.
+    it.each([
+      ['epochs', { epochs: 0 }],
+      ['epochs', { epochs: 1.5 }],
+      ['epochs', { epochs: 1_000_000 }],
+      ['epochs', { epochs: '1e999' as unknown as number }],
+      ['sampleRate', { sampleRate: 1 }],
+      ['sampleRate', { sampleRate: Number.NaN }],
+      ['sampleRate', { sampleRate: '44100' as unknown as number }],
+      ['batchSize', { batchSize: 0 }],
+      ['batchSize', { batchSize: 99_999 }],
+      ['batchSize', { batchSize: Number.POSITIVE_INFINITY }],
+    ])('rejects an out-of-contract %s without spawning', async (_field, overrides) => {
+      await expect(
+        service.startTraining({ voiceId: 'test-voice', ...overrides }),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(mockSpawn).not.toHaveBeenCalled();
+    });
+
+    it('does not record a job when a request is rejected', async () => {
+      await expect(
+        service.startTraining({ voiceId: '../evil' }),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(await service.listJobs()).toEqual([]);
+    });
+
+    // `buildTrainingCommand` is public, so it re-asserts rather than trusting
+    // that `startTraining` already validated the params it was handed.
+    it('re-validates params handed straight to buildTrainingCommand', () => {
+      expect(() =>
+        service.buildTrainingCommand({
+          batchSize: 8,
+          epochs: 100,
+          sampleRate: 22050,
+          voiceId: '../../etc',
+        }),
+      ).toThrow(BadRequestException);
+    });
+  });
+
   describe('getJob', () => {
     it('should return a training job by jobId', async () => {
       const mockChild = createMockChildProcess();

--- a/apps/server/voices/src/services/voice-training.service.ts
+++ b/apps/server/voices/src/services/voice-training.service.ts
@@ -7,6 +7,11 @@ import { TrainingStateStore } from '@libs/jobs/training-state.store';
 import { LoggerService } from '@libs/logger/logger.service';
 // biome-ignore lint/style/useImportType: NestJS DI requires runtime imports
 import { RedisService } from '@libs/redis/redis.service';
+import {
+  assertBoundedInteger,
+  assertSafeSegment,
+  resolveContainedPath,
+} from '@libs/security';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
 import {
   BadRequestException,
@@ -26,6 +31,16 @@ import type {
 const DEFAULT_SAMPLE_RATE = 22050;
 const DEFAULT_EPOCHS = 100;
 const DEFAULT_BATCH_SIZE = 8;
+
+const SAMPLE_RATE_BOUNDS = { max: 192_000, min: 8_000 };
+const EPOCHS_BOUNDS = { max: 10_000, min: 1 };
+const BATCH_SIZE_BOUNDS = { max: 1_024, min: 1 };
+
+/** Dataset subdirectory that holds every voice dataset. */
+const VOICE_DATASET_SUBDIR = 'voices';
+
+const createBadRequest = (message: string): Error =>
+  new BadRequestException(message);
 
 @Injectable()
 export class VoiceTrainingService implements OnModuleInit {
@@ -88,15 +103,34 @@ export class VoiceTrainingService implements OnModuleInit {
       throw new BadRequestException('voiceId is required');
     }
 
+    // Each of these becomes an argv element of the trainer, and `voiceId` is
+    // also interpolated into two filesystem paths. `spawn` runs without a
+    // shell, so the hazards are a value that starts with `-` (read as a flag by
+    // the child) and `../` inside the path segment.
+    const params: VoiceTrainingParams = {
+      batchSize: assertBoundedInteger(
+        request.batchSize ?? DEFAULT_BATCH_SIZE,
+        'batchSize',
+        BATCH_SIZE_BOUNDS,
+        createBadRequest,
+      ),
+      epochs: assertBoundedInteger(
+        request.epochs ?? DEFAULT_EPOCHS,
+        'epochs',
+        EPOCHS_BOUNDS,
+        createBadRequest,
+      ),
+      sampleRate: assertBoundedInteger(
+        request.sampleRate ?? DEFAULT_SAMPLE_RATE,
+        'sampleRate',
+        SAMPLE_RATE_BOUNDS,
+        createBadRequest,
+      ),
+      voiceId: assertSafeSegment(request.voiceId, 'voiceId', createBadRequest),
+    };
+
     const jobId = randomUUID();
     const now = new Date().toISOString();
-
-    const params: VoiceTrainingParams = {
-      batchSize: request.batchSize ?? DEFAULT_BATCH_SIZE,
-      epochs: request.epochs ?? DEFAULT_EPOCHS,
-      sampleRate: request.sampleRate ?? DEFAULT_SAMPLE_RATE,
-      voiceId: request.voiceId,
-    };
 
     const job: VoiceTrainingJob = {
       createdAt: now,
@@ -181,8 +215,42 @@ export class VoiceTrainingService implements OnModuleInit {
     const datasetsPath = this.configService.DATASETS_PATH;
     const modelsPath = this.configService.VOICE_MODELS_PATH;
 
-    const datasetDir = `${datasetsPath}/voices/${params.voiceId}`;
-    const outputDir = `${modelsPath}/${params.voiceId}`;
+    // Re-asserted here rather than trusted from `startTraining`: this method is
+    // public, and it is the last place before the values become argv.
+    const voiceId = assertSafeSegment(
+      params.voiceId,
+      'voiceId',
+      createBadRequest,
+    );
+    const sampleRate = assertBoundedInteger(
+      params.sampleRate,
+      'sampleRate',
+      SAMPLE_RATE_BOUNDS,
+      createBadRequest,
+    );
+    const epochs = assertBoundedInteger(
+      params.epochs,
+      'epochs',
+      EPOCHS_BOUNDS,
+      createBadRequest,
+    );
+    const batchSize = assertBoundedInteger(
+      params.batchSize,
+      'batchSize',
+      BATCH_SIZE_BOUNDS,
+      createBadRequest,
+    );
+
+    const datasetDir = resolveContainedPath(
+      `${datasetsPath}/${VOICE_DATASET_SUBDIR}`,
+      voiceId,
+      createBadRequest,
+    );
+    const outputDir = resolveContainedPath(
+      modelsPath,
+      voiceId,
+      createBadRequest,
+    );
 
     const args: string[] = [
       '--dataset_path',
@@ -190,11 +258,11 @@ export class VoiceTrainingService implements OnModuleInit {
       '--output_path',
       outputDir,
       '--sample_rate',
-      String(params.sampleRate),
+      String(sampleRate),
       '--epochs',
-      String(params.epochs),
+      String(epochs),
       '--batch_size',
-      String(params.batchSize),
+      String(batchSize),
     ];
 
     return { args, command: binaryPath };

--- a/packages/libs/security/arg-security.spec.ts
+++ b/packages/libs/security/arg-security.spec.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  assertBoundedInteger,
+  assertBoundedNumber,
+  assertSafeArgValue,
+  MAX_ARG_VALUE_LENGTH,
+  SAFE_ARG_VALUE_PATTERN,
+} from './arg-security';
+
+const createError = (message: string): Error => new Error(message);
+
+describe('assertSafeArgValue', () => {
+  it.each([
+    'persona',
+    'Persona 42',
+    'my_lora-v2',
+    'a.b.c',
+    'X',
+  ])('accepts %s', (value) => {
+    expect(assertSafeArgValue(value, 'triggerWord', createError)).toBe(value);
+  });
+
+  // The whole point of the guard: `spawn` passes argv verbatim, so a value
+  // starting with `-` is read by the child as a flag rather than as the value
+  // of the flag that preceded it.
+  it.each([
+    '--config_file=/etc/shadow',
+    '-o',
+    '--output_dir',
+    '-',
+    '--',
+  ])('rejects the argument-injection payload %s', (value) => {
+    expect(() => assertSafeArgValue(value, 'triggerWord', createError)).toThrow(
+      /may not start with/,
+    );
+  });
+
+  it.each([
+    ['an empty string', ''],
+    ['a path separator', 'a/b'],
+    ['a parent traversal', '../evil'],
+    ['a shell substitution', '$(whoami)'],
+    ['a backtick', 'a`b`'],
+    ['a semicolon', 'a;b'],
+    ['a newline', 'a\nb'],
+    ['a null byte', 'a\u0000b'],
+    ['a leading space', ' persona'],
+    ['a non-ASCII character', 'personaé'],
+  ])('rejects %s', (_label, value) => {
+    expect(() => assertSafeArgValue(value, 'triggerWord', createError)).toThrow(
+      Error,
+    );
+  });
+
+  it('rejects a value longer than the maximum', () => {
+    const tooLong = 'a'.repeat(MAX_ARG_VALUE_LENGTH + 1);
+
+    expect(() =>
+      assertSafeArgValue(tooLong, 'triggerWord', createError),
+    ).toThrow(/at most/);
+  });
+
+  it('accepts a value exactly at the maximum', () => {
+    const atLimit = 'a'.repeat(MAX_ARG_VALUE_LENGTH);
+
+    expect(assertSafeArgValue(atLimit, 'triggerWord', createError)).toBe(
+      atLimit,
+    );
+  });
+
+  it.each([
+    null,
+    undefined,
+    42,
+    {},
+    [],
+  ])('rejects the non-string %s', (value) => {
+    expect(() =>
+      assertSafeArgValue(value as unknown as string, 'name', createError),
+    ).toThrow(Error);
+  });
+
+  it('anchors the pattern at both ends', () => {
+    expect(SAFE_ARG_VALUE_PATTERN.source.startsWith('^')).toBe(true);
+    expect(SAFE_ARG_VALUE_PATTERN.source.endsWith('$')).toBe(true);
+  });
+});
+
+const BOUNDS = { max: 100, min: 1 };
+
+describe('assertBoundedNumber', () => {
+  it.each([1, 50, 100, 1.5])('accepts %s', (value) => {
+    expect(assertBoundedNumber(value, 'steps', BOUNDS, createError)).toBe(
+      value,
+    );
+  });
+
+  it.each([
+    0,
+    -1,
+    101,
+    Number.MAX_SAFE_INTEGER,
+  ])('rejects out-of-range %s', (value) => {
+    expect(() =>
+      assertBoundedNumber(value, 'steps', BOUNDS, createError),
+    ).toThrow(/between 1 and 100/);
+  });
+
+  it.each([
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    Number.NEGATIVE_INFINITY,
+  ])('rejects the non-finite %s', (value) => {
+    expect(() =>
+      assertBoundedNumber(value, 'steps', BOUNDS, createError),
+    ).toThrow(Error);
+  });
+
+  // A field typed `number` in TypeScript is still whatever JSON arrived at
+  // runtime. Coercing would accept these; rejecting is the only safe read.
+  it.each([
+    '50',
+    '1e999',
+    '',
+    ' ',
+    '0x10',
+    'NaN',
+  ])('rejects the string %s instead of coercing it', (value) => {
+    expect(() =>
+      assertBoundedNumber(value, 'steps', BOUNDS, createError),
+    ).toThrow(Error);
+  });
+
+  it.each([
+    null,
+    undefined,
+    {},
+    [],
+    true,
+  ])('rejects the non-number %s', (value) => {
+    expect(() =>
+      assertBoundedNumber(value, 'steps', BOUNDS, createError),
+    ).toThrow(Error);
+  });
+});
+
+describe('assertBoundedInteger', () => {
+  it.each([1, 50, 100])('accepts %s', (value) => {
+    expect(assertBoundedInteger(value, 'steps', BOUNDS, createError)).toBe(
+      value,
+    );
+  });
+
+  it.each([
+    1.5,
+    99.9,
+    Number.NaN,
+    '50',
+  ])('rejects the non-integer %s', (value) => {
+    expect(() =>
+      assertBoundedInteger(value, 'steps', BOUNDS, createError),
+    ).toThrow(/must be an integer/);
+  });
+
+  it.each([0, 101])('rejects out-of-range %s', (value) => {
+    expect(() =>
+      assertBoundedInteger(value, 'steps', BOUNDS, createError),
+    ).toThrow(/between 1 and 100/);
+  });
+
+  it('uses the error factory it is given', () => {
+    class DomainError extends Error {}
+
+    expect(() =>
+      assertBoundedInteger(
+        0,
+        'steps',
+        BOUNDS,
+        (message) => new DomainError(message),
+      ),
+    ).toThrow(DomainError);
+  });
+});

--- a/packages/libs/security/arg-security.ts
+++ b/packages/libs/security/arg-security.ts
@@ -1,0 +1,100 @@
+import type { SecurityErrorFactory } from '@libs/security/path-security';
+
+/**
+ * Guards for caller-supplied values that become `spawn()` argv elements.
+ *
+ * `spawn(cmd, args)` without a shell is immune to `;`/`|`/backtick injection —
+ * every element lands in `argv` verbatim. It is NOT immune to *argument*
+ * injection: an element whose text begins with `-` is parsed by the child as a
+ * flag, not as the value of the preceding flag. `--output_name` followed by
+ * `--config_file` hands the trainer a second option instead of a filename.
+ *
+ * Numeric parameters are the same hazard by a different route. A request field
+ * typed `number` in TypeScript is still whatever JSON the caller sent at
+ * runtime, and `String(value)` faithfully forwards a string into argv.
+ *
+ * Path-shaped identifiers belong to `assertSafeSegment` in `./path-security`;
+ * these two functions cover the non-path argv elements.
+ */
+
+/** Longest accepted free-text argument value. */
+export const MAX_ARG_VALUE_LENGTH = 128;
+
+/**
+ * Free-text argv element: printable ASCII, no leading `-`, no control
+ * characters, bounded length. Deliberately narrower than "any legal string" —
+ * these values are trainer parameters, not prose.
+ */
+export const SAFE_ARG_VALUE_PATTERN = /^[A-Za-z0-9][A-Za-z0-9 ._-]*$/;
+
+/**
+ * Assert a caller-supplied string is safe to pass as an argv element.
+ *
+ * The leading-character rule is the point: it is what stops the value from
+ * being re-read as a flag by the child process.
+ */
+export function assertSafeArgValue(
+  value: string,
+  name: string,
+  createError: SecurityErrorFactory,
+): string {
+  if (
+    typeof value !== 'string' ||
+    value.length > MAX_ARG_VALUE_LENGTH ||
+    !SAFE_ARG_VALUE_PATTERN.test(value)
+  ) {
+    throw createError(
+      `${name} must be at most ${MAX_ARG_VALUE_LENGTH} characters of letters, digits, spaces, '.', '-' or '_', and may not start with '-'`,
+    );
+  }
+
+  return value;
+}
+
+export interface NumericBounds {
+  max: number;
+  min: number;
+}
+
+/**
+ * Assert a caller-supplied value is a finite number inside `bounds`.
+ *
+ * Rejects strings outright rather than coercing them: `Number('1e999')` is
+ * `Infinity` and `Number('')` is `0`, so coercion would quietly accept input
+ * the caller never meant as a number.
+ */
+export function assertBoundedNumber(
+  value: unknown,
+  name: string,
+  bounds: NumericBounds,
+  createError: SecurityErrorFactory,
+): number {
+  if (
+    typeof value !== 'number' ||
+    !Number.isFinite(value) ||
+    value < bounds.min ||
+    value > bounds.max
+  ) {
+    throw createError(
+      `${name} must be a number between ${bounds.min} and ${bounds.max}`,
+    );
+  }
+
+  return value;
+}
+
+/** Integer-only variant of {@link assertBoundedNumber}. */
+export function assertBoundedInteger(
+  value: unknown,
+  name: string,
+  bounds: NumericBounds,
+  createError: SecurityErrorFactory,
+): number {
+  if (!Number.isInteger(value)) {
+    throw createError(
+      `${name} must be an integer between ${bounds.min} and ${bounds.max}`,
+    );
+  }
+
+  return assertBoundedNumber(value, name, bounds, createError);
+}

--- a/packages/libs/security/index.ts
+++ b/packages/libs/security/index.ts
@@ -1,4 +1,12 @@
 export {
+  assertBoundedInteger,
+  assertBoundedNumber,
+  assertSafeArgValue,
+  MAX_ARG_VALUE_LENGTH,
+  type NumericBounds,
+  SAFE_ARG_VALUE_PATTERN,
+} from '@libs/security/arg-security';
+export {
   assertSafeSegment,
   createPathSecurity,
   createPathSecurityClass,

--- a/packages/storage/src/local-storage.provider.spec.ts
+++ b/packages/storage/src/local-storage.provider.spec.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockAccess = vi.fn();
+const mockCopyFile = vi.fn();
+const mockMkdir = vi.fn();
+const mockReaddir = vi.fn();
+const mockStat = vi.fn();
+const mockUnlink = vi.fn();
+const mockWriteFile = vi.fn();
+
+vi.mock('node:fs', () => ({
+  existsSync: vi.fn(() => true),
+  mkdirSync: vi.fn(),
+}));
+
+vi.mock('node:fs/promises', () => ({
+  access: (...args: unknown[]) => mockAccess(...args),
+  copyFile: (...args: unknown[]) => mockCopyFile(...args),
+  mkdir: (...args: unknown[]) => mockMkdir(...args),
+  readdir: (...args: unknown[]) => mockReaddir(...args),
+  stat: (...args: unknown[]) => mockStat(...args),
+  unlink: (...args: unknown[]) => mockUnlink(...args),
+  writeFile: (...args: unknown[]) => mockWriteFile(...args),
+}));
+
+import { LocalStorageProvider } from './local-storage.provider';
+
+const BASE_DIR = '/srv/genfeed/files';
+
+/**
+ * Each of these escapes the storage root once `path.join` is done with it —
+ * either by walking up with `../` or, for the absolute forms, by replacing the
+ * root outright under `path.resolve`.
+ */
+const ESCAPING_PATHS = [
+  '../escaped.txt',
+  '../../etc/passwd',
+  'nested/../../escaped.txt',
+  '..',
+  '/etc/passwd',
+  '/srv/genfeed/files-sibling/escaped.txt',
+];
+
+describe('LocalStorageProvider path containment', () => {
+  let provider: LocalStorageProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockReaddir.mockResolvedValue([]);
+    provider = new LocalStorageProvider(BASE_DIR);
+  });
+
+  describe('upload', () => {
+    it.each(ESCAPING_PATHS)('rejects %s', async (filePath) => {
+      await expect(
+        provider.upload(Buffer.from('payload'), filePath),
+      ).rejects.toThrow(/must stay within/);
+
+      expect(mockWriteFile).not.toHaveBeenCalled();
+      expect(mockMkdir).not.toHaveBeenCalled();
+    });
+
+    it('writes inside the storage root for an ordinary path', async () => {
+      await provider.upload(Buffer.from('payload'), 'nested/ok.txt');
+
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        `${BASE_DIR}/nested/ok.txt`,
+        expect.any(Buffer),
+      );
+    });
+  });
+
+  describe('uploadFromFile', () => {
+    it.each(ESCAPING_PATHS)('rejects %s', async (filePath) => {
+      await expect(
+        provider.uploadFromFile(filePath, '/tmp/source.txt'),
+      ).rejects.toThrow(/must stay within/);
+
+      expect(mockCopyFile).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('download', () => {
+    it.each(ESCAPING_PATHS)('rejects %s', async (filePath) => {
+      await expect(
+        provider.download(filePath, '/tmp/destination.txt'),
+      ).rejects.toThrow(/must stay within/);
+
+      expect(mockCopyFile).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('delete', () => {
+    it.each(ESCAPING_PATHS)('rejects %s', async (filePath) => {
+      await expect(provider.delete(filePath)).rejects.toThrow(
+        /must stay within/,
+      );
+
+      expect(mockUnlink).not.toHaveBeenCalled();
+    });
+
+    it('unlinks inside the storage root for an ordinary path', async () => {
+      await provider.delete('nested/ok.txt');
+
+      expect(mockUnlink).toHaveBeenCalledWith(`${BASE_DIR}/nested/ok.txt`);
+    });
+  });
+
+  describe('list', () => {
+    it.each(ESCAPING_PATHS)('rejects %s', async (prefix) => {
+      await expect(provider.list(prefix)).rejects.toThrow(/must stay within/);
+
+      expect(mockReaddir).not.toHaveBeenCalled();
+    });
+
+    it('reads the resolved directory for an ordinary prefix', async () => {
+      await provider.list('images');
+
+      expect(mockReaddir).toHaveBeenCalledWith(`${BASE_DIR}/images`, {
+        withFileTypes: true,
+      });
+    });
+  });
+
+  describe('listObjects', () => {
+    it.each(ESCAPING_PATHS)('rejects %s', async (prefix) => {
+      await expect(provider.listObjects(prefix)).rejects.toThrow(
+        /must stay within/,
+      );
+
+      expect(mockReaddir).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('exists', () => {
+    it.each(
+      ESCAPING_PATHS,
+    )('rejects %s rather than probing it', async (filePath) => {
+      await expect(provider.exists(filePath)).rejects.toThrow(
+        /must stay within/,
+      );
+
+      expect(mockAccess).not.toHaveBeenCalled();
+    });
+  });
+
+  it('rejects a non-string path', async () => {
+    await expect(
+      provider.upload(Buffer.from('payload'), null as unknown as string),
+    ).rejects.toThrow(/must be a string/);
+
+    expect(mockWriteFile).not.toHaveBeenCalled();
+  });
+});

--- a/packages/storage/src/local-storage.provider.ts
+++ b/packages/storage/src/local-storage.provider.ts
@@ -39,6 +39,38 @@ function resolveBaseDir(): string {
   );
 }
 
+/**
+ * Resolve `candidate` against `root` and assert the result stays inside it.
+ *
+ * `path.join(root, candidate)` is not a containment check: enough leading
+ * `../` segments walk straight out of the storage directory. Resolving and
+ * then comparing against the root catches that, and also catches an absolute
+ * candidate, which `path.resolve` discards the root for entirely. Every method
+ * here takes its path from a caller, so every one of them resolves through
+ * this.
+ *
+ * `@libs/security` has the same guard, but this package deliberately depends
+ * on nothing but `@aws-sdk/client-s3` and `@genfeedai/config`, so it keeps its
+ * own copy rather than acquire a workspace dependency for six lines.
+ */
+function resolveWithin(root: string, candidate: string): string {
+  if (typeof candidate !== 'string') {
+    throw new Error('Storage path must be a string');
+  }
+
+  const resolvedRoot = path.resolve(root);
+  const resolved = path.resolve(resolvedRoot, candidate);
+
+  if (
+    resolved !== resolvedRoot &&
+    !resolved.startsWith(`${resolvedRoot}${path.sep}`)
+  ) {
+    throw new Error(`Storage path must stay within ${resolvedRoot}`);
+  }
+
+  return resolved;
+}
+
 export class LocalStorageProvider implements StorageProvider {
   private readonly baseDir: string;
 
@@ -49,12 +81,17 @@ export class LocalStorageProvider implements StorageProvider {
     }
   }
 
+  /** Resolve a caller-supplied path against the storage root. */
+  private resolvePath(filePath: string): string {
+    return resolveWithin(this.baseDir, filePath);
+  }
+
   async upload(
     file: Buffer,
     filePath: string,
     _contentType?: string,
   ): Promise<string> {
-    const fullPath = path.join(this.baseDir, filePath);
+    const fullPath = this.resolvePath(filePath);
     const dir = path.dirname(fullPath);
     await fs.mkdir(dir, { recursive: true });
     await fs.writeFile(fullPath, file);
@@ -66,14 +103,14 @@ export class LocalStorageProvider implements StorageProvider {
     localPath: string,
     _contentType?: string,
   ): Promise<string> {
-    const fullPath = path.join(this.baseDir, filePath);
+    const fullPath = this.resolvePath(filePath);
     await fs.mkdir(path.dirname(fullPath), { recursive: true });
     await fs.copyFile(localPath, fullPath);
     return filePath;
   }
 
   async download(filePath: string, localPath: string): Promise<void> {
-    const fullPath = path.join(this.baseDir, filePath);
+    const fullPath = this.resolvePath(filePath);
     await fs.mkdir(path.dirname(localPath), { recursive: true });
     await fs.copyFile(fullPath, localPath);
   }
@@ -83,7 +120,7 @@ export class LocalStorageProvider implements StorageProvider {
   }
 
   async delete(filePath: string): Promise<void> {
-    const fullPath = path.join(this.baseDir, filePath);
+    const fullPath = this.resolvePath(filePath);
     try {
       await fs.unlink(fullPath);
     } catch (err: unknown) {
@@ -94,7 +131,7 @@ export class LocalStorageProvider implements StorageProvider {
   }
 
   async list(prefix: string, options?: ListOptions): Promise<FileEntry[]> {
-    const dirPath = path.join(this.baseDir, prefix);
+    const dirPath = this.resolvePath(prefix);
     if (!existsSync(dirPath)) {
       return [];
     }
@@ -117,8 +154,7 @@ export class LocalStorageProvider implements StorageProvider {
       }
 
       const filePath = path.join(prefix, entry.name);
-      const fullPath = path.join(this.baseDir, filePath);
-      const stat = await fs.stat(fullPath);
+      const stat = await fs.stat(path.join(dirPath, entry.name));
 
       fileEntries.push({
         name: entry.name,
@@ -136,7 +172,7 @@ export class LocalStorageProvider implements StorageProvider {
   }
 
   async listObjects(prefix: string): Promise<StorageObject[]> {
-    const dirPath = path.join(this.baseDir, prefix);
+    const dirPath = this.resolvePath(prefix);
     if (!existsSync(dirPath)) {
       return [];
     }
@@ -165,7 +201,7 @@ export class LocalStorageProvider implements StorageProvider {
   }
 
   async exists(filePath: string): Promise<boolean> {
-    const fullPath = path.join(this.baseDir, filePath);
+    const fullPath = this.resolvePath(filePath);
     try {
       await fs.access(fullPath);
       return true;


### PR DESCRIPTION
## Summary

Closes three HIGH findings from the security scan: **F6** (image training spawn args), **F7** (voice training spawn args), **F9** (`LocalStorageProvider` path composition).

> **Merge order:** this is stacked on #2063 and targets `fix/media-service-guards`, not `master`. `assertSafeSegment` and `resolveContainedPath` are introduced there. GitHub will retarget this PR to `master` automatically once #2063 merges.

## The actual threat (F6, F7)

Both training services call `spawn(cmd, args)` **without a shell**, so this is *not* shell-metacharacter injection — every array element lands in `argv` verbatim. Three real exposures remain:

| Exposure | Mechanism |
| --- | --- |
| **Argument injection** | An argv element beginning with `-` is parsed by the child as a *flag*, not as the value of the flag before it. `--output_name` followed by `--config_file=/etc/shadow` hands the trainer a second option instead of a filename. |
| **Path traversal** | `personaSlug`, `loraName` and `voiceId` are interpolated into `datasetDir` / `outputDir` template literals, so `../` walks out of the configured root. |
| **Numeric fields** | `steps`, `loraRank`, `learningRate`, `epochs`, `sampleRate`, `batchSize` are typed `number` in TypeScript but are still arbitrary JSON at runtime, and `String(value)` forwards a string into argv faithfully. |

## New guards — `@libs/security/arg-security`

- **`assertSafeArgValue`** — printable ASCII, bounded length (128), **no leading `-`**. The leading-character rule is the whole point: it is what stops a value from being re-read as a flag by the child process. Spaces are allowed (trigger words like `ohwx person` are legitimate); path separators, control characters and non-ASCII are not.
- **`assertBoundedNumber`** / **`assertBoundedInteger`** — **reject** non-numbers rather than coercing them. `Number('1e999')` is `Infinity` and `Number('')` is `0`, so coercion would quietly accept input the caller never meant as a number.

Path-shaped identifiers keep using `assertSafeSegment` / `resolveContainedPath` from `@libs/security/path-security` (#2063).

## Validated twice, deliberately

Both services validate in **two** places, and this is intentional:

1. **`startTraining`** — before a job id or timestamp is minted, so a rejected request never creates job state or reaches the queue. (The `randomUUID()` / `new Date()` lines moved *below* the validated params block to make this true.)
2. **`buildTrainingCommand`** — a public method, and the last point before the values become argv. It re-asserts rather than trusting that `startTraining` already ran.

Tests assert both, and assert `spawn` is **never reached** on a rejected request.

## F9 — `LocalStorageProvider` containment

Every method took its path from a caller and composed it with `path.join(this.baseDir, …)`, which is not a containment check — enough leading `../` segments walk straight out of the storage root.

All **seven** caller-facing entry points (`upload`, `uploadFromFile`, `download`, `delete`, `list`, `listObjects`, `exists`) now resolve through one helper that resolves against the root and asserts the result stays inside it. That catches:

- `../` traversal, which `path.join` happily composes;
- absolute candidates, which `path.resolve` discards the root for entirely;
- prefix confusion — `/srv/genfeed/files-sibling` against a `/srv/genfeed/files` root — because the comparison is against `` `${root}${path.sep}` ``, not a bare `startsWith(root)`.

Empty prefixes still resolve to the root, so `list('')` / `listObjects('')` keep working; only non-strings are rejected outright.

`packages/storage` deliberately depends on nothing but `@aws-sdk/client-s3` and `@genfeedai/config`. Rather than acquire a workspace dependency on `@libs/security` (and transitively NestJS) for six lines, it keeps its own copy of the guard and throws a plain `Error`. The duplication is called out in a comment on both sides.

## Tests

- `packages/libs/security/arg-security.spec.ts` — **new**. Argument-injection payloads, traversal, metacharacters, control characters, length bounds, string-vs-number coercion, pattern anchoring, and error-factory pass-through.
- `packages/storage/src/local-storage.provider.spec.ts` — **new**; the first spec file in this package. Six escape shapes × seven entry points, each asserting both the rejection *and* that the filesystem call never fired.
- `apps/server/images/src/services/training.service.spec.ts` — security suite added: malicious `personaSlug` / `loraName` / `triggerWord`, out-of-contract `steps` / `loraRank` / `learningRate`, no-job-minted, direct `buildTrainingCommand` re-validation.
- `apps/server/voices/src/services/voice-training.service.spec.ts` — same shape for `voiceId` / `epochs` / `sampleRate` / `batchSize`.

## Review notes

- The `// biome-ignore lint/style/useImportType` comments in both training services are **pre-existing** and deliberate (NestJS DI needs runtime imports). Biome flags them as unused suppressions; that predates this branch.
- Local tests / typechecks were not run — CI is the gate.
