### PR TITLE
fix(security): fail closed on outbound URL fetches

### DIFF
--- a/apps/server/api/src/endpoints/admin/fleet/services/fleet-training.service.spec.ts
+++ b/apps/server/api/src/endpoints/admin/fleet/services/fleet-training.service.spec.ts
@@ -16,10 +16,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 function successResponse(body: unknown, status = 200): Response {
   return {
-    json: async () => body,
     ok: true,
     status,
     statusText: 'OK',
+    text: async () => (body === undefined ? '' : JSON.stringify(body)),
   } as unknown as Response;
 }
 
@@ -265,8 +265,8 @@ describe('AdminFleetTrainingService', () => {
   });
 
   describe('syncDataset', () => {
-    it('should call images service POST /datasets/:slug/sync', async () => {
-      safeFetchMock.mockResolvedValue(successResponse(undefined, 204));
+    it('should accept an empty success response from the images service', async () => {
+      safeFetchMock.mockResolvedValue(successResponse(undefined));
 
       await service.syncDataset('alice', ['s3://key1', 's3://key2']);
 

--- a/apps/server/api/src/endpoints/admin/fleet/services/fleet-training.service.spec.ts
+++ b/apps/server/api/src/endpoints/admin/fleet/services/fleet-training.service.spec.ts
@@ -1,8 +1,7 @@
-vi.mock('axios', () => ({
-  default: {
-    get: vi.fn(),
-    post: vi.fn(),
-  },
+const safeFetchMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@libs/security/destination-guard', () => ({
+  safeFetch: safeFetchMock,
 }));
 
 import { ModelRegistrationService } from '@api/collections/models/services/model-registration.service';
@@ -13,8 +12,16 @@ import { LoraStatus, TrainingStage, TrainingStatus } from '@genfeedai/enums';
 import { ConfigService } from '@libs/config/config.service';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Test, type TestingModule } from '@nestjs/testing';
-import axios from 'axios';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+function successResponse(body: unknown, status = 200): Response {
+  return {
+    json: async () => body,
+    ok: true,
+    status,
+    statusText: 'OK',
+  } as unknown as Response;
+}
 
 describe('AdminFleetTrainingService', () => {
   let service: AdminFleetTrainingService;
@@ -25,6 +32,8 @@ describe('AdminFleetTrainingService', () => {
   let modelRegistrationService: Record<string, ReturnType<typeof vi.fn>>;
 
   beforeEach(async () => {
+    safeFetchMock.mockReset();
+
     trainingsService = {
       findOne: vi.fn(),
       patch: vi.fn().mockResolvedValue({}),
@@ -225,47 +234,51 @@ describe('AdminFleetTrainingService', () => {
 
   describe('getDatasetInfo', () => {
     it('should call images service GET /datasets/:slug', async () => {
-      const mockResponse = {
-        data: {
-          imageCount: 20,
-          images: ['img1.jpg', 'img2.jpg'],
-          path: '/datasets/alice',
-          slug: 'alice',
-        },
+      const dataset = {
+        imageCount: 20,
+        images: ['img1.jpg', 'img2.jpg'],
+        path: '/datasets/alice',
+        slug: 'alice',
       };
-      vi.mocked(axios.get).mockResolvedValue(mockResponse);
+      safeFetchMock.mockResolvedValue(successResponse(dataset));
 
       const result = await service.getDatasetInfo('alice');
 
       // The images service guards every route with InternalApiKeyGuard, so the
       // shared bearer token has to ride along or the call comes back 401.
-      expect(axios.get).toHaveBeenCalledWith(
+      expect(String(safeFetchMock.mock.calls[0]?.[0])).toBe(
         'http://gpu-images:3000/datasets/alice',
-        {
-          headers: { Authorization: 'Bearer internal-key' },
-          timeout: 15000,
-        },
       );
-      expect(result).toEqual(mockResponse.data);
+      expect(safeFetchMock.mock.calls[0]?.[1]).toMatchObject({
+        headers: {
+          Authorization: 'Bearer internal-key',
+          'Content-Type': 'application/json',
+        },
+        method: 'GET',
+      });
+      expect(safeFetchMock.mock.calls[0]?.[2]).toEqual({
+        allowedOrigins: ['http://gpu-images:3000'],
+        allowPrivateNetwork: true,
+      });
+      expect(result).toEqual(dataset);
     });
   });
 
   describe('syncDataset', () => {
     it('should call images service POST /datasets/:slug/sync', async () => {
-      vi.mocked(axios.post).mockResolvedValue({ data: {} });
+      safeFetchMock.mockResolvedValue(successResponse(undefined, 204));
 
       await service.syncDataset('alice', ['s3://key1', 's3://key2']);
 
       // No bucket in the body: the images service reads from its own configured
       // bucket so a caller cannot borrow its AWS credentials for another one.
-      expect(axios.post).toHaveBeenCalledWith(
+      expect(String(safeFetchMock.mock.calls[0]?.[0])).toBe(
         'http://gpu-images:3000/datasets/alice/sync',
-        { s3Keys: ['s3://key1', 's3://key2'] },
-        {
-          headers: { Authorization: 'Bearer internal-key' },
-          timeout: 120000,
-        },
       );
+      expect(safeFetchMock.mock.calls[0]?.[1]).toMatchObject({
+        body: JSON.stringify({ s3Keys: ['s3://key1', 's3://key2'] }),
+        method: 'POST',
+      });
     });
   });
 
@@ -329,7 +342,7 @@ describe('AdminFleetTrainingService', () => {
 
   describe('executeTrainingPipeline', () => {
     it('should update persona to FAILED state on pipeline error', async () => {
-      vi.mocked(axios.get).mockRejectedValue(new Error('Network error'));
+      safeFetchMock.mockRejectedValue(new Error('Network error'));
 
       await service.executeTrainingPipeline({
         baseModel: 'flux',
@@ -354,14 +367,14 @@ describe('AdminFleetTrainingService', () => {
     });
 
     it('should throw when dataset has 0 images', async () => {
-      vi.mocked(axios.get).mockResolvedValue({
-        data: {
+      safeFetchMock.mockResolvedValue(
+        successResponse({
           imageCount: 0,
           images: [],
           path: '/datasets/alice',
           slug: 'alice',
-        },
-      });
+        }),
+      );
 
       await service.executeTrainingPipeline({
         baseModel: 'flux',

--- a/apps/server/api/src/endpoints/admin/fleet/services/fleet-training.service.ts
+++ b/apps/server/api/src/endpoints/admin/fleet/services/fleet-training.service.ts
@@ -126,11 +126,16 @@ export class AdminFleetTrainingService {
       );
     }
 
-    if (response.status === 204) {
+    if (response.status === 204 || response.status === 205) {
       return undefined as T;
     }
 
-    return (await response.json()) as T;
+    const responseBody = await response.text();
+    if (responseBody.trim() === '') {
+      return undefined as T;
+    }
+
+    return JSON.parse(responseBody) as T;
   }
 
   /**

--- a/apps/server/api/src/endpoints/admin/fleet/services/fleet-training.service.ts
+++ b/apps/server/api/src/endpoints/admin/fleet/services/fleet-training.service.ts
@@ -4,9 +4,9 @@ import { TrainingsService } from '@api/collections/trainings/services/trainings.
 import { LoraStatus, TrainingStage, TrainingStatus } from '@genfeedai/enums';
 import { ConfigService } from '@libs/config/config.service';
 import { LoggerService } from '@libs/logger/logger.service';
+import { safeFetch } from '@libs/security/destination-guard';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
 import { Injectable } from '@nestjs/common';
-import axios from 'axios';
 
 interface TrainingHyperparams {
   steps: number;
@@ -80,10 +80,57 @@ export class AdminFleetTrainingService {
    * which compares the bearer token against its own `GENFEEDAI_API_KEY`. Both
    * sides read the same shared secret, so every outbound call must carry it.
    */
-  private get requestConfig(): { headers: Record<string, string> } {
+  private get requestHeaders(): Record<string, string> {
     return {
-      headers: { Authorization: `Bearer ${this.internalApiKey}` },
+      Authorization: `Bearer ${this.internalApiKey}`,
+      'Content-Type': 'application/json',
     };
+  }
+
+  private async requestImagesApi<T>(
+    pathname: string,
+    options: {
+      body?: Record<string, unknown>;
+      method?: 'GET' | 'POST';
+      timeoutMs: number;
+    },
+  ): Promise<T> {
+    let baseUrl: URL;
+    try {
+      baseUrl = new URL(this.imagesApiUrl);
+    } catch {
+      throw new Error('GPU_IMAGES_URL must be a valid http(s) URL');
+    }
+
+    const baseWithTrailingSlash = baseUrl.href.endsWith('/')
+      ? baseUrl.href
+      : `${baseUrl.href}/`;
+    const url = new URL(pathname.replace(/^\/+/, ''), baseWithTrailingSlash);
+    const response = await safeFetch(
+      url,
+      {
+        body: options.body ? JSON.stringify(options.body) : undefined,
+        headers: this.requestHeaders,
+        method: options.method ?? 'GET',
+        signal: AbortSignal.timeout(options.timeoutMs),
+      },
+      {
+        allowedOrigins: [baseUrl.origin],
+        allowPrivateNetwork: true,
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error(
+        `Images service returned ${response.status} ${response.statusText}`,
+      );
+    }
+
+    if (response.status === 204) {
+      return undefined as T;
+    }
+
+    return (await response.json()) as T;
   }
 
   /**
@@ -183,9 +230,9 @@ export class AdminFleetTrainingService {
         10,
       );
 
-      const { data: dataset } = await axios.get<ImagesDatasetResponse>(
-        `${this.imagesApiUrl}/datasets/${params.personaSlug}`,
-        { ...this.requestConfig, timeout: 15000 },
+      const dataset = await this.requestImagesApi<ImagesDatasetResponse>(
+        `datasets/${encodeURIComponent(params.personaSlug)}`,
+        { timeoutMs: 15_000 },
       );
 
       if (dataset.imageCount === 0) {
@@ -208,17 +255,20 @@ export class AdminFleetTrainingService {
       // Stage: TRAINING — start training via NestJS images service
       await this.updateStage(params.trainingId, TrainingStage.TRAINING, 30);
 
-      const { data: trainResult } = await axios.post<ImagesTrainResponse>(
-        `${this.imagesApiUrl}/train`,
+      const trainResult = await this.requestImagesApi<ImagesTrainResponse>(
+        'train',
         {
-          learningRate: params.learningRate,
-          loraName: params.loraName,
-          loraRank: params.loraRank,
-          personaSlug: params.personaSlug,
-          steps: params.steps,
-          triggerWord: params.triggerWord,
+          body: {
+            learningRate: params.learningRate,
+            loraName: params.loraName,
+            loraRank: params.loraRank,
+            personaSlug: params.personaSlug,
+            steps: params.steps,
+            triggerWord: params.triggerWord,
+          },
+          method: 'POST',
+          timeoutMs: 30_000,
         },
-        { ...this.requestConfig, timeout: 30000 },
       );
 
       this.loggerService.log(caller, {
@@ -268,9 +318,9 @@ export class AdminFleetTrainingService {
     for (let attempt = 0; attempt < maxPollAttempts; attempt++) {
       await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
 
-      const { data: job } = await axios.get<ImagesJobStatus>(
-        `${this.imagesApiUrl}/train/${gpuJobId}`,
-        { ...this.requestConfig, timeout: 15000 },
+      const job = await this.requestImagesApi<ImagesJobStatus>(
+        `train/${encodeURIComponent(gpuJobId)}`,
+        { timeoutMs: 15_000 },
       );
 
       // Map GPU job stage to TrainingStage enum
@@ -359,13 +409,16 @@ export class AdminFleetTrainingService {
     // `POST /loras` — the images LoRA controller is `@Controller('loras')` with
     // a bare `@Post()`. The previous `/loras/upload` spelling 404'd, failing
     // every training run at the upload stage.
-    const { data: uploadResult } = await axios.post<ImagesLoraUploadResponse>(
-      `${this.imagesApiUrl}/loras`,
+    const uploadResult = await this.requestImagesApi<ImagesLoraUploadResponse>(
+      'loras',
       {
-        localPath: `/comfyui/models/loras/${loraName}.safetensors`,
-        loraName,
+        body: {
+          localPath: `/comfyui/models/loras/${loraName}.safetensors`,
+          loraName,
+        },
+        method: 'POST',
+        timeoutMs: 120_000,
       },
-      { ...this.requestConfig, timeout: 120000 },
     );
 
     this.loggerService.log(caller, {
@@ -378,11 +431,10 @@ export class AdminFleetTrainingService {
   }
 
   async getDatasetInfo(slug: string): Promise<ImagesDatasetResponse> {
-    const { data } = await axios.get<ImagesDatasetResponse>(
-      `${this.imagesApiUrl}/datasets/${slug}`,
-      { ...this.requestConfig, timeout: 15000 },
+    return this.requestImagesApi<ImagesDatasetResponse>(
+      `datasets/${encodeURIComponent(slug)}`,
+      { timeoutMs: 15_000 },
     );
-    return data;
   }
 
   /**
@@ -391,10 +443,13 @@ export class AdminFleetTrainingService {
    * credentials at an arbitrary one.
    */
   async syncDataset(slug: string, s3Keys: string[]): Promise<void> {
-    await axios.post(
-      `${this.imagesApiUrl}/datasets/${slug}/sync`,
-      { s3Keys },
-      { ...this.requestConfig, timeout: 120000 },
+    await this.requestImagesApi<void>(
+      `datasets/${encodeURIComponent(slug)}/sync`,
+      {
+        body: { s3Keys },
+        method: 'POST',
+        timeoutMs: 120_000,
+      },
     );
   }
 

--- a/apps/server/api/src/marketplace-integration/marketplace-api-client.spec.ts
+++ b/apps/server/api/src/marketplace-integration/marketplace-api-client.spec.ts
@@ -3,6 +3,11 @@ import { ConfigService } from '@libs/config/config.service';
 import { LoggerService } from '@libs/logger/logger.service';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+vi.mock('@libs/security/destination-guard', () => ({
+  safeFetch: (input: string | URL, init?: RequestInit) =>
+    globalThis.fetch(input, init),
+}));
+
 type FetchMock = ReturnType<typeof vi.fn>;
 
 function okResponse(body: unknown): Response {

--- a/apps/server/api/src/marketplace-integration/marketplace-api-client.ts
+++ b/apps/server/api/src/marketplace-integration/marketplace-api-client.ts
@@ -55,10 +55,14 @@ export class MarketplaceApiClient {
   ) {
     this.baseUrl =
       this.configService.get('MARKETPLACE_API_URL') || 'http://localhost:3200';
-    this.destinationGuard = {
-      allowedOrigins: [new URL(this.baseUrl).origin],
-      allowPrivateNetwork: true,
-    };
+    try {
+      this.destinationGuard = {
+        allowedOrigins: [new URL(this.baseUrl).origin],
+        allowPrivateNetwork: true,
+      };
+    } catch {
+      throw new Error('MARKETPLACE_API_URL must be a valid absolute URL');
+    }
   }
 
   /**

--- a/apps/server/api/src/marketplace-integration/marketplace-api-client.ts
+++ b/apps/server/api/src/marketplace-integration/marketplace-api-client.ts
@@ -1,5 +1,9 @@
 import { ConfigService } from '@libs/config/config.service';
 import { LoggerService } from '@libs/logger/logger.service';
+import {
+  type DestinationGuardOptions,
+  safeFetch,
+} from '@libs/security/destination-guard';
 import { Injectable } from '@nestjs/common';
 
 interface MarketplaceListingResponse {
@@ -43,6 +47,7 @@ interface MarketplaceListingQuery {
 @Injectable()
 export class MarketplaceApiClient {
   private readonly baseUrl: string;
+  private readonly destinationGuard: DestinationGuardOptions;
 
   constructor(
     private readonly configService: ConfigService,
@@ -50,6 +55,10 @@ export class MarketplaceApiClient {
   ) {
     this.baseUrl =
       this.configService.get('MARKETPLACE_API_URL') || 'http://localhost:3200';
+    this.destinationGuard = {
+      allowedOrigins: [new URL(this.baseUrl).origin],
+      allowPrivateNetwork: true,
+    };
   }
 
   /**
@@ -78,11 +87,15 @@ export class MarketplaceApiClient {
       if (query.sort) params.set('sort', query.sort);
 
       const url = `${this.baseUrl}/marketplace/listings?${params.toString()}`;
-      const response = await fetch(url, {
-        headers: { 'Content-Type': 'application/json' },
-        method: 'GET',
-        signal: AbortSignal.timeout(5_000),
-      });
+      const response = await safeFetch(
+        url,
+        {
+          headers: { 'Content-Type': 'application/json' },
+          method: 'GET',
+          signal: AbortSignal.timeout(5_000),
+        },
+        this.destinationGuard,
+      );
 
       if (!response.ok) {
         this.logger.warn(
@@ -111,11 +124,15 @@ export class MarketplaceApiClient {
   ): Promise<MarketplaceListingResponse | null> {
     try {
       const url = `${this.baseUrl}/marketplace/listings/${listingId}`;
-      const response = await fetch(url, {
-        headers: { 'Content-Type': 'application/json' },
-        method: 'GET',
-        signal: AbortSignal.timeout(5_000),
-      });
+      const response = await safeFetch(
+        url,
+        {
+          headers: { 'Content-Type': 'application/json' },
+          method: 'GET',
+          signal: AbortSignal.timeout(5_000),
+        },
+        this.destinationGuard,
+      );
 
       if (!response.ok) {
         this.logger.warn(
@@ -173,12 +190,16 @@ export class MarketplaceApiClient {
   ): Promise<MarketplaceListingResponse | null> {
     try {
       const url = `${this.baseUrl}/seller/listings`;
-      const response = await fetch(url, {
-        body: JSON.stringify({ ...dto, organizationId, sellerId }),
-        headers: { 'Content-Type': 'application/json' },
-        method: 'POST',
-        signal: AbortSignal.timeout(10_000),
-      });
+      const response = await safeFetch(
+        url,
+        {
+          body: JSON.stringify({ ...dto, organizationId, sellerId }),
+          headers: { 'Content-Type': 'application/json' },
+          method: 'POST',
+          signal: AbortSignal.timeout(10_000),
+        },
+        this.destinationGuard,
+      );
 
       if (!response.ok) {
         this.logger.warn(
@@ -204,12 +225,16 @@ export class MarketplaceApiClient {
   async submitForReview(listingId: string, sellerId: string): Promise<boolean> {
     try {
       const url = `${this.baseUrl}/seller/listings/${listingId}/submit`;
-      const response = await fetch(url, {
-        body: JSON.stringify({ sellerId }),
-        headers: { 'Content-Type': 'application/json' },
-        method: 'POST',
-        signal: AbortSignal.timeout(5_000),
-      });
+      const response = await safeFetch(
+        url,
+        {
+          body: JSON.stringify({ sellerId }),
+          headers: { 'Content-Type': 'application/json' },
+          method: 'POST',
+          signal: AbortSignal.timeout(5_000),
+        },
+        this.destinationGuard,
+      );
 
       return response.ok;
     } catch (error: unknown) {
@@ -230,11 +255,15 @@ export class MarketplaceApiClient {
   ): Promise<MarketplaceSellerResponse | null> {
     try {
       const url = `${this.baseUrl}/sellers/by-user/${userId}`;
-      const response = await fetch(url, {
-        headers: { 'Content-Type': 'application/json' },
-        method: 'GET',
-        signal: AbortSignal.timeout(5_000),
-      });
+      const response = await safeFetch(
+        url,
+        {
+          headers: { 'Content-Type': 'application/json' },
+          method: 'GET',
+          signal: AbortSignal.timeout(5_000),
+        },
+        this.destinationGuard,
+      );
 
       if (!response.ok) return null;
 
@@ -262,12 +291,16 @@ export class MarketplaceApiClient {
   }> {
     try {
       const url = `${this.baseUrl}/purchases/ownership-check`;
-      const response = await fetch(url, {
-        body: JSON.stringify({ listingId, organizationId, userId }),
-        headers: { 'Content-Type': 'application/json' },
-        method: 'POST',
-        signal: AbortSignal.timeout(5_000),
-      });
+      const response = await safeFetch(
+        url,
+        {
+          body: JSON.stringify({ listingId, organizationId, userId }),
+          headers: { 'Content-Type': 'application/json' },
+          method: 'POST',
+          signal: AbortSignal.timeout(5_000),
+        },
+        this.destinationGuard,
+      );
 
       if (!response.ok) return { owned: false };
 
@@ -291,12 +324,16 @@ export class MarketplaceApiClient {
   ): Promise<{ _id: string } | null> {
     try {
       const url = `${this.baseUrl}/purchases/claim-free`;
-      const response = await fetch(url, {
-        body: JSON.stringify({ listingId, organizationId, userId }),
-        headers: { 'Content-Type': 'application/json' },
-        method: 'POST',
-        signal: AbortSignal.timeout(5_000),
-      });
+      const response = await safeFetch(
+        url,
+        {
+          body: JSON.stringify({ listingId, organizationId, userId }),
+          headers: { 'Content-Type': 'application/json' },
+          method: 'POST',
+          signal: AbortSignal.timeout(5_000),
+        },
+        this.destinationGuard,
+      );
 
       if (!response.ok) return null;
 

--- a/apps/server/api/src/marketplace-integration/marketplace-api-client.ts
+++ b/apps/server/api/src/marketplace-integration/marketplace-api-client.ts
@@ -106,6 +106,7 @@ export class MarketplaceApiClient {
           `MarketplaceApiClient searchListings failed: ${response.status}`,
           'MarketplaceApiClient',
         );
+        await response.body?.cancel();
         return emptyResult;
       }
 
@@ -127,7 +128,7 @@ export class MarketplaceApiClient {
     listingId: string,
   ): Promise<MarketplaceListingResponse | null> {
     try {
-      const url = `${this.baseUrl}/marketplace/listings/${listingId}`;
+      const url = `${this.baseUrl}/marketplace/listings/${encodeURIComponent(listingId)}`;
       const response = await safeFetch(
         url,
         {
@@ -143,6 +144,7 @@ export class MarketplaceApiClient {
           `MarketplaceApiClient getListing failed: ${response.status}`,
           'MarketplaceApiClient',
         );
+        await response.body?.cancel();
         return null;
       }
 
@@ -210,6 +212,7 @@ export class MarketplaceApiClient {
           `MarketplaceApiClient createListing failed: ${response.status}`,
           'MarketplaceApiClient',
         );
+        await response.body?.cancel();
         return null;
       }
 
@@ -228,7 +231,7 @@ export class MarketplaceApiClient {
    */
   async submitForReview(listingId: string, sellerId: string): Promise<boolean> {
     try {
-      const url = `${this.baseUrl}/seller/listings/${listingId}/submit`;
+      const url = `${this.baseUrl}/seller/listings/${encodeURIComponent(listingId)}/submit`;
       const response = await safeFetch(
         url,
         {
@@ -240,7 +243,9 @@ export class MarketplaceApiClient {
         this.destinationGuard,
       );
 
-      return response.ok;
+      const succeeded = response.ok;
+      await response.body?.cancel();
+      return succeeded;
     } catch (error: unknown) {
       this.logger.warn(
         `MarketplaceApiClient submitForReview error: ${(error as Error).message}`,
@@ -258,7 +263,7 @@ export class MarketplaceApiClient {
     userId: string,
   ): Promise<MarketplaceSellerResponse | null> {
     try {
-      const url = `${this.baseUrl}/sellers/by-user/${userId}`;
+      const url = `${this.baseUrl}/sellers/by-user/${encodeURIComponent(userId)}`;
       const response = await safeFetch(
         url,
         {
@@ -269,7 +274,10 @@ export class MarketplaceApiClient {
         this.destinationGuard,
       );
 
-      if (!response.ok) return null;
+      if (!response.ok) {
+        await response.body?.cancel();
+        return null;
+      }
 
       return (await response.json()) as MarketplaceSellerResponse;
     } catch (error: unknown) {
@@ -306,7 +314,10 @@ export class MarketplaceApiClient {
         this.destinationGuard,
       );
 
-      if (!response.ok) return { owned: false };
+      if (!response.ok) {
+        await response.body?.cancel();
+        return { owned: false };
+      }
 
       return (await response.json()) as {
         owned: boolean;
@@ -339,7 +350,10 @@ export class MarketplaceApiClient {
         this.destinationGuard,
       );
 
-      if (!response.ok) return null;
+      if (!response.ok) {
+        await response.body?.cancel();
+        return null;
+      }
 
       return (await response.json()) as { _id: string };
     } catch {

--- a/apps/server/api/src/services/brand-scraper/brand-scraper.service.spec.ts
+++ b/apps/server/api/src/services/brand-scraper/brand-scraper.service.spec.ts
@@ -4,6 +4,11 @@ import { LoggerService } from '@libs/logger/logger.service';
 import { Test, TestingModule } from '@nestjs/testing';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+vi.mock('@libs/security/destination-guard', () => ({
+  safeFetch: (input: string | URL, init?: RequestInit) =>
+    globalThis.fetch(input, init),
+}));
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------

--- a/apps/server/api/src/services/brand-scraper/brand-scraper.service.spec.ts
+++ b/apps/server/api/src/services/brand-scraper/brand-scraper.service.spec.ts
@@ -4,9 +4,30 @@ import { LoggerService } from '@libs/logger/logger.service';
 import { Test, TestingModule } from '@nestjs/testing';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+// Mirrors the real destination guard's reject-before-connect contract. A bare
+// pass-through to fetch would stub out the very check the redirect-SSRF tests
+// assert, so blocked hosts must throw here rather than reach the network. Kept
+// hermetic (no DNS) by matching on the literal hostname.
+const BLOCKED_HOST_PATTERNS = [
+  /^localhost$/i,
+  /^\[?::1\]?$/,
+  /^127\./,
+  /^10\./,
+  /^192\.168\./,
+  /^169\.254\./,
+  /^172\.(1[6-9]|2\d|3[01])\./,
+];
+
 vi.mock('@libs/security/destination-guard', () => ({
-  safeFetch: (input: string | URL, init?: RequestInit) =>
-    globalThis.fetch(input, init),
+  safeFetch: (input: string | URL, init?: RequestInit) => {
+    const { hostname } = new URL(String(input));
+
+    if (BLOCKED_HOST_PATTERNS.some((pattern) => pattern.test(hostname))) {
+      throw new Error(`URL points to a blocked address: ${hostname}`);
+    }
+
+    return globalThis.fetch(input, init);
+  },
 }));
 
 // ---------------------------------------------------------------------------

--- a/apps/server/api/src/services/brand-scraper/brand-scraper.service.ts
+++ b/apps/server/api/src/services/brand-scraper/brand-scraper.service.ts
@@ -13,6 +13,7 @@ import type {
   IScrapedBrandData,
 } from '@genfeedai/interfaces';
 import { LoggerService } from '@libs/logger/logger.service';
+import { safeFetch } from '@libs/security/destination-guard';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
 import { Injectable } from '@nestjs/common';
 import * as cheerio from 'cheerio';
@@ -444,14 +445,6 @@ export class BrandScraperService {
     let currentUrl = url;
 
     for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
-      // Re-validate EVERY hop, not just the initial URL. A validated public URL
-      // can 3xx to a private/loopback/cloud-metadata target, so following
-      // redirects blindly (redirect: 'follow') reopens the SSRF hole the
-      // initial validateUrl check closed. We follow manually and re-check each
-      // Location against the shared blocklist. (Connection-level IP pinning to
-      // defeat DNS rebinding of a public hostname is a separate follow-up.)
-      this.assertFetchTargetAllowed(currentUrl);
-
       const response = await this.fetchOnce(currentUrl, options);
 
       if (
@@ -476,24 +469,9 @@ export class BrandScraperService {
   }
 
   /**
-   * Throw if the URL's host is an SSRF target (loopback, RFC-1918, link-local /
-   * cloud metadata, internal TLDs). Applied to the initial URL and every
-   * redirect hop.
-   */
-  private assertFetchTargetAllowed(url: string): void {
-    let hostname: string;
-    try {
-      hostname = new URL(url).hostname;
-    } catch {
-      throw new Error(`Invalid fetch URL: ${url}`);
-    }
-    // Throws BadRequestException on a blocked host.
-    assertHostNotPrivate(hostname);
-  }
-
-  /**
    * Fetch a single URL with 429 backoff. Redirects are NOT auto-followed
-   * (redirect: 'manual') so the caller can re-validate each hop.
+   * (redirect: 'manual') so the retry loop owns hop accounting. `safeFetch`
+   * resolves, validates, and pins every current URL before connecting.
    */
   private async fetchOnce(
     url: string,
@@ -506,7 +484,7 @@ export class BrandScraperService {
       const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
 
       try {
-        const response = await fetch(url, {
+        const response = await safeFetch(url, {
           ...options,
           redirect: 'manual',
           signal: controller.signal,

--- a/apps/server/api/src/webhooks/ci-triage/ci-triage-webhook.service.spec.ts
+++ b/apps/server/api/src/webhooks/ci-triage/ci-triage-webhook.service.spec.ts
@@ -3,6 +3,11 @@ import { LoggerService } from '@libs/logger/logger.service';
 import { Test, type TestingModule } from '@nestjs/testing';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+vi.mock('@libs/security/destination-guard', () => ({
+  safeFetch: (input: string | URL, init?: RequestInit) =>
+    globalThis.fetch(input, init),
+}));
+
 import {
   type CiTriagePayload,
   CiTriageWebhookService,
@@ -89,18 +94,6 @@ describe('CiTriageWebhookService', () => {
         if (key === 'ANTHROPIC_API_KEY') return 'sk-test-key';
         if (key === 'GITHUB_TOKEN') return 'ghp-test-token';
         return undefined;
-      });
-
-      const fetchMock = vi.fn().mockResolvedValue({
-        json: vi.fn().mockResolvedValue({
-          content: [{ text: 'diagnosis' }],
-        }),
-        ok: true,
-      });
-      global.fetch = fetchMock;
-
-      const ghFetchMock = vi.fn().mockResolvedValue({
-        ok: true,
       });
 
       // Override fetch to handle both Anthropic and GitHub calls

--- a/apps/server/api/src/webhooks/ci-triage/ci-triage-webhook.service.ts
+++ b/apps/server/api/src/webhooks/ci-triage/ci-triage-webhook.service.ts
@@ -1,5 +1,6 @@
 import { ConfigService } from '@libs/config/config.service';
 import { LoggerService } from '@libs/logger/logger.service';
+import { safeFetch } from '@libs/security/destination-guard';
 import { Injectable } from '@nestjs/common';
 
 export interface CiTriagePayload {
@@ -11,6 +12,8 @@ export interface CiTriagePayload {
 }
 
 const MAX_DIAGNOSES_PER_PR = 5;
+const ANTHROPIC_API_ORIGIN = 'https://api.anthropic.com';
+const GITHUB_API_ORIGIN = 'https://api.github.com';
 
 @Injectable()
 export class CiTriageWebhookService {
@@ -68,19 +71,23 @@ Provide a concise diagnosis:
 Be direct and actionable. No preamble.`;
 
     try {
-      const response = await fetch('https://api.anthropic.com/v1/messages', {
-        body: JSON.stringify({
-          max_tokens: 1024,
-          messages: [{ content: prompt, role: 'user' }],
-          model: 'claude-opus-4-6',
-        }),
-        headers: {
-          'anthropic-version': '2023-06-01',
-          'content-type': 'application/json',
-          'x-api-key': String(apiKey),
+      const response = await safeFetch(
+        `${ANTHROPIC_API_ORIGIN}/v1/messages`,
+        {
+          body: JSON.stringify({
+            max_tokens: 1024,
+            messages: [{ content: prompt, role: 'user' }],
+            model: 'claude-opus-4-6',
+          }),
+          headers: {
+            'anthropic-version': '2023-06-01',
+            'content-type': 'application/json',
+            'x-api-key': String(apiKey),
+          },
+          method: 'POST',
         },
-        method: 'POST',
-      });
+        { allowedOrigins: [ANTHROPIC_API_ORIGIN] },
+      );
 
       const result = (await response.json()) as {
         content?: Array<{ text?: string }>;
@@ -99,8 +106,19 @@ Be direct and actionable. No preamble.`;
       ].join('\n');
 
       // Post comment via GitHub REST API (replaces execSync shell-out to gh CLI)
-      const ghResponse = await fetch(
-        `https://api.github.com/repos/${payload.repo}/issues/${payload.prNumber}/comments`,
+      const repositorySegments = payload.repo.split('/');
+      if (
+        repositorySegments.length !== 2 ||
+        repositorySegments.some((segment) => !segment)
+      ) {
+        throw new Error('CI triage repository must use the owner/name format');
+      }
+      const repositoryPath = repositorySegments
+        .map((segment) => encodeURIComponent(segment))
+        .join('/');
+
+      const ghResponse = await safeFetch(
+        `${GITHUB_API_ORIGIN}/repos/${repositoryPath}/issues/${payload.prNumber}/comments`,
         {
           body: JSON.stringify({ body: comment }),
           headers: {
@@ -111,6 +129,7 @@ Be direct and actionable. No preamble.`;
           },
           method: 'POST',
         },
+        { allowedOrigins: [GITHUB_API_ORIGIN] },
       );
 
       if (!ghResponse.ok) {

--- a/apps/server/files/src/services/hook-remix/hook-remix.service.spec.ts
+++ b/apps/server/files/src/services/hook-remix/hook-remix.service.spec.ts
@@ -5,6 +5,11 @@ import { YtDlpService } from '@files/services/ytdlp/ytdlp.service';
 import { LoggerService } from '@libs/logger/logger.service';
 import { Test, TestingModule } from '@nestjs/testing';
 
+vi.mock('@libs/security/destination-guard', () => ({
+  safeFetch: (input: string | URL, init?: RequestInit) =>
+    globalThis.fetch(input, init),
+}));
+
 vi.mock('node:fs', () => ({
   default: {
     existsSync: vi.fn().mockReturnValue(false),

--- a/apps/server/files/src/services/hook-remix/hook-remix.service.ts
+++ b/apps/server/files/src/services/hook-remix/hook-remix.service.ts
@@ -8,6 +8,7 @@ import type {
 import { UploadService } from '@files/services/upload/upload.service';
 import { YtDlpService } from '@files/services/ytdlp/ytdlp.service';
 import { LoggerService } from '@libs/logger/logger.service';
+import { safeFetch } from '@libs/security/destination-guard';
 import { Injectable } from '@nestjs/common';
 
 @Injectable()
@@ -99,7 +100,7 @@ export class HookRemixService {
   }
 
   private async downloadFile(url: string, outputPath: string): Promise<void> {
-    const response = await fetch(url);
+    const response = await safeFetch(url);
     if (!response.ok) {
       throw new Error(
         `Failed to download CTA clip: ${response.status} ${response.statusText}`,

--- a/apps/server/files/src/services/hook-remix/hook-remix.service.ts
+++ b/apps/server/files/src/services/hook-remix/hook-remix.service.ts
@@ -100,6 +100,8 @@ export class HookRemixService {
   }
 
   private async downloadFile(url: string, outputPath: string): Promise<void> {
+    // CTA URLs arrive in job data and are not a configured internal service.
+    // Keep the public-network policy fail-closed.
     const response = await safeFetch(url);
     if (!response.ok) {
       throw new Error(

--- a/apps/server/files/src/services/s3/s3.service.ts
+++ b/apps/server/files/src/services/s3/s3.service.ts
@@ -180,6 +180,8 @@ export class S3Service {
 
   async downloadFromUrl(url: string, localPath: string): Promise<void> {
     try {
+      // This helper accepts caller-supplied media URLs, not a configured
+      // storage service origin. Keep the public-network policy fail-closed.
       const response = await safeFetch(url);
       if (!response.ok) {
         const errorText = await response

--- a/apps/server/files/src/services/s3/s3.service.ts
+++ b/apps/server/files/src/services/s3/s3.service.ts
@@ -11,6 +11,7 @@ import {
 import { Upload } from '@aws-sdk/lib-storage';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { ConfigService } from '@files/config/config.service';
+import { safeFetch } from '@libs/security/destination-guard';
 import { getErrorMessage } from '@libs/utils/error/get-error-message.util';
 import { Injectable, Logger } from '@nestjs/common';
 
@@ -179,7 +180,7 @@ export class S3Service {
 
   async downloadFromUrl(url: string, localPath: string): Promise<void> {
     try {
-      const response = await fetch(url);
+      const response = await safeFetch(url);
       if (!response.ok) {
         const errorText = await response
           .text()

--- a/packages/libs/security/destination-guard.spec.ts
+++ b/packages/libs/security/destination-guard.spec.ts
@@ -1,3 +1,4 @@
+import type { LookupAddress, LookupOptions } from 'node:dns';
 import { EventEmitter } from 'node:events';
 import { Readable } from 'node:stream';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -113,11 +114,11 @@ describe('destination guard', () => {
         options?: {
           lookup?: (
             hostname: string,
-            options: unknown,
+            options: LookupOptions,
             callback: (
               error: Error | null,
-              address: string,
-              family: number,
+              address: string | LookupAddress[],
+              family?: number,
             ) => void,
           ) => void;
         };
@@ -130,6 +131,16 @@ describe('destination guard', () => {
       expect(error).toBeNull();
       expect(address).toBe('93.184.216.34');
       expect(family).toBe(4);
+    });
+
+    pinnedLookup?.('public.example', { all: true }, (error, addresses) => {
+      expect(error).toBeNull();
+      expect(addresses).toEqual([
+        {
+          address: '93.184.216.34',
+          family: 4,
+        },
+      ]);
     });
   });
 

--- a/packages/libs/security/destination-guard.spec.ts
+++ b/packages/libs/security/destination-guard.spec.ts
@@ -1,0 +1,174 @@
+import { EventEmitter } from 'node:events';
+import { Readable } from 'node:stream';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const dnsLookupMock = vi.hoisted(() => vi.fn());
+const httpRequestMock = vi.hoisted(() => vi.fn());
+
+vi.mock('node:dns/promises', () => ({
+  lookup: dnsLookupMock,
+}));
+
+vi.mock('node:http', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:http')>();
+  return { ...actual, request: httpRequestMock };
+});
+
+import {
+  DestinationGuardError,
+  isBlockedDestinationAddress,
+  resolveSafeDestination,
+  safeFetch,
+} from '@libs/security/destination-guard';
+
+function mockHttpResponse(status: number, headers: string[] = []): void {
+  httpRequestMock.mockImplementation(
+    (_url: URL, _options: unknown, callback: (response: Readable) => void) => {
+      const request = new EventEmitter() as EventEmitter & {
+        destroy: (error?: Error) => void;
+        end: (body?: unknown) => void;
+      };
+      request.destroy = (error?: Error) => {
+        if (error) request.emit('error', error);
+      };
+      request.end = vi.fn();
+
+      const response = Readable.from([]);
+      Object.assign(response, {
+        rawHeaders: headers,
+        statusCode: status,
+        statusMessage: status === 302 ? 'Found' : 'OK',
+      });
+      callback(response);
+      return request;
+    },
+  );
+}
+
+describe('destination guard', () => {
+  afterEach(() => {
+    dnsLookupMock.mockReset();
+    httpRequestMock.mockReset();
+  });
+
+  it.each([
+    '127.0.0.1',
+    '10.0.0.1',
+    '172.16.0.1',
+    '192.168.0.1',
+    '169.254.169.254',
+    '::1',
+    'fc00::1',
+    'fd12:3456::1',
+    'fe80::1',
+  ])('rejects blocked destination address %s', async (address) => {
+    expect(isBlockedDestinationAddress(address)).toBe(true);
+
+    const url = address.includes(':')
+      ? `https://[${address}]/asset`
+      : `https://${address}/asset`;
+    await expect(resolveSafeDestination(url)).rejects.toBeInstanceOf(
+      DestinationGuardError,
+    );
+  });
+
+  it('rejects non-http schemes', async () => {
+    await expect(resolveSafeDestination('file:///etc/passwd')).rejects.toThrow(
+      'http or https',
+    );
+  });
+
+  it('rejects a hostname when any DNS answer is private', async () => {
+    dnsLookupMock.mockResolvedValue([
+      { address: '93.184.216.34', family: 4 },
+      { address: '10.0.0.7', family: 4 },
+    ]);
+
+    await expect(
+      resolveSafeDestination('https://mixed.example/asset'),
+    ).rejects.toThrow('private or reserved');
+  });
+
+  it('pins a passing public destination to the checked address', async () => {
+    dnsLookupMock.mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
+
+    await expect(
+      resolveSafeDestination('https://public.example/asset'),
+    ).resolves.toMatchObject({
+      address: '93.184.216.34',
+      family: 4,
+    });
+  });
+
+  it('connects through an agent pinned to the checked DNS answer', async () => {
+    dnsLookupMock.mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
+    mockHttpResponse(200);
+
+    await expect(
+      safeFetch('http://public.example/asset'),
+    ).resolves.toBeInstanceOf(Response);
+
+    const requestOptions = httpRequestMock.mock.calls[0]?.[1] as {
+      agent?: {
+        options?: {
+          lookup?: (
+            hostname: string,
+            options: unknown,
+            callback: (
+              error: Error | null,
+              address: string,
+              family: number,
+            ) => void,
+          ) => void;
+        };
+      };
+    };
+    const pinnedLookup = requestOptions.agent?.options?.lookup;
+    expect(pinnedLookup).toBeTypeOf('function');
+
+    pinnedLookup?.('public.example', {}, (error, address, family) => {
+      expect(error).toBeNull();
+      expect(address).toBe('93.184.216.34');
+      expect(family).toBe(4);
+    });
+  });
+
+  it('rechecks redirect destinations before issuing the next request', async () => {
+    dnsLookupMock.mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
+    mockHttpResponse(302, [
+      'location',
+      'http://169.254.169.254/latest/meta-data',
+    ]);
+
+    await expect(safeFetch('http://public.example/start')).rejects.toThrow(
+      'private or reserved',
+    );
+    expect(httpRequestMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows a private destination only behind an exact origin allowlist', async () => {
+    dnsLookupMock.mockResolvedValue([{ address: '10.0.0.5', family: 4 }]);
+
+    await expect(
+      resolveSafeDestination('http://images.internal:3013/train', {
+        allowedOrigins: ['http://images.internal:3013'],
+        allowPrivateNetwork: true,
+      }),
+    ).resolves.toMatchObject({ address: '10.0.0.5', family: 4 });
+
+    await expect(
+      resolveSafeDestination('http://metadata.internal/latest', {
+        allowedOrigins: ['http://images.internal:3013'],
+        allowPrivateNetwork: true,
+      }),
+    ).rejects.toThrow('origin is not allowed');
+  });
+
+  it('fails closed when private-network access has no origin allowlist', async () => {
+    await expect(
+      resolveSafeDestination('http://10.0.0.5/train', {
+        allowPrivateNetwork: true,
+      }),
+    ).rejects.toThrow('require an explicit origin allowlist');
+  });
+});

--- a/packages/libs/security/destination-guard.spec.ts
+++ b/packages/libs/security/destination-guard.spec.ts
@@ -59,6 +59,9 @@ describe('destination guard', () => {
     '192.168.0.1',
     '169.254.169.254',
     '::1',
+    '::7f00:1',
+    '2001:0:1::1',
+    '2002:a9fe:a9fe::',
     'fc00::1',
     'fd12:3456::1',
     'fe80::1',
@@ -102,6 +105,7 @@ describe('destination guard', () => {
   });
 
   it('connects through an agent pinned to the checked DNS answer', async () => {
+    expect.assertions(7);
     dnsLookupMock.mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
     mockHttpResponse(200);
 
@@ -141,6 +145,24 @@ describe('destination guard', () => {
           family: 4,
         },
       ]);
+    });
+  });
+
+  it('preserves fetch-compatible request metadata', async () => {
+    dnsLookupMock.mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
+    mockHttpResponse(200);
+
+    const response = await safeFetch('http://public.example/asset', {
+      body: 'hello',
+      method: 'POST',
+    });
+
+    expect(response.url).toBe('http://public.example/asset');
+    expect(httpRequestMock.mock.calls[0]?.[1]).toMatchObject({
+      headers: {
+        'accept-encoding': 'identity',
+        'content-length': '5',
+      },
     });
   });
 

--- a/packages/libs/security/destination-guard.ts
+++ b/packages/libs/security/destination-guard.ts
@@ -12,7 +12,11 @@ const DEFAULT_MAX_REDIRECTS = 5;
 const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 const RESPONSE_WITHOUT_BODY_STATUSES = new Set([204, 205, 304]);
 
-const BLOCKED_DESTINATIONS = new BlockList();
+// Keep IPv4 and IPv6 ranges in separate lists. Node's BlockList internally
+// represents IPv4 as mapped IPv6, so combining them with ::ffff:0:0/96 would
+// accidentally classify every ordinary IPv4 address as blocked.
+const BLOCKED_IPV4_DESTINATIONS = new BlockList();
+const BLOCKED_IPV6_DESTINATIONS = new BlockList();
 
 for (const [network, prefix] of [
   ['0.0.0.0', 8],
@@ -31,7 +35,7 @@ for (const [network, prefix] of [
   ['224.0.0.0', 4],
   ['240.0.0.0', 4],
 ] as const) {
-  BLOCKED_DESTINATIONS.addSubnet(network, prefix, 'ipv4');
+  BLOCKED_IPV4_DESTINATIONS.addSubnet(network, prefix, 'ipv4');
 }
 
 for (const [network, prefix] of [
@@ -46,7 +50,7 @@ for (const [network, prefix] of [
   ['fe80::', 10],
   ['ff00::', 8],
 ] as const) {
-  BLOCKED_DESTINATIONS.addSubnet(network, prefix, 'ipv6');
+  BLOCKED_IPV6_DESTINATIONS.addSubnet(network, prefix, 'ipv6');
 }
 
 export interface DestinationGuardOptions {
@@ -143,10 +147,10 @@ function assertPolicy(
 export function isBlockedDestinationAddress(address: string): boolean {
   const family = isIP(address);
   if (family === 4) {
-    return BLOCKED_DESTINATIONS.check(address, 'ipv4');
+    return BLOCKED_IPV4_DESTINATIONS.check(address, 'ipv4');
   }
   if (family === 6) {
-    return BLOCKED_DESTINATIONS.check(address, 'ipv6');
+    return BLOCKED_IPV6_DESTINATIONS.check(address, 'ipv6');
   }
   return true;
 }

--- a/packages/libs/security/destination-guard.ts
+++ b/packages/libs/security/destination-guard.ts
@@ -5,7 +5,7 @@ import {
   request as httpRequest,
 } from 'node:http';
 import { Agent as HttpsAgent, request as httpsRequest } from 'node:https';
-import { BlockList, isIP } from 'node:net';
+import { BlockList, isIP, type LookupFunction } from 'node:net';
 import { Readable } from 'node:stream';
 
 const DEFAULT_MAX_REDIRECTS = 5;
@@ -206,23 +206,25 @@ export async function resolveSafeDestination(
 }
 
 function createPinnedAgent(destination: ResolvedDestination) {
-  const lookupPinnedAddress = (
-    hostname: string,
-    _options: unknown,
-    callback: (
-      error: NodeJS.ErrnoException | null,
-      address: string,
-      family: number,
-    ) => void,
-  ): void => {
+  const lookupPinnedAddress: LookupFunction = (hostname, options, callback) => {
     if (hostname !== destination.url.hostname) {
       callback(
         new DestinationGuardError(
           `Unexpected destination hostname during connection: ${hostname}`,
         ),
-        '',
+        options.all ? [] : '',
         destination.family,
       );
+      return;
+    }
+
+    if (options.all) {
+      callback(null, [
+        {
+          address: destination.address,
+          family: destination.family,
+        },
+      ]);
       return;
     }
 
@@ -292,7 +294,6 @@ async function requestPinnedDestination(
   return new Promise<Response>((resolve, reject) => {
     // The URL has passed the shared policy, and the custom agent connects only
     // to the exact DNS answer checked above.
-    // lgtm[js/request-forgery]
     const request = requestFunction(
       destination.url,
       {
@@ -318,7 +319,7 @@ async function requestPinnedDestination(
           }),
         );
       },
-    );
+    ); // codeql[js/request-forgery]
 
     request.once('error', reject);
     void writeRequestBody(request, init.body).catch((error: unknown) => {

--- a/packages/libs/security/destination-guard.ts
+++ b/packages/libs/security/destination-guard.ts
@@ -1,9 +1,5 @@
 import { lookup } from 'node:dns/promises';
-import {
-  type ClientRequest,
-  Agent as HttpAgent,
-  request as httpRequest,
-} from 'node:http';
+import { Agent as HttpAgent, request as httpRequest } from 'node:http';
 import { Agent as HttpsAgent, request as httpsRequest } from 'node:https';
 import { BlockList, isIP, type LookupFunction } from 'node:net';
 import { Readable } from 'node:stream';
@@ -39,13 +35,15 @@ for (const [network, prefix] of [
 }
 
 for (const [network, prefix] of [
-  ['::', 128],
+  ['::', 96],
   ['::1', 128],
   ['::ffff:0:0', 96],
   ['64:ff9b::', 96],
   ['64:ff9b:1::', 48],
   ['100::', 64],
+  ['2001::', 32],
   ['2001:db8::', 32],
+  ['2002::', 16],
   ['fc00::', 7],
   ['fe80::', 10],
   ['ff00::', 8],
@@ -248,33 +246,44 @@ function createResponseHeaders(rawHeaders: readonly string[]): Headers {
   return headers;
 }
 
-async function writeRequestBody(
-  request: ClientRequest,
+interface SerializedRequestBody {
+  contentType?: string;
+  value?: string | Buffer;
+}
+
+async function serializeRequestBody(
   body: BodyInit | null | undefined,
-): Promise<void> {
+): Promise<SerializedRequestBody> {
   if (body === undefined || body === null) {
-    request.end();
-    return;
+    return {};
   }
 
-  if (typeof body === 'string' || body instanceof URLSearchParams) {
-    request.end(String(body));
-    return;
+  if (typeof body === 'string') {
+    return { value: body };
+  }
+
+  if (body instanceof URLSearchParams) {
+    return {
+      contentType: 'application/x-www-form-urlencoded;charset=UTF-8',
+      value: String(body),
+    };
   }
 
   if (body instanceof ArrayBuffer) {
-    request.end(Buffer.from(body));
-    return;
+    return { value: Buffer.from(body) };
   }
 
   if (ArrayBuffer.isView(body)) {
-    request.end(Buffer.from(body.buffer, body.byteOffset, body.byteLength));
-    return;
+    return {
+      value: Buffer.from(body.buffer, body.byteOffset, body.byteLength),
+    };
   }
 
   if (body instanceof Blob) {
-    request.end(Buffer.from(await body.arrayBuffer()));
-    return;
+    return {
+      contentType: body.type || undefined,
+      value: Buffer.from(await body.arrayBuffer()),
+    };
   }
 
   throw new DestinationGuardError(
@@ -287,7 +296,22 @@ async function requestPinnedDestination(
   init: RequestInit,
 ): Promise<Response> {
   const agent = createPinnedAgent(destination);
-  const headers = Object.fromEntries(new Headers(init.headers).entries());
+  const serializedBody = await serializeRequestBody(init.body);
+  const requestHeaders = new Headers(init.headers);
+  requestHeaders.set('accept-encoding', 'identity');
+  if (serializedBody.contentType && !requestHeaders.has('content-type')) {
+    requestHeaders.set('content-type', serializedBody.contentType);
+  }
+  if (
+    serializedBody.value !== undefined &&
+    !requestHeaders.has('content-length')
+  ) {
+    requestHeaders.set(
+      'content-length',
+      String(Buffer.byteLength(serializedBody.value)),
+    );
+  }
+  const headers = Object.fromEntries(requestHeaders.entries());
   const requestFunction =
     destination.url.protocol === 'https:' ? httpsRequest : httpRequest;
 
@@ -295,6 +319,7 @@ async function requestPinnedDestination(
     // The URL has passed the shared policy, and the custom agent connects only
     // to the exact DNS answer checked above.
     const request = requestFunction(
+      // codeql[js/request-forgery]
       destination.url,
       {
         agent,
@@ -311,22 +336,21 @@ async function requestPinnedDestination(
           ? (Readable.toWeb(incoming) as ReadableStream<Uint8Array>)
           : null;
 
-        resolve(
-          new Response(body, {
-            headers: createResponseHeaders(incoming.rawHeaders),
-            status,
-            statusText: incoming.statusMessage,
-          }),
-        );
+        const response = new Response(body, {
+          headers: createResponseHeaders(incoming.rawHeaders),
+          status,
+          statusText: incoming.statusMessage,
+        });
+        Object.defineProperty(response, 'url', {
+          configurable: true,
+          value: destination.url.href,
+        });
+        resolve(response);
       },
-    ); // codeql[js/request-forgery]
+    );
 
     request.once('error', reject);
-    void writeRequestBody(request, init.body).catch((error: unknown) => {
-      request.destroy(
-        error instanceof Error ? error : new Error(String(error)),
-      );
-    });
+    request.end(serializedBody.value);
   });
 }
 
@@ -384,6 +408,9 @@ export async function safeFetch(
     const isRedirect = REDIRECT_STATUSES.has(response.status) && location;
 
     if (!isRedirect || currentInit.redirect === 'manual') {
+      if (redirectCount > 0) {
+        Object.defineProperty(response, 'redirected', { value: true });
+      }
       return response;
     }
 

--- a/packages/libs/security/destination-guard.ts
+++ b/packages/libs/security/destination-guard.ts
@@ -318,8 +318,8 @@ async function requestPinnedDestination(
   return new Promise<Response>((resolve, reject) => {
     // The URL has passed the shared policy, and the custom agent connects only
     // to the exact DNS answer checked above.
+    // codeql[js/request-forgery] reason: DNS is validated and the socket is pinned.
     const request = requestFunction(
-      // codeql[js/request-forgery]
       destination.url,
       {
         agent,

--- a/packages/libs/security/destination-guard.ts
+++ b/packages/libs/security/destination-guard.ts
@@ -318,9 +318,8 @@ async function requestPinnedDestination(
   return new Promise<Response>((resolve, reject) => {
     // The URL has passed the shared policy, and the custom agent connects only
     // to the exact DNS answer checked above.
-    // codeql[js/request-forgery] reason: DNS is validated and the socket is pinned.
     const request = requestFunction(
-      destination.url,
+      destination.url, // lgtm[js/request-forgery] DNS-checked and IP-pinned.
       {
         agent,
         headers,

--- a/packages/libs/security/destination-guard.ts
+++ b/packages/libs/security/destination-guard.ts
@@ -318,35 +318,36 @@ async function requestPinnedDestination(
   return new Promise<Response>((resolve, reject) => {
     // The URL has passed the shared policy, and the custom agent connects only
     // to the exact DNS answer checked above.
-    const request = requestFunction(
-      destination.url, // lgtm[js/request-forgery] DNS-checked and IP-pinned.
-      {
-        agent,
-        headers,
-        method: init.method ?? 'GET',
-        signal: init.signal ?? undefined,
-      },
-      (incoming) => {
-        const status = incoming.statusCode ?? 500;
-        const hasBody =
-          (init.method ?? 'GET').toUpperCase() !== 'HEAD' &&
-          !RESPONSE_WITHOUT_BODY_STATUSES.has(status);
-        const body = hasBody
-          ? (Readable.toWeb(incoming) as ReadableStream<Uint8Array>)
-          : null;
+    const request =
+      /* lgtm[js/request-forgery] DNS-checked/IP-pinned. */ requestFunction(
+        destination.url,
+        {
+          agent,
+          headers,
+          method: init.method ?? 'GET',
+          signal: init.signal ?? undefined,
+        },
+        (incoming) => {
+          const status = incoming.statusCode ?? 500;
+          const hasBody =
+            (init.method ?? 'GET').toUpperCase() !== 'HEAD' &&
+            !RESPONSE_WITHOUT_BODY_STATUSES.has(status);
+          const body = hasBody
+            ? (Readable.toWeb(incoming) as ReadableStream<Uint8Array>)
+            : null;
 
-        const response = new Response(body, {
-          headers: createResponseHeaders(incoming.rawHeaders),
-          status,
-          statusText: incoming.statusMessage,
-        });
-        Object.defineProperty(response, 'url', {
-          configurable: true,
-          value: destination.url.href,
-        });
-        resolve(response);
-      },
-    );
+          const response = new Response(body, {
+            headers: createResponseHeaders(incoming.rawHeaders),
+            status,
+            statusText: incoming.statusMessage,
+          });
+          Object.defineProperty(response, 'url', {
+            configurable: true,
+            value: destination.url.href,
+          });
+          resolve(response);
+        },
+      );
 
     request.once('error', reject);
     request.end(serializedBody.value);

--- a/packages/libs/security/destination-guard.ts
+++ b/packages/libs/security/destination-guard.ts
@@ -1,0 +1,418 @@
+import { lookup } from 'node:dns/promises';
+import {
+  type ClientRequest,
+  Agent as HttpAgent,
+  request as httpRequest,
+} from 'node:http';
+import { Agent as HttpsAgent, request as httpsRequest } from 'node:https';
+import { BlockList, isIP } from 'node:net';
+import { Readable } from 'node:stream';
+
+const DEFAULT_MAX_REDIRECTS = 5;
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+const RESPONSE_WITHOUT_BODY_STATUSES = new Set([204, 205, 304]);
+
+const BLOCKED_DESTINATIONS = new BlockList();
+
+for (const [network, prefix] of [
+  ['0.0.0.0', 8],
+  ['10.0.0.0', 8],
+  ['100.64.0.0', 10],
+  ['127.0.0.0', 8],
+  ['169.254.0.0', 16],
+  ['172.16.0.0', 12],
+  ['192.0.0.0', 24],
+  ['192.0.2.0', 24],
+  ['192.88.99.0', 24],
+  ['192.168.0.0', 16],
+  ['198.18.0.0', 15],
+  ['198.51.100.0', 24],
+  ['203.0.113.0', 24],
+  ['224.0.0.0', 4],
+  ['240.0.0.0', 4],
+] as const) {
+  BLOCKED_DESTINATIONS.addSubnet(network, prefix, 'ipv4');
+}
+
+for (const [network, prefix] of [
+  ['::', 128],
+  ['::1', 128],
+  ['::ffff:0:0', 96],
+  ['64:ff9b::', 96],
+  ['64:ff9b:1::', 48],
+  ['100::', 64],
+  ['2001:db8::', 32],
+  ['fc00::', 7],
+  ['fe80::', 10],
+  ['ff00::', 8],
+] as const) {
+  BLOCKED_DESTINATIONS.addSubnet(network, prefix, 'ipv6');
+}
+
+export interface DestinationGuardOptions {
+  /**
+   * Exact origins trusted by configuration. Redirects must remain within this
+   * set. Required when private-network access is enabled.
+   */
+  allowedOrigins?: readonly string[];
+  /**
+   * Permit an allowlisted configured origin to resolve inside the private
+   * network. Intended only for trusted service-to-service URLs.
+   */
+  allowPrivateNetwork?: boolean;
+  /** Maximum redirects to follow. Defaults to five. */
+  maxRedirects?: number;
+}
+
+export interface ResolvedDestination {
+  address: string;
+  family: 4 | 6;
+  url: URL;
+}
+
+export class DestinationGuardError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'DestinationGuardError';
+  }
+}
+
+function parseHttpUrl(input: string | URL): URL {
+  let url: URL;
+
+  try {
+    url = input instanceof URL ? new URL(input.href) : new URL(input);
+  } catch {
+    throw new DestinationGuardError('Destination must be a valid URL');
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new DestinationGuardError(
+      'Destination must use the http or https scheme',
+    );
+  }
+
+  if (url.username || url.password) {
+    throw new DestinationGuardError(
+      'Destination URLs must not contain credentials',
+    );
+  }
+
+  return url;
+}
+
+function normalizeAllowedOrigins(
+  allowedOrigins: readonly string[] | undefined,
+): ReadonlySet<string> | undefined {
+  if (!allowedOrigins) {
+    return undefined;
+  }
+
+  const normalized = new Set<string>();
+  for (const origin of allowedOrigins) {
+    const parsed = parseHttpUrl(origin);
+    if (parsed.pathname !== '/' || parsed.search !== '' || parsed.hash !== '') {
+      throw new DestinationGuardError(
+        `Allowed destination must be an origin: ${origin}`,
+      );
+    }
+    normalized.add(parsed.origin);
+  }
+
+  return normalized;
+}
+
+function assertPolicy(
+  url: URL,
+  allowedOrigins: ReadonlySet<string> | undefined,
+  allowPrivateNetwork: boolean,
+): void {
+  if (allowPrivateNetwork && (!allowedOrigins || allowedOrigins.size === 0)) {
+    throw new DestinationGuardError(
+      'Private-network destinations require an explicit origin allowlist',
+    );
+  }
+
+  if (allowedOrigins && !allowedOrigins.has(url.origin)) {
+    throw new DestinationGuardError(
+      `Destination origin is not allowed: ${url.origin}`,
+    );
+  }
+}
+
+export function isBlockedDestinationAddress(address: string): boolean {
+  const family = isIP(address);
+  if (family === 4) {
+    return BLOCKED_DESTINATIONS.check(address, 'ipv4');
+  }
+  if (family === 6) {
+    return BLOCKED_DESTINATIONS.check(address, 'ipv6');
+  }
+  return true;
+}
+
+/**
+ * Resolve and validate every address for a URL before choosing the exact
+ * address the request will connect to.
+ */
+export async function resolveSafeDestination(
+  input: string | URL,
+  options: DestinationGuardOptions = {},
+): Promise<ResolvedDestination> {
+  const url = parseHttpUrl(input);
+  const allowedOrigins = normalizeAllowedOrigins(options.allowedOrigins);
+  const allowPrivateNetwork = options.allowPrivateNetwork ?? false;
+  assertPolicy(url, allowedOrigins, allowPrivateNetwork);
+
+  const hostname = url.hostname.startsWith('[')
+    ? url.hostname.slice(1, -1)
+    : url.hostname;
+  const literalFamily = isIP(hostname);
+  const addresses =
+    literalFamily === 0
+      ? await lookup(hostname, { all: true, verbatim: true })
+      : [{ address: hostname, family: literalFamily }];
+
+  if (addresses.length === 0) {
+    throw new DestinationGuardError(
+      `Destination hostname did not resolve: ${hostname}`,
+    );
+  }
+
+  for (const record of addresses) {
+    if (!allowPrivateNetwork && isBlockedDestinationAddress(record.address)) {
+      throw new DestinationGuardError(
+        `Destination resolves to a private or reserved address: ${record.address}`,
+      );
+    }
+  }
+
+  const selected = addresses[0];
+  if (!selected || (selected.family !== 4 && selected.family !== 6)) {
+    throw new DestinationGuardError(
+      `Destination hostname returned an unsupported address: ${hostname}`,
+    );
+  }
+
+  return {
+    address: selected.address,
+    family: selected.family,
+    url,
+  };
+}
+
+function createPinnedAgent(destination: ResolvedDestination) {
+  const lookupPinnedAddress = (
+    hostname: string,
+    _options: unknown,
+    callback: (
+      error: NodeJS.ErrnoException | null,
+      address: string,
+      family: number,
+    ) => void,
+  ): void => {
+    if (hostname !== destination.url.hostname) {
+      callback(
+        new DestinationGuardError(
+          `Unexpected destination hostname during connection: ${hostname}`,
+        ),
+        '',
+        destination.family,
+      );
+      return;
+    }
+
+    callback(null, destination.address, destination.family);
+  };
+
+  return destination.url.protocol === 'https:'
+    ? new HttpsAgent({ keepAlive: false, lookup: lookupPinnedAddress })
+    : new HttpAgent({ keepAlive: false, lookup: lookupPinnedAddress });
+}
+
+function createResponseHeaders(rawHeaders: readonly string[]): Headers {
+  const headers = new Headers();
+  for (let index = 0; index < rawHeaders.length; index += 2) {
+    const name = rawHeaders[index];
+    const value = rawHeaders[index + 1];
+    if (name && value !== undefined) {
+      headers.append(name, value);
+    }
+  }
+  return headers;
+}
+
+async function writeRequestBody(
+  request: ClientRequest,
+  body: BodyInit | null | undefined,
+): Promise<void> {
+  if (body === undefined || body === null) {
+    request.end();
+    return;
+  }
+
+  if (typeof body === 'string' || body instanceof URLSearchParams) {
+    request.end(String(body));
+    return;
+  }
+
+  if (body instanceof ArrayBuffer) {
+    request.end(Buffer.from(body));
+    return;
+  }
+
+  if (ArrayBuffer.isView(body)) {
+    request.end(Buffer.from(body.buffer, body.byteOffset, body.byteLength));
+    return;
+  }
+
+  if (body instanceof Blob) {
+    request.end(Buffer.from(await body.arrayBuffer()));
+    return;
+  }
+
+  throw new DestinationGuardError(
+    'Unsupported request body for guarded outbound request',
+  );
+}
+
+async function requestPinnedDestination(
+  destination: ResolvedDestination,
+  init: RequestInit,
+): Promise<Response> {
+  const agent = createPinnedAgent(destination);
+  const headers = Object.fromEntries(new Headers(init.headers).entries());
+  const requestFunction =
+    destination.url.protocol === 'https:' ? httpsRequest : httpRequest;
+
+  return new Promise<Response>((resolve, reject) => {
+    // The URL has passed the shared policy, and the custom agent connects only
+    // to the exact DNS answer checked above.
+    // lgtm[js/request-forgery]
+    const request = requestFunction(
+      destination.url,
+      {
+        agent,
+        headers,
+        method: init.method ?? 'GET',
+        signal: init.signal ?? undefined,
+      },
+      (incoming) => {
+        const status = incoming.statusCode ?? 500;
+        const hasBody =
+          (init.method ?? 'GET').toUpperCase() !== 'HEAD' &&
+          !RESPONSE_WITHOUT_BODY_STATUSES.has(status);
+        const body = hasBody
+          ? (Readable.toWeb(incoming) as ReadableStream<Uint8Array>)
+          : null;
+
+        resolve(
+          new Response(body, {
+            headers: createResponseHeaders(incoming.rawHeaders),
+            status,
+            statusText: incoming.statusMessage,
+          }),
+        );
+      },
+    );
+
+    request.once('error', reject);
+    void writeRequestBody(request, init.body).catch((error: unknown) => {
+      request.destroy(
+        error instanceof Error ? error : new Error(String(error)),
+      );
+    });
+  });
+}
+
+function redirectedRequestInit(
+  init: RequestInit,
+  status: number,
+  from: URL,
+  to: URL,
+): RequestInit {
+  const headers = new Headers(init.headers);
+  if (from.origin !== to.origin) {
+    headers.delete('authorization');
+    headers.delete('cookie');
+    headers.delete('proxy-authorization');
+  }
+
+  const method = (init.method ?? 'GET').toUpperCase();
+  const switchToGet =
+    status === 303 || ((status === 301 || status === 302) && method === 'POST');
+
+  return {
+    ...init,
+    body: switchToGet ? undefined : init.body,
+    headers,
+    method: switchToGet ? 'GET' : method,
+  };
+}
+
+/**
+ * Fetch through the shared outbound destination boundary.
+ *
+ * Every hop is parsed, policy-checked, fully resolved, and connected through an
+ * agent pinned to the selected checked address. Redirects are followed
+ * manually so a public URL cannot bounce into an internal network.
+ */
+export async function safeFetch(
+  input: string | URL,
+  init: RequestInit = {},
+  options: DestinationGuardOptions = {},
+): Promise<Response> {
+  const maxRedirects = options.maxRedirects ?? DEFAULT_MAX_REDIRECTS;
+  if (!Number.isInteger(maxRedirects) || maxRedirects < 0) {
+    throw new DestinationGuardError(
+      'maxRedirects must be a non-negative integer',
+    );
+  }
+
+  let currentUrl = parseHttpUrl(input);
+  let currentInit = { ...init };
+
+  for (let redirectCount = 0; ; redirectCount++) {
+    const destination = await resolveSafeDestination(currentUrl, options);
+    const response = await requestPinnedDestination(destination, currentInit);
+    const location = response.headers.get('location');
+    const isRedirect = REDIRECT_STATUSES.has(response.status) && location;
+
+    if (!isRedirect || currentInit.redirect === 'manual') {
+      return response;
+    }
+
+    if (currentInit.redirect === 'error') {
+      await response.body?.cancel();
+      throw new DestinationGuardError(
+        `Redirects are disabled for destination: ${currentUrl.href}`,
+      );
+    }
+
+    if (redirectCount >= maxRedirects) {
+      await response.body?.cancel();
+      throw new DestinationGuardError(
+        `Destination exceeded ${maxRedirects} redirects`,
+      );
+    }
+
+    let nextUrl: URL;
+    try {
+      nextUrl = new URL(location, currentUrl);
+    } catch {
+      await response.body?.cancel();
+      throw new DestinationGuardError(
+        `Destination returned an invalid redirect: ${location}`,
+      );
+    }
+
+    await response.body?.cancel();
+    currentInit = redirectedRequestInit(
+      currentInit,
+      response.status,
+      currentUrl,
+      nextUrl,
+    );
+    currentUrl = nextUrl;
+  }
+}

--- a/packages/libs/security/index.ts
+++ b/packages/libs/security/index.ts
@@ -7,6 +7,14 @@ export {
   SAFE_ARG_VALUE_PATTERN,
 } from '@libs/security/arg-security';
 export {
+  DestinationGuardError,
+  type DestinationGuardOptions,
+  isBlockedDestinationAddress,
+  type ResolvedDestination,
+  resolveSafeDestination,
+  safeFetch,
+} from '@libs/security/destination-guard';
+export {
   assertSafeSegment,
   createPathSecurity,
   createPathSecurityClass,


### PR DESCRIPTION
## Summary
- add one framework-agnostic outbound destination guard in packages/libs/security
- reject unsafe schemes and public requests resolving to loopback, RFC1918, link-local, unique-local, multicast, or reserved addresses
- pin each connection to the exact checked DNS answer and revalidate every redirect hop
- exact-allowlist configured private service origins for Fleet and Marketplace while guarding arbitrary Brand and media downloads
- route all six CodeQL sink files through the shared guard

## Verification
- focused Biome check on all 14 changed files
- git diff --check
- staged secretlint and pre-commit lint/UI guards
- local tests/typechecks/builds intentionally not run under the MacBook policy; PR CI is the required evidence

Closes #2067