### PR TITLE
fix(hooks): honor biome overrides for files in git worktrees

### DIFF
--- a/.claude/hooks/post-edit-biome.sh
+++ b/.claude/hooks/post-edit-biome.sh
@@ -16,11 +16,24 @@ case "$file" in
 esac
 [ -f "$file" ] || exit 0
 
-cd "${CLAUDE_PROJECT_DIR:-.}" || exit 0
+# Resolve the checkout that actually contains the file. Git worktrees live
+# outside CLAUDE_PROJECT_DIR, so running from the project dir against an
+# absolute worktree path silently loses every `overrides` entry in biome.json —
+# those globs (`apps/server/**`, ...) are matched relative to the config root.
+# Losing them turns `useImportType` back on and rewrites NestJS constructor-DI
+# and @Body/@Query DTO imports to `import type`, which erases design:paramtypes
+# under emitDecoratorMetadata: DI injects undefined and ValidationPipe silently
+# skips validation, while type-check and lint stay green.
+root=$(cd "$(dirname "$file")" 2>/dev/null && git rev-parse --show-toplevel 2>/dev/null)
+[ -n "$root" ] || root="${CLAUDE_PROJECT_DIR:-.}"
+cd "$root" || exit 0
 
-if ! output=$(bunx biome check --write --no-errors-on-unmatched "$file" 2>&1); then
+# Pass the path relative to that root so the overrides match.
+rel="${file#"$root"/}"
+
+if ! output=$(bunx biome check --write --no-errors-on-unmatched "$rel" 2>&1); then
   {
-    echo "Biome found unfixable issues in $file — fix them now:"
+    echo "Biome found unfixable issues in $rel — fix them now:"
     printf '%s\n' "$output" | tail -40
   } >&2
   exit 2


### PR DESCRIPTION
The post-edit Biome hook silently corrupts NestJS dependency injection for any file edited inside a git worktree.

## Root cause

`.claude/hooks/post-edit-biome.sh` did:

```bash
cd "${CLAUDE_PROJECT_DIR:-.}" || exit 0
bunx biome check --write --no-errors-on-unmatched "$file"   # $file is ABSOLUTE
```

Git worktrees live outside `CLAUDE_PROJECT_DIR`, so the absolute path cannot match any `overrides.includes` glob in `biome.json` — those globs are resolved relative to the config root. Every override is dropped for worktree files.

## Why that matters

`biome.json` sets `style.useImportType: "off"` for `apps/server/**` on purpose: the server compiles with `emitDecoratorMetadata`, and Nest reads constructor params and `@Body`/`@Query`/`@Param` DTO classes out of `design:paramtypes`. A type-only import erases that runtime value, so:

- constructor DI resolves `undefined`
- `ValidationPipe` loses the metatype and skips validation entirely

Both failure modes pass `bun type-check` and `bunx biome check`. They only surface at runtime. This is the exact hazard `.agents/memory/rules/nestjs_value_imports_for_di.md` documents and `bun run check:di-value-imports` guards.

Because worktrees are the standard workflow here, the hook was re-introducing the defect on every edit.

## Measurement

Same file (`outreach-campaigns.controller.ts`), same content:

| invocation | `useImportType` findings |
| --- | --- |
| from project dir, absolute worktree path (old hook) | 28 |
| from its own worktree, relative path (new hook) | 0 |

Observed live this session: 11 DI imports across `members.controller.ts` and `outreach-campaigns.controller.ts` were rewritten to `import type` mid-task and had to be restored by hand.

## Fix

Resolve the checkout that actually contains the file (`git rev-parse --show-toplevel` from the file own directory, so a worktree uses its own `biome.json`) and pass a repo-relative path.

## Verification

Replaying the real hook payload against a worktree file: exit 0, type-only import count unchanged (6 → 6). Previously the same invocation rewrote them. `bash -n` clean.