### PR TITLE
fix(security): remove polynomial regex backtracking

### DIFF
--- a/apps/server/api/src/collections/posts/services/post-generation-text.util.spec.ts
+++ b/apps/server/api/src/collections/posts/services/post-generation-text.util.spec.ts
@@ -1,4 +1,5 @@
 import {
+  extractPostGenerationLabel,
   parsePostGenerationContent,
   parsePostGenerationSlots,
 } from '@api/collections/posts/services/post-generation-text.util';
@@ -18,5 +19,20 @@ describe('post generation text parsing', () => {
     expect(
       parsePostGenerationContent(`${firstReply}\n${secondReply}\n---`, 2),
     ).toEqual([firstReply, secondReply]);
+  });
+
+  it('extracts a whitespace-normalized label without markup', () => {
+    expect(
+      extractPostGenerationLabel('<p>Hello <strong>launch</strong></p>'),
+    ).toBe('Hello launch');
+  });
+
+  it('preserves malformed markup text and caps the label', () => {
+    expect(extractPostGenerationLabel('Hello <unfinished')).toBe(
+      'Hello <unfinished',
+    );
+    expect(extractPostGenerationLabel('word '.repeat(20), 20)).toBe(
+      'word word word word...',
+    );
   });
 });

--- a/apps/server/api/src/collections/posts/services/post-generation-text.util.ts
+++ b/apps/server/api/src/collections/posts/services/post-generation-text.util.ts
@@ -1,8 +1,9 @@
+import { replaceMarkup } from '@api/shared/utils/string/strip-markup.util';
 import type { AccountPublishingContext } from '@genfeedai/interfaces';
 import { parseTweet } from 'twitter-text';
 
 function stripHtmlTags(html: string): string {
-  return html.replace(/<[^>]+>/g, '');
+  return replaceMarkup(html, '');
 }
 
 function isValidPostLength(
@@ -150,10 +151,7 @@ export function extractPostGenerationLabel(
     return '';
   }
 
-  const normalized = postText
-    .replace(/<[^>]+>/g, ' ')
-    .trim()
-    .replace(/\s+/g, ' ');
+  const normalized = replaceMarkup(postText, ' ').trim().replace(/\s+/g, ' ');
 
   if (normalized.length <= maxLength) {
     return normalized;

--- a/apps/server/api/src/collections/social-inbox/services/social-inbox.helpers.spec.ts
+++ b/apps/server/api/src/collections/social-inbox/services/social-inbox.helpers.spec.ts
@@ -1,0 +1,34 @@
+import {
+  normalizePlatform,
+  sanitizeBody,
+} from '@api/collections/social-inbox/services/social-inbox.helpers';
+import { BadRequestException } from '@nestjs/common';
+import { describe, expect, it } from 'vitest';
+
+describe('social inbox helpers', () => {
+  it('normalizes platform names', () => {
+    expect(normalizePlatform(' Instagram ')).toBe('instagram');
+  });
+
+  it('removes markup and complete script or style blocks from message bodies', () => {
+    expect(
+      sanitizeBody(
+        '<p>Hello</p><script>alert(1)</script><style>p{color:red}</style> world',
+      ),
+    ).toBe('Hello world');
+  });
+
+  it('preserves text from an unclosed blocked element like the previous matcher', () => {
+    expect(sanitizeBody('<script>visible fallback')).toBe('visible fallback');
+  });
+
+  it('rejects bodies that contain only removable markup', () => {
+    expect(() => sanitizeBody('<script>alert(1)</script>')).toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('bounds the stored body after sanitizing', () => {
+    expect(sanitizeBody('a'.repeat(20_000))).toHaveLength(10_000);
+  });
+});

--- a/apps/server/api/src/collections/social-inbox/services/social-inbox.helpers.ts
+++ b/apps/server/api/src/collections/social-inbox/services/social-inbox.helpers.ts
@@ -6,6 +6,7 @@ import type {
   SocialMessageDocument,
 } from '@api/collections/social-inbox/schemas/social-inbox.schema';
 import type { SocialInboxPage } from '@api/collections/social-inbox/services/social-inbox.types';
+import { replaceMarkup } from '@api/shared/utils/string/strip-markup.util';
 import { BadRequestException } from '@nestjs/common';
 
 type JsonRecord = Record<string, unknown>;
@@ -19,12 +20,7 @@ export function normalizePlatform(platform: string): string {
 }
 
 export function sanitizeBody(body: string): string {
-  const stripped = body
-    .replace(/<script[\s\S]*?>[\s\S]*?<\/script>/gi, '')
-    .replace(/<style[\s\S]*?>[\s\S]*?<\/style>/gi, '')
-    .replace(/<[^>]+>/g, '')
-    .replace(/\s+/g, ' ')
-    .trim();
+  const stripped = replaceMarkup(body, '', true).replace(/\s+/g, ' ').trim();
 
   if (!stripped) {
     throw new BadRequestException('Message body cannot be empty');

--- a/apps/server/api/src/collections/trends/services/trend-reference-corpus.service.spec.ts
+++ b/apps/server/api/src/collections/trends/services/trend-reference-corpus.service.spec.ts
@@ -758,6 +758,29 @@ describe('TrendReferenceCorpusService', () => {
     );
   });
 
+  it('normalizes malformed source URLs without backtracking', async () => {
+    const items: TrendSourceItem[] = [
+      {
+        contentType: 'video',
+        id: 'source_invalid',
+        platform: 'tiktok',
+        sourceUrl: `not a url/${'#'.repeat(50_000)}`,
+      },
+    ];
+
+    await service.annotateSourceItemsWithReferenceIds(items);
+
+    expect(prisma.trendSourceReference.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        take: 1,
+        where: {
+          canonicalUrl: { in: ['not a url'] },
+          isDeleted: false,
+        },
+      }),
+    );
+  });
+
   it('persists source classification when syncing public reference items', async () => {
     prisma.trendSourceReference.findFirst.mockResolvedValueOnce(null);
     prisma.trendSourceReference.create.mockResolvedValueOnce({

--- a/apps/server/api/src/collections/trends/services/trend-reference-corpus.service.ts
+++ b/apps/server/api/src/collections/trends/services/trend-reference-corpus.service.ts
@@ -39,6 +39,10 @@ interface SyncTrendInput {
   sourcePreview: TrendSourceItem[];
 }
 
+function removeTrailingSlash(value: string): string {
+  return value.endsWith('/') ? value.slice(0, -1) : value;
+}
+
 interface RemixLineagePayload {
   organizationId: string;
   brandId: string;
@@ -820,13 +824,23 @@ export class TrendReferenceCorpusService {
       const parsed = new URL(url);
       parsed.hash = '';
       parsed.search = '';
-      return parsed.toString().replace(/\/$/, '');
+      return removeTrailingSlash(parsed.toString());
     } catch (error) {
       this.loggerService.warn('Failed to normalize source URL', {
         error: error instanceof Error ? error.message : String(error),
         url,
       });
-      return url.replace(/[?#].*$/, '').replace(/\/$/, '');
+      const queryIndex = url.indexOf('?');
+      const hashIndex = url.indexOf('#');
+      const delimiterIndexes = [queryIndex, hashIndex].filter(
+        (index) => index >= 0,
+      );
+      const end =
+        delimiterIndexes.length > 0
+          ? Math.min(...delimiterIndexes)
+          : url.length;
+
+      return removeTrailingSlash(url.slice(0, end));
     }
   }
 

--- a/apps/server/api/src/collections/trends/services/trend-reference-corpus.service.ts
+++ b/apps/server/api/src/collections/trends/services/trend-reference-corpus.service.ts
@@ -23,6 +23,7 @@ import {
   TrendCorpusFreshnessService,
 } from '@api/collections/trends/services/modules/trend-corpus-freshness.service';
 import { normalizeTrendSourceClassification } from '@api/collections/trends/utils/trend-source-classification.util';
+import { normalizeTrendSourceUrl } from '@api/collections/trends/utils/trend-source-url.util';
 import { SecurityUtil } from '@api/helpers/utils/security/security.util';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { Prisma } from '@genfeedai/prisma';
@@ -37,10 +38,6 @@ interface SyncTrendInput {
   viralityScore: number;
   sourcePreviewState: 'live' | 'fallback' | 'empty';
   sourcePreview: TrendSourceItem[];
-}
-
-function removeTrailingSlash(value: string): string {
-  return value.endsWith('/') ? value.slice(0, -1) : value;
 }
 
 interface RemixLineagePayload {
@@ -820,28 +817,17 @@ export class TrendReferenceCorpusService {
   }
 
   private normalizeSourceUrl(url: string): string {
-    try {
-      const parsed = new URL(url);
-      parsed.hash = '';
-      parsed.search = '';
-      return removeTrailingSlash(parsed.toString());
-    } catch (error) {
+    const result = normalizeTrendSourceUrl(url);
+    if (!result.ok) {
       this.loggerService.warn('Failed to normalize source URL', {
-        error: error instanceof Error ? error.message : String(error),
+        error:
+          result.error instanceof Error
+            ? result.error.message
+            : String(result.error),
         url,
       });
-      const queryIndex = url.indexOf('?');
-      const hashIndex = url.indexOf('#');
-      const delimiterIndexes = [queryIndex, hashIndex].filter(
-        (index) => index >= 0,
-      );
-      const end =
-        delimiterIndexes.length > 0
-          ? Math.min(...delimiterIndexes)
-          : url.length;
-
-      return removeTrailingSlash(url.slice(0, end));
     }
+    return result.normalizedUrl;
   }
 
   private normalizeLimit(

--- a/apps/server/api/src/collections/trends/utils/trend-source-url.util.spec.ts
+++ b/apps/server/api/src/collections/trends/utils/trend-source-url.util.spec.ts
@@ -1,0 +1,42 @@
+import { normalizeTrendSourceUrl } from '@api/collections/trends/utils/trend-source-url.util';
+
+describe('normalizeTrendSourceUrl', () => {
+  it('removes query, fragment, and one trailing slash from valid URLs', () => {
+    expect(
+      normalizeTrendSourceUrl(
+        'https://example.com/reference/?campaign=launch#details',
+      ),
+    ).toEqual({
+      normalizedUrl: 'https://example.com/reference',
+      ok: true,
+    });
+  });
+
+  it('falls back to deterministic delimiter scanning for invalid URLs', () => {
+    const result = normalizeTrendSourceUrl(
+      'not a url/reference/?campaign=launch#details',
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.normalizedUrl).toBe('not a url/reference');
+    if (!result.ok) {
+      expect(result.error).toBeInstanceOf(Error);
+    }
+  });
+
+  it('preserves the original single-trailing-slash removal behavior', () => {
+    expect(normalizeTrendSourceUrl('not a url////?query').normalizedUrl).toBe(
+      'not a url///',
+    );
+  });
+
+  it('handles long delimiter tails without regular-expression backtracking', () => {
+    const path = `not a url/${'a'.repeat(50_000)}`;
+    const result = normalizeTrendSourceUrl(
+      `${path}?${'#'.repeat(50_000)}ignored`,
+    );
+
+    expect(result.normalizedUrl).toBe(path);
+    expect(result.ok).toBe(false);
+  });
+});

--- a/apps/server/api/src/collections/trends/utils/trend-source-url.util.ts
+++ b/apps/server/api/src/collections/trends/utils/trend-source-url.util.ts
@@ -1,0 +1,48 @@
+export type TrendSourceUrlNormalizationResult =
+  | {
+      normalizedUrl: string;
+      ok: true;
+    }
+  | {
+      error: unknown;
+      normalizedUrl: string;
+      ok: false;
+    };
+
+function removeTrailingSlash(value: string): string {
+  return value.endsWith('/') ? value.slice(0, -1) : value;
+}
+
+function stripQueryAndFragment(value: string): string {
+  let end = value.length;
+
+  for (const delimiter of ['?', '#']) {
+    const delimiterIndex = value.indexOf(delimiter);
+    if (delimiterIndex >= 0 && delimiterIndex < end) {
+      end = delimiterIndex;
+    }
+  }
+
+  return end === value.length ? value : value.slice(0, end);
+}
+
+export function normalizeTrendSourceUrl(
+  url: string,
+): TrendSourceUrlNormalizationResult {
+  try {
+    const parsed = new URL(url);
+    parsed.hash = '';
+    parsed.search = '';
+
+    return {
+      normalizedUrl: removeTrailingSlash(parsed.toString()),
+      ok: true,
+    };
+  } catch (error) {
+    return {
+      error,
+      normalizedUrl: removeTrailingSlash(stripQueryAndFragment(url)),
+      ok: false,
+    };
+  }
+}

--- a/apps/server/api/src/endpoints/admin/warmup-accounts/warmup-accounts.service.spec.ts
+++ b/apps/server/api/src/endpoints/admin/warmup-accounts/warmup-accounts.service.spec.ts
@@ -1,5 +1,8 @@
 import { InvitationService } from '@api/collections/members/services/invitation.service';
-import { AdminWarmupAccountsService } from '@api/endpoints/admin/warmup-accounts/warmup-accounts.service';
+import {
+  AdminWarmupAccountsService,
+  createSlugSeed,
+} from '@api/endpoints/admin/warmup-accounts/warmup-accounts.service';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { WarmupAccountStatus } from '@genfeedai/prisma';
 import { LoggerService } from '@libs/logger/logger.service';
@@ -7,6 +10,23 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const createdAt = new Date('2026-06-29T10:00:00.000Z');
 const updatedAt = new Date('2026-06-29T10:01:00.000Z');
+
+describe('createSlugSeed', () => {
+  it('collapses invalid runs and trims separators', () => {
+    expect(createSlugSeed('  --Warmup   Account--  ')).toBe('warmup-account');
+  });
+
+  it('preserves the existing fallback and length cap', () => {
+    expect(createSlugSeed('---')).toBe('warmup');
+    expect(createSlugSeed('a'.repeat(80))).toHaveLength(48);
+  });
+
+  it('handles long separator runs without ambiguous matching', () => {
+    expect(createSlugSeed(`lead${'-'.repeat(50_000)}account`)).toBe(
+      'lead-account',
+    );
+  });
+});
 
 function makeWarmupAccount(overrides: Record<string, unknown> = {}) {
   return {

--- a/apps/server/api/src/endpoints/admin/warmup-accounts/warmup-accounts.service.ts
+++ b/apps/server/api/src/endpoints/admin/warmup-accounts/warmup-accounts.service.ts
@@ -4,6 +4,10 @@ import { CreateWarmupAccountDto } from '@api/endpoints/admin/warmup-accounts/dto
 import { NotFoundException } from '@api/helpers/exceptions/http/not-found.exception';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
 import { findOrThrow } from '@api/shared/utils/find-or-throw/find-or-throw.util';
+import {
+  replaceCharacterRuns,
+  trimCharacter,
+} from '@api/shared/utils/string/linear-string.util';
 import type {
   IWarmupAccount,
   IWarmupAccountAuditEvent,
@@ -47,15 +51,20 @@ function makeTimestamp(): string {
   return new Date().toISOString();
 }
 
-function createSlugSeed(value: string): string {
-  return (
-    value
-      .trim()
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, '-')
-      .replace(/^-+|-+$/g, '')
-      .slice(0, 48) || 'warmup'
+function isSlugCharacter(character: string): boolean {
+  const code = character.charCodeAt(0);
+
+  return (code >= 48 && code <= 57) || (code >= 97 && code <= 122);
+}
+
+export function createSlugSeed(value: string): string {
+  const normalized = replaceCharacterRuns(
+    value.trim().toLowerCase(),
+    (character) => !isSlugCharacter(character),
+    '-',
   );
+
+  return trimCharacter(normalized, '-').slice(0, 48) || 'warmup';
 }
 
 function createHandle(email: string): string {

--- a/apps/server/api/src/helpers/utils/sort/sort.util.spec.ts
+++ b/apps/server/api/src/helpers/utils/sort/sort.util.spec.ts
@@ -24,4 +24,20 @@ describe('handleQuerySort', () => {
   it('falls back to default on invalid json', () => {
     expect(handleQuerySort('this-is-not-valid')).toEqual({ createdAt: -1 });
   });
+
+  it('accepts documented whitespace around separators', () => {
+    expect(handleQuerySort('createdAt : -1, label: 1')).toEqual({
+      createdAt: -1,
+      label: 1,
+    });
+  });
+
+  it.each([
+    'createdAt: 0',
+    'created-at: 1',
+    'createdAt: 1: -1',
+    `field${'0'.repeat(50_000)}`,
+  ])('falls back for invalid or adversarial input: %s', (query) => {
+    expect(handleQuerySort(query)).toEqual({ createdAt: -1 });
+  });
 });

--- a/apps/server/api/src/helpers/utils/sort/sort.util.ts
+++ b/apps/server/api/src/helpers/utils/sort/sort.util.ts
@@ -1,5 +1,24 @@
 import type { SortObject } from '@genfeedai/interfaces';
 
+function getDefaultSort(): SortObject {
+  return { createdAt: -1 };
+}
+
+function isSortFieldCharacter(character: string): boolean {
+  const code = character.charCodeAt(0);
+
+  return (
+    (code >= 48 && code <= 57) ||
+    (code >= 65 && code <= 90) ||
+    code === 95 ||
+    (code >= 97 && code <= 122)
+  );
+}
+
+function isValidSortField(field: string): boolean {
+  return field.length > 0 && [...field].every(isSortFieldCharacter);
+}
+
 /**
  * Handles field-direction sort query format
  *
@@ -19,19 +38,26 @@ export const handleQuerySort = (
 ): SortObject => {
   // Default sort if no query provided
   if (!query || query === '') {
-    return { createdAt: -1 };
+    return getDefaultSort();
   }
 
-  try {
-    // Convert the string to JSON object format
-    // Example: "id: -1, name: 1" to '{ "id": -1, "name": 1 }'
-    const toJSONString = `{${query}}`.replace(/(\w+:)|(\w+ :)/g, (matched) => {
-      return `"${matched.substring(0, matched.length - 1)}":`;
-    });
+  const sort: SortObject = {};
 
-    return JSON.parse(toJSONString) as SortObject;
-  } catch {
-    // Note: Logger not available in utility function - silent fallback to default sort
-    return { createdAt: -1 }; // Fallback to default sort
+  for (const segment of query.split(',')) {
+    const separatorIndex = segment.indexOf(':');
+    if (separatorIndex < 0 || segment.indexOf(':', separatorIndex + 1) >= 0) {
+      return getDefaultSort();
+    }
+
+    const field = segment.slice(0, separatorIndex).trim();
+    const direction = segment.slice(separatorIndex + 1).trim();
+
+    if (!isValidSortField(field) || (direction !== '1' && direction !== '-1')) {
+      return getDefaultSort();
+    }
+
+    sort[field] = direction === '1' ? 1 : -1;
   }
+
+  return Object.keys(sort).length > 0 ? sort : getDefaultSort();
 };

--- a/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.ts
+++ b/apps/server/api/src/services/agent-orchestrator/agent-orchestrator.service.ts
@@ -62,6 +62,11 @@ import {
   mergeAgentArtifactCompletionMetadata,
   persistRunArtifacts,
 } from '@api/services/agent-orchestrator/utils/agent-artifact-reference-metadata.util';
+import {
+  extractBatchTopic,
+  extractRecurringContentCount,
+  extractStyleNotes,
+} from '@api/services/agent-orchestrator/utils/agent-orchestrator-input-parsing.util';
 import { buildPageContextPrompt } from '@api/services/agent-orchestrator/utils/agent-page-context.util';
 import {
   buildAgentRoutingMetadata,
@@ -3327,9 +3332,7 @@ export class AgentOrchestratorService {
     defaultTimezone: string,
   ): RecurringTaskDraft {
     const normalized = content.toLowerCase();
-    const countMatch = normalized.match(
-      /\b(\d{1,2})\s+(?:instagram|tiktok|linkedin|x|twitter|facebook)?\s*(images?|videos?|posts?|newsletters?)\b/,
-    );
+    const count = extractRecurringContentCount(normalized);
     const contentType = normalized.includes('video')
       ? 'video'
       : normalized.includes('newsletter')
@@ -3344,7 +3347,7 @@ export class AgentOrchestratorService {
 
     return {
       contentType,
-      count: countMatch ? Number.parseInt(countMatch[1], 10) : 1,
+      count: count ?? 1,
       diversityMode: normalized.includes('distinct')
         ? 'high'
         : normalized.includes('consistent')
@@ -3404,8 +3407,7 @@ export class AgentOrchestratorService {
   }
 
   private extractStyleNotesFromMessage(content: string): string | undefined {
-    const styleMatch = content.match(/\b(?:in|with)\s+an?\s+(.+?)\s+style\b/i);
-    return styleMatch?.[1]?.trim();
+    return extractStyleNotes(content);
   }
 
   private extractCronScheduleFromMessage(
@@ -4054,24 +4056,7 @@ export class AgentOrchestratorService {
     originalContent: string,
     normalizedContent: string,
   ): string[] {
-    const aboutMatch = normalizedContent.match(
-      /\babout\s+(.+?)(?:\s+(?:for|on|this|next|over)\b|[.!?]|$)/,
-    );
-
-    if (!aboutMatch) {
-      return [];
-    }
-
-    const startIndex = aboutMatch.index ?? -1;
-    if (startIndex < 0) {
-      return [];
-    }
-
-    const originalSlice = originalContent.slice(
-      startIndex + 'about '.length,
-      startIndex + 'about '.length + aboutMatch[1].length,
-    );
-    const topic = originalSlice.trim();
+    const topic = extractBatchTopic(originalContent, normalizedContent);
 
     return topic ? [topic] : [];
   }

--- a/apps/server/api/src/services/agent-orchestrator/utils/agent-orchestrator-input-parsing.util.spec.ts
+++ b/apps/server/api/src/services/agent-orchestrator/utils/agent-orchestrator-input-parsing.util.spec.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import {
+  extractBatchTopic,
+  extractRecurringContentCount,
+  extractStyleNotes,
+} from './agent-orchestrator-input-parsing.util';
+
+describe('agent orchestrator input parsing', () => {
+  it.each([
+    ['create 5 instagram images every weekday', 5],
+    ['create 12 newsletters weekly', 12],
+    ['create 3 posts', 3],
+  ])('extracts recurring count from "%s"', (content, expected) => {
+    expect(extractRecurringContentCount(content)).toBe(expected);
+  });
+
+  it('does not join tokens across punctuation or accept three-digit counts', () => {
+    expect(extractRecurringContentCount('create 5, images')).toBeUndefined();
+    expect(extractRecurringContentCount('create 100 images')).toBeUndefined();
+  });
+
+  it('extracts style notes with their original casing', () => {
+    expect(
+      extractStyleNotes('Create images in a Minimal Beige Luxury style weekly'),
+    ).toBe('Minimal Beige Luxury');
+    expect(extractStyleNotes('Create images with an editorial style')).toBe(
+      'editorial',
+    );
+    expect(extractStyleNotes('Create images in a bold, editorial style')).toBe(
+      'bold, editorial',
+    );
+  });
+
+  it('extracts a topic before platform, date, or punctuation delimiters', () => {
+    expect(
+      extractBatchTopic(
+        'Create 5 posts about AI Safety for LinkedIn',
+        'create 5 posts about ai safety for linkedin',
+      ),
+    ).toBe('AI Safety');
+    expect(
+      extractBatchTopic(
+        'Create 5 posts about creator tools.',
+        'create 5 posts about creator tools.',
+      ),
+    ).toBe('creator tools');
+  });
+
+  it('handles long repeated spaces and words without ambiguous matching', () => {
+    const repeated = 'topic '.repeat(20_000);
+
+    expect(
+      extractStyleNotes(`create images in a ${repeated}style weekly`),
+    ).toBe(repeated.trim());
+    expect(
+      extractBatchTopic(
+        `create posts about ${repeated}for linkedin`,
+        `create posts about ${repeated}for linkedin`,
+      ),
+    ).toBe(repeated.trim());
+  });
+});

--- a/apps/server/api/src/services/agent-orchestrator/utils/agent-orchestrator-input-parsing.util.ts
+++ b/apps/server/api/src/services/agent-orchestrator/utils/agent-orchestrator-input-parsing.util.ts
@@ -1,0 +1,254 @@
+interface WordSpan {
+  end: number;
+  start: number;
+  value: string;
+}
+
+const RECURRING_PLATFORMS = new Set([
+  'facebook',
+  'instagram',
+  'linkedin',
+  'tiktok',
+  'twitter',
+  'x',
+]);
+const RECURRING_ASSETS = new Set([
+  'image',
+  'images',
+  'newsletter',
+  'newsletters',
+  'post',
+  'posts',
+  'video',
+  'videos',
+]);
+const BATCH_TOPIC_TERMINATORS = ['for', 'on', 'this', 'next', 'over'];
+
+function isAsciiWordCharacter(character: string): boolean {
+  const code = character.charCodeAt(0);
+
+  return (
+    (code >= 48 && code <= 57) ||
+    (code >= 65 && code <= 90) ||
+    code === 95 ||
+    (code >= 97 && code <= 122)
+  );
+}
+
+function isWhitespace(character: string): boolean {
+  return character.trim().length === 0;
+}
+
+function containsOnlyWhitespace(
+  value: string,
+  start: number,
+  end: number,
+): boolean {
+  if (start >= end) {
+    return false;
+  }
+
+  for (let index = start; index < end; index += 1) {
+    if (!isWhitespace(value[index])) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function collectWordSpans(value: string): WordSpan[] {
+  const words: WordSpan[] = [];
+  let cursor = 0;
+
+  while (cursor < value.length) {
+    if (!isAsciiWordCharacter(value[cursor])) {
+      cursor += 1;
+      continue;
+    }
+
+    const start = cursor;
+    while (cursor < value.length && isAsciiWordCharacter(value[cursor])) {
+      cursor += 1;
+    }
+
+    words.push({
+      end: cursor,
+      start,
+      value: value.slice(start, cursor).toLowerCase(),
+    });
+  }
+
+  return words;
+}
+
+function isOneOrTwoDigits(value: string): boolean {
+  if (value.length < 1 || value.length > 2) {
+    return false;
+  }
+
+  for (const character of value) {
+    const code = character.charCodeAt(0);
+    if (code < 48 || code > 57) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+export function extractRecurringContentCount(
+  content: string,
+): number | undefined {
+  const words = collectWordSpans(content);
+
+  for (let index = 0; index < words.length - 1; index += 1) {
+    const countWord = words[index];
+    if (!isOneOrTwoDigits(countWord.value)) {
+      continue;
+    }
+
+    let assetIndex = index + 1;
+    if (
+      !containsOnlyWhitespace(content, countWord.end, words[assetIndex].start)
+    ) {
+      continue;
+    }
+
+    if (RECURRING_PLATFORMS.has(words[assetIndex].value)) {
+      assetIndex += 1;
+      if (
+        assetIndex >= words.length ||
+        !containsOnlyWhitespace(
+          content,
+          words[assetIndex - 1].end,
+          words[assetIndex].start,
+        )
+      ) {
+        continue;
+      }
+    }
+
+    if (RECURRING_ASSETS.has(words[assetIndex].value)) {
+      return Number.parseInt(countWord.value, 10);
+    }
+  }
+
+  return undefined;
+}
+
+export function extractStyleNotes(content: string): string | undefined {
+  const words = collectWordSpans(content);
+
+  for (let index = 0; index < words.length - 2; index += 1) {
+    const preposition = words[index];
+    const article = words[index + 1];
+    if (
+      (preposition.value !== 'in' && preposition.value !== 'with') ||
+      (article.value !== 'a' && article.value !== 'an') ||
+      !containsOnlyWhitespace(content, preposition.end, article.start) ||
+      !containsOnlyWhitespace(content, article.end, words[index + 2].start)
+    ) {
+      continue;
+    }
+
+    const contentStart = article.end;
+    for (
+      let styleIndex = index + 2;
+      styleIndex < words.length;
+      styleIndex += 1
+    ) {
+      const styleWord = words[styleIndex];
+      if (styleWord.value !== 'style') {
+        continue;
+      }
+
+      let notesEnd = styleWord.start;
+      while (notesEnd > contentStart && isWhitespace(content[notesEnd - 1])) {
+        notesEnd -= 1;
+      }
+      if (notesEnd === styleWord.start) {
+        continue;
+      }
+
+      const notes = content.slice(contentStart, notesEnd).trim();
+      if (notes) {
+        return notes;
+      }
+    }
+
+    return undefined;
+  }
+
+  return undefined;
+}
+
+function startsWithTerminator(value: string, start: number): boolean {
+  return BATCH_TOPIC_TERMINATORS.some((terminator) => {
+    if (!value.startsWith(terminator, start)) {
+      return false;
+    }
+
+    const end = start + terminator.length;
+    return end >= value.length || !isAsciiWordCharacter(value[end]);
+  });
+}
+
+export function extractBatchTopic(
+  originalContent: string,
+  normalizedContent: string,
+): string | undefined {
+  const words = collectWordSpans(normalizedContent);
+
+  for (const word of words) {
+    if (word.value !== 'about' || word.end >= normalizedContent.length) {
+      continue;
+    }
+
+    let topicStart = word.end;
+    while (
+      topicStart < normalizedContent.length &&
+      isWhitespace(normalizedContent[topicStart])
+    ) {
+      topicStart += 1;
+    }
+
+    if (topicStart === word.end) {
+      continue;
+    }
+
+    let cursor = topicStart;
+    while (cursor < normalizedContent.length) {
+      const character = normalizedContent[cursor];
+      if (character === '.' || character === '!' || character === '?') {
+        break;
+      }
+
+      if (isWhitespace(character)) {
+        let nextWordStart = cursor;
+        while (
+          nextWordStart < normalizedContent.length &&
+          isWhitespace(normalizedContent[nextWordStart])
+        ) {
+          nextWordStart += 1;
+        }
+
+        if (startsWithTerminator(normalizedContent, nextWordStart)) {
+          break;
+        }
+
+        cursor = nextWordStart;
+        continue;
+      }
+
+      cursor += 1;
+    }
+
+    const topic = originalContent.slice(topicStart, cursor).trim();
+    if (topic) {
+      return topic;
+    }
+  }
+
+  return undefined;
+}

--- a/apps/server/api/src/services/integrations/ghost/services/ghost.service.ts
+++ b/apps/server/api/src/services/integrations/ghost/services/ghost.service.ts
@@ -1,4 +1,5 @@
 import { CredentialsService } from '@api/collections/credentials/services/credentials.service';
+import { trimTrailingCharacter } from '@api/shared/utils/string/linear-string.util';
 import { CredentialPlatform } from '@genfeedai/enums';
 import type {
   GhostImageUploadResponse,
@@ -227,7 +228,7 @@ export class GhostService {
    * Normalize a Ghost URL (strip trailing slashes, ensure https).
    */
   private normalizeUrl(ghostUrl: string): string {
-    let normalized = ghostUrl.replace(/\/+$/, '');
+    let normalized = trimTrailingCharacter(ghostUrl, '/');
 
     if (
       !normalized.startsWith('http://') &&

--- a/apps/server/api/src/services/integrations/mastodon/services/mastodon.service.spec.ts
+++ b/apps/server/api/src/services/integrations/mastodon/services/mastodon.service.spec.ts
@@ -119,6 +119,24 @@ describe('MastodonService', () => {
       );
     });
 
+    it('should remove every trailing slash from the instance URL', async () => {
+      const mockRegistration = {
+        client_id: 'client-id',
+        client_secret: 'client-secret',
+        id: 'app-id',
+        name: 'Genfeed.ai',
+        redirect_uri: 'https://callback',
+      };
+      httpService.post.mockReturnValue(of({ data: mockRegistration }) as never);
+
+      await service.registerApp(`${instanceUrl}///`, 'https://callback');
+
+      expect(httpService.post).toHaveBeenCalledWith(
+        `${instanceUrl}/api/v1/apps`,
+        expect.any(Object),
+      );
+    });
+
     it('should log error and rethrow on HTTP failure', async () => {
       httpService.post.mockReturnValue(
         throwError(() => new Error('Connection refused')) as never,
@@ -357,7 +375,7 @@ describe('MastodonService', () => {
 
     it('accepts redirect URIs under the configured app origin', () => {
       configService.get.mockImplementation((k: string) =>
-        k === 'GENFEEDAI_APP_URL' ? 'https://app.genfeed.ai' : `mock-${k}`,
+        k === 'GENFEEDAI_APP_URL' ? 'https://app.genfeed.ai///' : `mock-${k}`,
       );
 
       expect(() =>

--- a/apps/server/api/src/services/integrations/mastodon/services/mastodon.service.ts
+++ b/apps/server/api/src/services/integrations/mastodon/services/mastodon.service.ts
@@ -1,5 +1,6 @@
 import { CredentialsService } from '@api/collections/credentials/services/credentials.service';
 import { assertHostNotPrivate } from '@api/helpers/utils/ssrf/ssrf.util';
+import { trimTrailingCharacter } from '@api/shared/utils/string/linear-string.util';
 import { CredentialPlatform, OAuthGrantType } from '@genfeedai/enums';
 import { ConfigService } from '@libs/config/config.service';
 import { LoggerService } from '@libs/logger/logger.service';
@@ -74,9 +75,12 @@ export class MastodonService {
    * redirector / token-exfiltration helper.
    */
   private assertRedirectUriAllowed(redirectUri: string): void {
-    const appUrl = (
-      this.configService.get('GENFEEDAI_APP_URL') as string | undefined
-    )?.replace(/\/+$/, '');
+    const configuredAppUrl = this.configService.get('GENFEEDAI_APP_URL') as
+      | string
+      | undefined;
+    const appUrl = configuredAppUrl
+      ? trimTrailingCharacter(configuredAppUrl, '/')
+      : undefined;
 
     if (!appUrl) {
       this.loggerService.warn(
@@ -110,7 +114,7 @@ export class MastodonService {
       normalized = `https://${normalized}`;
     }
 
-    normalized = normalized.replace(/\/+$/, '');
+    normalized = trimTrailingCharacter(normalized, '/');
 
     // Parse and validate the hostname
     let parsedUrl: URL;

--- a/apps/server/api/src/services/integrations/unipile/services/unipile.service.spec.ts
+++ b/apps/server/api/src/services/integrations/unipile/services/unipile.service.spec.ts
@@ -68,7 +68,7 @@ describe('UnipileService', () => {
 
     const result = await service.configure('org_1', {
       allowedAccountIds: ['acct_1', 'acct_1', 'acct_2'],
-      apiBaseUrl: 'https://api1.unipile.com:13111',
+      apiBaseUrl: 'https://api1.unipile.com:13111///',
       apiKey: 'secret-key',
       defaultAccountId: 'acct_1',
     });

--- a/apps/server/api/src/services/integrations/unipile/services/unipile.service.ts
+++ b/apps/server/api/src/services/integrations/unipile/services/unipile.service.ts
@@ -15,6 +15,7 @@ import {
   type UnipileSendMessageInput,
 } from '@api/services/integrations/unipile/interfaces/unipile.interface';
 import { PrismaService } from '@api/shared/modules/prisma/prisma.service';
+import { trimTrailingCharacter } from '@api/shared/utils/string/linear-string.util';
 import { IntegrationStatus } from '@genfeedai/enums';
 import {
   getIntegrationProviderDefinition,
@@ -446,7 +447,7 @@ export class UnipileService {
   }
 
   private normalizeApiBaseUrl(value: string): string {
-    const trimmed = value.trim().replace(/\/+$/, '');
+    const trimmed = trimTrailingCharacter(value.trim(), '/');
     if (!trimmed) {
       throw new BadRequestException('Unipile API base URL is required');
     }

--- a/apps/server/api/src/shared/utils/string/linear-string.util.spec.ts
+++ b/apps/server/api/src/shared/utils/string/linear-string.util.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import {
+  replaceCharacterRuns,
+  trimCharacter,
+  trimTrailingCharacter,
+} from './linear-string.util';
+
+describe('linear string utilities', () => {
+  it('removes every matching trailing character', () => {
+    expect(trimTrailingCharacter('https://example.com///', '/')).toBe(
+      'https://example.com',
+    );
+    expect(trimTrailingCharacter('https://example.com', '/')).toBe(
+      'https://example.com',
+    );
+  });
+
+  it('removes matching characters from both edges', () => {
+    expect(trimCharacter('---hello---', '-')).toBe('hello');
+    expect(trimCharacter('hello', '-')).toBe('hello');
+  });
+
+  it('replaces each matching run once', () => {
+    expect(
+      replaceCharacterRuns(
+        'alpha---beta__gamma',
+        (character) => character === '-' || character === '_',
+        '.',
+      ),
+    ).toBe('alpha.beta.gamma');
+  });
+
+  it('handles long repeated input in a single pass', () => {
+    expect(trimTrailingCharacter(`value${'/'.repeat(50_000)}`, '/')).toBe(
+      'value',
+    );
+  });
+});

--- a/apps/server/api/src/shared/utils/string/linear-string.util.ts
+++ b/apps/server/api/src/shared/utils/string/linear-string.util.ts
@@ -1,0 +1,51 @@
+export function trimTrailingCharacter(
+  value: string,
+  character: string,
+): string {
+  let end = value.length;
+
+  while (end > 0 && value[end - 1] === character) {
+    end -= 1;
+  }
+
+  return end === value.length ? value : value.slice(0, end);
+}
+
+export function trimCharacter(value: string, character: string): string {
+  let start = 0;
+  let end = value.length;
+
+  while (start < end && value[start] === character) {
+    start += 1;
+  }
+
+  while (end > start && value[end - 1] === character) {
+    end -= 1;
+  }
+
+  return start === 0 && end === value.length ? value : value.slice(start, end);
+}
+
+export function replaceCharacterRuns(
+  value: string,
+  shouldReplace: (character: string) => boolean,
+  replacement: string,
+): string {
+  const result: string[] = [];
+  let replacing = false;
+
+  for (const character of value) {
+    if (shouldReplace(character)) {
+      if (!replacing) {
+        result.push(replacement);
+        replacing = true;
+      }
+      continue;
+    }
+
+    result.push(character);
+    replacing = false;
+  }
+
+  return result.join('');
+}

--- a/apps/server/api/src/shared/utils/string/strip-markup.util.spec.ts
+++ b/apps/server/api/src/shared/utils/string/strip-markup.util.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { replaceMarkup } from './strip-markup.util';
+
+describe('replaceMarkup', () => {
+  it('replaces complete tags while preserving text', () => {
+    expect(replaceMarkup('<p>Hello <strong>world</strong></p>', ' ')).toBe(
+      ' Hello  world  ',
+    );
+  });
+
+  it('preserves malformed fragments that have no closing angle bracket', () => {
+    expect(replaceMarkup('Hello <strong world', ' ')).toBe(
+      'Hello <strong world',
+    );
+  });
+
+  it('removes complete script and style blocks when requested', () => {
+    expect(
+      replaceMarkup(
+        '<p>Hello</p><script>alert(1)</script><style>p{color:red}</style>world',
+        '',
+        true,
+      ),
+    ).toBe('Helloworld');
+  });
+
+  it('preserves an unclosed blocked element body like the previous matcher', () => {
+    expect(replaceMarkup('<script>visible fallback', '', true)).toBe(
+      'visible fallback',
+    );
+  });
+
+  it('handles long malformed markup without repeated rescans', () => {
+    const input = '<'.repeat(50_000);
+    expect(replaceMarkup(input, ' ')).toBe(input);
+  });
+});

--- a/apps/server/api/src/shared/utils/string/strip-markup.util.ts
+++ b/apps/server/api/src/shared/utils/string/strip-markup.util.ts
@@ -1,0 +1,97 @@
+const BLOCK_ELEMENT_NAMES = ['script', 'style'] as const;
+
+function findTagEnd(value: string, start: number): number {
+  for (let index = start + 1; index < value.length; index += 1) {
+    if (value[index] === '>') {
+      return index;
+    }
+  }
+
+  return -1;
+}
+
+function getBlockElementName(
+  tagContent: string,
+): (typeof BLOCK_ELEMENT_NAMES)[number] | undefined {
+  const normalized = tagContent.toLowerCase();
+
+  return BLOCK_ELEMENT_NAMES.find((name) => normalized.startsWith(name));
+}
+
+function stripBlockedElements(value: string): string {
+  const output: string[] = [];
+  let blockName: (typeof BLOCK_ELEMENT_NAMES)[number] | undefined;
+  let blockStart = -1;
+  let copyStart = 0;
+  let cursor = 0;
+
+  while (cursor < value.length) {
+    const tagStart = value.indexOf('<', cursor);
+    if (tagStart < 0) {
+      break;
+    }
+
+    const tagEnd = findTagEnd(value, tagStart);
+    if (tagEnd < 0) {
+      break;
+    }
+
+    const tagContent = value.slice(tagStart + 1, tagEnd);
+
+    if (!blockName) {
+      const nextBlockName = getBlockElementName(tagContent);
+      if (nextBlockName) {
+        output.push(value.slice(copyStart, tagStart));
+        blockName = nextBlockName;
+        blockStart = tagStart;
+      }
+    } else if (tagContent.toLowerCase() === `/${blockName}`) {
+      blockName = undefined;
+      blockStart = -1;
+      copyStart = tagEnd + 1;
+    }
+
+    cursor = tagEnd + 1;
+  }
+
+  if (blockName && blockStart >= 0) {
+    output.push(value.slice(blockStart));
+  } else {
+    output.push(value.slice(copyStart));
+  }
+
+  return output.join('');
+}
+
+export function replaceMarkup(
+  value: string,
+  replacement: string,
+  removeBlockedElements = false,
+): string {
+  const input = removeBlockedElements ? stripBlockedElements(value) : value;
+  const output: string[] = [];
+  let copyStart = 0;
+  let cursor = 0;
+
+  while (cursor < input.length) {
+    const tagStart = input.indexOf('<', cursor);
+    if (tagStart < 0) {
+      break;
+    }
+
+    const tagEnd = findTagEnd(input, tagStart);
+    if (tagEnd < 0) {
+      break;
+    }
+
+    if (tagEnd > tagStart + 1) {
+      output.push(input.slice(copyStart, tagStart), replacement);
+      copyStart = tagEnd + 1;
+    }
+
+    cursor = tagEnd + 1;
+  }
+
+  output.push(input.slice(copyStart));
+  return output.join('');
+}

--- a/packages/agent/src/components/blocks/DynamicBlockGrid.tsx
+++ b/packages/agent/src/components/blocks/DynamicBlockGrid.tsx
@@ -3,6 +3,7 @@
 import CompositeLayout from '@genfeedai/agent/components/blocks/CompositeLayout';
 import DynamicChart from '@genfeedai/agent/components/blocks/DynamicChart';
 import DynamicTable from '@genfeedai/agent/components/blocks/DynamicTable';
+import { formatAnimatedValue } from '@genfeedai/agent/components/blocks/metric-value-format.util';
 import { SafeMarkdown } from '@genfeedai/agent/components/SafeMarkdown';
 import { ButtonVariant } from '@genfeedai/enums';
 import type {
@@ -109,14 +110,6 @@ function getAlertStyles(severity?: AlertBlock['severity']): {
         text: 'text-blue-400',
       };
   }
-}
-
-function formatAnimatedValue(value: number, template: string): string {
-  const suffixMatch = template.match(/([KMBT%]+)$/i);
-  const suffix = suffixMatch?.[1] ?? '';
-  const hasDecimals = /\.\d/.test(template);
-  const precision = hasDecimals ? 1 : 0;
-  return `${value.toFixed(precision)}${suffix}`;
 }
 
 function parseAnimatedValue(value: MetricCardBlock['value']): {

--- a/packages/agent/src/components/blocks/metric-value-format.util.spec.ts
+++ b/packages/agent/src/components/blocks/metric-value-format.util.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import {
+  extractMetricSuffix,
+  formatAnimatedValue,
+} from './metric-value-format.util';
+
+describe('metric value formatting', () => {
+  it.each([
+    ['42K', 'K'],
+    ['42mb', 'mb'],
+    ['42%', '%'],
+    ['42', ''],
+  ])('extracts the suffix from %s', (template, expected) => {
+    expect(extractMetricSuffix(template)).toBe(expected);
+  });
+
+  it('preserves suffix and decimal precision while animating', () => {
+    expect(formatAnimatedValue(12.34, '12.3K')).toBe('12.3K');
+    expect(formatAnimatedValue(12.34, '12%')).toBe('12%');
+  });
+
+  it('handles a long suffix in a single backwards scan', () => {
+    const suffix = '%'.repeat(50_000);
+    expect(extractMetricSuffix(`1${suffix}`)).toBe(suffix);
+  });
+});

--- a/packages/agent/src/components/blocks/metric-value-format.util.ts
+++ b/packages/agent/src/components/blocks/metric-value-format.util.ts
@@ -1,0 +1,30 @@
+function isMetricSuffixCharacter(character: string): boolean {
+  return (
+    character === '%' ||
+    character === 'K' ||
+    character === 'M' ||
+    character === 'B' ||
+    character === 'T' ||
+    character === 'k' ||
+    character === 'm' ||
+    character === 'b' ||
+    character === 't'
+  );
+}
+
+export function extractMetricSuffix(template: string): string {
+  let start = template.length;
+
+  while (start > 0 && isMetricSuffixCharacter(template[start - 1])) {
+    start -= 1;
+  }
+
+  return template.slice(start);
+}
+
+export function formatAnimatedValue(value: number, template: string): string {
+  const suffix = extractMetricSuffix(template);
+  const hasDecimals = /\.\d/.test(template);
+  const precision = hasDecimals ? 1 : 0;
+  return `${value.toFixed(precision)}${suffix}`;
+}

--- a/packages/api-types/__tests__/publish-webhook-events.contract.test.ts
+++ b/packages/api-types/__tests__/publish-webhook-events.contract.test.ts
@@ -167,6 +167,16 @@ describe('publish webhook helpers', () => {
     ).toBe('publish:target.published:release-123:target-123:published');
   });
 
+  test('normalizes long invalid event-id runs without ambiguous matching', () => {
+    expect(
+      createPublishWebhookEventId({
+        event: 'target.published',
+        releaseId: `---Release${' '.repeat(50_000)}123---`,
+        status: TargetExecutionState.PUBLISHED,
+      }),
+    ).toBe('publish:target.published:release-123:release:published');
+  });
+
   test.each([
     ['missing channel configuration', 'misconfiguration'],
     ['credential token expired', 'credential'],

--- a/packages/api-types/src/contracts/publish-webhook-events.contract.ts
+++ b/packages/api-types/src/contracts/publish-webhook-events.contract.ts
@@ -302,9 +302,36 @@ export function redactPublishWebhookText(value: string): string {
 }
 
 function normalizeEventIdSegment(value: string): string {
-  return value
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9._-]+/g, '-')
-    .replace(/^-+|-+$/g, '');
+  const input = value.trim().toLowerCase();
+  const result: string[] = [];
+  let replacing = false;
+
+  for (const character of input) {
+    const code = character.charCodeAt(0);
+    const isAllowed =
+      (code >= 48 && code <= 57) ||
+      (code >= 97 && code <= 122) ||
+      character === '.' ||
+      character === '_' ||
+      character === '-';
+
+    if (isAllowed) {
+      result.push(character);
+      replacing = false;
+    } else if (!replacing) {
+      result.push('-');
+      replacing = true;
+    }
+  }
+
+  let start = 0;
+  let end = result.length;
+  while (start < end && result[start] === '-') {
+    start += 1;
+  }
+  while (end > start && result[end - 1] === '-') {
+    end -= 1;
+  }
+
+  return result.slice(start, end).join('');
 }

--- a/packages/constants/src/lifecycle-emails.constant.test.ts
+++ b/packages/constants/src/lifecycle-emails.constant.test.ts
@@ -57,7 +57,7 @@ describe('lifecycle-emails.constant', () => {
     });
 
     expect(
-      buildLifecycleSystemEmailAction(checkout, 'https://app.genfeed.ai/'),
+      buildLifecycleSystemEmailAction(checkout, 'https://app.genfeed.ai///'),
     ).toEqual({
       label: 'Open Genfeed',
       url: 'https://app.genfeed.ai',

--- a/packages/constants/src/lifecycle-emails.constant.ts
+++ b/packages/constants/src/lifecycle-emails.constant.ts
@@ -254,5 +254,11 @@ export function buildLifecycleSystemEmailAction(
 }
 
 function stripTrailingSlash(value: string): string {
-  return value.replace(/\/+$/, '');
+  let end = value.length;
+
+  while (end > 0 && value[end - 1] === '/') {
+    end -= 1;
+  }
+
+  return end === value.length ? value : value.slice(0, end);
 }

--- a/packages/helpers/src/integrations/connect-genfeed.helper.test.ts
+++ b/packages/helpers/src/integrations/connect-genfeed.helper.test.ts
@@ -58,4 +58,15 @@ describe('buildConnectGenfeedInstructions', () => {
       buildConnectGenfeedInstructions('codex', 'file:///tmp/mcp'),
     ).toThrow('The MCP endpoint must use HTTP or HTTPS.');
   });
+
+  it('removes a long run of trailing slashes from a valid endpoint', () => {
+    const instructions = buildConnectGenfeedInstructions(
+      'codex',
+      `https://mcp.genfeed.ai/mcp${'/'.repeat(50_000)}`,
+    );
+
+    expect(instructions.primaryCommand).toContain(
+      'https://mcp.genfeed.ai/mcp --bearer-token-env-var',
+    );
+  });
 });

--- a/packages/helpers/src/integrations/connect-genfeed.helper.ts
+++ b/packages/helpers/src/integrations/connect-genfeed.helper.ts
@@ -12,7 +12,12 @@ function normalizeEndpoint(endpoint: string): string {
     throw new Error('The MCP endpoint must use HTTP or HTTPS.');
   }
 
-  return endpoint.replace(/\/+$/, '');
+  let end = endpoint.length;
+  while (end > 0 && endpoint[end - 1] === '/') {
+    end -= 1;
+  }
+
+  return end === endpoint.length ? endpoint : endpoint.slice(0, end);
 }
 
 export function buildConnectGenfeedInstructions(

--- a/packages/helpers/src/security/redact-sensitive-value.helper.test.ts
+++ b/packages/helpers/src/security/redact-sensitive-value.helper.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   REDACTED_VALUE,
+  redactSensitiveString,
   redactSensitiveValue,
 } from './redact-sensitive-value.helper';
 
@@ -39,5 +40,30 @@ describe('redactSensitiveValue', () => {
     expect(
       redactSensitiveValue({ attempts: 2, models: ['gpt-5', 'claude'] }),
     ).toEqual({ attempts: 2, models: ['gpt-5', 'claude'] });
+  });
+
+  it.each(['', 'RSA ', 'EC '])(
+    'redacts complete %sprivate key blocks',
+    (keyType) => {
+      const beginMarker = ['-----BEGIN ', keyType, 'PRIVATE KEY-----'].join('');
+      const endMarker = ['-----END ', keyType, 'PRIVATE KEY-----'].join('');
+      const value = [beginMarker, 'private-material', endMarker].join('\n');
+
+      expect(redactSensitiveString(`before ${value} after`)).toBe(
+        `before ${REDACTED_VALUE} after`,
+      );
+    },
+  );
+
+  it('preserves an incomplete private key marker like the previous matcher', () => {
+    const value = ['-----BEGIN ', 'PRIVATE KEY-----\ntruncated'].join('');
+    expect(redactSensitiveString(value)).toBe(value);
+  });
+
+  it('handles repeated unmatched begin markers without ambiguous matching', () => {
+    const marker = ['-----BEGIN ', 'PRIVATE KEY-----'].join('');
+    const value = marker.repeat(20_000);
+
+    expect(redactSensitiveString(value)).toBe(value);
   });
 });

--- a/packages/helpers/src/security/redact-sensitive-value.helper.test.ts
+++ b/packages/helpers/src/security/redact-sensitive-value.helper.test.ts
@@ -42,18 +42,19 @@ describe('redactSensitiveValue', () => {
     ).toEqual({ attempts: 2, models: ['gpt-5', 'claude'] });
   });
 
-  it.each(['', 'RSA ', 'EC '])(
-    'redacts complete %sprivate key blocks',
-    (keyType) => {
-      const beginMarker = ['-----BEGIN ', keyType, 'PRIVATE KEY-----'].join('');
-      const endMarker = ['-----END ', keyType, 'PRIVATE KEY-----'].join('');
-      const value = [beginMarker, 'private-material', endMarker].join('\n');
+  it.each([
+    '',
+    'RSA ',
+    'EC ',
+  ])('redacts complete %sprivate key blocks', (keyType) => {
+    const beginMarker = ['-----BEGIN ', keyType, 'PRIVATE KEY-----'].join('');
+    const endMarker = ['-----END ', keyType, 'PRIVATE KEY-----'].join('');
+    const value = [beginMarker, 'private-material', endMarker].join('\n');
 
-      expect(redactSensitiveString(`before ${value} after`)).toBe(
-        `before ${REDACTED_VALUE} after`,
-      );
-    },
-  );
+    expect(redactSensitiveString(`before ${value} after`)).toBe(
+      `before ${REDACTED_VALUE} after`,
+    );
+  });
 
   it('preserves an incomplete private key marker like the previous matcher', () => {
     const value = ['-----BEGIN ', 'PRIVATE KEY-----\ntruncated'].join('');

--- a/packages/helpers/src/security/redact-sensitive-value.helper.ts
+++ b/packages/helpers/src/security/redact-sensitive-value.helper.ts
@@ -11,16 +11,97 @@ const INLINE_SECRET_PATTERN =
   /\b((?:access[_-]?token|api[_-]?key|authorization|client[_-]?secret|id[_-]?token|password|private[_-]?key|refresh[_-]?token|secret|session|token)\s*[:=]\s*)["']?[^\s,&"'#]+/gi;
 const PROVIDER_TOKEN_PATTERN =
   /\b(?:sk-(?:proj-)?[A-Za-z0-9_-]{10,}|gh[pousr]_[A-Za-z0-9_]{10,})\b/g;
-const PRIVATE_KEY_BLOCK_PATTERN =
-  /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z ]*PRIVATE KEY-----/g;
+const PRIVATE_KEY_BEGIN_PREFIX = '-----BEGIN ';
+const PRIVATE_KEY_END_PREFIX = '-----END ';
+const PRIVATE_KEY_MARKER_SUFFIX = 'PRIVATE KEY-----';
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
+function findPrivateKeyMarkerEnd(
+  value: string,
+  start: number,
+  prefix: string,
+): number {
+  if (!value.startsWith(prefix, start)) {
+    return -1;
+  }
+
+  let cursor = start + prefix.length;
+  while (cursor < value.length) {
+    if (value.startsWith(PRIVATE_KEY_MARKER_SUFFIX, cursor)) {
+      return cursor + PRIVATE_KEY_MARKER_SUFFIX.length;
+    }
+
+    const code = value.charCodeAt(cursor);
+    const isUppercaseLetter = code >= 65 && code <= 90;
+    if (!isUppercaseLetter && value[cursor] !== ' ') {
+      return -1;
+    }
+
+    cursor += 1;
+  }
+
+  return -1;
+}
+
+function redactPrivateKeyBlocks(value: string): string {
+  const output: string[] = [];
+  let copyStart = 0;
+  let blockStart = -1;
+  let cursor = 0;
+
+  while (cursor < value.length) {
+    if (blockStart < 0) {
+      const candidate = value.indexOf(PRIVATE_KEY_BEGIN_PREFIX, cursor);
+      if (candidate < 0) {
+        break;
+      }
+
+      const markerEnd = findPrivateKeyMarkerEnd(
+        value,
+        candidate,
+        PRIVATE_KEY_BEGIN_PREFIX,
+      );
+      if (markerEnd < 0) {
+        cursor = candidate + 1;
+        continue;
+      }
+
+      output.push(value.slice(copyStart, candidate));
+      blockStart = candidate;
+      cursor = markerEnd;
+      continue;
+    }
+
+    const candidate = value.indexOf(PRIVATE_KEY_END_PREFIX, cursor);
+    if (candidate < 0) {
+      break;
+    }
+
+    const markerEnd = findPrivateKeyMarkerEnd(
+      value,
+      candidate,
+      PRIVATE_KEY_END_PREFIX,
+    );
+    if (markerEnd < 0) {
+      cursor = candidate + 1;
+      continue;
+    }
+
+    output.push(REDACTED_VALUE);
+    blockStart = -1;
+    copyStart = markerEnd;
+    cursor = markerEnd;
+  }
+
+  output.push(value.slice(blockStart >= 0 ? blockStart : copyStart));
+  return output.join('');
+}
+
 export function redactSensitiveString(value: string): string {
-  return value
-    .replace(PRIVATE_KEY_BLOCK_PATTERN, REDACTED_VALUE)
+  return redactPrivateKeyBlocks(value)
     .replace(AUTH_HEADER_PATTERN, (_match, scheme: string) => {
       return `${scheme} ${REDACTED_VALUE}`;
     })

--- a/packages/workflows/src/ui/stores/execution/executionApi.test.ts
+++ b/packages/workflows/src/ui/stores/execution/executionApi.test.ts
@@ -30,6 +30,14 @@ describe('executionApi', () => {
     it('uses a relative API boundary when no endpoint is configured', () => {
       expect(resolveExecutionApiBaseUrl(undefined)).toBe('/v1');
     });
+
+    it('removes a long run of trailing slashes without ambiguous matching', () => {
+      expect(
+        resolveExecutionApiBaseUrl(
+          `http://genfeed.localhost:3010/v1${'/'.repeat(50_000)}`,
+        ),
+      ).toBe('http://genfeed.localhost:3010/v1');
+    });
   });
 
   describe('execution headers', () => {

--- a/packages/workflows/src/ui/stores/execution/executionApi.ts
+++ b/packages/workflows/src/ui/stores/execution/executionApi.ts
@@ -22,7 +22,17 @@ import type {
  */
 
 export function resolveExecutionApiBaseUrl(value?: string): string {
-  const trimmed = value?.trim().replace(/\/+$/, '');
+  const normalized = value?.trim();
+  let end = normalized?.length ?? 0;
+
+  while (normalized && end > 0 && normalized[end - 1] === '/') {
+    end -= 1;
+  }
+
+  const trimmed =
+    normalized && end < normalized.length
+      ? normalized.slice(0, end)
+      : normalized;
   return trimmed || '/v1';
 }
 


### PR DESCRIPTION
## Summary

- reconciles the issue count against the latest master CodeQL SARIF: analysis `1504936169` at `ad631e53088c506d4b8e08e628ee805a7b9dfd27` contains **17** `js/polynomial-redos` results, and the alerts API returns the same 17; the issue text says 18, but there is no hidden or dismissed eighteenth alert
- classifies all 17 as reachable true positives and fixes all 17; **0 alerts are dismissed**
- replaces ambiguous regular expressions with deterministic string scans, token/span parsing, or explicit query parsing
- adds behavior-parity fixtures plus long repeated-input cases for every transformation family
- keeps open PR #2066 out of the file diff; there is no source-file overlap

## Alert triage

| Alert | Reachability evidence | Disposition |
| --- | --- | --- |
| #3 | external/user trend source URL reaches fallback normalization | fixed with earliest query/hash delimiter scan plus one trailing-slash check |
| #4 | admin warm-up request values become slugs and handles | fixed with an ASCII slug walker that collapses invalid runs and trims edges |
| #5 | HTTP sort query reaches `handleQuerySort` | fixed with explicit comma/colon parsing and documented `1`/`-1` validation |
| #6 | user chat drives recurring asset count extraction | fixed with word-span parsing |
| #7 | user chat drives style-note extraction | fixed with word-span and whitespace-boundary parsing |
| #8 | user chat drives batch topic extraction | fixed with a delimiter scanner |
| #9 | stored/request Ghost integration URL reaches request construction | fixed with deterministic trailing-slash trimming |
| #10 | request-supplied Mastodon instance URL reaches OAuth requests | fixed with deterministic trailing-slash trimming |
| #11 | organization/provider or environment Unipile base URL reaches HTTP requests | fixed with deterministic trailing-slash trimming |
| #12 | metric block/library and model data reaches animated suffix formatting | fixed with a backwards suffix scan |
| #13 | application/config URL reaches lifecycle email actions | fixed with deterministic trailing-slash trimming |
| #446 | webhook/provider data reaches event-id normalization | fixed with an allowed-character walker and edge trimming |
| #524 | model/user post content reaches label extraction | fixed with a linear markup-to-text pass |
| #525 | request body reaches social-inbox body sanitization | fixed with linear block/tag removal for the plain-text sink |
| #526 | library caller endpoint reaches generated MCP instructions | fixed with deterministic trailing-slash trimming |
| #527 | arbitrary error/log values reach sensitive-value redaction | fixed with a marker-based private-key block scanner |
| #528 | injected UI/config API URL reaches workflow requests | fixed with deterministic trailing-slash trimming |

No case is build-time-only or sufficiently trusted to justify dismissal. No CodeQL suppression or masking annotation is added.

## Approach

Two implementation families were compared:

1. Bound the current regular expressions or wrap them with timeouts.
   Rejected: a timeout still burns the event-loop CPU, and broad input caps would change message/content behavior.
2. Parse the limited grammars directly.
   Selected: deterministic scans are linear, make delimiter ownership explicit, and preserve the documented outputs without new runtime dependencies.

Shared API helpers cover character-run normalization and plain-text markup removal. Package-boundary cases keep small local scans to avoid dependency cycles.

## Verification

- pre-commit staged Biome check: passed
- pre-commit Secretlint: passed
- UI control guard: passed
- bespoke-card guard: passed
- `git diff --check`: passed
- local tests, typechecks, and builds: intentionally not run under the MacBook Pro machine policy; PR CI is the execution gate
- planning record: Claude planner `fable` and fallback planner `opus` both returned structured `Not logged in` failures, so the implementer fallback plan was used and `planning_degraded` recorded
- exact-current-head Claude verifier: required after CI and before merge

Closes #2069