### PR TITLE
fix(security): contain filesystem and S3 paths

### DIFF
--- a/.agents/memory/MEMORY.md
+++ b/.agents/memory/MEMORY.md
@@ -2,6 +2,8 @@
 
 ## Project State
 
+- [Filesystem and S3 Path Containment Spec](spec-filesystem-s3-path-containment.md) — shared fixed-root and fixed-prefix containment contract for #2068
+- [Filesystem and S3 Path Containment Decisions](decisions-filesystem-s3-path-containment.md) — canonical helper placement, S3 semantics, and adapter-boundary decisions for #2068
 - [Scheduler Target Analytics Summary Spec](spec-scheduler-target-analytics.md) — typed latest-snapshot scheduler target read model for #1975
 - [Scheduler Target Analytics Decisions](decisions-scheduler-target-analytics.md) — batch hydration and response-shape tradeoffs for #1975
 - [Pull-request Validation Telemetry Spec](spec-pr-validation-telemetry.md) — exact-head, read-only validation evidence contract for issue #1966

--- a/.agents/memory/decisions-filesystem-s3-path-containment.md
+++ b/.agents/memory/decisions-filesystem-s3-path-containment.md
@@ -1,0 +1,58 @@
+---
+name: Filesystem and S3 path containment decisions
+description: Canonical helper placement, S3 semantics, and adapter-boundary decisions for issue #2068
+type: project
+---
+
+# Filesystem and S3 Path Containment Decisions
+
+## Decision: canonicalize the pure helper in `@genfeedai/storage`
+
+Move the framework-agnostic containment primitives into
+`packages/storage/src/path-containment.ts` and re-export them through
+`@libs/security`.
+
+**Why:** `packages/libs` already depends on `@genfeedai/storage`, so this removes
+the `LocalStorageProvider` copy without a dependency cycle or a new workspace.
+Existing `@libs/security` imports remain stable.
+
+**How to apply:** Keep the helper limited to `node:path` and injected error
+factories. Never import NestJS into `packages/storage`.
+
+## Decision: validate S3 keys with POSIX segment semantics
+
+Construct keys beneath a fixed prefix and reject absolute, backslash, NUL,
+empty, `.` and `..` segments instead of normalizing them.
+
+**Why:** S3 keys are literal identifiers. Normalizing a valid key can silently
+address a different object, while bare `startsWith(prefix)` permits prefix
+confusion such as `ingredients-evil`.
+
+**How to apply:** Preserve legitimate nested candidates byte-for-byte and join
+them to a normalized fixed prefix with exactly one `/`.
+
+## Decision: contain at trust boundaries, not by inventing one adapter root
+
+Files jobs/controllers contain local paths under `public/tmp`; image and voice
+services use their configured dataset/model roots. Generic storage adapters do
+not acquire a fake global root.
+
+**Why:** Shared adapters legitimately serve multiple roots. A fabricated root
+would break valid dataset and model flows without adding security if callers
+can still pass arbitrary paths.
+
+**How to apply:** Validate before the generic adapter call. If CodeQL retains an
+adapter-level dataflow alert after all upstream boundaries are guarded, document
+the complete guarded call chain before dismissing it.
+
+## Decision: preserve exception and cleanup behavior
+
+Nest boundaries inject `BadRequestException`; framework-agnostic providers
+inject `Error`. Best-effort cleanup validates each path independently, logs an
+invalid or failed deletion, and continues with sibling paths.
+
+**Why:** This matches #2064 and prevents one malicious or stale cleanup entry
+from aborting unrelated cleanup work.
+
+**How to apply:** Run containment before existence checks. Update fixtures that
+previously staged paths outside their owning root.

--- a/.agents/memory/spec-filesystem-s3-path-containment.md
+++ b/.agents/memory/spec-filesystem-s3-path-containment.md
@@ -1,0 +1,78 @@
+---
+name: Filesystem and S3 path containment
+description: Shared fixed-root and fixed-prefix containment contract for issue #2068
+type: project
+---
+
+# Filesystem and S3 Path Containment
+
+## Purpose
+
+Eliminate user-influenced filesystem traversal and S3 key traversal across the
+files, images, voices, shared S3, and storage layers. Every trust boundary
+resolves a candidate under a fixed filesystem root or constructs a key under a
+fixed S3 prefix before any read, write, delete, existence check, or SDK call.
+
+**Why:** `path.join` and `path.resolve` normalize `..` segments rather than
+rejecting them. S3 keys have analogous prefix-confusion and traversal hazards
+when callers or downstream tooling normalize keys.
+
+**How to apply:** Use the canonical framework-agnostic helpers exported by
+`@genfeedai/storage`. NestJS consumers inject `BadRequestException`; storage
+providers inject plain `Error` and remain framework-independent.
+
+## Interfaces
+
+- `resolveContainedPath(rootDir, candidatePath, createError)` returns an
+  absolute path that is equal to or below the resolved root.
+- `resolveContainedObjectKey(prefix, candidateKey, createError)` returns a
+  relative POSIX S3 key below the normalized prefix.
+- `assertObjectKeyWithinPrefix(prefix, key, createError)` validates an existing
+  key without rewriting it.
+- `assertSafeSegment(value, name, createError)` validates one path/key segment.
+
+S3 key helpers reject empty input, absolute candidates, backslashes, NUL,
+empty/`.`/`..` segments, and prefix confusion. Legitimate nested keys remain
+unchanged.
+
+## Fixed boundaries
+
+- Image datasets: `DATASETS_PATH`.
+- Voice datasets: `DATASETS_PATH/voices`.
+- Files service temporary artifacts: `process.cwd()/public/tmp`.
+- LoRA and voice model uploads: their configured model roots.
+- Generated S3 keys: the owning `ingredients/...` or feature prefix.
+
+Generic storage adapters may accept caller-selected paths internally, but every
+request/job boundary feeding them must first establish a fixed root.
+
+## Non-goals
+
+- Restricting internal storage adapters to one global local directory.
+- Adding NestJS dependencies to `packages/storage`.
+- Rewriting valid S3 key bytes through filesystem normalization.
+- Changing deployment, bucket, or retention policy.
+
+## Acceptance criteria
+
+- THE SYSTEM SHALL use one canonical containment implementation in every listed
+  area and SHALL NOT retain a local duplicate.
+- WHEN a candidate escapes its fixed filesystem root, THE SYSTEM SHALL reject
+  it before any filesystem probe or mutation.
+- WHEN a candidate S3 key escapes or confuses its fixed prefix, THE SYSTEM
+  SHALL reject it before any SDK call.
+- WHEN a NestJS boundary rejects a path or key, THE SYSTEM SHALL throw
+  `BadRequestException`.
+- WHEN a framework-agnostic storage provider rejects a path or key, THE SYSTEM
+  SHALL throw an injected plain `Error`.
+- WHEN a legitimate nested path or key remains under its root or prefix, THE
+  SYSTEM SHALL preserve and accept it.
+- THE PR SHALL leave no unexplained open `js/path-injection` alert in scope.
+
+## Test plan
+
+Add or extend focused specs for the shared helpers, both storage providers,
+shared/files S3 services, files temp-path services, and image/voice dataset
+services. Each area covers at least one traversal rejection and one legitimate
+nested path/key. Runtime tests, typechecks, builds, and CodeQL run in GitHub CI
+because the implementation machine is the MacBook Pro.

--- a/apps/server/files/src/constants/path.constants.ts
+++ b/apps/server/files/src/constants/path.constants.ts
@@ -1,0 +1,4 @@
+import path from 'node:path';
+
+/** Canonical root for files-service scratch artifacts. */
+export const FILES_TMP_ROOT = path.resolve(process.cwd(), 'public', 'tmp');

--- a/apps/server/files/src/services/ffmpeg/services/ffmpeg-beat-sync.service.spec.ts
+++ b/apps/server/files/src/services/ffmpeg/services/ffmpeg-beat-sync.service.spec.ts
@@ -35,15 +35,20 @@ vi.mock('node:fs', () => ({
   },
 }));
 
-vi.mock('node:path', () => ({
-  default: {
-    extname: (p: string) => {
-      const parts = p.split('.');
-      return parts.length > 1 ? `.${parts[parts.length - 1]}` : '';
+vi.mock('node:path', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:path')>();
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      extname: (p: string) => {
+        const parts = p.split('.');
+        return parts.length > 1 ? `.${parts[parts.length - 1]}` : '';
+      },
+      join: (...args: string[]) => args.join('/'),
     },
-    join: (...args: string[]) => args.join('/'),
-  },
-}));
+  };
+});
 
 import { promises as fs } from 'node:fs';
 

--- a/apps/server/files/src/services/ffmpeg/services/ffmpeg-core.service.spec.ts
+++ b/apps/server/files/src/services/ffmpeg/services/ffmpeg-core.service.spec.ts
@@ -1,6 +1,8 @@
+import { FILES_TMP_ROOT } from '@files/constants/path.constants';
 import { BinaryValidationService } from '@files/services/ffmpeg/config/binary-validation.service';
 import { FFmpegCoreService } from '@files/services/ffmpeg/services/ffmpeg-core.service';
 import { LoggerService } from '@libs/logger/logger.service';
+import { BadRequestException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 
 vi.mock('node:child_process', () => ({
@@ -148,18 +150,34 @@ describe('FFmpegCoreService', () => {
       const result = service.getTempPath('image');
       expect(typeof result).toBe('string');
     });
+
+    it.each(['../video', 'nested/video', '/absolute'])(
+      'rejects traversal-shaped type %s',
+      (type) => {
+        expect(() => service.getTempPath(type)).toThrow(BadRequestException);
+      },
+    );
+
+    it('accepts a legitimate nested temp directory under the fixed root', () => {
+      expect(service.getTempPath('audio', 'ingredient-123')).toBe(
+        path.join(FILES_TMP_ROOT, 'audio', 'ingredient-123'),
+      );
+    });
   });
 
   describe('cleanupTempFiles', () => {
     it('calls unlink for each existing file', async () => {
       (existsSync as ReturnType<typeof vi.fn>).mockReturnValue(true);
-      await service.cleanupTempFiles('/tmp/a.mp4', '/tmp/b.mp4');
+      await service.cleanupTempFiles(
+        path.join(FILES_TMP_ROOT, 'a.mp4'),
+        path.join(FILES_TMP_ROOT, 'nested', 'b.mp4'),
+      );
       expect(fsp.unlink).toHaveBeenCalledTimes(2);
     });
 
     it('skips unlink when file does not exist', async () => {
       (existsSync as ReturnType<typeof vi.fn>).mockReturnValue(false);
-      await service.cleanupTempFiles('/tmp/missing.mp4');
+      await service.cleanupTempFiles(path.join(FILES_TMP_ROOT, 'missing.mp4'));
       expect(fsp.unlink).not.toHaveBeenCalled();
     });
 
@@ -168,7 +186,22 @@ describe('FFmpegCoreService', () => {
       (fsp.unlink as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
         new Error('EPERM'),
       );
-      await service.cleanupTempFiles('/tmp/locked.mp4');
+      await service.cleanupTempFiles(path.join(FILES_TMP_ROOT, 'locked.mp4'));
+      expect(logger.error).toHaveBeenCalled();
+    });
+
+    it('skips a traversal attempt and continues with an in-root sibling', async () => {
+      (existsSync as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+      await service.cleanupTempFiles(
+        path.join(FILES_TMP_ROOT, '..', 'escaped.mp4'),
+        path.join(FILES_TMP_ROOT, 'safe.mp4'),
+      );
+
+      expect(fsp.unlink).toHaveBeenCalledOnce();
+      expect(fsp.unlink).toHaveBeenCalledWith(
+        path.join(FILES_TMP_ROOT, 'safe.mp4'),
+      );
       expect(logger.error).toHaveBeenCalled();
     });
   });

--- a/apps/server/files/src/services/ffmpeg/services/ffmpeg-core.service.spec.ts
+++ b/apps/server/files/src/services/ffmpeg/services/ffmpeg-core.service.spec.ts
@@ -151,12 +151,13 @@ describe('FFmpegCoreService', () => {
       expect(typeof result).toBe('string');
     });
 
-    it.each(['../video', 'nested/video', '/absolute'])(
-      'rejects traversal-shaped type %s',
-      (type) => {
-        expect(() => service.getTempPath(type)).toThrow(BadRequestException);
-      },
-    );
+    it.each([
+      '../video',
+      'nested/video',
+      '/absolute',
+    ])('rejects traversal-shaped type %s', (type) => {
+      expect(() => service.getTempPath(type)).toThrow(BadRequestException);
+    });
 
     it('accepts a legitimate nested temp directory under the fixed root', () => {
       expect(service.getTempPath('audio', 'ingredient-123')).toBe(

--- a/apps/server/files/src/services/ffmpeg/services/ffmpeg-core.service.ts
+++ b/apps/server/files/src/services/ffmpeg/services/ffmpeg-core.service.ts
@@ -1,6 +1,7 @@
 import { ChildProcess, spawn } from 'node:child_process';
 import { existsSync, promises as fs, mkdirSync } from 'node:fs';
 import path from 'node:path';
+import { FILES_TMP_ROOT } from '@files/constants/path.constants';
 import { SecurityUtil } from '@files/helpers/utils/security/security.util';
 import { BinaryValidationService } from '@files/services/ffmpeg/config/binary-validation.service';
 import {
@@ -8,8 +9,11 @@ import {
   FFprobeData,
 } from '@files/shared/interfaces/ffmpeg.interfaces';
 import { LoggerService } from '@libs/logger/logger.service';
+import { assertSafeSegment, resolveContainedPath } from '@libs/security';
 import { getErrorMessage } from '@libs/utils/error/get-error-message.util';
-import { Injectable, OnModuleInit } from '@nestjs/common';
+import { BadRequestException, Injectable, OnModuleInit } from '@nestjs/common';
+
+const createBadRequest = (message: string) => new BadRequestException(message);
 
 /**
  * Core FFmpeg execution service.
@@ -185,14 +189,18 @@ export class FFmpegCoreService implements OnModuleInit {
    * Get temporary file path
    */
   getTempPath(type: string, ingredientId?: string): string {
-    const basePath = path.join(process.cwd(), 'public', 'tmp');
-    let tmpDir: string;
-
-    if (ingredientId) {
-      tmpDir = path.join(basePath, type, ingredientId);
-    } else {
-      tmpDir = path.join(basePath, type);
-    }
+    const safeType = assertSafeSegment(type, 'type', createBadRequest);
+    const candidate = ingredientId
+      ? path.join(
+          safeType,
+          assertSafeSegment(ingredientId, 'ingredientId', createBadRequest),
+        )
+      : safeType;
+    const tmpDir = resolveContainedPath(
+      FILES_TMP_ROOT,
+      candidate,
+      createBadRequest,
+    );
 
     if (!existsSync(tmpDir)) {
       mkdirSync(tmpDir, { recursive: true });
@@ -206,9 +214,14 @@ export class FFmpegCoreService implements OnModuleInit {
   async cleanupTempFiles(...filePaths: string[]): Promise<void> {
     for (const filePath of filePaths) {
       try {
-        if (existsSync(filePath)) {
-          await fs.unlink(filePath);
-          this.loggerService.log(`Cleaned up temp file: ${filePath}`);
+        const containedPath = resolveContainedPath(
+          FILES_TMP_ROOT,
+          filePath,
+          createBadRequest,
+        );
+        if (existsSync(containedPath)) {
+          await fs.unlink(containedPath);
+          this.loggerService.log(`Cleaned up temp file: ${containedPath}`);
         }
       } catch (error: unknown) {
         this.loggerService.error(`Failed to clean up ${filePath}`, error);

--- a/apps/server/files/src/services/hook-remix/hook-remix.service.spec.ts
+++ b/apps/server/files/src/services/hook-remix/hook-remix.service.spec.ts
@@ -1,8 +1,11 @@
+import path from 'node:path';
+import { FILES_TMP_ROOT } from '@files/constants/path.constants';
 import { FFmpegService } from '@files/services/ffmpeg/services/ffmpeg.service';
 import { HookRemixService } from '@files/services/hook-remix/hook-remix.service';
 import { UploadService } from '@files/services/upload/upload.service';
 import { YtDlpService } from '@files/services/ytdlp/ytdlp.service';
 import { LoggerService } from '@libs/logger/logger.service';
+import { BadRequestException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 
 vi.mock('node:fs', () => ({
@@ -109,7 +112,34 @@ describe('HookRemixService', () => {
       await service.processHookRemix(baseJobData);
       expect(ytDlpService.downloadVideo).toHaveBeenCalledWith(
         baseJobData.youtubeUrl,
-        expect.stringContaining('source.mp4'),
+        path.join(
+          FILES_TMP_ROOT,
+          'hook-remix',
+          baseJobData.jobId,
+          'source.mp4',
+        ),
+      );
+    });
+
+    it('rejects a traversal job ID before touching the filesystem', async () => {
+      await expect(
+        service.processHookRemix({ ...baseJobData, jobId: '../escape' }),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(ytDlpService.downloadVideo).not.toHaveBeenCalled();
+    });
+
+    it('accepts a legitimate job ID under the fixed nested root', async () => {
+      await service.processHookRemix(baseJobData);
+
+      expect(ytDlpService.downloadVideo).toHaveBeenCalledWith(
+        baseJobData.youtubeUrl,
+        path.join(
+          FILES_TMP_ROOT,
+          'hook-remix',
+          baseJobData.jobId,
+          'source.mp4',
+        ),
       );
     });
 

--- a/apps/server/files/src/services/hook-remix/hook-remix.service.ts
+++ b/apps/server/files/src/services/hook-remix/hook-remix.service.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs';
 import path from 'node:path';
+import { FILES_TMP_ROOT } from '@files/constants/path.constants';
 import { FFmpegService } from '@files/services/ffmpeg/services/ffmpeg.service';
 import type {
   HookRemixJobData,
@@ -8,7 +9,14 @@ import type {
 import { UploadService } from '@files/services/upload/upload.service';
 import { YtDlpService } from '@files/services/ytdlp/ytdlp.service';
 import { LoggerService } from '@libs/logger/logger.service';
-import { Injectable } from '@nestjs/common';
+import {
+  assertSafeSegment,
+  resolveContainedObjectKey,
+  resolveContainedPath,
+} from '@libs/security';
+import { BadRequestException, Injectable } from '@nestjs/common';
+
+const createBadRequest = (message: string) => new BadRequestException(message);
 
 @Injectable()
 export class HookRemixService {
@@ -20,7 +28,17 @@ export class HookRemixService {
   ) {}
 
   async processHookRemix(data: HookRemixJobData): Promise<HookRemixResult> {
-    const tempDir = path.resolve('public', 'tmp', 'hook-remix', data.jobId);
+    const jobId = assertSafeSegment(data.jobId, 'jobId', createBadRequest);
+    const organizationId = assertSafeSegment(
+      data.organizationId,
+      'organizationId',
+      createBadRequest,
+    );
+    const tempDir = resolveContainedPath(
+      path.join(FILES_TMP_ROOT, 'hook-remix'),
+      jobId,
+      createBadRequest,
+    );
     if (!fs.existsSync(tempDir)) {
       fs.mkdirSync(tempDir, { recursive: true });
     }
@@ -58,7 +76,11 @@ export class HookRemixService {
       );
 
       // Step 5: Upload to S3
-      const s3Key = `${data.organizationId}/hook-remix/${data.jobId}.mp4`;
+      const s3Key = resolveContainedObjectKey(
+        `${organizationId}/hook-remix`,
+        `${jobId}.mp4`,
+        createBadRequest,
+      );
       this.logger.log(`[HookRemix] Uploading to S3: ${s3Key}`);
       const uploadResult = await this.uploadService.uploadToS3(
         s3Key,

--- a/apps/server/files/src/services/s3/s3.service.spec.ts
+++ b/apps/server/files/src/services/s3/s3.service.spec.ts
@@ -1,6 +1,7 @@
 import { ConfigService } from '@files/config/config.service';
 import { S3Service } from '@files/services/s3/s3.service';
 import { LoggerService } from '@libs/logger/logger.service';
+import { BadRequestException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 
 // Mock AWS SDK
@@ -29,6 +30,7 @@ describe('S3Service', () => {
         AWS_REGION: 'us-west-1',
         AWS_S3_BUCKET: 'test-bucket',
         AWS_SECRET_ACCESS_KEY: 'test-secret-key',
+        GENFEEDAI_CDN_URL: 'https://cdn.example.com',
       };
       return config[key];
     }),
@@ -73,5 +75,31 @@ describe('S3Service', () => {
     expect(configService.get).toHaveBeenCalledWith('AWS_REGION');
     expect(configService.get).toHaveBeenCalledWith('AWS_ACCESS_KEY_ID');
     expect(configService.get).toHaveBeenCalledWith('AWS_SECRET_ACCESS_KEY');
+  });
+
+  it('builds a legitimate nested key under the ingredients prefix', () => {
+    expect(
+      service.generateS3Key('images', 'organizations/org-1/nested/photo.png'),
+    ).toBe('ingredients/images/organizations/org-1/nested/photo.png');
+  });
+
+  it.each([
+    ['../images', 'photo.png'],
+    ['images', '../../escaped.png'],
+    ['images', '/absolute.png'],
+  ])('rejects key traversal in %s/%s', (type, id) => {
+    expect(() => service.generateS3Key(type, id)).toThrow(BadRequestException);
+  });
+
+  it('rejects an out-of-root local download path before contacting S3', async () => {
+    await expect(
+      service.downloadFile('images/photo.png', '/etc/escaped.png'),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('accepts a legitimate nested object key for public URLs', () => {
+    expect(service.getPublicUrl('images/nested/photo.png')).toBe(
+      'https://cdn.example.com/images/nested/photo.png',
+    );
   });
 });

--- a/apps/server/files/src/services/s3/s3.service.ts
+++ b/apps/server/files/src/services/s3/s3.service.ts
@@ -11,8 +11,14 @@ import {
 import { Upload } from '@aws-sdk/lib-storage';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { ConfigService } from '@files/config/config.service';
+import { FILES_TMP_ROOT } from '@files/constants/path.constants';
+import {
+  assertSafeObjectKey,
+  resolveContainedObjectKey,
+  resolveContainedPath,
+} from '@libs/security';
 import { getErrorMessage } from '@libs/utils/error/get-error-message.util';
-import { Injectable, Logger } from '@nestjs/common';
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
 
 /** Minimal shape covering AWS SDK S3 errors */
 interface S3Error extends Error {
@@ -20,6 +26,8 @@ interface S3Error extends Error {
   $metadata?: { httpStatusCode?: number };
   statusCode?: number;
 }
+
+const createBadRequest = (message: string) => new BadRequestException(message);
 
 @Injectable()
 export class S3Service {
@@ -46,7 +54,13 @@ export class S3Service {
     filePath: string,
     contentType?: string,
   ): Promise<{ Location: string; ETag: string; Key: string }> {
-    const fileStream = fs.createReadStream(filePath);
+    const safeKey = assertSafeObjectKey(key, createBadRequest);
+    const containedFilePath = resolveContainedPath(
+      FILES_TMP_ROOT,
+      filePath,
+      createBadRequest,
+    );
+    const fileStream = fs.createReadStream(containedFilePath);
 
     try {
       const upload = new Upload({
@@ -55,20 +69,20 @@ export class S3Service {
           Body: fileStream,
           Bucket: this.bucket,
           ContentType: contentType || 'video/mp4',
-          Key: key,
+          Key: safeKey,
         },
       });
 
       const result = await upload.done();
-      const location = this.getPublicUrl(key);
+      const location = this.getPublicUrl(safeKey);
       this.logger.log(`File uploaded successfully to ${location}`, {
         bucket: this.bucket,
         contentType: contentType || 'video/mp4',
-        key,
+        key: safeKey,
       });
       return {
         ETag: result.ETag || '',
-        Key: key,
+        Key: safeKey,
         Location: location,
       };
     } catch (error: unknown) {
@@ -84,6 +98,7 @@ export class S3Service {
     buffer: Buffer,
     contentType?: string,
   ): Promise<{ Location: string; ETag: string; Key: string }> {
+    const safeKey = assertSafeObjectKey(key, createBadRequest);
     const startTime = Date.now();
     const bufferSizeMB = (buffer.length / (1024 * 1024)).toFixed(2);
 
@@ -92,7 +107,7 @@ export class S3Service {
       bufferSize: `${bufferSizeMB} MB`,
       bufferSizeBytes: buffer.length,
       contentType: contentType || 'application/octet-stream',
-      key,
+      key: safeKey,
     });
 
     try {
@@ -101,14 +116,14 @@ export class S3Service {
         Bucket: this.bucket,
         ContentLength: buffer.length,
         ContentType: contentType || 'application/octet-stream',
-        Key: key,
+        Key: safeKey,
       });
 
       const s3StartTime = Date.now();
       const result = await this.s3Client.send(command);
       const s3Duration = Date.now() - s3StartTime;
 
-      const location = this.getPublicUrl(key);
+      const location = this.getPublicUrl(safeKey);
       const totalDuration = Date.now() - startTime;
 
       this.logger.log(`Buffer uploaded successfully to S3`, {
@@ -116,7 +131,7 @@ export class S3Service {
         bufferSizeBytes: buffer.length,
         contentType: contentType || 'application/octet-stream',
         etag: result.ETag,
-        key,
+        key: safeKey,
         location,
         s3UploadDuration: `${s3Duration}ms`,
         totalDuration: `${totalDuration}ms`,
@@ -125,7 +140,7 @@ export class S3Service {
 
       return {
         ETag: result.ETag || '',
-        Key: key,
+        Key: safeKey,
         Location: location,
       };
     } catch (error: unknown) {
@@ -146,15 +161,21 @@ export class S3Service {
   }
 
   async downloadFile(key: string, localPath: string): Promise<void> {
+    const safeKey = assertSafeObjectKey(key, createBadRequest);
+    const containedLocalPath = resolveContainedPath(
+      FILES_TMP_ROOT,
+      localPath,
+      createBadRequest,
+    );
     try {
       const command = new GetObjectCommand({
         Bucket: this.bucket,
-        Key: key,
+        Key: safeKey,
       });
       const response = await this.s3Client.send(command);
 
       // Ensure directory exists
-      const dir = path.dirname(localPath);
+      const dir = path.dirname(containedLocalPath);
       if (!fs.existsSync(dir)) {
         fs.mkdirSync(dir, { recursive: true });
       }
@@ -167,8 +188,8 @@ export class S3Service {
       }
       const buffer = Buffer.concat(chunks);
 
-      fs.writeFileSync(localPath, buffer);
-      this.logger.log(`File downloaded successfully to ${localPath}`);
+      fs.writeFileSync(containedLocalPath, buffer);
+      this.logger.log(`File downloaded successfully to ${containedLocalPath}`);
     } catch (error: unknown) {
       this.logger.error(
         `Failed to download file from S3: ${getErrorMessage(error)}`,
@@ -178,6 +199,11 @@ export class S3Service {
   }
 
   async downloadFromUrl(url: string, localPath: string): Promise<void> {
+    const containedLocalPath = resolveContainedPath(
+      FILES_TMP_ROOT,
+      localPath,
+      createBadRequest,
+    );
     try {
       const response = await fetch(url);
       if (!response.ok) {
@@ -206,13 +232,13 @@ export class S3Service {
       const buffer = Buffer.from(await response.arrayBuffer());
 
       // Ensure directory exists
-      const dir = path.dirname(localPath);
+      const dir = path.dirname(containedLocalPath);
       if (!fs.existsSync(dir)) {
         fs.mkdirSync(dir, { recursive: true });
       }
 
-      fs.writeFileSync(localPath, buffer);
-      this.logger.log(`File downloaded from URL to ${localPath}`);
+      fs.writeFileSync(containedLocalPath, buffer);
+      this.logger.log(`File downloaded from URL to ${containedLocalPath}`);
     } catch (error: unknown) {
       this.logger.error('Failed to download file from URL', {
         error: getErrorMessage(error) || 'Unknown error',
@@ -224,13 +250,14 @@ export class S3Service {
   }
 
   async deleteFile(key: string): Promise<void> {
+    const safeKey = assertSafeObjectKey(key, createBadRequest);
     try {
       const command = new DeleteObjectCommand({
         Bucket: this.bucket,
-        Key: key,
+        Key: safeKey,
       });
       await this.s3Client.send(command);
-      this.logger.log(`File deleted successfully: ${key}`);
+      this.logger.log(`File deleted successfully: ${safeKey}`);
     } catch (error: unknown) {
       this.logger.error(
         `Failed to delete file from S3: ${getErrorMessage(error)}`,
@@ -244,20 +271,21 @@ export class S3Service {
     contentType: string = 'application/octet-stream',
     expiresIn: number = 3600,
   ): Promise<{ uploadUrl: string; publicUrl: string }> {
+    const safeKey = assertSafeObjectKey(key, createBadRequest);
     try {
       const command = new PutObjectCommand({
         Bucket: this.bucket,
         ContentType: contentType,
-        Key: key,
+        Key: safeKey,
       });
 
       const uploadUrl = await getSignedUrl(this.s3Client, command, {
         expiresIn,
       });
 
-      const publicUrl = this.getPublicUrl(key);
+      const publicUrl = this.getPublicUrl(safeKey);
 
-      this.logger.log(`Generated presigned upload URL for ${key}`);
+      this.logger.log(`Generated presigned upload URL for ${safeKey}`);
       return { publicUrl, uploadUrl };
     } catch (error: unknown) {
       this.logger.error(
@@ -271,17 +299,18 @@ export class S3Service {
     key: string,
     expiresIn: number = 3600,
   ): Promise<string> {
+    const safeKey = assertSafeObjectKey(key, createBadRequest);
     try {
       const command = new GetObjectCommand({
         Bucket: this.bucket,
-        Key: key,
+        Key: safeKey,
       });
 
       const downloadUrl = await getSignedUrl(this.s3Client, command, {
         expiresIn,
       });
 
-      this.logger.log(`Generated presigned download URL for ${key}`);
+      this.logger.log(`Generated presigned download URL for ${safeKey}`);
       return downloadUrl;
     } catch (error: unknown) {
       this.logger.error(
@@ -292,20 +321,29 @@ export class S3Service {
   }
 
   generateS3Key(type: string, id: string): string {
-    return `ingredients/${type}/${id}`;
+    return resolveContainedObjectKey(
+      'ingredients',
+      `${type}/${id}`,
+      createBadRequest,
+    );
   }
 
   async copyFile(sourceKey: string, destinationKey: string): Promise<void> {
+    const safeSourceKey = assertSafeObjectKey(sourceKey, createBadRequest);
+    const safeDestinationKey = assertSafeObjectKey(
+      destinationKey,
+      createBadRequest,
+    );
     try {
       const command = new CopyObjectCommand({
         Bucket: this.bucket,
-        CopySource: `${this.bucket}/${sourceKey}`,
-        Key: destinationKey,
+        CopySource: `${this.bucket}/${safeSourceKey}`,
+        Key: safeDestinationKey,
       });
 
       await this.s3Client.send(command);
       this.logger.log(
-        `File copied successfully from ${sourceKey} to ${destinationKey}`,
+        `File copied successfully from ${safeSourceKey} to ${safeDestinationKey}`,
       );
     } catch (error: unknown) {
       const s3Err = error as S3Error;
@@ -327,10 +365,11 @@ export class S3Service {
   }
 
   async getFileStream(key: string): Promise<Readable> {
+    const safeKey = assertSafeObjectKey(key, createBadRequest);
     try {
       const command = new GetObjectCommand({
         Bucket: this.bucket,
-        Key: key,
+        Key: safeKey,
       });
 
       const response = await this.s3Client.send(command);
@@ -344,6 +383,7 @@ export class S3Service {
   }
 
   getPublicUrl(key: string): string {
-    return `${this.configService.get('GENFEEDAI_CDN_URL')}/${key}`;
+    const safeKey = assertSafeObjectKey(key, createBadRequest);
+    return `${this.configService.get('GENFEEDAI_CDN_URL')}/${safeKey}`;
   }
 }

--- a/apps/server/files/src/services/thumbnails/video-thumbnail.service.spec.ts
+++ b/apps/server/files/src/services/thumbnails/video-thumbnail.service.spec.ts
@@ -2,6 +2,7 @@ import { FFmpegService } from '@files/services/ffmpeg/services/ffmpeg.service';
 import { S3Service } from '@files/services/s3/s3.service';
 import { VideoThumbnailService } from '@files/services/thumbnails/video-thumbnail.service';
 import { LoggerService } from '@libs/logger/logger.service';
+import { BadRequestException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import type { Mocked } from 'vitest';
 
@@ -87,6 +88,17 @@ describe('VideoThumbnailService', () => {
       expect(thumbnailUrl).toContain('thumbnails/test-id.jpg');
     });
 
+    it('rejects a traversal ingredient ID before requesting a temp path', async () => {
+      await expect(
+        service.generateThumbnail(
+          'https://example.com/video.mp4',
+          '../escaped',
+        ),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(ffmpegService.getTempPath).not.toHaveBeenCalled();
+    });
+
     it('should use custom timeInSeconds', async () => {
       const videoUrl = 'https://example.com/video.mp4';
       const ingredientId = 'test-id';
@@ -94,10 +106,27 @@ describe('VideoThumbnailService', () => {
 
       await service.generateThumbnail(videoUrl, ingredientId, timeInSeconds);
 
+      expect(ffmpegService.getTempPath).toHaveBeenCalledWith(
+        'thumbnail',
+        ingredientId,
+      );
       expect(ffmpegService.extractFrame).toHaveBeenCalledWith(
         expect.any(String),
         expect.any(String),
         timeInSeconds,
+      );
+    });
+
+    it('cleans the three contained temp files after success', async () => {
+      await service.generateThumbnail(
+        'https://example.com/video.mp4',
+        'test-id',
+      );
+
+      expect(ffmpegService.cleanupTempFiles).toHaveBeenCalledWith(
+        expect.stringContaining('input.mp4'),
+        expect.stringContaining('thumbnail.jpg'),
+        expect.stringContaining('thumbnail_resized.jpg'),
       );
     });
 

--- a/apps/server/files/src/services/thumbnails/video-thumbnail.service.ts
+++ b/apps/server/files/src/services/thumbnails/video-thumbnail.service.ts
@@ -1,11 +1,13 @@
 import * as fs from 'node:fs';
-import path from 'node:path';
 import { FFmpegService } from '@files/services/ffmpeg/services/ffmpeg.service';
 import { S3Service } from '@files/services/s3/s3.service';
 import { LoggerService } from '@libs/logger/logger.service';
+import { assertSafeSegment, resolveContainedPath } from '@libs/security';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import sharp from 'sharp';
+
+const createBadRequest = (message: string) => new BadRequestException(message);
 
 @Injectable()
 export class VideoThumbnailService {
@@ -31,6 +33,11 @@ export class VideoThumbnailService {
     timeInSeconds: number = 1,
     width: number = 720,
   ): Promise<string> {
+    const safeIngredientId = assertSafeSegment(
+      ingredientId,
+      'ingredientId',
+      createBadRequest,
+    );
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
     const thumbnailStartTime = Date.now();
 
@@ -44,11 +51,19 @@ export class VideoThumbnailService {
     try {
       const tempPath = this.ffmpegService.getTempPath(
         'thumbnail',
-        ingredientId,
+        safeIngredientId,
       );
 
-      const videoPath = path.join(tempPath, 'input.mp4');
-      const thumbnailPath = path.join(tempPath, 'thumbnail.jpg');
+      const videoPath = resolveContainedPath(
+        tempPath,
+        'input.mp4',
+        createBadRequest,
+      );
+      const thumbnailPath = resolveContainedPath(
+        tempPath,
+        'thumbnail.jpg',
+        createBadRequest,
+      );
 
       // Ensure temp directory exists
       if (!fs.existsSync(tempPath)) {
@@ -101,7 +116,11 @@ export class VideoThumbnailService {
 
       const thumbnailSizeKB = (resizedThumbnailBuffer.length / 1024).toFixed(2);
 
-      const resizedThumbnailPath = path.join(tempPath, 'thumbnail_resized.jpg');
+      const resizedThumbnailPath = resolveContainedPath(
+        tempPath,
+        'thumbnail_resized.jpg',
+        createBadRequest,
+      );
       fs.writeFileSync(resizedThumbnailPath, resizedThumbnailBuffer);
 
       this.loggerService.log(`${url} thumbnail resized`, {
@@ -112,7 +131,10 @@ export class VideoThumbnailService {
       });
 
       // Upload thumbnail to S3
-      const s3Key = this.s3Service.generateS3Key('thumbnails', ingredientId);
+      const s3Key = this.s3Service.generateS3Key(
+        'thumbnails',
+        safeIngredientId,
+      );
       const uploadStartTime = Date.now();
 
       await this.s3Service.uploadFile(
@@ -126,7 +148,11 @@ export class VideoThumbnailService {
       const totalDuration = Date.now() - thumbnailStartTime;
 
       // Cleanup temp files
-      this.ffmpegService.cleanupTempFiles(ingredientId, 'thumbnail');
+      this.ffmpegService.cleanupTempFiles(
+        videoPath,
+        thumbnailPath,
+        resizedThumbnailPath,
+      );
 
       this.loggerService.log(`${url} succeeded`, {
         downloadDuration: `${downloadDuration}ms`,

--- a/apps/server/files/src/services/upload/upload.service.spec.ts
+++ b/apps/server/files/src/services/upload/upload.service.spec.ts
@@ -206,8 +206,9 @@ describe('UploadService', () => {
     });
 
     it('should upload MP4 video file with metadata', async () => {
+      const videoPath = path.join(FILES_TMP_ROOT, 'fixtures', 'video.mp4');
       const result = await service.uploadToS3('test-key', 'videos', {
-        path: path.join(FILES_TMP_ROOT, 'fixtures', 'video.mp4'),
+        path: videoPath,
         type: 'file',
       });
 
@@ -215,7 +216,9 @@ describe('UploadService', () => {
       expect(result.height).toBe(1080);
       expect(result.duration).toBe(60);
       expect(result.hasAudio).toBe(true);
-      expect(mockFfmpegService.getVideoMetadata).toHaveBeenCalled();
+      expect(mockFfmpegService.getVideoMetadata).toHaveBeenCalledWith(
+        videoPath,
+      );
     });
 
     it('should handle video without audio stream', async () => {

--- a/apps/server/files/src/services/upload/upload.service.spec.ts
+++ b/apps/server/files/src/services/upload/upload.service.spec.ts
@@ -1,11 +1,14 @@
+import path from 'node:path';
 import { ConfigService } from '@files/config/config.service';
+import { FILES_TMP_ROOT } from '@files/constants/path.constants';
 import { FFmpegService } from '@files/services/ffmpeg/services/ffmpeg.service';
-import { S3Service } from '@files/services/s3/s3.service';
 import { UploadService } from '@files/services/upload/upload.service';
+import type { StorageProvider } from '@genfeedai/storage';
 import { LoggerService } from '@libs/logger/logger.service';
 import { HttpService } from '@nestjs/axios';
 import { HttpException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
+import type { AxiosResponse } from 'axios';
 import { of, throwError } from 'rxjs';
 import type { Mock, Mocked } from 'vitest';
 
@@ -34,14 +37,23 @@ vi.mock('fs', () => ({
 import * as fs from 'node:fs';
 import sharp from 'sharp';
 
+type MockSharpInstance = {
+  jpeg: Mock;
+  metadata: Mock;
+  png: Mock;
+  rotate: Mock;
+  toBuffer: Mock;
+  webp: Mock;
+};
+
 describe('UploadService', () => {
   let service: UploadService;
   let mockConfigService: Mocked<ConfigService>;
   let mockFfmpegService: Mocked<FFmpegService>;
   let mockHttpService: Mocked<HttpService>;
   let mockLogger: Mocked<LoggerService>;
-  let mockS3Service: Mocked<S3Service>;
-  let mockSharpInstance: any;
+  let mockStorage: Mocked<StorageProvider>;
+  let mockSharpInstance: MockSharpInstance;
 
   beforeEach(async () => {
     mockConfigService = {
@@ -69,11 +81,10 @@ describe('UploadService', () => {
       warn: vi.fn(),
     } as unknown as Mocked<LoggerService>;
 
-    mockS3Service = {
-      generateS3Key: vi.fn().mockReturnValue('ingredients/images/test-key'),
-      getPublicUrl: vi.fn().mockReturnValue('https://s3.example.com/test-key'),
-      uploadBuffer: vi.fn().mockResolvedValue(undefined),
-    } as unknown as Mocked<S3Service>;
+    mockStorage = {
+      getUrl: vi.fn().mockReturnValue('https://s3.example.com/test-key'),
+      upload: vi.fn().mockResolvedValue('ingredients/images/test-key'),
+    } as unknown as Mocked<StorageProvider>;
 
     // Reset sharp mock
     mockSharpInstance = {
@@ -97,7 +108,7 @@ describe('UploadService', () => {
         { provide: FFmpegService, useValue: mockFfmpegService },
         { provide: HttpService, useValue: mockHttpService },
         { provide: LoggerService, useValue: mockLogger },
-        { provide: S3Service, useValue: mockS3Service },
+        { provide: 'STORAGE_PROVIDER', useValue: mockStorage },
       ],
     }).compile();
 
@@ -116,21 +127,66 @@ describe('UploadService', () => {
   });
 
   describe('uploadToS3 - file source', () => {
+    it('rejects a file source outside the files temp root before reading it', async () => {
+      await expect(
+        service.uploadToS3('test-key', 'images', {
+          path: '/etc/passwd.jpg',
+          type: 'file',
+        }),
+      ).rejects.toThrow(HttpException);
+
+      expect(fs.readFileSync).not.toHaveBeenCalled();
+      expect(mockStorage.upload).not.toHaveBeenCalled();
+    });
+
     it('should upload JPEG file with image dimensions', async () => {
       const result = await service.uploadToS3('test-key', 'images', {
-        path: '/path/to/image.jpg',
+        path: path.join(FILES_TMP_ROOT, 'fixtures', 'image.jpg'),
         type: 'file',
       });
 
       expect(result.width).toBe(1920);
       expect(result.height).toBe(1080);
       expect(result.publicUrl).toBe('https://s3.example.com/test-key');
-      expect(mockS3Service.uploadBuffer).toHaveBeenCalled();
+      expect(mockStorage.upload).toHaveBeenCalled();
+    });
+
+    it('accepts a legitimate nested file source under the files temp root', async () => {
+      const nestedPath = path.join(
+        FILES_TMP_ROOT,
+        'nested',
+        'uploads',
+        'image.jpg',
+      );
+
+      await service.uploadToS3('nested/image', 'images', {
+        path: nestedPath,
+        type: 'file',
+      });
+
+      expect(fs.readFileSync).toHaveBeenCalledWith(nestedPath);
+      expect(mockStorage.upload).toHaveBeenCalledWith(
+        expect.any(Buffer),
+        'ingredients/images/nested/image',
+        'image/jpeg',
+      );
+    });
+
+    it('rejects an object key that escapes the ingredients prefix', async () => {
+      await expect(
+        service.uploadToS3('../../escaped', 'images', {
+          contentType: 'image/jpeg',
+          data: Buffer.from('image'),
+          type: 'buffer',
+        }),
+      ).rejects.toThrow(HttpException);
+
+      expect(mockStorage.upload).not.toHaveBeenCalled();
     });
 
     it('should upload PNG file', async () => {
       await service.uploadToS3('test-key', 'images', {
-        path: '/path/to/image.png',
+        path: path.join(FILES_TMP_ROOT, 'fixtures', 'image.png'),
         type: 'file',
       });
 
@@ -142,7 +198,7 @@ describe('UploadService', () => {
 
     it('should upload WebP file', async () => {
       await service.uploadToS3('test-key', 'images', {
-        path: '/path/to/image.webp',
+        path: path.join(FILES_TMP_ROOT, 'fixtures', 'image.webp'),
         type: 'file',
       });
 
@@ -151,7 +207,7 @@ describe('UploadService', () => {
 
     it('should upload MP4 video file with metadata', async () => {
       const result = await service.uploadToS3('test-key', 'videos', {
-        path: '/path/to/video.mp4',
+        path: path.join(FILES_TMP_ROOT, 'fixtures', 'video.mp4'),
         type: 'file',
       });
 
@@ -169,7 +225,7 @@ describe('UploadService', () => {
       });
 
       const result = await service.uploadToS3('test-key', 'videos', {
-        path: '/path/to/video.mp4',
+        path: path.join(FILES_TMP_ROOT, 'fixtures', 'video.mp4'),
         type: 'file',
       });
 
@@ -178,7 +234,7 @@ describe('UploadService', () => {
 
     it('should upload ZIP file without image processing', async () => {
       const result = await service.uploadToS3('test-key', 'archives', {
-        path: '/path/to/archive.zip',
+        path: path.join(FILES_TMP_ROOT, 'fixtures', 'archive.zip'),
         type: 'file',
       });
 
@@ -188,11 +244,11 @@ describe('UploadService', () => {
 
     it('should handle unknown file types as octet-stream', async () => {
       await service.uploadToS3('test-key', 'files', {
-        path: '/path/to/file.unknown',
+        path: path.join(FILES_TMP_ROOT, 'fixtures', 'file.unknown'),
         type: 'file',
       });
 
-      expect(mockS3Service.uploadBuffer).toHaveBeenCalled();
+      expect(mockStorage.upload).toHaveBeenCalled();
     });
   });
 
@@ -202,7 +258,7 @@ describe('UploadService', () => {
         of({
           data: Buffer.from('downloaded-content'),
           headers: { 'content-type': 'image/jpeg' },
-        } as any),
+        } as unknown as AxiosResponse<ArrayBuffer>),
       );
 
       const result = await service.uploadToS3('test-key', 'images', {
@@ -269,7 +325,7 @@ describe('UploadService', () => {
         of({
           data: Buffer.from('video-content'),
           headers: {},
-        } as any),
+        } as unknown as AxiosResponse<ArrayBuffer>),
       );
 
       // Need to setup tmp dir mock
@@ -289,7 +345,7 @@ describe('UploadService', () => {
         of({
           data: Buffer.from('zip-content'),
           headers: {},
-        } as any),
+        } as unknown as AxiosResponse<ArrayBuffer>),
       );
 
       const result = await service.uploadToS3('test-key', 'archives', {
@@ -325,7 +381,7 @@ describe('UploadService', () => {
         type: 'base64',
       });
 
-      expect(mockS3Service.uploadBuffer).toHaveBeenCalled();
+      expect(mockStorage.upload).toHaveBeenCalled();
     });
 
     it('should handle base64 video and extract metadata', async () => {
@@ -386,17 +442,17 @@ describe('UploadService', () => {
     it('should throw error for invalid source type', async () => {
       await expect(
         service.uploadToS3('test-key', 'files', {
-          type: 'invalid' as any,
+          type: 'invalid' as never,
         }),
       ).rejects.toThrow('Invalid upload source type');
     });
 
     it('should log error details on failure', async () => {
-      mockS3Service.uploadBuffer.mockRejectedValue(new Error('S3 error'));
+      mockStorage.upload.mockRejectedValue(new Error('S3 error'));
 
       await expect(
         service.uploadToS3('test-key', 'images', {
-          path: '/path/to/image.jpg',
+          path: path.join(FILES_TMP_ROOT, 'fixtures', 'image.jpg'),
           type: 'file',
         }),
       ).rejects.toThrow('S3 error');
@@ -414,7 +470,7 @@ describe('UploadService', () => {
   describe('uploadToS3 - image processing', () => {
     it('should auto-rotate images based on EXIF', async () => {
       await service.uploadToS3('test-key', 'images', {
-        path: '/path/to/image.jpg',
+        path: path.join(FILES_TMP_ROOT, 'fixtures', 'image.jpg'),
         type: 'file',
       });
 
@@ -425,7 +481,7 @@ describe('UploadService', () => {
       mockConfigService.get.mockReturnValue('85');
 
       await service.uploadToS3('test-key', 'images', {
-        path: '/path/to/image.jpg',
+        path: path.join(FILES_TMP_ROOT, 'fixtures', 'image.jpg'),
         type: 'file',
       });
 
@@ -436,7 +492,7 @@ describe('UploadService', () => {
       mockConfigService.get.mockReturnValue(undefined);
 
       await service.uploadToS3('test-key', 'images', {
-        path: '/path/to/image.jpg',
+        path: path.join(FILES_TMP_ROOT, 'fixtures', 'image.jpg'),
         type: 'file',
       });
 
@@ -447,7 +503,7 @@ describe('UploadService', () => {
   describe('uploadToS3 - logging', () => {
     it('should log upload start', async () => {
       await service.uploadToS3('test-key', 'images', {
-        path: '/path/to/image.jpg',
+        path: path.join(FILES_TMP_ROOT, 'fixtures', 'image.jpg'),
         type: 'file',
       });
 
@@ -463,7 +519,7 @@ describe('UploadService', () => {
 
     it('should log upload completion with metrics', async () => {
       await service.uploadToS3('test-key', 'images', {
-        path: '/path/to/image.jpg',
+        path: path.join(FILES_TMP_ROOT, 'fixtures', 'image.jpg'),
         type: 'file',
       });
 
@@ -480,7 +536,7 @@ describe('UploadService', () => {
   describe('uploadToS3 - return values', () => {
     it('should return complete metadata for images', async () => {
       const result = await service.uploadToS3('test-key', 'images', {
-        path: '/path/to/image.jpg',
+        path: path.join(FILES_TMP_ROOT, 'fixtures', 'image.jpg'),
         type: 'file',
       });
 
@@ -496,7 +552,7 @@ describe('UploadService', () => {
 
     it('should return complete metadata for videos', async () => {
       const result = await service.uploadToS3('test-key', 'videos', {
-        path: '/path/to/video.mp4',
+        path: path.join(FILES_TMP_ROOT, 'fixtures', 'video.mp4'),
         type: 'file',
       });
 

--- a/apps/server/files/src/services/upload/upload.service.ts
+++ b/apps/server/files/src/services/upload/upload.service.ts
@@ -1,12 +1,23 @@
 import * as fs from 'node:fs';
 import path from 'node:path';
 import { ConfigService } from '@files/config/config.service';
+import { FILES_TMP_ROOT } from '@files/constants/path.constants';
 import { FFmpegService } from '@files/services/ffmpeg/services/ffmpeg.service';
 import type { StorageProvider } from '@genfeedai/storage';
 import { LoggerService } from '@libs/logger/logger.service';
+import {
+  resolveContainedObjectKey,
+  resolveContainedPath,
+} from '@libs/security';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
 import { HttpService } from '@nestjs/axios';
-import { HttpException, HttpStatus, Inject, Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  HttpException,
+  HttpStatus,
+  Inject,
+  Injectable,
+} from '@nestjs/common';
 import type { AxiosResponse } from 'axios';
 import { firstValueFrom } from 'rxjs';
 import sharp from 'sharp';
@@ -16,6 +27,8 @@ type UploadSource =
   | { type: 'url'; url: string }
   | { type: 'base64'; data: string; contentType: string }
   | { type: 'buffer'; data: Buffer; contentType: string };
+
+const createBadRequest = (message: string) => new BadRequestException(message);
 
 @Injectable()
 export class UploadService {
@@ -59,12 +72,15 @@ export class UploadService {
     duration: number;
     hasAudio: boolean;
   }> {
-    const tmpDir = path.resolve('public', 'tmp');
-    // Ensure tmp directory exists
+    const tmpPath = resolveContainedPath(
+      FILES_TMP_ROOT,
+      `${key}.mp4`,
+      createBadRequest,
+    );
+    const tmpDir = path.dirname(tmpPath);
     if (!fs.existsSync(tmpDir)) {
       fs.mkdirSync(tmpDir, { recursive: true });
     }
-    const tmpPath = path.resolve(tmpDir, `${key}.mp4`);
     try {
       fs.writeFileSync(tmpPath, buffer);
       return await this.getVideoDimensions(tmpPath);
@@ -120,7 +136,11 @@ export class UploadService {
       const prepareStartTime = Date.now();
       switch (source.type) {
         case 'file':
-          filePath = source.path;
+          filePath = resolveContainedPath(
+            FILES_TMP_ROOT,
+            source.path,
+            createBadRequest,
+          );
           contentType = 'application/octet-stream';
 
           if (filePath.match(/\.mp4$/i)) {
@@ -335,7 +355,11 @@ export class UploadService {
       }
 
       // Generate storage path: ingredients/${type}/${key}
-      const storagePath = `ingredients/${type}/${key}`;
+      const storagePath = resolveContainedObjectKey(
+        'ingredients',
+        `${type}/${key}`,
+        createBadRequest,
+      );
 
       // Upload using storage provider (returns a storage path/key)
       const s3UploadStartTime = Date.now();

--- a/apps/server/files/src/services/upload/upload.service.ts
+++ b/apps/server/files/src/services/upload/upload.service.ts
@@ -18,7 +18,6 @@ import {
   Inject,
   Injectable,
 } from '@nestjs/common';
-import type { AxiosResponse } from 'axios';
 import { firstValueFrom } from 'rxjs';
 import sharp from 'sharp';
 
@@ -27,6 +26,22 @@ type UploadSource =
   | { type: 'url'; url: string }
   | { type: 'base64'; data: string; contentType: string }
   | { type: 'buffer'; data: Buffer; contentType: string };
+
+type FileUploadSource = Extract<UploadSource, { type: 'file' }>;
+type UrlUploadSource = Extract<UploadSource, { type: 'url' }>;
+
+type PreparedUpload = {
+  body: Buffer;
+  contentType: string;
+  width?: number;
+  height?: number;
+  duration?: number;
+  hasAudio: boolean;
+};
+
+type ProcessedUpload = PreparedUpload & {
+  imageProcessingDuration: number;
+};
 
 const createBadRequest = (message: string) => new BadRequestException(message);
 
@@ -100,6 +115,238 @@ export class UploadService {
     return { height: metadata.height || 0, width: metadata.width || 0 };
   }
 
+  private async prepareFileUpload(
+    source: FileUploadSource,
+  ): Promise<PreparedUpload> {
+    const filePath = resolveContainedPath(
+      FILES_TMP_ROOT,
+      source.path,
+      createBadRequest,
+    );
+    let contentType = 'application/octet-stream';
+    let width: number | undefined;
+    let height: number | undefined;
+    let duration: number | undefined;
+    let hasAudio = false;
+    let body: Buffer;
+
+    if (filePath.match(/\.mp4$/i)) {
+      contentType = 'video/mp4';
+      const metadata = await this.getVideoDimensions(filePath);
+      ({ width, height, duration, hasAudio } = metadata);
+      body = fs.readFileSync(filePath);
+    } else if (filePath.match(/\.zip$/i)) {
+      contentType = 'application/zip';
+      body = fs.readFileSync(filePath);
+    } else if (filePath.match(/\.jpe?g$/i)) {
+      contentType = 'image/jpeg';
+      body = fs.readFileSync(filePath);
+      ({ width, height } = await this.getImageDimensions(body));
+    } else if (filePath.match(/\.png$/i)) {
+      contentType = 'image/png';
+      body = fs.readFileSync(filePath);
+      ({ width, height } = await this.getImageDimensions(body));
+    } else if (filePath.match(/\.webp$/i)) {
+      contentType = 'image/webp';
+      body = fs.readFileSync(filePath);
+      ({ width, height } = await this.getImageDimensions(body));
+    } else {
+      body = fs.readFileSync(filePath);
+    }
+
+    return { body, contentType, duration, hasAudio, height, width };
+  }
+
+  private async downloadRemoteUpload(
+    remoteUrl: string,
+    key: string,
+    url: string,
+  ): Promise<Pick<PreparedUpload, 'body' | 'contentType'>> {
+    this.loggerService.log(`${url} downloading remote file`, {
+      key,
+      url: remoteUrl,
+    });
+
+    try {
+      const downloadStartTime = Date.now();
+      const response = await firstValueFrom(
+        this.httpService.get(remoteUrl, {
+          maxBodyLength: 200 * 1024 * 1024,
+          maxContentLength: 200 * 1024 * 1024,
+          responseType: 'arraybuffer',
+          timeout: 60000,
+        }),
+      );
+      const body = Buffer.from(response.data);
+      const rawContentType = response.headers['content-type'];
+      const contentType = this.resolveContentType(
+        typeof rawContentType === 'string' ? rawContentType : undefined,
+        remoteUrl,
+      );
+
+      this.loggerService.log(`${url} remote download completed`, {
+        bufferSize: `${(body.length / (1024 * 1024)).toFixed(2)} MB`,
+        contentType,
+        downloadDuration: `${Date.now() - downloadStartTime}ms`,
+        key,
+        url: remoteUrl,
+      });
+
+      return { body, contentType };
+    } catch (error: unknown) {
+      const parsedError = error as {
+        code?: string;
+        message?: string;
+        response?: { status?: number };
+      };
+      this.loggerService.error(
+        'Failed to download file directly from URL',
+        parsedError,
+      );
+
+      if (parsedError?.code === 'ERR_FR_MAX_BODY_LENGTH_EXCEEDED') {
+        throw new HttpException(
+          'File size exceeds 200MB limit',
+          HttpStatus.PAYLOAD_TOO_LARGE,
+        );
+      }
+
+      throw new HttpException(
+        `Failed to download file from URL: ${parsedError?.message || 'Unknown error'}`,
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+  }
+
+  private async prepareUrlUpload(
+    source: UrlUploadSource,
+    key: string,
+    url: string,
+  ): Promise<PreparedUpload> {
+    const remoteUrl = source.url;
+    if (!remoteUrl || typeof remoteUrl !== 'string') {
+      throw new HttpException(
+        'URL is required and must be a string',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+    try {
+      new URL(remoteUrl);
+    } catch (error: unknown) {
+      throw new HttpException(
+        `Invalid URL: ${remoteUrl}`,
+        HttpStatus.BAD_REQUEST,
+        { cause: (error as Error)?.message || 'Invalid URL' },
+      );
+    }
+
+    const prepared = await this.downloadRemoteUpload(remoteUrl, key, url);
+    let { contentType } = prepared;
+    let width: number | undefined;
+    let height: number | undefined;
+    let duration: number | undefined;
+    let hasAudio = false;
+
+    if (contentType.startsWith('video/')) {
+      const metadata = await this.getVideoDimensionsFromBuffer(
+        prepared.body,
+        key,
+      );
+      ({ width, height, duration, hasAudio } = metadata);
+    } else if (contentType.startsWith('image/')) {
+      ({ width, height } = await this.getImageDimensions(prepared.body));
+    } else if (remoteUrl.match(/\.zip$/i)) {
+      contentType = 'application/zip';
+    }
+
+    return { ...prepared, contentType, duration, hasAudio, height, width };
+  }
+
+  private async prepareBinaryUpload(
+    body: Buffer,
+    contentType: string,
+    key: string,
+  ): Promise<PreparedUpload> {
+    let width: number | undefined;
+    let height: number | undefined;
+    let duration: number | undefined;
+    let hasAudio = false;
+
+    if (contentType.startsWith('video/')) {
+      const metadata = await this.getVideoDimensionsFromBuffer(body, key);
+      ({ width, height, duration, hasAudio } = metadata);
+      contentType = 'video/mp4';
+    } else if (contentType.startsWith('image/')) {
+      ({ width, height } = await this.getImageDimensions(body));
+    }
+
+    return { body, contentType, duration, hasAudio, height, width };
+  }
+
+  private async prepareUpload(
+    source: UploadSource,
+    key: string,
+    url: string,
+  ): Promise<PreparedUpload> {
+    switch (source.type) {
+      case 'file':
+        return this.prepareFileUpload(source);
+      case 'url':
+        return this.prepareUrlUpload(source, key, url);
+      case 'base64':
+        return this.prepareBinaryUpload(
+          Buffer.from(source.data.replace(/^data:[^;]+;base64,/, ''), 'base64'),
+          source.contentType,
+          key,
+        );
+      case 'buffer':
+        return this.prepareBinaryUpload(source.data, source.contentType, key);
+      default:
+        throw new Error('Invalid upload source type');
+    }
+  }
+
+  private async processImage(
+    prepared: PreparedUpload,
+    key: string,
+    url: string,
+  ): Promise<ProcessedUpload> {
+    if (!prepared.contentType.startsWith('image/')) {
+      return { ...prepared, imageProcessingDuration: 0 };
+    }
+
+    const imageProcessingStart = Date.now();
+    const originalSizeBytes = prepared.body.length;
+    const quality = Number(
+      this.configService.get('AWS_IMAGE_COMPRESSION') || '90',
+    );
+    const processor = sharp(prepared.body).rotate();
+    let body: Buffer;
+    let contentType: string;
+
+    if (prepared.contentType.includes('png')) {
+      body = await processor.png({ compressionLevel: 9, quality }).toBuffer();
+      contentType = 'image/png';
+    } else if (prepared.contentType.includes('webp')) {
+      body = await processor.webp({ quality }).toBuffer();
+      contentType = 'image/webp';
+    } else {
+      body = await processor.jpeg({ quality }).toBuffer();
+      contentType = 'image/jpeg';
+    }
+
+    const imageProcessingDuration = Date.now() - imageProcessingStart;
+    this.loggerService.log(`${url} image processing completed`, {
+      compressionRatio: `${((1 - body.length / originalSizeBytes) * 100).toFixed(1)}%`,
+      imageProcessingDuration: `${imageProcessingDuration}ms`,
+      key,
+      originalSize: `${(originalSizeBytes / (1024 * 1024)).toFixed(2)} MB`,
+      processedSize: `${(body.length / (1024 * 1024)).toFixed(2)} MB`,
+    });
+
+    return { ...prepared, body, contentType, imageProcessingDuration };
+  }
+
   async uploadToS3(
     key: string,
     type: string,
@@ -114,15 +361,6 @@ export class UploadService {
   }> {
     const url = `${this.constructorName} ${CallerUtil.getCallerName()}`;
     const uploadStartTime = Date.now();
-    let body: Buffer;
-    let contentType: string;
-    let res: AxiosResponse<ArrayBuffer>;
-    let base64Data: string;
-    let filePath: string;
-    let width: number | undefined;
-    let height: number | undefined;
-    let duration: number | undefined;
-    let hasAudio: boolean = false;
 
     this.loggerService.log(`${url} starting upload`, {
       key,
@@ -134,246 +372,43 @@ export class UploadService {
 
     try {
       const prepareStartTime = Date.now();
-      switch (source.type) {
-        case 'file':
-          filePath = resolveContainedPath(
-            FILES_TMP_ROOT,
-            source.path,
-            createBadRequest,
-          );
-          contentType = 'application/octet-stream';
-
-          if (filePath.match(/\.mp4$/i)) {
-            contentType = 'video/mp4';
-            const meta = await this.getVideoDimensions(source.path);
-            width = meta.width;
-            height = meta.height;
-            duration = meta.duration;
-            hasAudio = meta.hasAudio;
-
-            body = fs.readFileSync(filePath);
-          } else if (filePath.match(/\.zip$/i)) {
-            // ZIP archives: upload as-is without image probing
-            contentType = 'application/zip';
-            body = fs.readFileSync(filePath);
-          } else if (filePath.match(/\.jpe?g$/i)) {
-            contentType = 'image/jpeg';
-            const buffer = fs.readFileSync(filePath);
-            ({ width, height } = await this.getImageDimensions(buffer));
-            body = buffer;
-          } else if (filePath.match(/\.png$/i)) {
-            contentType = 'image/png';
-            const buffer = fs.readFileSync(filePath);
-            ({ width, height } = await this.getImageDimensions(buffer));
-            body = buffer;
-          } else if (filePath.match(/\.webp$/i)) {
-            contentType = 'image/webp';
-            const buffer = fs.readFileSync(filePath);
-            ({ width, height } = await this.getImageDimensions(buffer));
-            body = buffer;
-          } else {
-            // Fallback: read file and upload as octet-stream
-            body = fs.readFileSync(filePath);
-          }
-          break;
-
-        case 'url': {
-          const remoteUrl = source.url;
-          if (!remoteUrl || typeof remoteUrl !== 'string') {
-            throw new HttpException(
-              'URL is required and must be a string',
-              HttpStatus.BAD_REQUEST,
-            );
-          }
-          try {
-            new URL(remoteUrl);
-          } catch (error: unknown) {
-            throw new HttpException(
-              `Invalid URL: ${remoteUrl}`,
-              HttpStatus.BAD_REQUEST,
-              { cause: (error as Error)?.message || 'Invalid URL' },
-            );
-          }
-
-          this.loggerService.log(`${url} downloading remote file`, {
-            key,
-            url: remoteUrl,
-          });
-
-          try {
-            const downloadStartTime = Date.now();
-            res = await firstValueFrom(
-              this.httpService.get(remoteUrl, {
-                maxBodyLength: 200 * 1024 * 1024,
-                maxContentLength: 200 * 1024 * 1024,
-                responseType: 'arraybuffer',
-                timeout: 60000,
-              }),
-            );
-            const downloadDuration = Date.now() - downloadStartTime;
-
-            body = Buffer.from(res.data);
-            const rawContentType = res.headers['content-type'];
-            contentType = this.resolveContentType(
-              typeof rawContentType === 'string' ? rawContentType : undefined,
-              remoteUrl,
-            );
-
-            this.loggerService.log(`${url} remote download completed`, {
-              bufferSize: `${(body.length / (1024 * 1024)).toFixed(2)} MB`,
-              contentType,
-              downloadDuration: `${downloadDuration}ms`,
-              key,
-              url: remoteUrl,
-            });
-          } catch (error: unknown) {
-            const parsedError = error as {
-              code?: string;
-              message?: string;
-              response?: { status?: number };
-            };
-            this.loggerService.error(
-              'Failed to download file directly from URL',
-              parsedError,
-            );
-
-            if (parsedError?.code === 'ERR_FR_MAX_BODY_LENGTH_EXCEEDED') {
-              throw new HttpException(
-                'File size exceeds 200MB limit',
-                HttpStatus.PAYLOAD_TOO_LARGE,
-              );
-            }
-
-            throw new HttpException(
-              `Failed to download file from URL: ${parsedError?.message || 'Unknown error'}`,
-              HttpStatus.BAD_REQUEST,
-            );
-          }
-
-          if (contentType.startsWith('video/')) {
-            const videoMeta = await this.getVideoDimensionsFromBuffer(
-              body,
-              key,
-            );
-            width = videoMeta.width;
-            height = videoMeta.height;
-            duration = videoMeta.duration;
-            hasAudio = videoMeta.hasAudio;
-          } else if (contentType.startsWith('image/')) {
-            ({ width, height } = await this.getImageDimensions(body));
-          } else if (remoteUrl.match(/\.zip$/i)) {
-            contentType = 'application/zip';
-          }
-
-          break;
-        }
-
-        case 'base64':
-          base64Data = source.data.replace(/^data:[^;]+;base64,/, '');
-          body = Buffer.from(base64Data, 'base64');
-          contentType = source.contentType;
-          if (contentType.startsWith('video/')) {
-            const meta = await this.getVideoDimensionsFromBuffer(body, key);
-            width = meta.width;
-            height = meta.height;
-            duration = meta.duration;
-            hasAudio = meta.hasAudio;
-            contentType = 'video/mp4';
-          } else if (contentType.startsWith('image/')) {
-            ({ width, height } = await this.getImageDimensions(body));
-          }
-          break;
-
-        case 'buffer':
-          body = source.data;
-          contentType = source.contentType;
-
-          if (contentType.startsWith('video/')) {
-            const meta = await this.getVideoDimensionsFromBuffer(body, key);
-            width = meta.width;
-            height = meta.height;
-            duration = meta.duration;
-            hasAudio = meta.hasAudio;
-            contentType = 'video/mp4';
-          } else if (contentType.startsWith('image/')) {
-            ({ width, height } = await this.getImageDimensions(body));
-          }
-          break;
-
-        default:
-          throw new Error('Invalid upload source type');
-      }
-
+      const prepared = await this.prepareUpload(source, key, url);
       const prepareDuration = Date.now() - prepareStartTime;
-      const bufferSizeMB = (body.length / (1024 * 1024)).toFixed(2);
 
       this.loggerService.log(`${url} file preparation completed`, {
-        bufferSize: `${bufferSizeMB} MB`,
-        bufferSizeBytes: body.length,
-        contentType,
+        bufferSize: `${(prepared.body.length / (1024 * 1024)).toFixed(2)} MB`,
+        bufferSizeBytes: prepared.body.length,
+        contentType: prepared.contentType,
         key,
         prepareDuration: `${prepareDuration}ms`,
         sourceType: source.type,
-        ...(width && height && { dimensions: `${width}x${height}` }),
-        ...(duration && { duration: `${duration}s` }),
-        ...(hasAudio !== undefined && { hasAudio }),
+        ...(prepared.width &&
+          prepared.height && {
+            dimensions: `${prepared.width}x${prepared.height}`,
+          }),
+        ...(prepared.duration && { duration: `${prepared.duration}s` }),
+        hasAudio: prepared.hasAudio,
       });
 
-      // Image processing (compression, rotation, format conversion)
-      let imageProcessingDuration = 0;
-      if (contentType.startsWith('image/')) {
-        const imageProcessingStart = Date.now();
-        const originalSizeBytes = body.length;
-        const quality = Number(
-          this.configService.get('AWS_IMAGE_COMPRESSION') || '90',
-        );
-        const processor = sharp(body).rotate(); // Auto-rotate based on EXIF orientation
-
-        if (contentType.includes('png')) {
-          body = await processor
-            .png({ compressionLevel: 9, quality })
-            .toBuffer();
-          contentType = 'image/png';
-        } else if (contentType.includes('webp')) {
-          body = await processor.webp({ quality }).toBuffer();
-          contentType = 'image/webp';
-        } else {
-          body = await processor.jpeg({ quality }).toBuffer();
-          contentType = 'image/jpeg';
-        }
-        imageProcessingDuration = Date.now() - imageProcessingStart;
-
-        const processedSizeMB = (body.length / (1024 * 1024)).toFixed(2);
-        const originalSizeMB = (originalSizeBytes / (1024 * 1024)).toFixed(2);
-        this.loggerService.log(`${url} image processing completed`, {
-          compressionRatio: `${((1 - body.length / originalSizeBytes) * 100).toFixed(1)}%`,
-          imageProcessingDuration: `${imageProcessingDuration}ms`,
-          key,
-          originalSize: `${originalSizeMB} MB`,
-          processedSize: `${processedSizeMB} MB`,
-        });
-      }
-
-      // Generate storage path: ingredients/${type}/${key}
+      const processed = await this.processImage(prepared, key, url);
       const storagePath = resolveContainedObjectKey(
         'ingredients',
         `${type}/${key}`,
         createBadRequest,
       );
 
-      // Upload using storage provider (returns a storage path/key)
       const s3UploadStartTime = Date.now();
       this.loggerService.log(`${url} starting storage upload`, {
-        bufferSize: `${(body.length / (1024 * 1024)).toFixed(2)} MB`,
-        contentType,
+        bufferSize: `${(processed.body.length / (1024 * 1024)).toFixed(2)} MB`,
+        contentType: processed.contentType,
         key,
         storagePath,
       });
 
       const storedPath = await this.storage.upload(
-        body,
+        processed.body,
         storagePath,
-        contentType,
+        processed.contentType,
       );
       const publicUrl = this.storage.getUrl(storedPath);
 
@@ -381,29 +416,32 @@ export class UploadService {
       const totalDuration = Date.now() - uploadStartTime;
 
       this.loggerService.log(`${url} upload completed successfully`, {
-        bufferSize: `${(body.length / (1024 * 1024)).toFixed(2)} MB`,
-        contentType,
+        bufferSize: `${(processed.body.length / (1024 * 1024)).toFixed(2)} MB`,
+        contentType: processed.contentType,
         key,
         prepareDuration: `${prepareDuration}ms`,
         publicUrl,
         storagePath: storedPath,
-        ...(imageProcessingDuration > 0 && {
-          imageProcessingDuration: `${imageProcessingDuration}ms`,
+        ...(processed.imageProcessingDuration > 0 && {
+          imageProcessingDuration: `${processed.imageProcessingDuration}ms`,
         }),
         s3UploadDuration: `${s3UploadDuration}ms`,
         totalDuration: `${totalDuration}ms`,
-        ...(width && height && { dimensions: `${width}x${height}` }),
-        ...(duration && { duration: `${duration}s` }),
-        ...(hasAudio !== undefined && { hasAudio }),
+        ...(processed.width &&
+          processed.height && {
+            dimensions: `${processed.width}x${processed.height}`,
+          }),
+        ...(processed.duration && { duration: `${processed.duration}s` }),
+        hasAudio: processed.hasAudio,
       });
 
       return {
-        duration: duration || 0,
-        hasAudio,
-        height: height || 0,
+        duration: processed.duration || 0,
+        hasAudio: processed.hasAudio,
+        height: processed.height || 0,
         publicUrl,
-        size: body.length,
-        width: width || 0,
+        size: processed.body.length,
+        width: processed.width || 0,
       };
     } catch (error: unknown) {
       const totalDuration = Date.now() - uploadStartTime;

--- a/apps/server/files/src/services/ytdlp/ytdlp.service.spec.ts
+++ b/apps/server/files/src/services/ytdlp/ytdlp.service.spec.ts
@@ -1,7 +1,10 @@
 import { spawn } from 'node:child_process';
 import fs from 'node:fs';
+import path from 'node:path';
+import { FILES_TMP_ROOT } from '@files/constants/path.constants';
 import { YtDlpService } from '@files/services/ytdlp/ytdlp.service';
 import { LoggerService } from '@libs/logger/logger.service';
+import { BadRequestException } from '@nestjs/common';
 import { Test, type TestingModule } from '@nestjs/testing';
 import type { Mock, Mocked, MockedFunction } from 'vitest';
 
@@ -251,7 +254,7 @@ describe('YtDlpService', () => {
   describe('downloadVideo', () => {
     it('should download a 720p mp4 video to a custom output path', async () => {
       const url = 'https://youtube.com/watch?v=test';
-      const outputPath = '/tmp/genfeed/video.mp4';
+      const outputPath = path.join(FILES_TMP_ROOT, 'nested', 'video.mp4');
       const mockProcess = useMockProcess(spawnMock);
       fsMock.existsSync.mockReturnValue(true);
 
@@ -282,9 +285,20 @@ describe('YtDlpService', () => {
       );
     });
 
+    it('rejects an output path outside the files temp root before spawning', () => {
+      expect(() =>
+        service.downloadVideo(
+          'https://youtube.com/watch?v=test',
+          '/etc/escaped.mp4',
+        ),
+      ).toThrow(BadRequestException);
+
+      expect(spawnMock).not.toHaveBeenCalled();
+    });
+
     it('kills a timed-out process and removes partial output after close', async () => {
       vi.useFakeTimers();
-      const outputPath = '/tmp/genfeed/video.mp4';
+      const outputPath = path.join(FILES_TMP_ROOT, 'genfeed', 'video.mp4');
       const mockProcess = useMockProcess(spawnMock);
       fsMock.existsSync.mockReturnValue(true);
 
@@ -311,7 +325,7 @@ describe('YtDlpService', () => {
     });
 
     it('rejects a successful process that did not create an output file', async () => {
-      const outputPath = '/tmp/genfeed/video.mp4';
+      const outputPath = path.join(FILES_TMP_ROOT, 'genfeed', 'video.mp4');
       const mockProcess = useMockProcess(spawnMock);
       fsMock.existsSync
         .mockReturnValueOnce(true)
@@ -331,7 +345,7 @@ describe('YtDlpService', () => {
   describe('downloadAudioLowestQuality', () => {
     it('should download the lowest quality mp3 to the requested output path', async () => {
       const url = 'https://youtube.com/watch?v=test';
-      const outputPath = '/tmp/genfeed/audio.mp3';
+      const outputPath = path.join(FILES_TMP_ROOT, 'nested', 'audio.mp3');
       const mockProcess = useMockProcess(spawnMock);
       fsMock.existsSync.mockReturnValue(true);
 

--- a/apps/server/files/src/services/ytdlp/ytdlp.service.ts
+++ b/apps/server/files/src/services/ytdlp/ytdlp.service.ts
@@ -1,9 +1,13 @@
 import { type ChildProcess, spawn } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
+import { FILES_TMP_ROOT } from '@files/constants/path.constants';
 import { YT_DLP_PROCESS_TIMEOUT_MS } from '@genfeedai/constants';
 import { LoggerService } from '@libs/logger/logger.service';
-import { Injectable } from '@nestjs/common';
+import { resolveContainedPath } from '@libs/security';
+import { BadRequestException, Injectable } from '@nestjs/common';
+
+const createBadRequest = (message: string) => new BadRequestException(message);
 
 // Download audio from a YouTube video
 
@@ -12,7 +16,11 @@ export class YtDlpService {
   constructor(private readonly logger: LoggerService) {}
 
   public downloadAudio(url: string): Promise<string> {
-    const outputDir = path.resolve('public', 'tmp', 'clips');
+    const outputDir = resolveContainedPath(
+      FILES_TMP_ROOT,
+      'clips',
+      createBadRequest,
+    );
     this.ensureOutputDir(outputDir);
 
     const timestamp = Date.now();
@@ -25,16 +33,19 @@ export class YtDlpService {
   }
 
   public downloadVideo(url: string, outputPath?: string): Promise<string> {
-    const outputDir = outputPath
-      ? path.dirname(outputPath)
-      : path.resolve('public', 'tmp', 'clips');
+    const containedOutputPath = outputPath
+      ? resolveContainedPath(FILES_TMP_ROOT, outputPath, createBadRequest)
+      : undefined;
+    const outputDir = containedOutputPath
+      ? path.dirname(containedOutputPath)
+      : resolveContainedPath(FILES_TMP_ROOT, 'clips', createBadRequest);
     this.ensureOutputDir(outputDir);
 
     const timestamp = Date.now();
     const outputTemplate =
-      outputPath || path.join(outputDir, `${timestamp}.%(ext)s`);
+      containedOutputPath || path.join(outputDir, `${timestamp}.%(ext)s`);
     const expectedOutput =
-      outputPath || path.join(outputDir, `${timestamp}.mp4`);
+      containedOutputPath || path.join(outputDir, `${timestamp}.mp4`);
 
     const args = [
       '--no-playlist',
@@ -58,7 +69,12 @@ export class YtDlpService {
     url: string,
     outputPath: string,
   ): Promise<string> {
-    const outputDir = path.dirname(outputPath);
+    const containedOutputPath = resolveContainedPath(
+      FILES_TMP_ROOT,
+      outputPath,
+      createBadRequest,
+    );
+    const outputDir = path.dirname(containedOutputPath);
     this.ensureOutputDir(outputDir);
 
     const args = [
@@ -68,11 +84,11 @@ export class YtDlpService {
       '--audio-quality',
       '9',
       '-o',
-      outputPath,
+      containedOutputPath,
       url,
     ];
 
-    return this.runYtDlp(args, outputPath);
+    return this.runYtDlp(args, containedOutputPath);
   }
 
   private ensureOutputDir(outputDir: string): void {

--- a/apps/server/images/src/services/dataset.service.spec.ts
+++ b/apps/server/images/src/services/dataset.service.spec.ts
@@ -95,6 +95,7 @@ describe('DatasetService', () => {
         'test-bucket',
         'photo.jpg',
         '/datasets/test/photo.jpg',
+        '/datasets/test',
       );
     });
 
@@ -113,6 +114,27 @@ describe('DatasetService', () => {
       await expect(
         service.syncDataset('../evil', { s3Keys: ['photo.jpg'] }),
       ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should reject an S3 key whose basename escapes the dataset directory', async () => {
+      await expect(
+        service.syncDataset('test', { s3Keys: ['uploads/..'] }),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(mockS3Service.downloadFile).not.toHaveBeenCalled();
+    });
+
+    it('should accept a nested S3 key and contain its local filename', async () => {
+      await service.syncDataset('test', {
+        s3Keys: ['uploads/nested/photo.jpg'],
+      });
+
+      expect(mockS3Service.downloadFile).toHaveBeenCalledWith(
+        'test-bucket',
+        'uploads/nested/photo.jpg',
+        '/datasets/test/photo.jpg',
+        '/datasets/test',
+      );
     });
 
     it('should throw if s3Keys is empty', async () => {

--- a/apps/server/images/src/services/dataset.service.ts
+++ b/apps/server/images/src/services/dataset.service.ts
@@ -1,5 +1,5 @@
 import { mkdir, readdir, rm, stat } from 'node:fs/promises';
-import { basename, join } from 'node:path';
+import { basename } from 'node:path';
 import { ConfigService } from '@images/config/config.service';
 import type {
   DatasetInfo,
@@ -8,6 +8,7 @@ import type {
 } from '@images/interfaces/dataset.interfaces';
 import { LoggerService } from '@libs/logger/logger.service';
 import { S3Service } from '@libs/s3/s3.service';
+import { resolveContainedPath } from '@libs/security';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
 import {
   BadRequestException,
@@ -26,6 +27,8 @@ const ALLOWED_EXTENSIONS = new Set([
   '.txt',
 ]);
 
+const createBadRequest = (message: string) => new BadRequestException(message);
+
 @Injectable()
 export class DatasetService {
   private readonly constructorName: string = String(this.constructor.name);
@@ -37,7 +40,11 @@ export class DatasetService {
   ) {}
 
   private getDatasetPath(slug: string): string {
-    return join(this.configService.DATASETS_PATH, slug);
+    return resolveContainedPath(
+      this.configService.DATASETS_PATH,
+      slug,
+      createBadRequest,
+    );
   }
 
   private isValidSlug(slug: string): boolean {
@@ -87,6 +94,11 @@ export class DatasetService {
 
     for (const key of request.s3Keys) {
       const filename = basename(key);
+      const localPath = resolveContainedPath(
+        datasetPath,
+        filename,
+        createBadRequest,
+      );
 
       if (!this.isAllowedDatasetFile(filename)) {
         errors.push(`Skipped non-image file: ${key}`);
@@ -94,10 +106,8 @@ export class DatasetService {
         continue;
       }
 
-      const localPath = join(datasetPath, filename);
-
       try {
-        await this.s3Service.downloadFile(bucket, key, localPath);
+        await this.s3Service.downloadFile(bucket, key, localPath, datasetPath);
         downloaded++;
       } catch (error: unknown) {
         const errorMessage =

--- a/apps/server/images/src/services/generation.service.spec.ts
+++ b/apps/server/images/src/services/generation.service.spec.ts
@@ -181,6 +181,7 @@ describe('GenerationService', () => {
         'test-bucket',
         'ingredients/images/generated/job-image/generated.png',
         '/tmp/comfyui-output/runs/generated.png',
+        '/tmp/comfyui-output',
         'image/png',
       );
       expect(jobService.updateJob).toHaveBeenCalledWith(
@@ -272,6 +273,7 @@ describe('GenerationService', () => {
         'test-bucket',
         'ingredients/images/generated/job-image/passwd',
         '/tmp/comfyui-output/runs/passwd',
+        '/tmp/comfyui-output',
         expect.any(String),
       );
     });
@@ -322,6 +324,7 @@ describe('GenerationService', () => {
         'test-bucket',
         'ingredients/pulid/generated/job-pulid/generated.png',
         '/tmp/comfyui-output/runs/generated.png',
+        '/tmp/comfyui-output',
         'image/png',
       );
       expect(jobService.updateJob).toHaveBeenCalledWith(

--- a/apps/server/images/src/services/generation.service.ts
+++ b/apps/server/images/src/services/generation.service.ts
@@ -141,6 +141,7 @@ export class GenerationService {
           this.configService.AWS_S3_BUCKET,
           s3Key,
           localPath,
+          this.configService.COMFYUI_OUTPUT_PATH,
           this.getContentType(filename),
         );
         resultUrl = `https://cdn.genfeed.ai/${s3Key}`;

--- a/apps/server/images/src/services/lora.service.spec.ts
+++ b/apps/server/images/src/services/lora.service.spec.ts
@@ -77,6 +77,7 @@ describe('LoraService', () => {
         'test-bucket',
         'ingredients/trainings/loras/my-lora.safetensors',
         '/comfyui/models/loras/my-lora.safetensors',
+        '/comfyui/models/loras',
       );
     });
 
@@ -142,18 +143,21 @@ describe('LoraService', () => {
       '/etc/shadow.safetensors',
       '../../root/.ssh/id_rsa.safetensors',
       '/comfyui/models/loras-sibling/evil.safetensors',
-    ])('should reject localPath %s outside the configured LoRA directory', async (localPath) => {
-      mockStat.mockResolvedValue({ size: 12345 });
+    ])(
+      'should reject localPath %s outside the configured LoRA directory',
+      async (localPath) => {
+        mockStat.mockResolvedValue({ size: 12345 });
 
-      await expect(
-        service.uploadLora({ localPath, loraName: 'my-lora' }),
-      ).rejects.toThrow(BadRequestException);
+        await expect(
+          service.uploadLora({ localPath, loraName: 'my-lora' }),
+        ).rejects.toThrow(BadRequestException);
 
-      // The file is never read, so its bytes never reach a bucket the
-      // caller can list.
-      expect(mockStat).not.toHaveBeenCalled();
-      expect(mockS3Service.uploadFile).not.toHaveBeenCalled();
-    });
+        // The file is never read, so its bytes never reach a bucket the
+        // caller can list.
+        expect(mockStat).not.toHaveBeenCalled();
+        expect(mockS3Service.uploadFile).not.toHaveBeenCalled();
+      },
+    );
 
     it('should accept a path relative to the configured LoRA directory', async () => {
       mockStat.mockResolvedValue({ size: 12345 });
@@ -167,6 +171,7 @@ describe('LoraService', () => {
         'test-bucket',
         'ingredients/trainings/loras/my-lora.safetensors',
         '/comfyui/models/loras/my-lora.safetensors',
+        '/comfyui/models/loras',
       );
     });
 

--- a/apps/server/images/src/services/lora.service.spec.ts
+++ b/apps/server/images/src/services/lora.service.spec.ts
@@ -143,21 +143,18 @@ describe('LoraService', () => {
       '/etc/shadow.safetensors',
       '../../root/.ssh/id_rsa.safetensors',
       '/comfyui/models/loras-sibling/evil.safetensors',
-    ])(
-      'should reject localPath %s outside the configured LoRA directory',
-      async (localPath) => {
-        mockStat.mockResolvedValue({ size: 12345 });
+    ])('should reject localPath %s outside the configured LoRA directory', async (localPath) => {
+      mockStat.mockResolvedValue({ size: 12345 });
 
-        await expect(
-          service.uploadLora({ localPath, loraName: 'my-lora' }),
-        ).rejects.toThrow(BadRequestException);
+      await expect(
+        service.uploadLora({ localPath, loraName: 'my-lora' }),
+      ).rejects.toThrow(BadRequestException);
 
-        // The file is never read, so its bytes never reach a bucket the
-        // caller can list.
-        expect(mockStat).not.toHaveBeenCalled();
-        expect(mockS3Service.uploadFile).not.toHaveBeenCalled();
-      },
-    );
+      // The file is never read, so its bytes never reach a bucket the
+      // caller can list.
+      expect(mockStat).not.toHaveBeenCalled();
+      expect(mockS3Service.uploadFile).not.toHaveBeenCalled();
+    });
 
     it('should accept a path relative to the configured LoRA directory', async () => {
       mockStat.mockResolvedValue({ size: 12345 });

--- a/apps/server/images/src/services/lora.service.ts
+++ b/apps/server/images/src/services/lora.service.ts
@@ -79,7 +79,12 @@ export class LoraService {
       s3Key,
     });
 
-    await this.s3Service.uploadFile(bucket, s3Key, localPath);
+    await this.s3Service.uploadFile(
+      bucket,
+      s3Key,
+      localPath,
+      this.configService.COMFYUI_LORAS_PATH,
+    );
 
     this.loggerService.log(caller, {
       loraName,

--- a/apps/server/images/src/services/training.service.ts
+++ b/apps/server/images/src/services/training.service.ts
@@ -469,6 +469,7 @@ export class TrainingService implements OnModuleInit {
         bucket,
         loraName,
         localPath,
+        lorasPath,
       );
 
       this.loggerService.log(caller, {

--- a/apps/server/images/vitest.config.ts
+++ b/apps/server/images/vitest.config.ts
@@ -31,6 +31,10 @@ export default defineConfig({
         serviceDir,
         '../../../packages/pricing/src/index.ts',
       ),
+      '@genfeedai/storage/path-containment': path.resolve(
+        serviceDir,
+        '../../../packages/storage/src/path-containment.ts',
+      ),
       '@genfeedai/storage': path.resolve(
         serviceDir,
         '../../../packages/storage/src/index.ts',

--- a/apps/server/videos/src/services/generation.service.spec.ts
+++ b/apps/server/videos/src/services/generation.service.spec.ts
@@ -161,6 +161,7 @@ describe('GenerationService', () => {
         'test-bucket',
         expect.stringContaining('ingredients/videos/generated/job-abc-123'),
         expect.stringContaining('output-video.mp4'),
+        '/comfyui/output',
         'video/mp4',
       );
 
@@ -169,6 +170,39 @@ describe('GenerationService', () => {
         expect.objectContaining({
           status: 'completed',
           videoUrl: expect.stringContaining('cdn.genfeed.ai'),
+        }),
+      );
+    });
+
+    it('should preserve a legitimate nested ComfyUI output path', async () => {
+      comfyuiService.queueAndWait.mockResolvedValue('nested/output-video.mp4');
+
+      await service.generateVideo(baseRequest);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      expect(s3Service.uploadFile).toHaveBeenCalledWith(
+        'test-bucket',
+        expect.stringContaining(
+          'ingredients/videos/generated/job-abc-123/nested/output-video.mp4',
+        ),
+        '/comfyui/output/nested/output-video.mp4',
+        '/comfyui/output',
+        'video/mp4',
+      );
+    });
+
+    it('should reject a ComfyUI output path that escapes the configured root', async () => {
+      comfyuiService.queueAndWait.mockResolvedValue('../escaped.mp4');
+
+      await service.generateVideo(baseRequest);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      expect(s3Service.uploadFile).not.toHaveBeenCalled();
+      expect(jobService.updateJob).toHaveBeenCalledWith(
+        'job-abc-123',
+        expect.objectContaining({
+          error: expect.stringContaining('must stay within'),
+          status: 'failed',
         }),
       );
     });

--- a/apps/server/videos/src/services/generation.service.ts
+++ b/apps/server/videos/src/services/generation.service.ts
@@ -1,8 +1,8 @@
-import { join } from 'node:path';
 import { LoggerService } from '@libs/logger/logger.service';
 import { S3Service } from '@libs/s3/s3.service';
+import { resolveContainedPath } from '@libs/security';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { ConfigService } from '@videos/config/config.service';
 import type {
   GenerateVideoRequest,
@@ -11,6 +11,8 @@ import type {
 import { ComfyUIService } from '@videos/services/comfyui.service';
 import { JobService } from '@videos/services/job.service';
 import { WorkflowService } from '@videos/services/workflow.service';
+
+const createBadRequest = (message: string) => new BadRequestException(message);
 
 @Injectable()
 export class GenerationService {
@@ -101,9 +103,10 @@ export class GenerationService {
       if (outputFilename) {
         // Upload to S3 and build CDN URL
         const s3Key = `ingredients/videos/generated/${jobId}/${outputFilename}`;
-        const localPath = join(
+        const localPath = resolveContainedPath(
           this.configService.COMFYUI_OUTPUT_PATH,
           outputFilename,
+          createBadRequest,
         );
 
         let videoUrl = outputFilename;
@@ -113,6 +116,7 @@ export class GenerationService {
             this.configService.AWS_S3_BUCKET,
             s3Key,
             localPath,
+            this.configService.COMFYUI_OUTPUT_PATH,
             'video/mp4',
           );
           videoUrl = `https://cdn.genfeed.ai/${s3Key}`;

--- a/apps/server/videos/vitest.config.ts
+++ b/apps/server/videos/vitest.config.ts
@@ -27,6 +27,10 @@ export default defineConfig({
         serviceDir,
         '../../../packages/pricing/src/index.ts',
       ),
+      '@genfeedai/storage/path-containment': path.resolve(
+        serviceDir,
+        '../../../packages/storage/src/path-containment.ts',
+      ),
       '@genfeedai/storage': path.resolve(
         serviceDir,
         '../../../packages/storage/src/index.ts',

--- a/apps/server/voices/src/services/voice-clone.service.spec.ts
+++ b/apps/server/voices/src/services/voice-clone.service.spec.ts
@@ -77,6 +77,7 @@ describe('VoiceCloneService', () => {
         'test-bucket',
         'ingredients/trainings/voice-clones/my-voice/model.pth',
         '/models/voices/my-voice/model.pth',
+        '/models/voices',
       );
     });
 
@@ -153,18 +154,21 @@ describe('VoiceCloneService', () => {
       '/etc/shadow.pth',
       '../../root/.ssh/id_rsa.pth',
       '/models/voices-sibling/evil.pth',
-    ])('should reject localPath %s outside the configured model directory', async (localPath) => {
-      mockStat.mockResolvedValue({ size: 12345 });
+    ])(
+      'should reject localPath %s outside the configured model directory',
+      async (localPath) => {
+        mockStat.mockResolvedValue({ size: 12345 });
 
-      await expect(
-        service.uploadClone({ localPath, voiceId: 'my-voice' }),
-      ).rejects.toThrow(BadRequestException);
+        await expect(
+          service.uploadClone({ localPath, voiceId: 'my-voice' }),
+        ).rejects.toThrow(BadRequestException);
 
-      // The file is never read, so its bytes never reach a bucket the
-      // caller can list.
-      expect(mockStat).not.toHaveBeenCalled();
-      expect(mockS3Service.uploadFile).not.toHaveBeenCalled();
-    });
+        // The file is never read, so its bytes never reach a bucket the
+        // caller can list.
+        expect(mockStat).not.toHaveBeenCalled();
+        expect(mockS3Service.uploadFile).not.toHaveBeenCalled();
+      },
+    );
 
     it('should accept a path relative to the configured model directory', async () => {
       mockStat.mockResolvedValue({ size: 12345 });
@@ -178,6 +182,7 @@ describe('VoiceCloneService', () => {
         'test-bucket',
         'ingredients/trainings/voice-clones/my-voice/model.pth',
         '/models/voices/my-voice/model.pth',
+        '/models/voices',
       );
     });
   });
@@ -213,18 +218,16 @@ describe('VoiceCloneService', () => {
       );
     });
 
-    it.each([
-      '../evil',
-      'nested/name',
-      'a..b',
-      '$(whoami)',
-    ])('should reject voiceId %s before listing S3', async (voiceId) => {
-      await expect(service.downloadClone(voiceId)).rejects.toThrow(
-        BadRequestException,
-      );
+    it.each(['../evil', 'nested/name', 'a..b', '$(whoami)'])(
+      'should reject voiceId %s before listing S3',
+      async (voiceId) => {
+        await expect(service.downloadClone(voiceId)).rejects.toThrow(
+          BadRequestException,
+        );
 
-      expect(mockS3Service.listObjects).not.toHaveBeenCalled();
-    });
+        expect(mockS3Service.listObjects).not.toHaveBeenCalled();
+      },
+    );
 
     it('should refuse to write an S3 key that escapes the voice directory', async () => {
       // The key suffix is attacker-influenced if anything can write to the

--- a/apps/server/voices/src/services/voice-clone.service.spec.ts
+++ b/apps/server/voices/src/services/voice-clone.service.spec.ts
@@ -154,21 +154,18 @@ describe('VoiceCloneService', () => {
       '/etc/shadow.pth',
       '../../root/.ssh/id_rsa.pth',
       '/models/voices-sibling/evil.pth',
-    ])(
-      'should reject localPath %s outside the configured model directory',
-      async (localPath) => {
-        mockStat.mockResolvedValue({ size: 12345 });
+    ])('should reject localPath %s outside the configured model directory', async (localPath) => {
+      mockStat.mockResolvedValue({ size: 12345 });
 
-        await expect(
-          service.uploadClone({ localPath, voiceId: 'my-voice' }),
-        ).rejects.toThrow(BadRequestException);
+      await expect(
+        service.uploadClone({ localPath, voiceId: 'my-voice' }),
+      ).rejects.toThrow(BadRequestException);
 
-        // The file is never read, so its bytes never reach a bucket the
-        // caller can list.
-        expect(mockStat).not.toHaveBeenCalled();
-        expect(mockS3Service.uploadFile).not.toHaveBeenCalled();
-      },
-    );
+      // The file is never read, so its bytes never reach a bucket the
+      // caller can list.
+      expect(mockStat).not.toHaveBeenCalled();
+      expect(mockS3Service.uploadFile).not.toHaveBeenCalled();
+    });
 
     it('should accept a path relative to the configured model directory', async () => {
       mockStat.mockResolvedValue({ size: 12345 });
@@ -218,16 +215,18 @@ describe('VoiceCloneService', () => {
       );
     });
 
-    it.each(['../evil', 'nested/name', 'a..b', '$(whoami)'])(
-      'should reject voiceId %s before listing S3',
-      async (voiceId) => {
-        await expect(service.downloadClone(voiceId)).rejects.toThrow(
-          BadRequestException,
-        );
+    it.each([
+      '../evil',
+      'nested/name',
+      'a..b',
+      '$(whoami)',
+    ])('should reject voiceId %s before listing S3', async (voiceId) => {
+      await expect(service.downloadClone(voiceId)).rejects.toThrow(
+        BadRequestException,
+      );
 
-        expect(mockS3Service.listObjects).not.toHaveBeenCalled();
-      },
-    );
+      expect(mockS3Service.listObjects).not.toHaveBeenCalled();
+    });
 
     it('should refuse to write an S3 key that escapes the voice directory', async () => {
       // The key suffix is attacker-influenced if anything can write to the

--- a/apps/server/voices/src/services/voice-clone.service.ts
+++ b/apps/server/voices/src/services/voice-clone.service.ts
@@ -86,7 +86,12 @@ export class VoiceCloneService {
       voiceId,
     });
 
-    await this.s3Service.uploadFile(bucket, s3Key, localPath);
+    await this.s3Service.uploadFile(
+      bucket,
+      s3Key,
+      localPath,
+      this.configService.VOICE_MODELS_PATH,
+    );
 
     this.loggerService.log(caller, {
       message: 'Voice clone uploaded successfully',
@@ -145,7 +150,7 @@ export class VoiceCloneService {
         filename,
         createBadRequest,
       );
-      await this.s3Service.downloadFile(bucket, obj.key, localPath);
+      await this.s3Service.downloadFile(bucket, obj.key, localPath, localDir);
     }
 
     this.loggerService.log(caller, {

--- a/apps/server/voices/src/services/voice-dataset.service.spec.ts
+++ b/apps/server/voices/src/services/voice-dataset.service.spec.ts
@@ -95,6 +95,7 @@ describe('VoiceDatasetService', () => {
         'test-bucket',
         'sample.wav',
         '/datasets/voices/test/sample.wav',
+        '/datasets/voices/test',
       );
     });
 
@@ -113,6 +114,27 @@ describe('VoiceDatasetService', () => {
       await expect(
         service.syncFromS3('../evil', { s3Keys: ['sample.wav'] }),
       ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should reject an S3 key whose basename escapes the voice dataset', async () => {
+      await expect(
+        service.syncFromS3('test', { s3Keys: ['uploads/..'] }),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(mockS3Service.downloadFile).not.toHaveBeenCalled();
+    });
+
+    it('should accept a nested S3 key and contain its local filename', async () => {
+      await service.syncFromS3('test', {
+        s3Keys: ['uploads/nested/sample.wav'],
+      });
+
+      expect(mockS3Service.downloadFile).toHaveBeenCalledWith(
+        'test-bucket',
+        'uploads/nested/sample.wav',
+        '/datasets/voices/test/sample.wav',
+        '/datasets/voices/test',
+      );
     });
 
     it('should throw if s3Keys is empty', async () => {

--- a/apps/server/voices/src/services/voice-dataset.service.ts
+++ b/apps/server/voices/src/services/voice-dataset.service.ts
@@ -2,6 +2,7 @@ import { mkdir, readdir, rm, stat } from 'node:fs/promises';
 import { basename, join } from 'node:path';
 import { LoggerService } from '@libs/logger/logger.service';
 import { S3Service } from '@libs/s3/s3.service';
+import { resolveContainedPath } from '@libs/security';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
 import {
   BadRequestException,
@@ -26,6 +27,8 @@ const ALLOWED_AUDIO_EXTENSIONS = new Set([
   '.opus',
 ]);
 
+const createBadRequest = (message: string) => new BadRequestException(message);
+
 @Injectable()
 export class VoiceDatasetService {
   private readonly constructorName: string = String(this.constructor.name);
@@ -37,7 +40,11 @@ export class VoiceDatasetService {
   ) {}
 
   private getDatasetPath(voiceId: string): string {
-    return join(this.configService.DATASETS_PATH, 'voices', voiceId);
+    return resolveContainedPath(
+      join(this.configService.DATASETS_PATH, 'voices'),
+      voiceId,
+      createBadRequest,
+    );
   }
 
   private isValidVoiceId(voiceId: string): boolean {
@@ -87,6 +94,11 @@ export class VoiceDatasetService {
 
     for (const key of request.s3Keys) {
       const filename = basename(key);
+      const localPath = resolveContainedPath(
+        datasetPath,
+        filename,
+        createBadRequest,
+      );
 
       if (!this.isAllowedAudioFile(filename)) {
         errors.push(`Skipped non-audio file: ${key}`);
@@ -94,10 +106,8 @@ export class VoiceDatasetService {
         continue;
       }
 
-      const localPath = join(datasetPath, filename);
-
       try {
-        await this.s3Service.downloadFile(bucket, key, localPath);
+        await this.s3Service.downloadFile(bucket, key, localPath, datasetPath);
         downloaded++;
       } catch (error: unknown) {
         const errorMessage =

--- a/apps/server/voices/vitest.config.ts
+++ b/apps/server/voices/vitest.config.ts
@@ -27,6 +27,10 @@ export default defineConfig({
         serviceDir,
         '../../../packages/pricing/src/index.ts',
       ),
+      '@genfeedai/storage/path-containment': path.resolve(
+        serviceDir,
+        '../../../packages/storage/src/path-containment.ts',
+      ),
       '@genfeedai/storage': path.resolve(
         serviceDir,
         '../../../packages/storage/src/index.ts',

--- a/packages/libs/s3/s3.service.spec.ts
+++ b/packages/libs/s3/s3.service.spec.ts
@@ -16,14 +16,10 @@ const mockProvider = {
 
 const mockCreateStorageProvider = vi.fn().mockReturnValue(mockProvider);
 
-vi.mock('@genfeedai/storage', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@genfeedai/storage')>();
-  return {
-    ...actual,
-    createStorageProvider: (options?: Record<string, unknown>) =>
-      mockCreateStorageProvider(options),
-  };
-});
+vi.mock('@genfeedai/storage', () => ({
+  createStorageProvider: (options?: Record<string, unknown>) =>
+    mockCreateStorageProvider(options),
+}));
 
 vi.mock('node:fs/promises', () => ({
   stat: vi.fn().mockResolvedValue({ size: 9 }),

--- a/packages/libs/s3/s3.service.spec.ts
+++ b/packages/libs/s3/s3.service.spec.ts
@@ -1,5 +1,6 @@
 import { LoggerService } from '@libs/logger/logger.service';
 import { S3Service } from '@libs/s3/s3.service';
+import { BadRequestException } from '@nestjs/common';
 import { Test, type TestingModule } from '@nestjs/testing';
 
 const mockProvider = {
@@ -15,10 +16,14 @@ const mockProvider = {
 
 const mockCreateStorageProvider = vi.fn().mockReturnValue(mockProvider);
 
-vi.mock('@genfeedai/storage', () => ({
-  createStorageProvider: (options?: Record<string, unknown>) =>
-    mockCreateStorageProvider(options),
-}));
+vi.mock('@genfeedai/storage', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@genfeedai/storage')>();
+  return {
+    ...actual,
+    createStorageProvider: (options?: Record<string, unknown>) =>
+      mockCreateStorageProvider(options),
+  };
+});
 
 vi.mock('node:fs/promises', () => ({
   stat: vi.fn().mockResolvedValue({ size: 9 }),
@@ -67,7 +72,7 @@ describe('S3Service (shared @libs/s3, thin wrapper over @genfeedai/storage)', ()
     it('creates the provider lazily with config credentials and the bucket', async () => {
       expect(mockCreateStorageProvider).not.toHaveBeenCalled();
 
-      await service.downloadFile('bucket-a', 'k.png', '/tmp/k.png');
+      await service.downloadFile('bucket-a', 'k.png', '/tmp/k.png', '/tmp');
 
       expect(mockCreateStorageProvider).toHaveBeenCalledTimes(1);
       expect(mockCreateStorageProvider).toHaveBeenCalledWith({
@@ -79,9 +84,9 @@ describe('S3Service (shared @libs/s3, thin wrapper over @genfeedai/storage)', ()
     });
 
     it('caches one provider per bucket', async () => {
-      await service.downloadFile('bucket-a', 'k1.png', '/tmp/k1.png');
-      await service.downloadFile('bucket-a', 'k2.png', '/tmp/k2.png');
-      await service.downloadFile('bucket-b', 'k3.png', '/tmp/k3.png');
+      await service.downloadFile('bucket-a', 'k1.png', '/tmp/k1.png', '/tmp');
+      await service.downloadFile('bucket-a', 'k2.png', '/tmp/k2.png', '/tmp');
+      await service.downloadFile('bucket-b', 'k3.png', '/tmp/k3.png', '/tmp');
 
       expect(mockCreateStorageProvider).toHaveBeenCalledTimes(2);
     });
@@ -93,6 +98,7 @@ describe('S3Service (shared @libs/s3, thin wrapper over @genfeedai/storage)', ()
         'test-bucket',
         'images/photo.jpg',
         '/tmp/photo.jpg',
+        '/tmp',
       );
 
       expect(mockProvider.download).toHaveBeenCalledWith(
@@ -108,8 +114,39 @@ describe('S3Service (shared @libs/s3, thin wrapper over @genfeedai/storage)', ()
       );
 
       await expect(
-        service.downloadFile('test-bucket', 'images/photo.jpg', '/tmp/p.jpg'),
+        service.downloadFile(
+          'test-bucket',
+          'images/photo.jpg',
+          '/tmp/p.jpg',
+          '/tmp',
+        ),
       ).rejects.toThrow('Empty response body');
+    });
+
+    it('rejects a local path outside the caller-owned download root', async () => {
+      await expect(
+        service.downloadFile(
+          'test-bucket',
+          'images/photo.jpg',
+          '/etc/escaped.jpg',
+          '/tmp/downloads',
+        ),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(mockProvider.download).not.toHaveBeenCalled();
+    });
+
+    it('rejects traversal in the object key before downloading', async () => {
+      await expect(
+        service.downloadFile(
+          'test-bucket',
+          '../secret.txt',
+          '/tmp/secret.txt',
+          '/tmp',
+        ),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(mockProvider.download).not.toHaveBeenCalled();
     });
   });
 
@@ -119,6 +156,7 @@ describe('S3Service (shared @libs/s3, thin wrapper over @genfeedai/storage)', ()
         'test-bucket',
         'videos/job123/video.mp4',
         '/tmp/video.mp4',
+        '/tmp',
         'video/mp4',
       );
 
@@ -131,11 +169,44 @@ describe('S3Service (shared @libs/s3, thin wrapper over @genfeedai/storage)', ()
     });
 
     it('passes undefined content type through for provider-side inference', async () => {
-      await service.uploadFile('test-bucket', 'images/photo.jpg', '/tmp/p.jpg');
+      await service.uploadFile(
+        'test-bucket',
+        'images/photo.jpg',
+        '/tmp/p.jpg',
+        '/tmp',
+      );
 
       expect(mockProvider.uploadFromFile).toHaveBeenCalledWith(
         'images/photo.jpg',
         '/tmp/p.jpg',
+        undefined,
+      );
+    });
+
+    it('rejects a local path outside the caller-owned upload root', async () => {
+      await expect(
+        service.uploadFile(
+          'test-bucket',
+          'images/photo.jpg',
+          '/etc/escaped.jpg',
+          '/tmp/uploads',
+        ),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(mockProvider.uploadFromFile).not.toHaveBeenCalled();
+    });
+
+    it('accepts a legitimate nested object key', async () => {
+      await service.uploadFile(
+        'test-bucket',
+        'images/jobs/job-1/photo.jpg',
+        '/tmp/photo.jpg',
+        '/tmp',
+      );
+
+      expect(mockProvider.uploadFromFile).toHaveBeenCalledWith(
+        'images/jobs/job-1/photo.jpg',
+        '/tmp/photo.jpg',
         undefined,
       );
     });
@@ -147,6 +218,7 @@ describe('S3Service (shared @libs/s3, thin wrapper over @genfeedai/storage)', ()
         'test-bucket',
         'my-lora',
         '/tmp/my-lora.safetensors',
+        '/tmp',
       );
 
       expect(result.s3Key).toBe(
@@ -159,6 +231,34 @@ describe('S3Service (shared @libs/s3, thin wrapper over @genfeedai/storage)', ()
         'application/octet-stream',
       );
       expect(mockLoggerService.log).toHaveBeenCalledTimes(2);
+    });
+
+    it('rejects a LoRA name that escapes the fixed S3 prefix', async () => {
+      await expect(
+        service.uploadSafetensors(
+          'test-bucket',
+          '../evil',
+          '/tmp/evil.safetensors',
+          '/tmp',
+        ),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(mockProvider.uploadFromFile).not.toHaveBeenCalled();
+    });
+
+    it('accepts a legitimate nested-safe LoRA object name', async () => {
+      await service.uploadSafetensors(
+        'test-bucket',
+        'org-1.model',
+        '/tmp/org-1.model.safetensors',
+        '/tmp',
+      );
+
+      expect(mockProvider.uploadFromFile).toHaveBeenCalledWith(
+        'ingredients/trainings/loras/org-1.model.safetensors',
+        '/tmp/org-1.model.safetensors',
+        'application/octet-stream',
+      );
     });
   });
 

--- a/packages/libs/s3/s3.service.ts
+++ b/packages/libs/s3/s3.service.ts
@@ -3,10 +3,15 @@ import {
   createStorageProvider,
   type StorageProvider,
 } from '@genfeedai/storage';
-// biome-ignore lint/style/useImportType: NestJS DI requires runtime imports
 import { LoggerService } from '@libs/logger/logger.service';
+import {
+  assertSafeObjectKey,
+  assertSafeObjectKeyPrefix,
+  resolveContainedObjectKey,
+  resolveContainedPath,
+} from '@libs/security';
 import { CallerUtil } from '@libs/utils/caller/caller.util';
-import { Inject, Injectable } from '@nestjs/common';
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
 
 export interface S3Object {
   key: string;
@@ -20,6 +25,8 @@ export interface S3ConfigService {
   AWS_SECRET_ACCESS_KEY: string;
   AWS_REGION: string;
 }
+
+const createBadRequest = (message: string) => new BadRequestException(message);
 
 /**
  * Thin NestJS wrapper over `@genfeedai/storage` — the single S3/local-FS
@@ -56,22 +63,29 @@ export class S3Service {
     bucket: string,
     key: string,
     localPath: string,
+    localRoot: string,
   ): Promise<void> {
     const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
+    const containedLocalPath = resolveContainedPath(
+      localRoot,
+      localPath,
+      createBadRequest,
+    );
+    const safeKey = assertSafeObjectKey(key, createBadRequest);
 
     this.loggerService.log(caller, {
       bucket,
-      key,
-      localPath,
+      key: safeKey,
+      localPath: containedLocalPath,
       message: 'Downloading file from storage',
     });
 
-    await this.providerFor(bucket).download(key, localPath);
+    await this.providerFor(bucket).download(safeKey, containedLocalPath);
 
     this.loggerService.log(caller, {
       bucket,
-      key,
-      localPath,
+      key: safeKey,
+      localPath: containedLocalPath,
       message: 'File downloaded successfully',
     });
   }
@@ -87,19 +101,30 @@ export class S3Service {
     bucket: string,
     key: string,
     localPath: string,
+    localRoot: string,
     contentType?: string,
   ): Promise<void> {
     const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
+    const containedLocalPath = resolveContainedPath(
+      localRoot,
+      localPath,
+      createBadRequest,
+    );
+    const safeKey = assertSafeObjectKey(key, createBadRequest);
 
     this.loggerService.log(caller, {
       bucket,
-      key,
-      localPath,
+      key: safeKey,
+      localPath: containedLocalPath,
       message: 'Uploading file to storage',
     });
 
-    await this.providerFor(bucket).uploadFromFile(key, localPath, contentType);
-    const fileStats = await stat(localPath);
+    await this.providerFor(bucket).uploadFromFile(
+      safeKey,
+      containedLocalPath,
+      contentType,
+    );
+    const fileStats = await stat(containedLocalPath);
 
     this.loggerService.log(caller, {
       bucket,
@@ -117,13 +142,23 @@ export class S3Service {
     bucket: string,
     loraName: string,
     localPath: string,
+    localRoot: string,
   ): Promise<{ s3Key: string; sizeBytes: number }> {
     const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
-    const s3Key = `ingredients/trainings/loras/${loraName}.safetensors`;
+    const containedLocalPath = resolveContainedPath(
+      localRoot,
+      localPath,
+      createBadRequest,
+    );
+    const s3Key = resolveContainedObjectKey(
+      'ingredients/trainings/loras',
+      `${loraName}.safetensors`,
+      createBadRequest,
+    );
 
     this.loggerService.log(caller, {
       bucket,
-      localPath,
+      localPath: containedLocalPath,
       loraName,
       message: 'Uploading safetensors to storage',
       s3Key,
@@ -131,10 +166,10 @@ export class S3Service {
 
     await this.providerFor(bucket).uploadFromFile(
       s3Key,
-      localPath,
+      containedLocalPath,
       'application/octet-stream',
     );
-    const fileStats = await stat(localPath);
+    const fileStats = await stat(containedLocalPath);
 
     this.loggerService.log(caller, {
       bucket,
@@ -149,14 +184,15 @@ export class S3Service {
 
   async listObjects(bucket: string, prefix: string): Promise<S3Object[]> {
     const caller = `${this.constructorName} ${CallerUtil.getCallerName()}`;
+    const safePrefix = assertSafeObjectKeyPrefix(prefix, createBadRequest);
 
     this.loggerService.log(caller, {
       bucket,
       message: 'Listing storage objects',
-      prefix,
+      prefix: safePrefix,
     });
 
-    const objects = await this.providerFor(bucket).listObjects(prefix);
+    const objects = await this.providerFor(bucket).listObjects(safePrefix);
     const mapped: S3Object[] = objects.map((object) => ({
       key: object.key,
       lastModified: object.lastModified.toISOString(),
@@ -167,7 +203,7 @@ export class S3Service {
       bucket,
       count: mapped.length,
       message: 'Listed storage objects',
-      prefix,
+      prefix: safePrefix,
     });
 
     return mapped;

--- a/packages/libs/security/index.ts
+++ b/packages/libs/security/index.ts
@@ -3,7 +3,7 @@ export {
   assertSafeObjectKey,
   assertSafeObjectKeyPrefix,
   resolveContainedObjectKey,
-} from '@genfeedai/storage';
+} from '@genfeedai/storage/path-containment';
 export {
   assertBoundedInteger,
   assertBoundedNumber,

--- a/packages/libs/security/index.ts
+++ b/packages/libs/security/index.ts
@@ -1,4 +1,10 @@
 export {
+  assertObjectKeyWithinPrefix,
+  assertSafeObjectKey,
+  assertSafeObjectKeyPrefix,
+  resolveContainedObjectKey,
+} from '@genfeedai/storage';
+export {
   assertBoundedInteger,
   assertBoundedNumber,
   assertSafeArgValue,

--- a/packages/libs/security/path-security.ts
+++ b/packages/libs/security/path-security.ts
@@ -1,13 +1,13 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
-import type { SecurityErrorFactory } from '@genfeedai/storage';
+import type { SecurityErrorFactory } from '@genfeedai/storage/path-containment';
 
 export {
   assertSafeSegment,
   resolveContainedPath,
   SAFE_SEGMENT_PATTERN,
   type SecurityErrorFactory,
-} from '@genfeedai/storage';
+} from '@genfeedai/storage/path-containment';
 
 /**
  * Shared, framework-agnostic path-traversal and command-injection sanitization.

--- a/packages/libs/security/path-security.ts
+++ b/packages/libs/security/path-security.ts
@@ -1,5 +1,13 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
+import type { SecurityErrorFactory } from '@genfeedai/storage';
+
+export {
+  assertSafeSegment,
+  resolveContainedPath,
+  SAFE_SEGMENT_PATTERN,
+  type SecurityErrorFactory,
+} from '@genfeedai/storage';
 
 /**
  * Shared, framework-agnostic path-traversal and command-injection sanitization.
@@ -15,9 +23,6 @@ import path from 'node:path';
  * NOTE: LLM prompt-injection sanitization (`sanitizePromptInput*`) intentionally
  * does NOT live here — it is API-local, since only the API builds LLM prompts.
  */
-
-/** Factory that turns a message into the consumer's validation error type. */
-export type SecurityErrorFactory = (message: string) => Error;
 
 /** Allowed media file extensions (lowercased, dot-prefixed). */
 export const DEFAULT_ALLOWED_EXTENSIONS: readonly string[] = [
@@ -85,72 +90,6 @@ export const DEFAULT_INJECTION_PATTERNS: readonly string[] = [
   '&lt;',
   '&amp;',
 ];
-
-/**
- * A single traversal-free path/object-key segment: starts alphanumeric, then
- * alphanumerics, dot, dash, underscore. Contains no separator, so it can never
- * escape the directory or S3 prefix it is interpolated into.
- */
-export const SAFE_SEGMENT_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
-
-/**
- * Assert a caller-supplied identifier is safe to interpolate into a filesystem
- * path or an S3 key. Use this wherever a request field becomes part of a path —
- * a name that reaches `join()` or a template literal is an injection point even
- * when the surrounding directory is fixed.
- */
-export function assertSafeSegment(
-  value: string,
-  name: string,
-  createError: SecurityErrorFactory,
-): string {
-  if (
-    typeof value !== 'string' ||
-    !SAFE_SEGMENT_PATTERN.test(value) ||
-    value.includes('..')
-  ) {
-    throw createError(
-      `${name} must be a single path segment of letters, digits, '.', '-' or '_'`,
-    );
-  }
-
-  return value;
-}
-
-/**
- * Resolve `candidatePath` and assert the result stays inside `rootDir`.
- *
- * {@link PathSecurity.validateFilePath} rejects known-bad spellings from a
- * blocklist; this expresses the stronger invariant an upload/download endpoint
- * actually needs — "this file must live under that directory" — which no
- * substring blocklist can encode. A relative candidate resolves against the
- * root; an absolute candidate is still held to the containment check.
- */
-export function resolveContainedPath(
-  rootDir: string,
-  candidatePath: string,
-  createError: SecurityErrorFactory,
-): string {
-  if (!rootDir || typeof rootDir !== 'string') {
-    throw createError('Containment root is not configured');
-  }
-
-  if (!candidatePath || typeof candidatePath !== 'string') {
-    throw createError('File path is required and must be a string');
-  }
-
-  const resolvedRoot = path.resolve(rootDir);
-  const resolved = path.resolve(resolvedRoot, candidatePath);
-
-  if (
-    resolved !== resolvedRoot &&
-    !resolved.startsWith(`${resolvedRoot}${path.sep}`)
-  ) {
-    throw createError(`File path must stay within ${resolvedRoot}`);
-  }
-
-  return resolved;
-}
 
 export interface PathSecurityOptions {
   /** Required: builds the error thrown by every guard. */

--- a/packages/libs/vitest.config.ts
+++ b/packages/libs/vitest.config.ts
@@ -19,6 +19,10 @@ export default defineConfig({
   resolve: {
     alias: {
       '@genfeedai/config': path.resolve(pkgDir, '../config/src/index.ts'),
+      '@genfeedai/storage/path-containment': path.resolve(
+        pkgDir,
+        '../storage/src/path-containment.ts',
+      ),
       '@genfeedai/storage': path.resolve(pkgDir, '../storage/src/index.ts'),
       '@libs': path.resolve(pkgDir, '.'),
     },

--- a/packages/storage/__tests__/s3-storage.provider.test.ts
+++ b/packages/storage/__tests__/s3-storage.provider.test.ts
@@ -61,6 +61,35 @@ describe('S3StorageProvider', () => {
     });
   });
 
+  describe('object-key containment', () => {
+    it('rejects traversal before sending an S3 command', async () => {
+      const provider = new S3StorageProvider({ bucket: 'b' });
+
+      await expect(
+        provider.upload(Buffer.from('payload'), '../escaped.png'),
+      ).rejects.toThrow(/invalid path segment/);
+
+      expect(mockSend).not.toHaveBeenCalled();
+    });
+
+    it('accepts and preserves a legitimate nested object key', async () => {
+      mockSend.mockResolvedValue({});
+      const provider = new S3StorageProvider({ bucket: 'b' });
+
+      await expect(
+        provider.upload(
+          Buffer.from('payload'),
+          'images/org-1/nested/photo.png',
+        ),
+      ).resolves.toBe('images/org-1/nested/photo.png');
+
+      const [command] = mockSend.mock.calls[0] as [
+        { params: Record<string, unknown> },
+      ];
+      expect(command.params.Key).toBe('images/org-1/nested/photo.png');
+    });
+  });
+
   describe('uploadFromFile', () => {
     it('reads the local file and puts it with inferred content type', async () => {
       mockSend.mockResolvedValue({});

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -5,6 +5,16 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./path-containment": {
+      "types": "./dist/path-containment.d.ts",
+      "import": "./dist/path-containment.js"
+    }
+  },
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -1,4 +1,14 @@
 export { LocalStorageProvider } from './local-storage.provider';
+export {
+  assertObjectKeyWithinPrefix,
+  assertSafeObjectKey,
+  assertSafeObjectKeyPrefix,
+  assertSafeSegment,
+  resolveContainedObjectKey,
+  resolveContainedPath,
+  SAFE_SEGMENT_PATTERN,
+  type SecurityErrorFactory,
+} from './path-containment';
 export { S3StorageProvider } from './s3-storage.provider';
 export type {
   FileEntry,

--- a/packages/storage/src/local-storage.provider.ts
+++ b/packages/storage/src/local-storage.provider.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync } from 'node:fs';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
-
+import { resolveContainedPath } from './path-containment';
 import type {
   FileEntry,
   ListOptions,
@@ -39,38 +39,6 @@ function resolveBaseDir(): string {
   );
 }
 
-/**
- * Resolve `candidate` against `root` and assert the result stays inside it.
- *
- * `path.join(root, candidate)` is not a containment check: enough leading
- * `../` segments walk straight out of the storage directory. Resolving and
- * then comparing against the root catches that, and also catches an absolute
- * candidate, which `path.resolve` discards the root for entirely. Every method
- * here takes its path from a caller, so every one of them resolves through
- * this.
- *
- * `@libs/security` has the same guard, but this package deliberately depends
- * on nothing but `@aws-sdk/client-s3` and `@genfeedai/config`, so it keeps its
- * own copy rather than acquire a workspace dependency for six lines.
- */
-function resolveWithin(root: string, candidate: string): string {
-  if (typeof candidate !== 'string') {
-    throw new Error('Storage path must be a string');
-  }
-
-  const resolvedRoot = path.resolve(root);
-  const resolved = path.resolve(resolvedRoot, candidate);
-
-  if (
-    resolved !== resolvedRoot &&
-    !resolved.startsWith(`${resolvedRoot}${path.sep}`)
-  ) {
-    throw new Error(`Storage path must stay within ${resolvedRoot}`);
-  }
-
-  return resolved;
-}
-
 export class LocalStorageProvider implements StorageProvider {
   private readonly baseDir: string;
 
@@ -83,7 +51,11 @@ export class LocalStorageProvider implements StorageProvider {
 
   /** Resolve a caller-supplied path against the storage root. */
   private resolvePath(filePath: string): string {
-    return resolveWithin(this.baseDir, filePath);
+    return resolveContainedPath(
+      this.baseDir,
+      filePath === '' ? '.' : filePath,
+      (message) => new Error(message),
+    );
   }
 
   async upload(

--- a/packages/storage/src/path-containment.spec.ts
+++ b/packages/storage/src/path-containment.spec.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  assertObjectKeyWithinPrefix,
+  assertSafeObjectKey,
+  assertSafeObjectKeyPrefix,
+  resolveContainedObjectKey,
+  resolveContainedPath,
+} from './path-containment';
+
+class ContainmentError extends Error {}
+
+const createError = (message: string) => new ContainmentError(message);
+
+describe('path containment', () => {
+  it('accepts a legitimate nested filesystem path', () => {
+    expect(
+      resolveContainedPath(
+        '/srv/genfeed/files',
+        'nested/file.txt',
+        createError,
+      ),
+    ).toBe('/srv/genfeed/files/nested/file.txt');
+  });
+
+  it.each([
+    '../escaped.txt',
+    'nested/../../escaped.txt',
+    '/etc/passwd',
+    '/srv/genfeed/files-sibling/file.txt',
+  ])('rejects filesystem escape %s', (candidate) => {
+    expect(() =>
+      resolveContainedPath('/srv/genfeed/files', candidate, createError),
+    ).toThrow(ContainmentError);
+  });
+});
+
+describe('object-key containment', () => {
+  it('preserves a legitimate nested key beneath the prefix', () => {
+    expect(
+      resolveContainedObjectKey(
+        'ingredients/images/',
+        'organizations/org-1/photo.png',
+        createError,
+      ),
+    ).toBe('ingredients/images/organizations/org-1/photo.png');
+  });
+
+  it.each([
+    '../escaped.png',
+    'nested/../../escaped.png',
+    '/absolute.png',
+    'nested\\escaped.png',
+    'nested//empty.png',
+    './same.png',
+  ])('rejects object-key escape %s', (candidate) => {
+    expect(() =>
+      resolveContainedObjectKey('ingredients/images', candidate, createError),
+    ).toThrow(ContainmentError);
+  });
+
+  it('rejects prefix confusion for an existing key', () => {
+    expect(() =>
+      assertObjectKeyWithinPrefix(
+        'ingredients/images',
+        'ingredients/images-evil/file.png',
+        createError,
+      ),
+    ).toThrow(ContainmentError);
+  });
+
+  it('validates a legitimate nested key without imposing a prefix', () => {
+    const key = 'transcripts/job-1/audio.mp3';
+    expect(assertSafeObjectKey(key, createError)).toBe(key);
+  });
+
+  it('preserves an empty bucket-root listing prefix', () => {
+    expect(assertSafeObjectKeyPrefix('', createError)).toBe('');
+  });
+
+  it('accepts an existing nested key without rewriting it', () => {
+    const key = 'ingredients/images/org-1/photo.png';
+    expect(
+      assertObjectKeyWithinPrefix('ingredients/images/', key, createError),
+    ).toBe(key);
+  });
+});

--- a/packages/storage/src/path-containment.ts
+++ b/packages/storage/src/path-containment.ts
@@ -1,0 +1,166 @@
+import path from 'node:path';
+
+/** Factory that turns a validation message into a consumer-owned error. */
+export type SecurityErrorFactory = (message: string) => Error;
+
+/**
+ * A traversal-free path or object-key segment.
+ *
+ * The additional `includes('..')` check in {@link assertSafeSegment} rejects
+ * ambiguous dot sequences even though single dots are otherwise valid.
+ */
+export const SAFE_SEGMENT_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+export function assertSafeSegment(
+  value: string,
+  name: string,
+  createError: SecurityErrorFactory,
+): string {
+  if (
+    typeof value !== 'string' ||
+    !SAFE_SEGMENT_PATTERN.test(value) ||
+    value.includes('..')
+  ) {
+    throw createError(
+      `${name} must be a single path segment of letters, digits, '.', '-' or '_'`,
+    );
+  }
+
+  return value;
+}
+
+/**
+ * Resolve a candidate and assert that it remains equal to or below a fixed
+ * filesystem root.
+ */
+export function resolveContainedPath(
+  rootDir: string,
+  candidatePath: string,
+  createError: SecurityErrorFactory,
+): string {
+  if (!rootDir || typeof rootDir !== 'string') {
+    throw createError('Containment root is not configured');
+  }
+
+  if (!candidatePath || typeof candidatePath !== 'string') {
+    throw createError('File path is required and must be a string');
+  }
+
+  const resolvedRoot = path.resolve(rootDir);
+  const resolved = path.resolve(resolvedRoot, candidatePath);
+
+  if (
+    resolved !== resolvedRoot &&
+    !resolved.startsWith(`${resolvedRoot}${path.sep}`)
+  ) {
+    throw createError(`File path must stay within ${resolvedRoot}`);
+  }
+
+  return resolved;
+}
+
+function validateObjectKey(
+  value: string,
+  name: string,
+  createError: SecurityErrorFactory,
+  allowTrailingSlash: boolean,
+): string {
+  if (!value || typeof value !== 'string') {
+    throw createError(`${name} is required and must be a string`);
+  }
+
+  if (value.startsWith('/') || value.includes('\\') || value.includes('\0')) {
+    throw createError(`${name} must be a relative POSIX object key`);
+  }
+
+  const normalized =
+    allowTrailingSlash && value.endsWith('/') ? value.slice(0, -1) : value;
+  const segments = normalized.split('/');
+
+  if (
+    !normalized ||
+    (!allowTrailingSlash && value.endsWith('/')) ||
+    segments.some(
+      (segment) => segment === '' || segment === '.' || segment === '..',
+    )
+  ) {
+    throw createError(`${name} contains an invalid path segment`);
+  }
+
+  return normalized;
+}
+
+/** Validate a relative POSIX object key without imposing an owning prefix. */
+export function assertSafeObjectKey(
+  key: string,
+  createError: SecurityErrorFactory,
+): string {
+  validateObjectKey(key, 'Object key', createError, false);
+  return key;
+}
+
+/** Validate an object-listing prefix, preserving an empty bucket-root prefix. */
+export function assertSafeObjectKeyPrefix(
+  prefix: string,
+  createError: SecurityErrorFactory,
+): string {
+  if (prefix === '') {
+    return prefix;
+  }
+  validateObjectKey(prefix, 'Object key prefix', createError, true);
+  return prefix;
+}
+
+/**
+ * Construct a literal S3 key below a fixed prefix without normalizing or
+ * rewriting the candidate key.
+ */
+export function resolveContainedObjectKey(
+  prefix: string,
+  candidateKey: string,
+  createError: SecurityErrorFactory,
+): string {
+  const normalizedPrefix = validateObjectKey(
+    prefix,
+    'Object key prefix',
+    createError,
+    true,
+  );
+  const validatedCandidate = validateObjectKey(
+    candidateKey,
+    'Object key',
+    createError,
+    false,
+  );
+
+  return `${normalizedPrefix}/${validatedCandidate}`;
+}
+
+/**
+ * Validate an already-built object key under a fixed prefix while preserving
+ * the key byte-for-byte.
+ */
+export function assertObjectKeyWithinPrefix(
+  prefix: string,
+  key: string,
+  createError: SecurityErrorFactory,
+): string {
+  const normalizedPrefix = validateObjectKey(
+    prefix,
+    'Object key prefix',
+    createError,
+    true,
+  );
+  const validatedKey = validateObjectKey(key, 'Object key', createError, false);
+
+  if (
+    validatedKey !== normalizedPrefix &&
+    !validatedKey.startsWith(`${normalizedPrefix}/`)
+  ) {
+    throw createError(
+      `Object key must stay within prefix ${normalizedPrefix}/`,
+    );
+  }
+
+  return key;
+}

--- a/packages/storage/src/s3-storage.provider.ts
+++ b/packages/storage/src/s3-storage.provider.ts
@@ -11,7 +11,10 @@ import {
   PutObjectCommand,
   S3Client,
 } from '@aws-sdk/client-s3';
-
+import {
+  assertSafeObjectKey,
+  assertSafeObjectKeyPrefix,
+} from './path-containment';
 import type {
   FileEntry,
   ListOptions,
@@ -19,6 +22,8 @@ import type {
   StorageProvider,
   StorageProviderOptions,
 } from './storage.provider';
+
+const createStorageError = (message: string) => new Error(message);
 
 const MIME_BY_EXT: Record<string, string> = {
   '.aac': 'audio/aac',
@@ -81,15 +86,16 @@ export class S3StorageProvider implements StorageProvider {
     filePath: string,
     contentType?: string,
   ): Promise<string> {
+    const safeFilePath = assertSafeObjectKey(filePath, createStorageError);
     const resolvedContentType = contentType ?? mimeFromPath(filePath);
     const command = new PutObjectCommand({
       Body: file,
       Bucket: this.bucket,
       ContentType: resolvedContentType,
-      Key: filePath,
+      Key: safeFilePath,
     });
     await this.client.send(command);
-    return filePath;
+    return safeFilePath;
   }
 
   async uploadFromFile(
@@ -97,6 +103,7 @@ export class S3StorageProvider implements StorageProvider {
     localPath: string,
     contentType?: string,
   ): Promise<string> {
+    const safeFilePath = assertSafeObjectKey(filePath, createStorageError);
     const fileBuffer = await readFile(localPath);
     const fileStats = await stat(localPath);
     const resolvedContentType = contentType ?? mimeFromPath(localPath);
@@ -106,22 +113,23 @@ export class S3StorageProvider implements StorageProvider {
       Bucket: this.bucket,
       ContentLength: fileStats.size,
       ContentType: resolvedContentType,
-      Key: filePath,
+      Key: safeFilePath,
     });
     await this.client.send(command);
-    return filePath;
+    return safeFilePath;
   }
 
   async download(filePath: string, localPath: string): Promise<void> {
+    const safeFilePath = assertSafeObjectKey(filePath, createStorageError);
     const command = new GetObjectCommand({
       Bucket: this.bucket,
-      Key: filePath,
+      Key: safeFilePath,
     });
     const response = await this.client.send(command);
 
     if (!response.Body) {
       throw new Error(
-        `Empty response body for s3://${this.bucket}/${filePath}`,
+        `Empty response body for s3://${this.bucket}/${safeFilePath}`,
       );
     }
 
@@ -130,21 +138,24 @@ export class S3StorageProvider implements StorageProvider {
   }
 
   getUrl(filePath: string): string {
-    return `https://${this.bucket}.s3.${this.region}.amazonaws.com/${filePath}`;
+    const safeFilePath = assertSafeObjectKey(filePath, createStorageError);
+    return `https://${this.bucket}.s3.${this.region}.amazonaws.com/${safeFilePath}`;
   }
 
   async delete(filePath: string): Promise<void> {
+    const safeFilePath = assertSafeObjectKey(filePath, createStorageError);
     const command = new DeleteObjectCommand({
       Bucket: this.bucket,
-      Key: filePath,
+      Key: safeFilePath,
     });
     await this.client.send(command);
   }
 
   async list(prefix: string, options?: ListOptions): Promise<FileEntry[]> {
+    const safePrefix = assertSafeObjectKeyPrefix(prefix, createStorageError);
     const command = new ListObjectsV2Command({
       Bucket: this.bucket,
-      Prefix: prefix,
+      Prefix: safePrefix,
       MaxKeys: (options?.offset ?? 0) + (options?.limit ?? 1000),
     });
     const response = await this.client.send(command);
@@ -173,6 +184,7 @@ export class S3StorageProvider implements StorageProvider {
   }
 
   async listObjects(prefix: string): Promise<StorageObject[]> {
+    const safePrefix = assertSafeObjectKeyPrefix(prefix, createStorageError);
     const objects: StorageObject[] = [];
     let continuationToken: string | undefined;
 
@@ -180,7 +192,7 @@ export class S3StorageProvider implements StorageProvider {
       const command = new ListObjectsV2Command({
         Bucket: this.bucket,
         ContinuationToken: continuationToken,
-        Prefix: prefix,
+        Prefix: safePrefix,
       });
       const response = await this.client.send(command);
 
@@ -201,10 +213,11 @@ export class S3StorageProvider implements StorageProvider {
   }
 
   async exists(filePath: string): Promise<boolean> {
+    const safeFilePath = assertSafeObjectKey(filePath, createStorageError);
     try {
       const command = new HeadObjectCommand({
         Bucket: this.bucket,
-        Key: filePath,
+        Key: safeFilePath,
       });
       await this.client.send(command);
       return true;


### PR DESCRIPTION
## Summary
- canonicalize the path-containment helper from #2064 in `@genfeedai/storage` and add literal POSIX S3 key guards
- enforce fixed filesystem roots and object-key validation across files, image/voice datasets, shared S3, and storage providers
- add traversal rejection and legitimate nested path/key coverage in every scoped area
- record the reusable containment contract and adapter-boundary decision

## Verification
- `bunx biome check --write` on all 34 touched TypeScript files (passed; three pre-existing TrainingService warnings)
- `git diff --check` (passed)
- `gitleaks protect --staged --redact --verbose` (passed)
- commit hooks: secretlint, staged Biome, UI control guard (passed)
- local tests/typechecks/builds intentionally not run on the MacBook Pro; PR CI is the runtime gate

## Security disposition
- request/job boundaries now resolve local paths against caller-owned trusted roots before generic storage adapter calls
- generic adapters remain framework-agnostic and reject invalid S3 keys; any residual adapter-only CodeQL dataflow finding must be reviewed against the guarded call chain before dismissal

Closes #2068