### PR TITLE
fix(security): replace insecure random identifiers

### DIFF
--- a/apps/server/api/src/services/integrations/discord/controllers/discord.controller.spec.ts
+++ b/apps/server/api/src/services/integrations/discord/controllers/discord.controller.spec.ts
@@ -7,8 +7,6 @@ import { Test, TestingModule } from '@nestjs/testing';
 
 describe('DiscordController', () => {
   let controller: DiscordController;
-  let discordService: DiscordService;
-  let credentialsService: CredentialsService;
 
   const mockDiscordService = {
     exchangeCodeForToken: vi.fn(),
@@ -43,8 +41,6 @@ describe('DiscordController', () => {
       .compile();
 
     controller = module.get<DiscordController>(DiscordController);
-    discordService = module.get<DiscordService>(DiscordService);
-    credentialsService = module.get<CredentialsService>(CredentialsService);
   });
 
   it('should be defined', () => {
@@ -71,8 +67,15 @@ describe('DiscordController', () => {
 
       expect(result).toHaveProperty('url');
       expect(result).toHaveProperty('state');
-      expect(mockCredentialsService.create).toHaveBeenCalled();
-      expect(mockDiscordService.generateAuthUrl).toHaveBeenCalled();
+      expect(result.state).toMatch(/^[A-Za-z0-9_-]{43}$/);
+      expect(mockCredentialsService.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          oauthState: result.state,
+        }),
+      );
+      expect(mockDiscordService.generateAuthUrl).toHaveBeenCalledWith(
+        result.state,
+      );
     });
 
     it('should update existing credential when one exists', async () => {

--- a/apps/server/api/src/services/integrations/discord/controllers/discord.controller.ts
+++ b/apps/server/api/src/services/integrations/discord/controllers/discord.controller.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'node:crypto';
 import { CredentialsService } from '@api/collections/credentials/services/credentials.service';
 import { CurrentUser } from '@api/helpers/decorators/user/current-user.decorator';
 import { DiscordService } from '@api/services/integrations/discord/services/discord.service';
@@ -28,8 +29,8 @@ export class DiscordController {
     @Body('organizationId') organizationId: string,
     @Body('brandId') brandId: string,
   ) {
-    // Generate random state for CSRF protection
-    const state = Math.random().toString(36).substring(2, 15);
+    // Generate a cryptographically unpredictable state for CSRF protection.
+    const state = randomBytes(32).toString('base64url');
 
     // Create or update pending credential with state
     const existingCredential = await this.credentialsService.findOne({

--- a/apps/server/api/src/services/integrations/slack/controllers/slack.controller.spec.ts
+++ b/apps/server/api/src/services/integrations/slack/controllers/slack.controller.spec.ts
@@ -1,4 +1,8 @@
+import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticated-user.interface';
+import type { BrandsService } from '@api/collections/brands/services/brands.service';
+import type { CredentialsService } from '@api/collections/credentials/services/credentials.service';
 import { SlackController } from '@api/services/integrations/slack/controllers/slack.controller';
+import type { SlackService } from '@api/services/integrations/slack/services/slack.service';
 import { HttpException } from '@nestjs/common';
 
 describe('SlackController', () => {
@@ -11,7 +15,7 @@ describe('SlackController', () => {
       organization: mockOrganization,
       user: mockUserId,
     },
-  };
+  } as unknown as User;
 
   const mockBrandsService = {
     findOne: vi.fn(),
@@ -34,9 +38,9 @@ describe('SlackController', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     controller = new SlackController(
-      mockSlackService as any,
-      mockCredentialsService as any,
-      mockBrandsService as any,
+      mockSlackService as unknown as SlackService,
+      mockCredentialsService as unknown as CredentialsService,
+      mockBrandsService as unknown as BrandsService,
     );
   });
 
@@ -45,7 +49,7 @@ describe('SlackController', () => {
       mockBrandsService.findOne.mockResolvedValue(null);
 
       await expect(
-        controller.connect(mockUser as any, mockBrandId),
+        controller.connect(mockUser, mockBrandId),
       ).rejects.toBeInstanceOf(HttpException);
 
       expect(mockBrandsService.findOne).toHaveBeenCalledWith(
@@ -62,12 +66,17 @@ describe('SlackController', () => {
       mockCredentialsService.findOne.mockResolvedValue(null);
       mockCredentialsService.create.mockResolvedValue({});
 
-      await controller.connect(mockUser as any, mockBrandId);
+      const result = await controller.connect(mockUser, mockBrandId);
 
       expect(mockCredentialsService.create).toHaveBeenCalledWith(
         expect.objectContaining({
+          oauthState: result.state,
           user: mockUserId,
         }),
+      );
+      expect(result.state).toMatch(/^[A-Za-z0-9_-]{43}$/);
+      expect(mockSlackService.generateAuthUrl).toHaveBeenCalledWith(
+        result.state,
       );
     });
   });
@@ -77,7 +86,7 @@ describe('SlackController', () => {
       mockBrandsService.findOne.mockResolvedValue(null);
 
       await expect(
-        controller.verify(mockUser as any, mockBrandId, 'code', 'state'),
+        controller.verify(mockUser, mockBrandId, 'code', 'state'),
       ).rejects.toBeInstanceOf(HttpException);
 
       expect(mockSlackService.exchangeCodeForToken).not.toHaveBeenCalled();

--- a/apps/server/api/src/services/integrations/slack/controllers/slack.controller.ts
+++ b/apps/server/api/src/services/integrations/slack/controllers/slack.controller.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'node:crypto';
 import type { AuthenticatedUser as User } from '@api/auth/interfaces/authenticated-user.interface';
 import { BrandsService } from '@api/collections/brands/services/brands.service';
 import { CredentialsService } from '@api/collections/credentials/services/credentials.service';
@@ -42,7 +43,7 @@ export class SlackController {
     }
 
     const orgId = organization;
-    const state = Math.random().toString(36).substring(2, 15);
+    const state = randomBytes(32).toString('base64url');
 
     const existingCredential = await this.credentialsService.findOne({
       brand: brandId,

--- a/packages/services/analytics/link-tracking.service.test.ts
+++ b/packages/services/analytics/link-tracking.service.test.ts
@@ -66,6 +66,28 @@ describe('LinkTrackingService', () => {
     expect(typeof LinkTrackingService.getInstance).toBe('function');
   });
 
+  it('creates a cryptographically random analytics session ID', () => {
+    const randomUUID = vi
+      .fn()
+      .mockReturnValue('123e4567-e89b-42d3-a456-426614174000');
+    const localStorage = {
+      getItem: vi.fn().mockReturnValue(null),
+      setItem: vi.fn(),
+    };
+    vi.stubGlobal('window', {});
+    vi.stubGlobal('crypto', { randomUUID });
+    vi.stubGlobal('localStorage', localStorage);
+
+    const sessionId = service.getOrCreateSessionId();
+
+    expect(sessionId).toBe('sess_123e4567-e89b-42d3-a456-426614174000');
+    expect(randomUUID).toHaveBeenCalledOnce();
+    expect(localStorage.setItem).toHaveBeenCalledWith(
+      'genfeed_session_id',
+      sessionId,
+    );
+  });
+
   it('sends GA events through gtag when available', () => {
     const gtag = vi.fn();
     vi.stubGlobal('window', { gtag });

--- a/packages/services/analytics/link-tracking.service.ts
+++ b/packages/services/analytics/link-tracking.service.ts
@@ -284,7 +284,7 @@ export class LinkTrackingService extends HTTPBaseService {
     let sessionId = localStorage.getItem(storageKey);
 
     if (!sessionId) {
-      sessionId = `sess_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+      sessionId = `sess_${crypto.randomUUID()}`;
       localStorage.setItem(storageKey, sessionId);
     }
 


### PR DESCRIPTION
Fixes #2070

## Summary
- replace Slack and Discord OAuth state generation with 256-bit base64url tokens from Node crypto
- replace the client analytics session identifier with a Web Crypto UUID
- add focused assertions that generated values are persisted and passed through the OAuth and analytics flows

## CodeQL triage
The live default-branch scan contains five alerts, although the issue records four. Alerts 58-59 and 60-61 are duplicate data-flow sinks from the Discord and Slack OAuth state generators; alert 62 is the client-visible analytics session identifier. All five are security-relevant and fixed in code. None were dismissed.

## Verification
- biome check on all six changed files
- staged secretlint, UI guard, and Biome pre-commit hooks passed
- no Math.random remains in any of the three flagged generator paths
- local tests, typechecks, and builds intentionally not run under the MacBook Pro policy; PR CI is the execution gate

## Planning record
Claude fable planning and opus fallback calls both failed because the local CLI profiles were not authenticated. Per repository policy, the Codex implementer produced the bounded fallback plan and continued. Exact-current-head Claude opus verification remains required before merge.