### PR TITLE
fix(security): harden ReDoS parser edge cases

### DIFF
--- a/apps/server/api/src/collections/trends/utils/trend-source-url.util.spec.ts
+++ b/apps/server/api/src/collections/trends/utils/trend-source-url.util.spec.ts
@@ -30,6 +30,13 @@ describe('normalizeTrendSourceUrl', () => {
     );
   });
 
+  it('drops every line after a delimiter in malformed multi-line input', () => {
+    expect(
+      normalizeTrendSourceUrl('not a url/reference?query\nuntrusted-line')
+        .normalizedUrl,
+    ).toBe('not a url/reference');
+  });
+
   it('handles long delimiter tails without regular-expression backtracking', () => {
     const path = `not a url/${'a'.repeat(50_000)}`;
     const result = normalizeTrendSourceUrl(

--- a/apps/server/api/src/collections/trends/utils/trend-source-url.util.ts
+++ b/apps/server/api/src/collections/trends/utils/trend-source-url.util.ts
@@ -13,6 +13,10 @@ function removeTrailingSlash(value: string): string {
   return value.endsWith('/') ? value.slice(0, -1) : value;
 }
 
+/**
+ * Treat the first delimiter as terminal even for malformed multi-line input.
+ * This intentionally avoids retaining attacker-controlled lines after a URL.
+ */
 function stripQueryAndFragment(value: string): string {
   let end = value.length;
 

--- a/apps/server/api/src/services/agent-orchestrator/utils/agent-orchestrator-input-parsing.util.spec.ts
+++ b/apps/server/api/src/services/agent-orchestrator/utils/agent-orchestrator-input-parsing.util.spec.ts
@@ -31,6 +31,15 @@ describe('agent orchestrator input parsing', () => {
     );
   });
 
+  it('preserves the previous single-line style capture semantics', () => {
+    expect(
+      extractStyleNotes('Create images in a bold\neditorial style'),
+    ).toBeUndefined();
+    expect(extractStyleNotes('in a broken\nstyle, with a valid style')).toBe(
+      'valid',
+    );
+  });
+
   it('extracts a topic before platform, date, or punctuation delimiters', () => {
     expect(
       extractBatchTopic(
@@ -44,6 +53,21 @@ describe('agent orchestrator input parsing', () => {
         'create 5 posts about creator tools.',
       ),
     ).toBe('creator tools');
+  });
+
+  it('preserves the previous single-line topic capture semantics', () => {
+    expect(
+      extractBatchTopic(
+        'Create posts about AI\nSafety today',
+        'create posts about ai\nsafety today',
+      ),
+    ).toBeUndefined();
+    expect(
+      extractBatchTopic(
+        'Create posts about AI Safety\nfor LinkedIn',
+        'create posts about ai safety\nfor linkedin',
+      ),
+    ).toBe('AI Safety');
   });
 
   it('handles long repeated spaces and words without ambiguous matching', () => {

--- a/apps/server/api/src/services/agent-orchestrator/utils/agent-orchestrator-input-parsing.util.spec.ts
+++ b/apps/server/api/src/services/agent-orchestrator/utils/agent-orchestrator-input-parsing.util.spec.ts
@@ -35,9 +35,9 @@ describe('agent orchestrator input parsing', () => {
     expect(
       extractStyleNotes('Create images in a bold\neditorial style'),
     ).toBeUndefined();
-    expect(extractStyleNotes('in a broken\nstyle, with a valid style')).toBe(
-      'valid',
-    );
+    expect(
+      extractStyleNotes('in a broken\neditorial style, with a valid style'),
+    ).toBe('valid');
   });
 
   it('extracts a topic before platform, date, or punctuation delimiters', () => {

--- a/apps/server/api/src/services/agent-orchestrator/utils/agent-orchestrator-input-parsing.util.ts
+++ b/apps/server/api/src/services/agent-orchestrator/utils/agent-orchestrator-input-parsing.util.ts
@@ -39,6 +39,29 @@ function isWhitespace(character: string): boolean {
   return character.trim().length === 0;
 }
 
+function isLineTerminator(character: string): boolean {
+  return (
+    character === '\n' ||
+    character === '\r' ||
+    character === '\u2028' ||
+    character === '\u2029'
+  );
+}
+
+function containsLineTerminator(
+  value: string,
+  start: number,
+  end: number,
+): boolean {
+  for (let index = start; index < end; index += 1) {
+    if (isLineTerminator(value[index])) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 function containsOnlyWhitespace(
   value: string,
   start: number,
@@ -171,13 +194,19 @@ export function extractStyleNotes(content: string): string | undefined {
         continue;
       }
 
+      let notesStart = contentStart;
+      while (notesStart < notesEnd && isWhitespace(content[notesStart])) {
+        notesStart += 1;
+      }
+      if (containsLineTerminator(content, notesStart, notesEnd)) {
+        continue;
+      }
+
       const notes = content.slice(contentStart, notesEnd).trim();
       if (notes) {
         return notes;
       }
     }
-
-    return undefined;
   }
 
   return undefined;
@@ -218,6 +247,7 @@ export function extractBatchTopic(
     }
 
     let cursor = topicStart;
+    let crossedUnsupportedLineBreak = false;
     while (cursor < normalizedContent.length) {
       const character = normalizedContent[cursor];
       if (character === '.' || character === '!' || character === '?') {
@@ -237,11 +267,23 @@ export function extractBatchTopic(
           break;
         }
 
+        if (
+          nextWordStart < normalizedContent.length &&
+          containsLineTerminator(normalizedContent, cursor, nextWordStart)
+        ) {
+          crossedUnsupportedLineBreak = true;
+          break;
+        }
+
         cursor = nextWordStart;
         continue;
       }
 
       cursor += 1;
+    }
+
+    if (crossedUnsupportedLineBreak) {
+      continue;
     }
 
     const topic = originalContent.slice(topicStart, cursor).trim();

--- a/apps/server/api/src/services/integrations/ghost/services/ghost.service.spec.ts
+++ b/apps/server/api/src/services/integrations/ghost/services/ghost.service.spec.ts
@@ -257,6 +257,25 @@ describe('GhostService', () => {
         expect.any(Object),
       );
     });
+
+    it('should handle a long trailing-slash run without backtracking', async () => {
+      httpService.post.mockReturnValue(
+        of(makeAxiosResponse({ posts: [{ id: '1' }] })),
+      );
+
+      await service.createPost(
+        `https://myblog.ghost.io${'/'.repeat(50_000)}`,
+        apiKey,
+        'Title',
+        '<p>Body</p>',
+      );
+
+      expect(httpService.post).toHaveBeenCalledWith(
+        'https://myblog.ghost.io/ghost/api/admin/posts/',
+        expect.any(Object),
+        expect.any(Object),
+      );
+    });
   });
 
   describe('getSiteInfo', () => {

--- a/apps/server/api/src/services/integrations/unipile/services/unipile.service.spec.ts
+++ b/apps/server/api/src/services/integrations/unipile/services/unipile.service.spec.ts
@@ -96,6 +96,27 @@ describe('UnipileService', () => {
     });
   });
 
+  it('normalizes a long trailing-slash run without backtracking', async () => {
+    mockOrgIntegration.findFirst.mockResolvedValue(null);
+    mockOrgIntegration.create.mockResolvedValue({
+      id: 'integration_1',
+      status: 'ACTIVE',
+    });
+
+    await service.configure('org_1', {
+      apiBaseUrl: `https://api1.unipile.com:13111${'/'.repeat(50_000)}`,
+      apiKey: 'secret-key',
+    });
+
+    expect(mockOrgIntegration.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        config: expect.objectContaining({
+          apiBaseUrl: 'https://api1.unipile.com:13111/api/v1',
+        }),
+      }),
+    });
+  });
+
   it('filters connected accounts to the org allow-list and redacts secrets', async () => {
     mockOrgIntegration.findFirst.mockResolvedValue({
       config: {

--- a/apps/server/api/src/shared/utils/string/strip-markup.util.spec.ts
+++ b/apps/server/api/src/shared/utils/string/strip-markup.util.spec.ts
@@ -24,6 +24,15 @@ describe('replaceMarkup', () => {
     ).toBe('Helloworld');
   });
 
+  it('does not mistake less-than signs in blocked content for tag starts', () => {
+    expect(
+      replaceMarkup('<script>if (a<b) { alert(1); }</script>x', '', true),
+    ).toBe('x');
+    expect(
+      replaceMarkup("<style>a::before{content:'<'}</style>x", '', true),
+    ).toBe('x');
+  });
+
   it('preserves an unclosed blocked element body like the previous matcher', () => {
     expect(replaceMarkup('<script>visible fallback', '', true)).toBe(
       'visible fallback',

--- a/apps/server/api/src/shared/utils/string/strip-markup.util.ts
+++ b/apps/server/api/src/shared/utils/string/strip-markup.util.ts
@@ -18,10 +18,50 @@ function getBlockElementName(
   return BLOCK_ELEMENT_NAMES.find((name) => normalized.startsWith(name));
 }
 
+function matchesAsciiCaseInsensitive(
+  value: string,
+  start: number,
+  expected: string,
+): boolean {
+  if (start + expected.length > value.length) {
+    return false;
+  }
+
+  for (let offset = 0; offset < expected.length; offset += 1) {
+    if (value[start + offset].toLowerCase() !== expected[offset]) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function findBlockedElementEnd(
+  value: string,
+  blockName: (typeof BLOCK_ELEMENT_NAMES)[number],
+  start: number,
+): number {
+  const closingTag = `</${blockName}>`;
+  let cursor = start;
+
+  while (cursor < value.length) {
+    const tagStart = value.indexOf('<', cursor);
+    if (tagStart < 0) {
+      return -1;
+    }
+
+    if (matchesAsciiCaseInsensitive(value, tagStart, closingTag)) {
+      return tagStart + closingTag.length;
+    }
+
+    cursor = tagStart + 1;
+  }
+
+  return -1;
+}
+
 function stripBlockedElements(value: string): string {
   const output: string[] = [];
-  let blockName: (typeof BLOCK_ELEMENT_NAMES)[number] | undefined;
-  let blockStart = -1;
   let copyStart = 0;
   let cursor = 0;
 
@@ -37,29 +77,23 @@ function stripBlockedElements(value: string): string {
     }
 
     const tagContent = value.slice(tagStart + 1, tagEnd);
-
+    const blockName = getBlockElementName(tagContent);
     if (!blockName) {
-      const nextBlockName = getBlockElementName(tagContent);
-      if (nextBlockName) {
-        output.push(value.slice(copyStart, tagStart));
-        blockName = nextBlockName;
-        blockStart = tagStart;
-      }
-    } else if (tagContent.toLowerCase() === `/${blockName}`) {
-      blockName = undefined;
-      blockStart = -1;
-      copyStart = tagEnd + 1;
+      cursor = tagEnd + 1;
+      continue;
     }
 
-    cursor = tagEnd + 1;
+    const blockEnd = findBlockedElementEnd(value, blockName, tagEnd + 1);
+    if (blockEnd < 0) {
+      break;
+    }
+
+    output.push(value.slice(copyStart, tagStart));
+    copyStart = blockEnd;
+    cursor = blockEnd;
   }
 
-  if (blockName && blockStart >= 0) {
-    output.push(value.slice(blockStart));
-  } else {
-    output.push(value.slice(copyStart));
-  }
-
+  output.push(value.slice(copyStart));
   return output.join('');
 }
 


### PR DESCRIPTION
## Summary

- repairs the genuine exact-head verifier finding from #2075: deterministic script/style stripping now searches directly for the case-insensitive closing marker, so a bare `<` inside blocked content cannot consume the real closing tag and leak script/style text
- restores the former single-line capture behavior for style/topic parsing while continuing to scan later valid candidates
- documents and pins the intentional malformed multi-line URL tightening
- adds the missing long trailing-slash coverage for Ghost and Unipile

## Verification context

PR #2075 was merged by the repository owner while its exact-head verifier was still running. The verifier returned `FAIL` against `d197f7d804a9ea422b6b194db6d44dd82df65604`. Its critical reversion findings were caused by an incorrectly supplied two-dot diff against a newer master base; the actual squash merge `c3a2100005c8cb6dbf4425c41ca845365ea00c7b` applied only the 37-file ReDoS change atop `a6de7ee7860280c5481e8302896f25f961e23fd3`. This PR addresses every actionable finding from the correct PR diff.

The suggested cross-package trailing-slash consolidation is intentionally not applied: `@genfeedai/helpers` already depends on `@genfeedai/constants`, so moving the constants implementation into helpers would create a dependency cycle; adding helpers to the UI-focused workflows package would also expand its public runtime boundary for a three-line scan.

## Checks

- locked Biome 2.5.3 scoped check: passed
- `git diff --check`: passed
- pre-commit Secretlint: passed
- pre-commit staged Biome check: passed
- UI control guard: passed
- local tests, typechecks, and builds: not run under the MacBook Pro policy; PR CI is the execution gate

Follow-up to #2075 and #2069.